### PR TITLE
backport were broken

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "targetBranchChoices": [
     { "name": "main", "checked": true },
-    "8.5",
+    "8.5"
   ],
   "fork": false,
   "targetPRLabels": ["backport"],


### PR DESCRIPTION
The auto-backport feature was broken because of a trailing comma