### PR TITLE
speed up the memory lookups by doing a single call per item

### DIFF
--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -149,7 +149,8 @@ async def test_mem_queue(patch_logger):
 
     async def remove_data():
         await asyncio.sleep(0.1)
-        await queue.get()
+        size, item = await queue.get()
+        assert (size, item) == (64, "small stuff")
         await asyncio.sleep(0)
         await queue.get()  # removes the 2kb
         assert not queue.mem_full()


### PR DESCRIPTION

I've realized during a bench that `asizeof` is pretty CPU-heavy and slows down the event loop.
This patch dramatically speeds up the memory lookup by:

- avoiding computing 3 times for each item
- avoiding computing the whole batch (that's very expensive)


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
