### PR TITLE
Make run_ml_inference true by default

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -157,7 +157,7 @@ class PipelineSettings:
         self.name = pipeline.get("name", "ent-search-generic-ingestion")
         self.extract_binary_content = pipeline.get("extract_binary_content", True)
         self.reduce_whitespace = pipeline.get("reduce_whitespace", True)
-        self.run_ml_inference = pipeline.get("run_ml_inference", False)
+        self.run_ml_inference = pipeline.get("run_ml_inference", True)
 
 
 class BYOConnector:


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/2811

Makes `run_ml_inference` true by default


## Related Pull Requests

- https://github.com/elastic/kibana/pull/141161
- https://github.com/elastic/connectors-ruby/pull/326
- https://github.com/elastic/ent-search/pull/6852


