### PR TITLE
Add NOTICE.txt + fix license headers

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,2 @@
+connectors-py
+Copyright 2022 Elasticsearch B.V.

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -1,3 +1,4 @@
+#
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.

--- a/connectors/quartz.py
+++ b/connectors/quartz.py
@@ -1,3 +1,9 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
 # vendored version of https://pypi.org/project/cron-schedule-triggers/
 # the repo is gone
 # TODO: simplify this code then port it to ruby

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -1,3 +1,4 @@
+#
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.

--- a/connectors/sources/tests/fixtures/mysql/loadsample.py
+++ b/connectors/sources/tests/fixtures/mysql/loadsample.py
@@ -1,3 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
 from mysql.connector import connect
 
 DATABASE_NAME = "customerinfo"

--- a/connectors/sources/tests/fixtures/mysql/remove.py
+++ b/connectors/sources/tests/fixtures/mysql/remove.py
@@ -1,3 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
 from mysql.connector import connect
 import random
 


### PR DESCRIPTION
Part of work on open-sourcing the project (see https://github.com/elastic/open-source/issues/324).

2 things changed:

- Added a NOTICE.txt of standard format (since we don't publicly distribute connectors at all, this file is small. Once we publicly distribute the package with connectors, we'll need to make this file include notices of all used libs)
- Added missing license headers or reformatted the ones existing to fit expected format