### PR TITLE
Change mongo->mongodb for MongoDB source

### DIFF
--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -105,7 +105,7 @@ We require the connector to have a unit test and to have a 90% coverage reported
 
 If this first step pass, we'll start your Docker instance or configure your backend, then run::
 
-   make ftest NAME=mongo
+   make ftest NAME=mongodb
 
 This will configure the connector in Elasticsearch to run a full sync.
 The script will verify that the Elasticsearch index receives documents.

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ A source class can be any Python class, and is declared into the
 .. code-block:: yaml
 
   sources:
-    mongo: connectors.sources.mongo:MongoDataSource
+    mongodb: connectors.sources.mongo:MongoDataSource
     s3: connectors.sources.aws:S3DataSource
 
 

--- a/config.yml
+++ b/config.yml
@@ -19,7 +19,7 @@ service:
 
 native_service_types:
   - s3
-  - mongo
+  - mongodb
 
 # some id
 #connector_id: '1'

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -83,7 +83,7 @@ def _parser():
         "--config-file", type=str, help="Configuration file", default=DEFAULT_CONFIG
     )
     parser.add_argument(
-        "--service-type", type=str, help="Service type", default="mongo"
+        "--service-type", type=str, help="Service type", default="mongodb"
     )
     parser.add_argument(
         "--index-name",

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -83,7 +83,7 @@ mongo = {
         },
     },
     "index_name": "search-airbnb",
-    "service_type": "mongo",
+    "service_type": "mongodb",
     "status": "configured",
     "last_sync_status": "null",
     "last_sync_error": "",

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -39,7 +39,7 @@ def _parser():
         "--config-file", type=str, help="Configuration file", default=DEFAULT_CONFIG
     )
     parser.add_argument(
-        "--service-type", type=str, help="Service type", default="mongo"
+        "--service-type", type=str, help="Service type", default="mongodb"
     )
     parser.add_argument(
         "--index-name", type=str, help="Elasticsearch index", default="search-mongo"


### PR DESCRIPTION
Consistency change: let's make `mongo` source service_type `mongodb` instead (Kibana creates native connectors with this service type now, and I find it better)