### PR TITLE
memory info utility

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,6 +16,7 @@ service:
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600
+  trace_mem: false
 
 native_service_types:
   - mysql

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -14,7 +14,7 @@ from elasticsearch import NotFoundError as ElasticNotFoundError
 from elasticsearch.helpers import async_scan
 
 from connectors.logger import logger
-from connectors.utils import iso_utc, ESClient
+from connectors.utils import iso_utc, ESClient, get_size
 
 
 OP_INDEX = "index"
@@ -51,6 +51,9 @@ class Bulker:
 
     async def _batch_bulk(self, operations):
         # todo treat result to retry errors like in async_streaming_bulk
+        logger.debug(
+            f"Sending a batch of {len(operations)} ops -- {get_size(operations)}MiB"
+        )
         start = time.time()
         try:
             res = await self.client.bulk(
@@ -343,6 +346,7 @@ class ElasticServer(ESClient):
             f"Found {len(existing_ids)} docs in {index} (duration "
             f"{int(time.time() - start)} seconds)"
         )
+        logger.debug(f"Size of ids in memory is {get_size(existing_ids)}MiB")
 
         # start the fetcher
         fetcher = Fetcher(

--- a/connectors/conftest.py
+++ b/connectors/conftest.py
@@ -38,6 +38,14 @@ class Logger:
                 return
         raise AssertionError(f"Could not find an instance of {instance}")
 
+    def assert_not_present(self, lines):
+        if isinstance(lines, str):
+            lines = [lines]
+        for msg in lines:
+            for log in self.logs:
+                if isinstance(log, str) and msg in log:
+                    raise AssertionError(f"'{msg}' found in {self.logs}")
+
     def assert_present(self, lines):
         if isinstance(lines, str):
             lines = [lines]

--- a/connectors/tests/config_mem.yml
+++ b/connectors/tests/config_mem.yml
@@ -1,0 +1,23 @@
+elasticsearch:
+  host: http://nowhere.com:9200
+  user: elastic
+  password: ${elasticsearch.password}
+  bulk_queue_max_size: 1024
+  bulk_chunck_size: 250
+  max_wait_duration: 1
+  initial_backoff_duration: 0
+  backoff_multiplier: 0
+
+service:
+  idling: 0.5
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  trace_mem: true
+
+connector_id: '1'
+
+sources:
+  fake: test_runner:FakeSource
+  large_fake: test_runner:LargeFakeSource
+  fail_once: test_runner:FailsThenWork

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -7,6 +7,9 @@ from datetime import datetime, timezone
 import logging
 import time
 import asyncio
+import tracemalloc
+import gc
+import contextlib
 
 from elasticsearch import (
     AsyncElasticsearch,
@@ -15,6 +18,8 @@ from elasticsearch import (
     NotFoundError,
 )
 from elastic_transport.client_utils import url_to_node_config
+from guppy import hpy
+from pympler import asizeof
 
 from connectors.logger import set_extra_logger, logger
 from connectors.quartz import QuartzCron
@@ -190,3 +195,56 @@ class CancellableSleeps:
     def cancel(self):
         for task in self._sleeps:
             task.cancel()
+
+
+def _snapshot():
+    if not tracemalloc.is_tracing():
+        tracemalloc.start()
+    logger.info("Taking a memory snapshot")
+    gc.collect()
+    trace = tracemalloc.take_snapshot()
+    return trace.filter_traces(
+        (
+            tracemalloc.Filter(False, "<frozen importlib._bootstrap>"),
+            tracemalloc.Filter(False, "<frozen importlib._bootstrap_external>"),
+            tracemalloc.Filter(False, "<unknown>"),
+            tracemalloc.Filter(False, tracemalloc.__file__),
+        )
+    )
+
+
+@contextlib.contextmanager
+def trace_mem(activated=False):
+    if not activated:
+        yield
+    else:
+        hp = hpy()
+        heap_before = hp.heap()
+        before = _snapshot()
+        try:
+            yield
+        finally:
+            after = _snapshot()
+            heap_after = hp.heap()
+            leftover = heap_after - heap_before
+            logger.info(leftover)
+            largest = after.statistics("traceback")[0]
+            logger.info("===> Largest memory usage:")
+            for line in largest.traceback.format():
+                logger.info(line)
+            logger.info("<===")
+            stats = after.statistics("filename")
+            logger.info("===> Top 5 stats grouped by filename")
+            for s in stats[:5]:
+                logger.info(s)
+            logger.info("<===")
+            top_stats = after.compare_to(before, "lineno")
+            logger.info("===> Memory snapshot diff top 5")
+            for stat in top_stats[:5]:
+                logger.info(stat)
+            logger.info("<===")
+
+
+def get_size(ob):
+    """Returns size in MiB"""
+    return round(asizeof.asizeof(ob) / (1024 * 1024), 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ pytz>=2022.1
 aiohttp>=3.8.1
 pyyaml>=6.0
 envyaml>=1.10.211231
+pympler>=1.0.1
+guppy3>=3.1.2
 
 # tests
 black>=22.6.0


### PR DESCRIPTION
Memory investigation tooling:

- Adds a `trace_mem` utility (deactivated by default) to dump memory allocation info
- Displays the size in MiB in memory for the ids lists and and the bulk requests