### PR TITLE
silent stdout

### DIFF
--- a/connectors/sources/tests/test_directory.py
+++ b/connectors/sources/tests/test_directory.py
@@ -14,7 +14,7 @@ async def test_basics():
 
 
 @pytest.mark.asyncio
-async def test_get_docs(patch_logger):
+async def test_get_docs(patch_logger, catch_stdout):
     source = create_source(DirectoryDataSource)
     num = 0
     async for (doc, dl) in source.get_docs():

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -116,7 +116,7 @@ async def test_ping():
 
 
 @pytest.mark.asyncio
-async def test_ping_negative():
+async def test_ping_negative(catch_stdout):
     """Test ping method of MySqlDataSource class with negative case"""
     # Setup
     source = create_source(MySqlDataSource)

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -9,7 +9,6 @@ import asyncio
 import json
 from unittest import mock
 from functools import partial
-import json
 from aioresponses import CallbackResult
 
 from connectors.runner import ConnectorService, run
@@ -349,7 +348,7 @@ async def test_connector_service_poll_not_native(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_with_entsearch(
-    mock_responses, patch_logger, patch_ping, set_env
+    mock_responses, patch_logger, patch_ping, set_env, catch_stdout
 ):
     with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG}):
         await set_server_responses(mock_responses)


### PR DESCRIPTION
Removes spurious outputs when we run `make test`