### PR TITLE
Populate service_type and configuration for custom connectors

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -22,11 +22,10 @@ service:
   trace_mem: false
 
 native_service_types:
-  - mongodb
+  - mysql
 
 # some id
-connector_id: 'WTHqV4QBO_lgw7YQkNd_'
-service_type: mysql
+#connector_id: '1'
 
 sources:
   mongodb: connectors.sources.mongo:MongoDataSource

--- a/config.yml
+++ b/config.yml
@@ -22,10 +22,11 @@ service:
   trace_mem: false
 
 native_service_types:
-  - mysql
+  - mongodb
 
 # some id
-#connector_id: '1'
+connector_id: 'WTHqV4QBO_lgw7YQkNd_'
+service_type: mysql
 
 sources:
   mongodb: connectors.sources.mongo:MongoDataSource

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -247,6 +247,15 @@ class BYOConnector:
 
     async def populate_configuration(self, configuration):
         self.doc_source["configuration"] = configuration
+        status = (
+            Status.CONFIGURED
+            if all(
+                isinstance(value, dict) and value["value"] is not None
+                for value in configuration.values()
+            )
+            else Status.NEEDS_CONFIGURATION
+        )
+        self.doc_source["status"] = status.name.lower()
         self.update_config(self.doc_source)
         await self._write()
 

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -89,7 +89,9 @@ class BYOIndex(ESClient):
         document = dict(connector.doc_source)
 
         # read only we never update
-        for key in (NATIVE_READ_ONLY_FIELDS if connector.native else CUSTOM_READ_ONLY_FIELDS):
+        for key in (
+            NATIVE_READ_ONLY_FIELDS if connector.native else CUSTOM_READ_ONLY_FIELDS
+        ):
             if key in document:
                 del document[key]
 
@@ -121,12 +123,6 @@ class BYOIndex(ESClient):
 
         logger.debug(f"Found {len(resp['hits']['hits'])} connectors")
         for hit in resp["hits"]["hits"]:
-            yield BYOConnector(
-                    self,
-                    hit["_id"],
-                    hit["_source"],
-                    bulk_queue_max_size=self.bulk_queue_max_size,
-                )
             yield BYOConnector(
                 self,
                 hit["_id"],

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -55,12 +55,10 @@ class JobStatus(Enum):
 
 
 READ_ONLY_FIELDS = (
-    "service_type",
     "is_native",
     "api_key_id",
     "pipeline",
     "scheduling",
-    "configuration",
 )
 
 
@@ -234,6 +232,16 @@ class BYOConnector:
     @property
     def status(self):
         return self._status
+
+    async def populate_service_type(self, service_type):
+        self.doc_source["service_type"] = service_type
+        self.update_config(self.doc_source)
+        await self._write()
+
+    async def populate_configuration(self, configuration):
+        self.doc_source["configuration"] = configuration
+        self.update_config(self.doc_source)
+        await self._write()
 
     async def close(self):
         self._closed = True

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -24,6 +24,7 @@ from connectors.logger import logger
 from connectors.source import (
     get_data_sources,
     get_data_source,
+    initialize_custom_connector,
     ServiceTypeNotSupportedError,
     DataSourceError,
 )
@@ -102,6 +103,7 @@ class ConnectorService:
             else:
                 # in other cases, we can
                 try:
+                    await initialize_custom_connector(connector, self.config)
                     data_source = get_data_source(connector, self.config)
                 except ServiceTypeNotSupportedError:
                     logger.debug(

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -97,32 +97,29 @@ class ConnectorService:
             if connector.native:
                 logger.debug(f"Connector {connector.id} natively supported")
 
+            try:
+                data_source = await get_data_source(connector, self.config)
+            except ServiceTypeNotConfiguredError:
+                logger.error(
+                    f"Service type is not configured for connector {self.config['connector_id']}"
+                )
+                return
+            except ConnectorUpdateError as e:
+                logger.error(e)
+                return
+            except ServiceTypeNotSupportedError:
+                logger.debug(f"Can't handle source of type {connector.service_type}")
+                return
+            except DataSourceError as e:
+                await connector.error(e)
+                logger.critical(e, exc_info=True)
+                self.raise_if_spurious(e)
+                return
+
             if connector.status in (Status.CREATED, Status.NEEDS_CONFIGURATION):
                 # we can't sync in that state
                 logger.info(f"Can't sync with status `{e2str(connector.status)}`")
                 data_source = None
-            else:
-                # in other cases, we can
-                try:
-                    data_source = await get_data_source(connector, self.config)
-                except ServiceTypeNotConfiguredError:
-                    logger.error(
-                        f"Service type is not configured for connector {self.config['connector_id']}"
-                    )
-                    return
-                except ConnectorUpdateError as e:
-                    logger.error(e)
-                    return
-                except ServiceTypeNotSupportedError:
-                    logger.debug(
-                        f"Can't handle source of type {connector.service_type}"
-                    )
-                    return
-                except DataSourceError as e:
-                    await connector.error(e)
-                    logger.critical(e, exc_info=True)
-                    self.raise_if_spurious(e)
-                    return
 
             try:
                 # the heartbeat is always triggered
@@ -219,7 +216,7 @@ class ConnectorService:
         return 0
 
     def shutdown(self, sig):
-        logger.info(f"Caught {sig.name}. Gracefull shutdown.")
+        logger.info(f"Caught {sig.name}. Gracefully shutdown.")
         self.stop()
 
 

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -25,6 +25,7 @@ from connectors.source import (
     get_data_sources,
     get_data_source,
     ServiceTypeNotConfiguredError,
+    ConnectorUpdateError,
     ServiceTypeNotSupportedError,
     DataSourceError,
 )
@@ -108,6 +109,9 @@ class ConnectorService:
                     logger.error(
                         f"Service type is not configured for connector {self.config['connector_id']}"
                     )
+                    return
+                except ConnectorUpdateError as e:
+                    logger.error(e)
                     return
                 except ServiceTypeNotSupportedError:
                     logger.debug(

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -24,6 +24,7 @@ from connectors.logger import logger
 from connectors.source import (
     get_data_sources,
     get_data_source,
+    ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
     DataSourceError,
 )
@@ -103,6 +104,11 @@ class ConnectorService:
                 # in other cases, we can
                 try:
                     data_source = await get_data_source(connector, self.config)
+                except ServiceTypeNotConfiguredError:
+                    logger.error(
+                        f"Service type is not configured for connector {self.config['connector_id']}"
+                    )
+                    return
                 except ServiceTypeNotSupportedError:
                     logger.debug(
                         f"Can't handle source of type {connector.service_type}"

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -24,7 +24,6 @@ from connectors.logger import logger
 from connectors.source import (
     get_data_sources,
     get_data_source,
-    initialize_custom_connector,
     ServiceTypeNotSupportedError,
     DataSourceError,
 )
@@ -103,8 +102,7 @@ class ConnectorService:
             else:
                 # in other cases, we can
                 try:
-                    await initialize_custom_connector(connector, self.config)
-                    data_source = get_data_source(connector, self.config)
+                    data_source = await get_data_source(connector, self.config)
                 except ServiceTypeNotSupportedError:
                     logger.debug(
                         f"Can't handle source of type {connector.service_type}"

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -216,7 +216,7 @@ class ConnectorService:
         return 0
 
     def shutdown(self, sig):
-        logger.info(f"Caught {sig.name}. Gracefully shutdown.")
+        logger.info(f"Caught {sig.name}. Graceful shutdown.")
         self.stop()
 
 

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -60,6 +60,9 @@ class DataSourceConfiguration:
     def get_fields(self):
         return self._config.values()
 
+    def is_empty(self):
+        return not self._config
+
 
 class BaseDataSource:
     """Base class, defines a lose contract."""
@@ -153,3 +156,22 @@ def get_data_sources(config):
     """Returns an iterator of all registered sources."""
     for name, fqn in config["sources"].items():
         yield get_source_klass(fqn)
+
+async def initialize_custom_connector(connector, config):
+    """Update service_type and configuration for a custome connector if it's absent"""
+    if connector.id != config["connector_id"]:
+        return
+    if connector.service_type is None:
+        await connector.populate_service_type(config["service_type"])
+
+    if connector.configuration.is_empty():
+        if connector.service_type not in config["sources"]:
+            raise ServiceTypeNotSupportedError(connector.service_type)
+
+        fqn = config["sources"][connector.service_type]
+        try:
+            source_klass = get_source_klass(fqn)
+        except Exception as e:
+            logger.critical(e, exc_info=True)
+            raise DataSourceError(f"Could not get source class for {connector.service_type}")
+        await connector.populate_configuration(source_klass.get_default_configuration())

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -156,23 +156,13 @@ async def get_data_source(connector, config):
     """
     configured_connector_id = config.get("connector_id", "")
     configured_service_type = config.get("service_type", "")
-
     if connector.id == configured_connector_id and connector.service_type is None:
         if not configured_service_type:
             logger.error(
                 f"Service type is not configured for connector {configured_connector_id}"
             )
             raise ServiceTypeNotConfiguredError("Service type is not configured.")
-        try:
-            await connector.populate_service_type(configured_service_type)
-            logger.debug(
-                f"Populated service type {configured_service_type} for connector {connector.id}"
-            )
-        except Exception as e:
-            logger.critical(e, exc_info=True)
-            raise ConnectorUpdateError(
-                f"Could not update service type for connector {connector.id}"
-            )
+        connector.service_type = configured_service_type
 
     service_type = connector.service_type
     if service_type not in config["sources"]:
@@ -182,20 +172,17 @@ async def get_data_source(connector, config):
     try:
         source_klass = get_source_klass(fqn)
         if connector.configuration.is_empty():
-            try:
-                default_config = source_klass.get_default_configuration()
-            except Exception:
-                # XXX do we really need to push {} to Elasticsearch ?
-                default_config = {}
+            connector.config = source_klass.get_default_configuration()
+            logger.debug(f"Populated configuration for connector {connector.id}")
 
-            try:
-                await connector.populate_configuration(default_config)
-                logger.debug(f"Populated configuration for connector {connector.id}")
-            except Exception as e:
-                logger.critical(e, exc_info=True)
-                raise ConnectorUpdateError(
-                    f"Could not update configuration for connector {connector.id}"
-                )
+        # sync state if needed (when service type or configuration is updated)
+        try:
+            await connector.sync_doc(force=False)
+        except Exception as e:
+            logger.critical(e, exc_info=True)
+            raise ConnectorUpdateError(
+                f"Could not update configuration for connector {connector.id}"
+            )
 
         return source_klass(connector)
     except Exception as e:

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -156,6 +156,9 @@ async def get_data_source(connector, config):
     """
     configured_connector_id = config.get("connector_id", "")
     configured_service_type = config.get("service_type", "")
+
+    # XXX I could not write a test for this. what would be the scenario
+    # to have  `connector.service_type is None` ?
     if connector.id == configured_connector_id and connector.service_type is None:
         if not configured_service_type:
             logger.error(
@@ -172,7 +175,7 @@ async def get_data_source(connector, config):
     try:
         source_klass = get_source_klass(fqn)
         if connector.configuration.is_empty():
-            connector.config = source_klass.get_default_configuration()
+            connector.configuration = source_klass.get_default_configuration()
             logger.debug(f"Populated configuration for connector {connector.id}")
 
         # sync state if needed (when service type or configuration is updated)

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -157,8 +157,6 @@ async def get_data_source(connector, config):
     configured_connector_id = config.get("connector_id", "")
     configured_service_type = config.get("service_type", "")
 
-    # XXX I could not write a test for this. what would be the scenario
-    # to have  `connector.service_type is None` ?
     if connector.id == configured_connector_id and connector.service_type is None:
         if not configured_service_type:
             logger.error(

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -40,13 +40,14 @@ class DataSourceConfiguration:
 
     def __init__(self, config):
         self._config = {}
-        for key, value in config.items():
-            self.set_field(
-                key,
-                value.get("label"),
-                value.get("value", ""),
-                value.get("type", "str"),
-            )
+        if config is not None:
+            for key, value in config.items():
+                self.set_field(
+                    key,
+                    value.get("label"),
+                    value.get("value", ""),
+                    value.get("type", "str"),
+                )
 
     def __getitem__(self, key):
         return self._config[key].value
@@ -150,6 +151,9 @@ async def get_data_source(connector, config):
     """Returns a source class instance, given a service type"""
     configured_connector_id = config.get("connector_id", "")
     configured_service_type = config.get("service_type", "")
+    logger.info(
+        f"connector.id = {connector.id}, connector.service_type = {connector.service_type}, configured_connector_id = {configured_connector_id}, configured_service_type = {configured_service_type}"
+    )
     if connector.id == configured_connector_id and connector.service_type is None:
         if not configured_service_type:
             logger.error(
@@ -176,7 +180,7 @@ async def get_data_source(connector, config):
         if connector.configuration.is_empty():
             try:
                 await connector.populate_configuration(
-                    source_klass.get_default_configuration()
+                    source_klass.get_default_configuration() or {}
                 )
                 logger.debug(f"Populated configuration for connector {connector.id}")
             except Exception as e:

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -166,6 +166,7 @@ async def get_data_source(connector, config):
             )
             raise ServiceTypeNotConfiguredError("Service type is not configured.")
         connector.service_type = configured_service_type
+        logger.debug(f"Populated service type for connector {connector.id}")
 
     service_type = connector.service_type
     if service_type not in config["sources"]:

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -172,6 +172,14 @@ async def test_connectors_get_list(mock_responses):
     await connectors.close()
 
 
+class StubIndex:
+    def __init__(self):
+        self.client = None
+
+    async def save(self, connector):
+        pass
+
+
 @pytest.mark.asyncio
 async def test_sync_mongo(mock_responses, patch_logger):
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
@@ -257,10 +265,6 @@ async def test_sync_mongo(mock_responses, patch_logger):
 
     doc = {"_id": 1}
 
-    class StubIndex:
-        def __init__(self):
-            self.client = None
-
     class Data:
         def __init__(self):
             self.connector = self.make_connector()
@@ -295,3 +299,36 @@ async def test_sync_mongo(mock_responses, patch_logger):
     finally:
         await connectors.close()
         await es.close()
+
+
+@pytest.mark.asyncio
+async def test_properties(mock_responses):
+
+    connector_src = {
+        "service_type": "test",
+        "index_name": "search-some-index",
+        "configuration": {},
+        "scheduling": {},
+        "status": "created",
+    }
+
+    connector = BYOConnector(StubIndex(), "test", connector_src)
+
+    assert connector.status == Status.CREATED
+    assert connector.service_type == "test"
+    connector.service_type = "test2"
+    assert connector.service_type == "test2"
+    assert connector._dirty
+
+    await connector.sync_doc()
+    assert not connector._dirty
+
+    # setting some config with a value that is None
+    connector.configuration = {"cool": {"value": "foo"}, "cool2": {"value": None}}
+
+    assert connector.status == Status.NEEDS_CONFIGURATION
+
+    # setting some config
+    connector.configuration = {"cool": {"value": "foo"}, "cool2": {"value": "baz"}}
+
+    assert connector.status == Status.CONFIGURED

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -332,3 +332,6 @@ async def test_properties(mock_responses):
     connector.configuration = {"cool": {"value": "foo"}, "cool2": {"value": "baz"}}
 
     assert connector.status == Status.CONFIGURED
+
+    with pytest.raises(TypeError):
+        connector.status = 1234

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -307,11 +307,9 @@ async def set_server_responses(
     def update_connector(url, **kw):
         read_only_fields = [
             "is_native",
-            "service_type",
             "api_key_id",
             "pipeline",
             "scheduling",
-            "configuration",
         ]
         fields = json.loads(kw["data"])["doc"].keys()
         for field in fields:

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -453,7 +453,8 @@ async def test_connector_service_poll_cron_broken(
         doc = json.loads(kw["data"])["doc"]
         calls.append(doc)
 
-    # if a connector is correctly configured but we don't sync (not scheduled)
+    # if a connector is correctly configured but we don't sync because the cron
+    # is broken
     # we still want to tell kibana we are connected
     await set_server_responses(
         mock_responses, FAKE_CONFIG_CRON_BROKEN, connectors_update=upd

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -52,6 +52,7 @@ def test_default():
 
 
 class MyConnector:
+    id = '1'
     service_type = "yea"
 
     def __init__(self, *args):

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -52,7 +52,7 @@ def test_default():
 
 
 class MyConnector:
-    id = '1'
+    id = "1"
     service_type = "yea"
 
     def __init__(self, *args):

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -3,12 +3,18 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import pytest
+
 from connectors.source import (
     Field,
     DataSourceConfiguration,
     get_source_klass,
     get_data_sources,
+    get_data_source,
+    BaseDataSource,
 )
+from connectors.byoc import BYOConnector, Status
+
 
 CONFIG = {
     "host": {
@@ -70,3 +76,63 @@ def test_get_data_sources():
 
     sources = list(get_data_sources(settings))
     assert sources == [MyConnector, MyConnector]
+
+
+class Banana(BaseDataSource):
+    """Banana"""
+
+    @classmethod
+    def get_default_configuration(cls):
+        return {"one": {"value": None}}
+
+
+@pytest.mark.asyncio
+async def test_get_custom_data_source_no_service_type(mock_responses):
+    class Client:
+        pass
+
+    class Index:
+        client = Client()
+
+        async def save(self, conn):
+            pass
+
+    # generic empty doc created by the user through the Kibana UI
+    doc = {
+        "status": "created",
+        "service_type": "banana",
+        "index_name": "test",
+        "configuration": {},
+        "scheduling": {"enabled": False},
+    }
+    connector = BYOConnector(Index(), "1", doc)
+
+    config = {
+        "connector_id": "1",
+        "service_type": "banana",
+        "sources": {"banana": "connectors.tests.test_source:Banana"},
+    }
+
+    source = await get_data_source(connector, config)
+    assert str(source) == "Datasource `Banana`"
+    assert connector.status == Status.NEEDS_CONFIGURATION
+
+
+@pytest.mark.asyncio
+async def test_base_class():
+    class Connector:
+        configuration = {}
+
+    base = BaseDataSource(Connector())
+
+    # ABCs
+    with pytest.raises(NotImplementedError):
+        BaseDataSource.get_default_configuration()
+
+    with pytest.raises(NotImplementedError):
+        await base.ping()
+
+    await base.close()
+
+    with pytest.raises(NotImplementedError):
+        await base.get_docs()

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -98,9 +98,11 @@ async def test_get_custom_data_source_no_service_type(mock_responses):
             pass
 
     # generic empty doc created by the user through the Kibana UI
+    # when it's created that way, the service type is None,
+    # so it's up to the connector to set it back to its value
     doc = {
         "status": "created",
-        "service_type": "banana",
+        "service_type": None,
         "index_name": "test",
         "configuration": {},
         "scheduling": {"enabled": False},


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2906
## Closes https://github.com/elastic/connectors-python/issues/38
## Closes https://github.com/elastic/connectors-python/issues/37

For custom connectors, connector service should populate `service_type` and `configuration`.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally