### PR TITLE
[8.5] Remove the two-phase for files (#148)

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -79,20 +79,10 @@ class Bulker:
         batch = []
         self.bulk_time = 0
         self.bulking = True
-        docs_ended = downloads_ended = False
         while True:
             doc = await self.queue.get()
             if doc in ("END_DOCS", "FETCH_ERROR"):
-                docs_ended = True
-            if doc == "END_DOWNLOADS":
-                downloads_ended = True
-
-            if docs_ended and downloads_ended:
                 break
-
-            if doc in ("END_DOCS", "END_DOWNLOADS", "FETCH_ERROR"):
-                continue
-
             operation = doc["_op_type"]
             self.ops[operation] += 1
             batch.extend(self._bulk_op(doc, operation))
@@ -124,7 +114,6 @@ class Fetcher:
         self.bulk_time = 0
         self.bulking = False
         self.index = index
-        self._downloads = asyncio.Queue(maxsize=queue_size)
         self.loop = asyncio.get_event_loop()
         self.existing_ids = existing_ids
         self.sync_runs = False
@@ -143,46 +132,8 @@ class Fetcher:
             f"delete: {self.total_docs_deleted}>"
         )
 
-    # XXX this can be defferred
-    async def get_attachments(self):
-        logger.info("Starting downloads")
-
-        while self.sync_runs:
-            coro = await self._downloads.get()
-            if coro == "END":
-                break
-
-            data = await coro
-            await asyncio.sleep(0)
-
-            if data is None:
-                continue
-
-            self.total_downloads += 1
-
-            # This is an upsert because we're pusing content
-            # from attached file *after* the document was indexed
-            await self.queue.put(
-                {
-                    "_op_type": OP_UPSERT,
-                    "_index": self.index,
-                    "_id": data.pop("_id"),
-                    "doc": data,
-                }
-            )
-
-            if divmod(self.total_downloads, 10)[-1] == 0:
-                logger.info(f"Downloaded {self.total_downloads} files.")
-
-            await asyncio.sleep(0)
-
-        await self.queue.put("END_DOWNLOADS")
-        logger.info(f"Downloads done {self.total_downloads} files.")
-
     async def run(self, generator):
-        t1 = self.loop.create_task(self.get_docs(generator))
-        t2 = self.loop.create_task(self.get_attachments())
-        await asyncio.gather(t1, t2)
+        await self.get_docs(generator)
 
     async def get_docs(self, generator):
         logger.info("Starting doc lookups")
@@ -221,11 +172,12 @@ class Fetcher:
                     doc["timestamp"] = iso_utc()
 
                 if lazy_download is not None:
-                    await self._downloads.put(
-                        self.loop.create_task(
-                            lazy_download(doit=True, timestamp=doc["timestamp"])
-                        )
-                    )
+                    data = await lazy_download(doit=True, timestamp=doc["timestamp"])
+                    if data is not None:
+                        self.total_downloads += 1
+                        data.pop("_id", None)
+                        data.pop("timestamp", None)
+                        doc.update(data)
 
                 await self.queue.put(
                     {
@@ -238,7 +190,6 @@ class Fetcher:
                 await asyncio.sleep(0)
         except Exception as e:
             logger.critical("The document fetcher failed", exc_info=True)
-            await self._downloads.put("END")
             await self.queue.put("FETCH_ERROR")
             self.fetch_error = e
             return
@@ -258,7 +209,6 @@ class Fetcher:
             )
             self.total_docs_deleted += 1
 
-        await self._downloads.put("END")
         await self.queue.put("END_DOCS")
 
 
@@ -266,7 +216,6 @@ class ElasticServer(ESClient):
     def __init__(self, elastic_config):
         logger.debug(f"ElasticServer connecting to {elastic_config['host']}")
         super().__init__(elastic_config)
-        self._downloads = []
         self.loop = asyncio.get_event_loop()
 
     async def prepare_index(

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -184,7 +184,7 @@ async def test_async_bulk(mock_responses, patch_logger):
     res = await es.async_bulk("search-some-index", get_docs(), pipeline)
 
     assert res == {
-        "bulk_operations": {"index": 2, "delete": 1, "update": 1},
+        "bulk_operations": {"index": 2, "delete": 1},
         "doc_created": 1,
         "doc_deleted": 1,
         "attachment_extracted": 1,
@@ -197,7 +197,7 @@ async def test_async_bulk(mock_responses, patch_logger):
     res = await es.async_bulk("search-some-index", get_docs(), pipeline)
 
     assert res == {
-        "bulk_operations": {"index": 2, "delete": 1, "update": 1},
+        "bulk_operations": {"index": 2, "delete": 1},
         "doc_created": 1,
         "doc_deleted": 1,
         "attachment_extracted": 1,

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -482,7 +482,10 @@ async def test_connector_service_poll_large(
     service = ConnectorService(CONFIG)
     asyncio.get_event_loop().call_soon(service.stop)
     await service.poll()
-    assert_re(r"Sync done: 10001 indexed, 0  deleted", patch_logger.logs)
+    # let's make sure we are seeing bulk batches of various sizes
+    assert_re(".*15.01MiB", patch_logger.logs)
+    assert_re(".*3.0MiB", patch_logger.logs)
+    assert_re("Sync done: 1001 indexed, 0  deleted", patch_logger.logs)
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -482,10 +482,7 @@ async def test_connector_service_poll_large(
     service = ConnectorService(CONFIG)
     asyncio.get_event_loop().call_soon(service.stop)
     await service.poll()
-    # let's make sure we are seeing bulk batches of various sizes
-    assert_re(".*15.01MiB", patch_logger.logs)
-    assert_re(".*3.0MiB", patch_logger.logs)
-    assert_re("Sync done: 1001 indexed, 0  deleted", patch_logger.logs)
+    assert_re(r"Sync done: 10001 indexed, 0 deleted", patch_logger.logs)
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -482,7 +482,7 @@ async def test_connector_service_poll_large(
     service = ConnectorService(CONFIG)
     asyncio.get_event_loop().call_soon(service.stop)
     await service.poll()
-    assert_re(r"Sync done: 10001 indexed, 0 deleted", patch_logger.logs)
+    assert_re(r"Sync done: 10001 indexed, 0  deleted", patch_logger.logs)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Remove the two-phase for files (#148)