### PR TITLE
do not add a new ts if the backend provides it

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -177,7 +177,8 @@ class Fetcher:
                 else:
                     operation = OP_INDEX
                     self.total_docs_created += 1
-                    doc["timestamp"] = iso_utc()
+                    if "timestamp" not in doc:
+                        doc["timestamp"] = iso_utc()
 
                 if lazy_download is not None:
                     data = await lazy_download(doit=True, timestamp=doc["timestamp"])

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -30,6 +30,7 @@ from connectors.utils import (
 OP_INDEX = "index"
 OP_UPSERT = "update"
 OP_DELETE = "delete"
+TIMESTAMP_FIELD = "_timestamp"
 
 
 class Bulker:
@@ -165,7 +166,7 @@ class Fetcher:
                     #
                     # Some backends do not know how to do this so it's optional.
                     # For them we update the docs in any case.
-                    if "timestamp" in doc and ts == doc["timestamp"]:
+                    if TIMESTAMP_FIELD in doc and ts == doc[TIMESTAMP_FIELD]:
                         # cancel the download
                         if lazy_download is not None:
                             await lazy_download(doit=False)
@@ -177,15 +178,17 @@ class Fetcher:
                 else:
                     operation = OP_INDEX
                     self.total_docs_created += 1
-                    if "timestamp" not in doc:
-                        doc["timestamp"] = iso_utc()
+                    if TIMESTAMP_FIELD not in doc:
+                        doc[TIMESTAMP_FIELD] = iso_utc()
 
                 if lazy_download is not None:
-                    data = await lazy_download(doit=True, timestamp=doc["timestamp"])
+                    data = await lazy_download(
+                        doit=True, timestamp=doc[TIMESTAMP_FIELD]
+                    )
                     if data is not None:
                         self.total_downloads += 1
                         data.pop("_id", None)
-                        data.pop("timestamp", None)
+                        data.pop(TIMESTAMP_FIELD, None)
                         doc.update(data)
 
                 await self.queue.put(
@@ -286,7 +289,7 @@ class ElasticServer(ESClient):
             doc_id += 1
 
     async def get_existing_ids(self, index):
-        """Returns an iterator on the `id` and `timestamp` fields of all documents in an index.
+        """Returns an iterator on the `id` and `_timestamp` fields of all documents in an index.
 
 
         WARNING
@@ -305,10 +308,10 @@ class ElasticServer(ESClient):
         async for doc in async_scan(
             client=self.client,
             index=index,
-            _source=["id", "timestamp"],
+            _source=["id", TIMESTAMP_FIELD],
         ):
             doc_id = doc["_source"].get("id", doc["_id"])
-            ts = doc["_source"].get("timestamp")
+            ts = doc["_source"].get(TIMESTAMP_FIELD)
             yield doc_id, ts
 
     async def async_bulk(

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -266,7 +266,7 @@ class MySqlDataSource(BaseDataSource):
                 row.update(
                     {
                         "_id": f"{database}_{table}_{keys_value}",
-                        "timestamp": last_update_time[0][0],
+                        "_timestamp": last_update_time[0][0],
                         "Database": database,
                         "Table": table,
                     }

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -233,7 +233,7 @@ async def test_fetch_documents():
             "Database": "database_name",
             "Table": "table_name",
             "_id": "database_name_table_name_",
-            "timestamp": "table1",
+            "_timestamp": "table1",
         }
 
 

--- a/connectors/tests/config.yml
+++ b/connectors/tests/config.yml
@@ -20,3 +20,4 @@ sources:
   fake: test_runner:FakeSource
   large_fake: test_runner:LargeFakeSource
   fail_once: test_runner:FailsThenWork
+  fake_ts: test_runner:FakeSourceTS

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -89,8 +89,8 @@ def set_responses(mock_responses, ts=None):
         payload={"_id": "1"},
         headers=headers,
     )
-    source_1 = {"id": "1", "timestamp": ts}
-    source_2 = {"id": "2", "timestamp": ts}
+    source_1 = {"id": "1", "_timestamp": ts}
+    source_2 = {"id": "2", "_timestamp": ts}
 
     mock_responses.post(
         "http://nowhere.com:9200/search-some-index/_search?scroll=5m",
@@ -176,9 +176,9 @@ async def test_async_bulk(mock_responses, patch_logger):
         async def _dl(doit=True, timestamp=None):
             if not doit:
                 return
-            return {"TEXT": "DATA", "timestamp": timestamp, "_id": "1"}
+            return {"TEXT": "DATA", "_timestamp": timestamp, "_id": "1"}
 
-        yield {"_id": "1", "timestamp": datetime.datetime.now().isoformat()}, _dl
+        yield {"_id": "1", "_timestamp": datetime.datetime.now().isoformat()}, _dl
         yield {"_id": "3"}, _dl_none
 
     res = await es.async_bulk("search-some-index", get_docs(), pipeline)
@@ -221,10 +221,10 @@ async def test_async_bulk_same_ts(mock_responses, patch_logger):
         async def _dl(doit=True, timestamp=None):
             if not doit:
                 return  # Canceled
-            return {"TEXT": "DATA", "timestamp": timestamp, "_id": "1"}
+            return {"TEXT": "DATA", "_timestamp": timestamp, "_id": "1"}
 
-        yield {"_id": "1", "timestamp": ts}, _dl
-        yield {"_id": "3", "timestamp": ts}, None
+        yield {"_id": "1", "_timestamp": ts}, _dl
+        yield {"_id": "3", "_timestamp": ts}, None
 
     res = await es.async_bulk("search-some-index", get_docs(), pipeline)
 

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -189,7 +189,7 @@ class FakeSource:
     async def _dl(self, doc_id, timestamp=None, doit=None):
         if not doit:
             return
-        return {"_id": doc_id, "timestamp": timestamp, "text": "xx"}
+        return {"_id": doc_id, "_timestamp": timestamp, "text": "xx"}
 
     async def get_docs(self):
         if self.fail:
@@ -210,7 +210,7 @@ class FakeSourceTS(FakeSource):
     async def get_docs(self):
         if self.fail:
             raise Exception("I fail while syncing")
-        yield {"_id": "1", "timestamp": self.ts}, partial(self._dl, "1")
+        yield {"_id": "1", "_timestamp": self.ts}, partial(self._dl, "1")
 
 
 class FailsThenWork(FakeSource):
@@ -606,7 +606,7 @@ async def test_connector_service_poll_sync_ts(
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
 
     # make sure we kept the original ts
-    assert indexed[0]["timestamp"] == FakeSourceTS.ts
+    assert indexed[0]["_timestamp"] == FakeSourceTS.ts
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -69,6 +69,8 @@ FAKE_CONFIG_PIPELINE_CHANGED["pipeline"] = {
     "reduce_whitespace": False,
     "run_ml_inference": False,
 }
+FAKE_CONFIG_TS = copy.deepcopy(FAKE_CONFIG)
+FAKE_CONFIG_TS["service_type"] = "fake_ts"
 
 
 FAKE_CONFIG_NOT_NATIVE = {
@@ -197,6 +199,18 @@ class FakeSource:
     @classmethod
     def get_default_configuration(cls):
         return []
+
+
+class FakeSourceTS(FakeSource):
+    """Fake source with stable TS"""
+
+    service_type = "fake_ts"
+    ts = "2022-10-31T09:04:35.277558"
+
+    async def get_docs(self):
+        if self.fail:
+            raise Exception("I fail while syncing")
+        yield {"_id": "1", "timestamp": self.ts}, partial(self._dl, "1")
 
 
 class FailsThenWork(FakeSource):
@@ -573,6 +587,26 @@ async def test_connector_service_poll_sync_now(
     # one_sync means it won't loop forever
     await service.poll(sync_now=True, one_sync=True)
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
+
+
+@pytest.mark.asyncio
+async def test_connector_service_poll_sync_ts(
+    mock_responses, patch_logger, patch_ping, set_env
+):
+    indexed = []
+
+    def bulk_call(url, **kw):
+        queries = [json.loads(call.strip()) for call in kw["data"].split(b"\n") if call]
+        indexed.append(queries[1])
+        return CallbackResult(status=200, payload={"items": []})
+
+    await set_server_responses(mock_responses, FAKE_CONFIG_TS, bulk_call=bulk_call)
+    service = ConnectorService(CONFIG)
+    await service.poll(sync_now=True, one_sync=True)
+    patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
+
+    # make sure we kept the original ts
+    assert indexed[0]["timestamp"] == FakeSourceTS.ts
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Not sure why that was lost at some point. We need to keep the timestamp of the document when it's provided by the connector. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
