### PR TITLE
Add missing config

### DIFF
--- a/connectors/tests/config_keep_alive.yml
+++ b/connectors/tests/config_keep_alive.yml
@@ -1,0 +1,21 @@
+elasticsearch:
+  host: http://nowhere.com:9200
+  user: elastic
+  password: ${elasticsearch.password}
+  bulk_queue_max_size: 1024
+  max_wait_duration: 1
+  initial_backoff_duration: 0
+  backoff_multiplier: 0
+
+service:
+  idling: 0.5
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  keep_alive: true
+
+connector_id: '1'
+
+sources:
+  fake: test_runner:FakeSource
+  large_fake: test_runner:LargeFakeSource


### PR DESCRIPTION
Main was failing CI with errors like:
```
�_bk;t=1663349190292�>       assert isinstance(patch_logger.logs[-3], Exception)
�_bk;t=1663349190292�E       IndexError: list index out of range
```

Upon investigation, it was because the specified config file was missing.


## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally


