### PR TITLE
added service.name for filebeat output

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -20,7 +20,6 @@ from connectors.utils import iso_utc, ESClient
 class Bulker:
     """Send bulk operations in batches by consuming a queue."""
 
-
     def __init__(self, client, queue, chunk_size, pipeline_settings):
         self.client = client
         self.queue = queue
@@ -331,7 +330,9 @@ class ElasticServer(ESClient):
         fetcher_task = asyncio.create_task(fetcher.run(generator))
 
         # start the bulker
-        bulker = Bulker(self.client, stream, self.config.get("bulk_chunk_size", 500), pipeline)
+        bulker = Bulker(
+            self.client, stream, self.config.get("bulk_chunk_size", 500), pipeline
+        )
         bulker_task = asyncio.create_task(bulker.run())
 
         await asyncio.gather(fetcher_task, bulker_task)

--- a/connectors/logger.py
+++ b/connectors/logger.py
@@ -24,11 +24,14 @@ def _formatter(prefix):
 class ExtraLogger(logging.Logger):
     def _log(self, level, msg, args, exc_info=None, extra=None):
         if extra is None:
-            extra = {
+            extra = {}
+        extra.update(
+            {
                 "service.type": "connectors-python",
                 "service.version": __version__,
                 "labels.index_date": datetime.now().strftime("%Y.%m.%d"),
             }
+        )
         super(ExtraLogger, self)._log(level, msg, args, exc_info, extra)
 
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/###

Adds `service.name` for the cloud console

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [X] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
