### PR TITLE
Pin dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-elasticsearch[async]
-motor
-pyyaml
-aioboto3
-crontab
+elasticsearch[async]>=8.3.1
+motor>=3.0.0
+pyyaml>=6.0
+aioboto3>=9.6.0
+crontab>=0.23.0
 
-black
-flake8
-aioresponses
-pytest
-pytest-cov
-pytest-asyncio
+black>=22.6.0
+flake8>=4.0.1
+aioresponses>=0.7.3
+pytest>=7.1.2
+pytest-cov>=3.0.0
+pytest-asyncio>=0.19.0


### PR DESCRIPTION
Suggestion when reading CONTRIBUTING.rst - pin requirements of currently used dependencies declared in requirements.txt.