### PR TITLE
Replace `timestamp` field with `_timestamp` in Network Drives

### DIFF
--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -120,7 +120,7 @@ class NASDataSource(BaseDataSource):
                 "size": file_details["allocation_size"].get_value(),
                 "_id": file_details["file_id"].get_value(),
                 "created_at": iso_utc(file_details["creation_time"].get_value()),
-                "timestamp": iso_utc(file_details["change_time"].get_value()),
+                "_timestamp": iso_utc(file_details["change_time"].get_value()),
                 "type": "folder" if file.is_dir() else "file",
                 "title": file.name,
             }
@@ -170,7 +170,7 @@ class NASDataSource(BaseDataSource):
 
         return {
             "_id": file["id"],
-            "timestamp": file["timestamp"],
+            "_timestamp": file["_timestamp"],
             "text": content,
         }
 

--- a/connectors/sources/tests/test_network_drive.py
+++ b/connectors/sources/tests/test_network_drive.py
@@ -179,7 +179,7 @@ async def test_get_files(dir_mock):
     expected_output = [
         {
             "_id": "1",
-            "timestamp": "2022-04-21T12:12:30",
+            "_timestamp": "2022-04-21T12:12:30",
             "path": "\\1.2.3.4/dummy_path/a1.md",
             "title": "a1.md",
             "created_at": "2022-01-11T12:12:30",
@@ -188,7 +188,7 @@ async def test_get_files(dir_mock):
         },
         {
             "_id": "122",
-            "timestamp": "2022-05-21T12:12:30",
+            "_timestamp": "2022-05-21T12:12:30",
             "path": "\\1.2.3.4/dummy_path/A",
             "title": "A",
             "created_at": "2022-02-11T12:12:30",
@@ -239,7 +239,7 @@ async def test_get_content(file_mock):
 
     mock_response = {
         "id": "1",
-        "timestamp": "2022-04-21T12:12:30",
+        "_timestamp": "2022-04-21T12:12:30",
         "title": "file1.txt",
         "path": "\\1.2.3.4/Users/folder1/file1.txt",
         "size": "50",
@@ -249,7 +249,7 @@ async def test_get_content(file_mock):
 
     expected_output = {
         "_id": "1",
-        "timestamp": "2022-04-21T12:12:30",
+        "_timestamp": "2022-04-21T12:12:30",
         "text": "Mock...",
     }
 
@@ -268,7 +268,7 @@ async def test_get_content_when_doit_false():
     source = create_source(NASDataSource)
     mock_response = {
         "id": "1",
-        "timestamp": "2022-04-21T12:12:30",
+        "_timestamp": "2022-04-21T12:12:30",
         "title": "file1.txt",
     }
 
@@ -286,7 +286,7 @@ async def test_get_content_when_file_type_not_supported():
     source = create_source(NASDataSource)
     mock_response = {
         "id": "1",
-        "timestamp": "2022-04-21T12:12:30",
+        "_timestamp": "2022-04-21T12:12:30",
         "title": "file2.xml",
     }
 


### PR DESCRIPTION
Due to recent changes in byoei file we will need to use '_timestamp' in place of 'timestamp'. 

https://github.com/elastic/connectors-python/blob/4abe3f2e677d7454706cc83206f79d3fc52841d8/connectors/byoei.py#L34

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->
