### PR TITLE
[DO NOT MERGE] draft of rss limits

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,6 +18,10 @@ service:
   max_errors: 20
   max_errors_span: 600
   trace_mem: false
+  # 300MB
+  max_rss: 307200
+  # 400MB
+  max_peak_rss: 409600
 
 native_service_types:
   - mysql

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -193,7 +193,7 @@ class BYOConnector:
         doc_source,
         bulk_queue_max_size=DEFAULT_QUEUE_SIZE,
         bulk_display_every=DEFAULT_DISPLAY_EVERY,
-        max_peak_rss=-1
+        max_peak_rss=-1,
     ):
         self.doc_source = doc_source
         self.id = connector_id

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -19,7 +19,6 @@ from connectors.utils import (
     ESClient,
     get_size,
     get_rss,
-    DEFAULT_CHUNK_SIZE,
     DEFAULT_QUEUE_SIZE,
     DEFAULT_DISPLAY_EVERY,
 )
@@ -370,7 +369,7 @@ class ElasticServer(ESClient):
         pipeline,
         queue_size=DEFAULT_QUEUE_SIZE,
         display_every=DEFAULT_DISPLAY_EVERY,
-        max_peak_rss=-1
+        max_peak_rss=-1,
     ):
         start = time.time()
         stream = asyncio.Queue(maxsize=queue_size)

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -114,9 +114,18 @@ mongo = {
 }
 
 
+CONFIG = {
+    "elasticsearch": {
+        "host": "http://nowhere.com:9200",
+        "user": "tarek",
+        "password": "blah",
+    },
+    "service": {"max_rss": 307200, "max_peak_rss": 409600},
+}
+
+
 @pytest.mark.asyncio
 async def test_heartbeat(mock_responses, patch_logger):
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
@@ -135,7 +144,7 @@ async def test_heartbeat(mock_responses, patch_logger):
             headers=headers,
         )
 
-    connectors = BYOIndex(config)
+    connectors = BYOIndex(CONFIG)
     conns = []
 
     async for connector in connectors.get_list():
@@ -150,7 +159,6 @@ async def test_heartbeat(mock_responses, patch_logger):
 
 @pytest.mark.asyncio
 async def test_connectors_get_list(mock_responses):
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
@@ -162,7 +170,7 @@ async def test_connectors_get_list(mock_responses):
         headers=headers,
     )
 
-    connectors = BYOIndex(config)
+    connectors = BYOIndex(CONFIG)
     conns = []
 
     async for connector in connectors.get_list():
@@ -174,7 +182,6 @@ async def test_connectors_get_list(mock_responses):
 
 @pytest.mark.asyncio
 async def test_sync_mongo(mock_responses, patch_logger):
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
@@ -286,8 +293,8 @@ async def test_sync_mongo(mock_responses, patch_logger):
             }
             return BYOConnector(StubIndex(), "test", connector_src)
 
-    es = ElasticServer(config)
-    connectors = BYOIndex(config)
+    es = ElasticServer(CONFIG["elasticsearch"])
+    connectors = BYOIndex(CONFIG)
     try:
         async for connector in connectors.get_list():
             await connector.sync(Data(), es, 0)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -21,6 +21,7 @@ from elastic_transport.client_utils import url_to_node_config
 from guppy import hpy
 from pympler import asizeof
 from cstriggers.core.trigger import QuartzCron
+import psutil
 
 from connectors.logger import set_extra_logger, logger
 
@@ -253,3 +254,9 @@ def trace_mem(activated=False):
 def get_size(ob):
     """Returns size in MiB"""
     return round(asizeof.asizeof(ob) / (1024 * 1024), 2)
+
+
+def get_rss():
+    """Returns the current RSS in KiB"""
+    p = psutil.Process()
+    return round(p.memory_info().rss / 1024.0, 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pympler==1.0.1
 guppy3==3.1.2
 cron-schedule-triggers==0.0.11
 pytz==2019.3
+psutil>=5.9.2
 
 # please put your connectors deps below this line
 # mysql


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3092

Adds:
- `max_rss`: maximum RSS size in KiB. If the service reaches that limit, gracefully exits. checked after each sync.
- `max_peak_rss`: maximum RSS size in KiB during a sync. If the service reaches that limit, stops the sync and errors out.

The first value can be used to keep the service under a RSS at all time, the second one to set an upper limit during syncs
to control memory bloats.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
