### PR TITLE
Remove the two-phase for files

### DIFF
--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -184,7 +184,7 @@ async def test_async_bulk(mock_responses, patch_logger):
     res = await es.async_bulk("search-some-index", get_docs(), pipeline)
 
     assert res == {
-        "bulk_operations": {"index": 2, "delete": 1, "update": 1},
+        "bulk_operations": {"index": 2, "delete": 1},
         "doc_created": 1,
         "doc_deleted": 1,
         "attachment_extracted": 1,
@@ -197,7 +197,7 @@ async def test_async_bulk(mock_responses, patch_logger):
     res = await es.async_bulk("search-some-index", get_docs(), pipeline)
 
     assert res == {
-        "bulk_operations": {"index": 2, "delete": 1, "update": 1},
+        "bulk_operations": {"index": 2, "delete": 1},
         "doc_created": 1,
         "doc_deleted": 1,
         "attachment_extracted": 1,

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -491,9 +491,9 @@ async def test_connector_service_poll_large(
     await service.poll()
 
     # let's make sure we are seeing bulk batches of various sizes
-    assert_re("Sending a batch of 14 ops -- 15.01MiB", patch_logger.logs)
-    assert_re("Sending a batch of 30 ops -- 3.02MiB", patch_logger.logs)
-    assert_re(r"Sync done: 1001 indexed, 0  deleted", patch_logger.logs)
+    assert_re(".*15.01MiB", patch_logger.logs)
+    assert_re(".*3.0MiB", patch_logger.logs)
+    assert_re("Sync done: 1001 indexed, 0  deleted", patch_logger.logs)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

Remove the `upsert` ops that are done with the result of the file download.
This two-phase is overkill and adds conflict issues. Let's just sent out the document once with everything.


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
