### PR TITLE
[MySQL-python] Verify that the number of documents is correct after configuring multiple dbs

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -252,12 +252,14 @@ class MySqlDataSource(BaseDataSource):
         Yields:
             dictionary: Row dictionary containing meta-data of the row.
         """
-        if isinstance(self.configuration["database"], str):
-            databases = [self.configuration["database"]]
-        elif self.configuration["database"] is None:
+        database_config = self.configuration["database"]
+        if isinstance(database_config, str):
+            dbs = database_config.split(",")
+            databases = list(map(lambda s: s.strip(), dbs))
+        elif database_config is None:
             databases = []
         else:
-            databases = self.configuration["database"]
+            databases = database_config
 
         if len(databases) == 0:
             databases = await self._fetch_all_databases()

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -210,7 +210,9 @@ class LargeFakeSource(FakeSource):
 
 
 async def set_server_responses(
-    mock_responses, config=FAKE_CONFIG, connectors_update=None,
+    mock_responses,
+    config=FAKE_CONFIG,
+    connectors_update=None,
     host="http://nowhere.com:9200",
 ):
     await purge_connectors()


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2933

If the database config contained a comma-separated list of dbs, it wasn't parsed properly.
I added code to convert it to a list.

The other file (test_runner) was changed by `make lint`.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
