### PR TITLE
Changing native connector types for 8.5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,11 +18,8 @@ service:
   max_errors_span: 600
 
 native_service_types:
+  - mysql
   - s3
-  - mongodb
-
-# some id
-#connector_id: '1'
 
 sources:
   mongodb: connectors.sources.mongo:MongoDataSource


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2912

We don't want to expose mongo as a native connector in 8.5, but we do want to expose mysql.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally

NOTE: doesn't need a backport as this change is already in main and I target the branch, specifically.
