### PR TITLE
Fix elastic-ingest --action list not working due to DirectoryDataSource missing _doc_

### DIFF
--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -17,6 +17,8 @@ HERE = os.path.dirname(__file__)
 
 
 class DirectoryDataSource:
+    """Directory"""
+
     def __init__(self, connector):
         self.directory = connector.configuration["directory"]
         self.pattern = connector.configuration["pattern"]


### PR DESCRIPTION
## Fixes https://github.com/elastic/connectors-python/issues/17

Calling `elastic-ingest --action list` displays an error in terminal:

```
 Traceback (most recent call last):
  File "/Users/artemshelkovnikov/git_tree/connectors-py/bin/elastic-ingest", line 33, in <module>
    sys.exit(load_entry_point('elasticsearch-connectors', 'console_scripts', 'elastic-ingest')())
  File "/Users/artemshelkovnikov/git_tree/connectors-py/connectors/cli.py", line 77, in main
    return run(args)
  File "/Users/artemshelkovnikov/git_tree/connectors-py/connectors/runner.py", line 144, in run
    loop.run_until_complete(coro)
  File "/usr/local/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/Users/artemshelkovnikov/git_tree/connectors-py/connectors/runner.py", line 122, in get_list
    logger.info(f"- {source.__doc__.strip()}")
AttributeError: 'NoneType' object has no attribute 'strip'
```

It happens due to the fact that the `class DirectoryDataSource` is missing a doc comment after the class definition. Adding the class definition fixes the problem.