### PR TITLE
[8.5] limit the bulk queue and request in memory (#147)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,8 +4,10 @@ elasticsearch:
   password: changeme
   ssl: true
   bulk_queue_max_size: 1024
+  bulk_queue_max_mem_size: 25
   bulk_display_every: 100
-  bulk_chunk_size: 150
+  bulk_chunk_size: 500
+  bulk_chunk_max_mem_size: 5
   request_timeout: 120
   max_wait_duration: 120
   initial_backoff_duration: 1

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -17,6 +17,8 @@ from connectors.utils import (
     ESClient,
     DEFAULT_QUEUE_SIZE,
     DEFAULT_DISPLAY_EVERY,
+    DEFAULT_QUEUE_MEM_SIZE,
+    DEFAULT_CHUNK_MEM_SIZE,
 )
 from connectors.logger import logger
 from connectors.source import DataSourceConfiguration
@@ -68,6 +70,12 @@ class BYOIndex(ESClient):
         self.bulk_display_every = elastic_config.get(
             "bulk_display_every", DEFAULT_DISPLAY_EVERY
         )
+        self.bulk_queue_max_mem_size = elastic_config.get(
+            "bulk_queue_max_mem_size", DEFAULT_QUEUE_MEM_SIZE
+        )
+        self.bulk_chunk_max_mem_size = elastic_config.get(
+            "bulk_chunk_max_mem_size", DEFAULT_CHUNK_MEM_SIZE
+        )
 
     async def save(self, connector):
         # we never update the configuration
@@ -112,6 +120,8 @@ class BYOIndex(ESClient):
                 hit["_source"],
                 bulk_queue_max_size=self.bulk_queue_max_size,
                 bulk_display_every=self.bulk_display_every,
+                bulk_queue_max_mem_size=self.bulk_queue_max_mem_size,
+                bulk_chunk_max_mem_size=self.bulk_chunk_max_mem_size,
             )
 
 
@@ -189,6 +199,8 @@ class BYOConnector:
         doc_source,
         bulk_queue_max_size=DEFAULT_QUEUE_SIZE,
         bulk_display_every=DEFAULT_DISPLAY_EVERY,
+        bulk_queue_max_mem_size=DEFAULT_QUEUE_MEM_SIZE,
+        bulk_chunk_max_mem_size=DEFAULT_CHUNK_MEM_SIZE,
     ):
         self.doc_source = doc_source
         self.id = connector_id
@@ -202,6 +214,8 @@ class BYOConnector:
         self._hb = None
         self.bulk_queue_max_size = bulk_queue_max_size
         self.bulk_display_every = bulk_display_every
+        self.bulk_queue_max_mem_size = bulk_queue_max_mem_size
+        self.bulk_chunk_max_mem_size = bulk_chunk_max_mem_size
 
     def update_config(self, doc_source):
         self._status = Status[doc_source["status"].upper()]
@@ -366,6 +380,8 @@ class BYOConnector:
                 data_provider.connector.pipeline,
                 queue_size=self.bulk_queue_max_size,
                 display_every=self.bulk_display_every,
+                queue_mem_size=self.bulk_queue_max_mem_size,
+                chunk_mem_size=self.bulk_chunk_max_mem_size,
             )
             await self._sync_done(job, result)
 

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -20,7 +20,10 @@ from connectors.utils import (
     get_size,
     DEFAULT_CHUNK_SIZE,
     DEFAULT_QUEUE_SIZE,
+    DEFAULT_QUEUE_MEM_SIZE,
+    DEFAULT_CHUNK_MEM_SIZE,
     DEFAULT_DISPLAY_EVERY,
+    MemQueue,
 )
 
 
@@ -33,7 +36,7 @@ TIMESTAMP_FIELD = "_timestamp"
 class Bulker:
     """Send bulk operations in batches by consuming a queue."""
 
-    def __init__(self, client, queue, chunk_size, pipeline_settings):
+    def __init__(self, client, queue, chunk_size, pipeline_settings, chunk_mem_size):
         self.client = client
         self.queue = queue
         self.bulk_time = 0
@@ -41,6 +44,7 @@ class Bulker:
         self.ops = defaultdict(int)
         self.chunk_size = chunk_size
         self.pipeline_settings = pipeline_settings
+        self.chunk_mem_size = chunk_mem_size
 
     def _bulk_op(self, doc, operation=OP_INDEX):
         doc_id = doc["_id"]
@@ -92,7 +96,7 @@ class Bulker:
             self.ops[operation] += 1
             batch.extend(self._bulk_op(doc, operation))
 
-            if len(batch) >= self.chunk_size:
+            if len(batch) >= self.chunk_size or get_size(batch) > self.chunk_mem_size:
                 await self._batch_bulk(batch)
                 batch.clear()
 
@@ -315,9 +319,11 @@ class ElasticServer(ESClient):
         pipeline,
         queue_size=DEFAULT_QUEUE_SIZE,
         display_every=DEFAULT_DISPLAY_EVERY,
+        queue_mem_size=DEFAULT_QUEUE_MEM_SIZE,
+        chunk_mem_size=DEFAULT_CHUNK_MEM_SIZE,
     ):
         start = time.time()
-        stream = asyncio.Queue(maxsize=queue_size)
+        stream = MemQueue(maxsize=queue_size, maxmemsize=queue_mem_size * 1024 * 1024)
         existing_ids = {k: v async for (k, v) in self.get_existing_ids(index)}
         logger.debug(
             f"Found {len(existing_ids)} docs in {index} (duration "
@@ -342,6 +348,7 @@ class ElasticServer(ESClient):
             stream,
             self.config.get("bulk_chunk_size", DEFAULT_CHUNK_SIZE),
             pipeline,
+            chunk_mem_size=chunk_mem_size,
         )
         bulker_task = asyncio.create_task(bulker.run())
 

--- a/connectors/tests/memconfig.yml
+++ b/connectors/tests/memconfig.yml
@@ -1,0 +1,24 @@
+elasticsearch:
+  host: http://nowhere.com:9200
+  user: elastic
+  password: ${elasticsearch.password}
+  bulk_queue_max_size: 1024
+  bulk_chunk_size: 500
+  bulk_chunk_max_mem_size: 15
+  bulk_queue_max_mem_size: 25
+  max_wait_duration: 1
+  initial_backoff_duration: 0
+  backoff_multiplier: 0
+
+service:
+  idling: 0.5
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+
+connector_id: '1'
+
+sources:
+  fake: test_runner:FakeSource
+  large_fake: test_runner:LargeFakeSource
+  fail_once: test_runner:FailsThenWork

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -504,8 +504,8 @@ async def test_connector_service_poll_large(
     await service.poll()
 
     # let's make sure we are seeing bulk batches of various sizes
-    assert_re("Sending a batch of 14 ops -- 15.01MiB", patch_logger.logs)
-    assert_re("Sending a batch of 30 ops -- 3.02MiB", patch_logger.logs)
+    assert_re("Sending a batch of .* ops -- 15.*M", patch_logger.logs)
+    assert_re("Sending a batch of .* ops -- 3.*M", patch_logger.logs)
     assert_re(r"Sync done: 1001 indexed, 0  deleted", patch_logger.logs)
 
 

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -22,6 +22,7 @@ ES_CONFIG = os.path.join(os.path.dirname(__file__), "entsearch.yml")
 CONFIG_2 = os.path.join(os.path.dirname(__file__), "config_2.yml")
 CONFIG_HTTPS = os.path.join(os.path.dirname(__file__), "config_https.yml")
 CONFIG_MEM = os.path.join(os.path.dirname(__file__), "config_mem.yml")
+MEM_CONFIG = os.path.join(os.path.dirname(__file__), "memconfig.yml")
 
 
 FAKE_CONFIG = {
@@ -230,9 +231,11 @@ class LargeFakeSource(FakeSource):
     service_type = "large_fake"
 
     async def get_docs(self):
-        for i in range(10001):
+        for i in range(1001):
             doc_id = str(i + 1)
-            yield {"_id": doc_id}, partial(self._dl, doc_id)
+            yield {"_id": doc_id, "data": "big" * 1024 * 1024}, partial(
+                self._dl, doc_id
+            )
 
 
 async def set_server_responses(
@@ -496,10 +499,14 @@ async def test_connector_service_poll_large(
     mock_responses, patch_logger, patch_ping, set_env
 ):
     await set_server_responses(mock_responses, LARGE_FAKE_CONFIG)
-    service = ConnectorService(CONFIG)
+    service = ConnectorService(MEM_CONFIG)
     asyncio.get_event_loop().call_soon(service.stop)
     await service.poll()
-    assert_re(r"Sync done: 10001 indexed, 0  deleted", patch_logger.logs)
+
+    # let's make sure we are seeing bulk batches of various sizes
+    assert_re("Sending a batch of 14 ops -- 15.01MiB", patch_logger.logs)
+    assert_re("Sending a batch of 30 ops -- 3.02MiB", patch_logger.logs)
+    assert_re(r"Sync done: 1001 indexed, 0  deleted", patch_logger.logs)
 
 
 @pytest.mark.asyncio

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -11,6 +11,10 @@ Configuration lives in [config.yml](../config.yml).
   - `ca_certs`: Path to a CA bundle.
   - `bulk_display_every`: The number of docs between each counters display. Defaults to 100.
   - `bulk_queue_max_size`: The max size of the bulk queue. Defaults to 1024.
+  - `bulk_queue_max_mem_size`: The max size in MB of the bulk queue. When it's reached, the next put
+     operation waits for the queue size to get under that limit. Defaults to 25.
+  - `bulk_chunk_max_mem_size`: The max size in MB of a bulk request. When the next request being
+     prepared reaches that size, the query is emited even if `bulk_chunk_size` is not yet reached. Defaults to 5.
   - `bulk_chunk_size`: The max size of the bulk operation to Elasticsearch. Defaults to 500.
   - `retry_on_timeout`: Whether to retry on request timeout. Defaults to `true`.
   - `request_timeout`: The request timeout to be passed to transport in options. Defaults to 120.
@@ -39,7 +43,7 @@ When you have an Enterprise Search deployment on Elastic Cloud post 8.5.0, the c
 
 ### Run the connector service in native mode
 
-1. Make sure the service types of supported native connectors are configured in `native_service_types`. 
+1. Make sure the service types of supported native connectors are configured in `native_service_types`.
 2. Configure the Elasticsearch connection, with basic auth (`username` and `password`), or with API key (generated via _Stack Management_ > _Security_ > _API keys_ > _Create API key_). Make sure the user or the API key has at least the privileges to `manage`, `read` and `write` the connector index (`.elastic-connectors`), the connector job index (`.elastic-connectors-sync-jobs`) and the connector content indices (`search-*`).
 3. Run the connector service with
     ```shell


### PR DESCRIPTION
Backports the following commits to 8.5:
 - limit the bulk queue and request in memory (#147)