### PR TITLE
avoid creating source class if not needed

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -17,7 +17,7 @@ from connectors.utils import (
     ESClient,
 )
 from connectors.logger import logger
-from connectors.source import DataSourceConfiguration
+from connectors.source import DataSourceConfiguration, get_source_klass
 from elasticsearch.exceptions import ApiError
 from connectors.index import defaults_for, DEFAULT_LANGUAGE
 
@@ -62,6 +62,22 @@ NATIVE_READ_ONLY_FIELDS = CUSTOM_READ_ONLY_FIELDS + (
     "service_type",
     "configuration",
 )
+
+
+class ServiceTypeNotSupportedError(Exception):
+    pass
+
+
+class ServiceTypeNotConfiguredError(Exception):
+    pass
+
+
+class ConnectorUpdateError(Exception):
+    pass
+
+
+class DataSourceError(Exception):
+    pass
 
 
 class BYOIndex(ESClient):
@@ -214,6 +230,8 @@ class BYOConnector:
         self.bulk_options = bulk_options
         self.language_code = language_code
         self.analysis_icu = analysis_icu
+        self.source_klass = None
+        self.data_provider = None
 
     def _update_config(self, doc_source):
         self.status = doc_source["status"]
@@ -272,6 +290,9 @@ class BYOConnector:
         if self._heartbeat_started:
             self._hb.cancel()
             self._heartbeat_started = False
+        if self.data_provider is not None:
+            await self.data_provider.close()
+            self.data_provider = None
 
     async def sync_doc(self, force=True):
         if not self._dirty and not force:
@@ -361,12 +382,60 @@ class BYOConnector:
             doc["_run_ml_inference"] = self.pipeline.run_ml_inference
             yield doc, lazy_download
 
-    async def sync(self, data_provider, elastic_server, idling, sync_now=False):
+    async def prepare(self, config):
+        """Prepares the connector, given a configuration
+
+        If the connector id and the service is in the config, we want to
+        populate the service type and then sets the default configuration.
+
+        Returns the source class.
+        """
+        configured_connector_id = config.get("connector_id", "")
+        configured_service_type = config.get("service_type", "")
+
+        if self.id == configured_connector_id and self.service_type is None:
+            if not configured_service_type:
+                logger.error(
+                    f"Service type is not configured for connector {configured_connector_id}"
+                )
+                raise ServiceTypeNotConfiguredError("Service type is not configured.")
+            self.service_type = configured_service_type
+            logger.debug(f"Populated service type for connector {self.id}")
+
+        service_type = self.service_type
+        if service_type not in config["sources"]:
+            raise ServiceTypeNotSupportedError(service_type)
+
+        fqn = config["sources"][service_type]
+        try:
+            source_klass = get_source_klass(fqn)
+            if self.configuration.is_empty():
+                self.configuration = source_klass.get_default_configuration()
+                logger.debug(f"Populated configuration for connector {self.id}")
+
+            # sync state if needed (when service type or configuration is updated)
+            try:
+                await self.sync_doc(force=False)
+            except Exception as e:
+                logger.critical(e, exc_info=True)
+                raise ConnectorUpdateError(
+                    f"Could not update configuration for connector {self.id}"
+                )
+        except Exception as e:
+            logger.critical(e, exc_info=True)
+            raise DataSourceError(f"Could not instantiate {fqn} for {service_type}")
+
+        self.source_klass = source_klass
+
+    async def sync(self, elastic_server, idling, sync_now=False):
         # If anything bad happens before we create a sync job
         # (like bad scheduling config, etc)
         #
         # we will raise the error in the logs here and let Kibana knows
         # by toggling the status and setting the error and status field
+        if self.source_klass is None:
+            raise Exception("Can't call `sync()` before `prepare()`")
+
         try:
             service_type = self.service_type
             if not sync_now:
@@ -387,7 +456,15 @@ class BYOConnector:
             else:
                 logger.info("Sync forced")
 
-            if not await data_provider.changed():
+            try:
+                self.data_provider = self.source_klass(self)
+            except Exception as e:
+                logger.critical(e, exc_info=True)
+                raise DataSourceError(
+                    f"Could not instantiate {self.source_klass} for {service_type}"
+                )
+
+            if not await self.data_provider.changed():
                 logger.debug(f"No change in {service_type} data provider, skipping...")
                 return
         except Exception as exc:
@@ -400,8 +477,8 @@ class BYOConnector:
         self._syncing = True
         job = await self._sync_starts()
         try:
-            logger.debug(f"Pinging the {data_provider} backend")
-            await data_provider.ping()
+            logger.debug(f"Pinging the {self.data_provider} backend")
+            await self.data_provider.ping()
             await asyncio.sleep(0)
 
             mappings, settings = defaults_for(
@@ -417,8 +494,8 @@ class BYOConnector:
 
             result = await elastic_server.async_bulk(
                 self.index_name,
-                self.prepare_docs(data_provider),
-                data_provider.connector.pipeline,
+                self.prepare_docs(self.data_provider),
+                self.data_provider.connector.pipeline,
                 options=self.bulk_options,
             )
             await self._sync_done(job, result)

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -207,6 +207,18 @@ class PipelineSettings:
 
 
 class BYOConnector:
+    """Represents one doc in `.elastic-connectors` and triggers sync.
+
+    The pattern to use it is:
+
+        await connector.prepare(config)
+        await connector.start_heartbeat(delay)
+        try:
+            await connector.sync(es)
+        finally:
+            await connector.close()
+    """
+
     def __init__(
         self,
         index,

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -97,8 +97,13 @@ class ConnectorService:
             if connector.native:
                 logger.debug(f"Connector {connector.id} natively supported")
 
+            do_not_sync = connector.status in (
+                Status.CREATED,
+                Status.NEEDS_CONFIGURATION,
+            )
+
             try:
-                data_source = await get_data_source(connector, self.config)
+                data_source = await get_data_source(connector, self.config, do_not_sync)
             except ServiceTypeNotConfiguredError:
                 logger.error(
                     f"Service type is not configured for connector {self.config['connector_id']}"
@@ -116,7 +121,7 @@ class ConnectorService:
                 self.raise_if_spurious(e)
                 return
 
-            if connector.status in (Status.CREATED, Status.NEEDS_CONFIGURATION):
+            if do_not_sync:
                 # we can't sync in that state
                 logger.info(f"Can't sync with status `{e2str(connector.status)}`")
                 data_source = None

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -147,7 +147,7 @@ def get_source_klass(fqn):
     return getattr(module, klass_name)
 
 
-async def get_data_source(connector, config):
+async def get_data_source(connector, config, do_not_sync):
     """Returns a source class instance, given a service type
 
 
@@ -185,6 +185,9 @@ async def get_data_source(connector, config):
             raise ConnectorUpdateError(
                 f"Could not update configuration for connector {connector.id}"
             )
+
+        if do_not_sync:
+            return None
 
         return source_klass(connector)
     except Exception as e:

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -6,23 +6,6 @@
 """ Helpers to build sources + FQN-based Registry
 """
 import importlib
-from connectors.logger import logger
-
-
-class ServiceTypeNotSupportedError(Exception):
-    pass
-
-
-class ServiceTypeNotConfiguredError(Exception):
-    pass
-
-
-class ConnectorUpdateError(Exception):
-    pass
-
-
-class DataSourceError(Exception):
-    pass
 
 
 class Field:
@@ -145,54 +128,6 @@ def get_source_klass(fqn):
     module_name, klass_name = fqn.split(":")
     module = importlib.import_module(module_name)
     return getattr(module, klass_name)
-
-
-async def get_data_source(connector, config, do_not_sync):
-    """Returns a source class instance, given a service type
-
-
-    If the connector id and the service is in the config, we want to
-    populate the service type and then sets the default configuration.
-    """
-    configured_connector_id = config.get("connector_id", "")
-    configured_service_type = config.get("service_type", "")
-
-    if connector.id == configured_connector_id and connector.service_type is None:
-        if not configured_service_type:
-            logger.error(
-                f"Service type is not configured for connector {configured_connector_id}"
-            )
-            raise ServiceTypeNotConfiguredError("Service type is not configured.")
-        connector.service_type = configured_service_type
-        logger.debug(f"Populated service type for connector {connector.id}")
-
-    service_type = connector.service_type
-    if service_type not in config["sources"]:
-        raise ServiceTypeNotSupportedError(service_type)
-
-    fqn = config["sources"][service_type]
-    try:
-        source_klass = get_source_klass(fqn)
-        if connector.configuration.is_empty():
-            connector.configuration = source_klass.get_default_configuration()
-            logger.debug(f"Populated configuration for connector {connector.id}")
-
-        # sync state if needed (when service type or configuration is updated)
-        try:
-            await connector.sync_doc(force=False)
-        except Exception as e:
-            logger.critical(e, exc_info=True)
-            raise ConnectorUpdateError(
-                f"Could not update configuration for connector {connector.id}"
-            )
-
-        if do_not_sync:
-            return None
-
-        return source_klass(connector)
-    except Exception as e:
-        logger.critical(e, exc_info=True)
-        raise DataSourceError(f"Could not instantiate {fqn} for {service_type}")
 
 
 def get_data_sources(config):

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -13,7 +13,7 @@ from functools import partial
 from aioresponses import CallbackResult
 
 from connectors.runner import ConnectorService, run
-from connectors.source import DataSourceError
+from connectors.byoc import DataSourceError
 from connectors.conftest import assert_re
 
 
@@ -638,7 +638,10 @@ async def test_connector_service_poll_buggy_service(
 ):
     def connectors_update(url, **kw):
         doc = json.loads(kw["data"])["doc"]
-        assert doc["error"] == "Could not instantiate test_runner:FakeSource for fake"
+        assert (
+            doc["error"]
+            == "Could not instantiate <class 'test_runner.FakeSource'> for fake"
+        )
         return CallbackResult(status=200)
 
     await set_server_responses(
@@ -651,6 +654,7 @@ async def test_connector_service_poll_buggy_service(
     for log in patch_logger.logs:
         if isinstance(log, DataSourceError):
             return
+
     raise AssertionError
 
 

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -10,10 +10,8 @@ from connectors.source import (
     DataSourceConfiguration,
     get_source_klass,
     get_data_sources,
-    get_data_source,
     BaseDataSource,
 )
-from connectors.byoc import BYOConnector, Status
 
 
 CONFIG = {
@@ -76,48 +74,6 @@ def test_get_data_sources():
 
     sources = list(get_data_sources(settings))
     assert sources == [MyConnector, MyConnector]
-
-
-class Banana(BaseDataSource):
-    """Banana"""
-
-    @classmethod
-    def get_default_configuration(cls):
-        return {"one": {"value": None}}
-
-
-@pytest.mark.asyncio
-async def test_get_custom_data_source_no_service_type(mock_responses):
-    class Client:
-        pass
-
-    class Index:
-        client = Client()
-
-        async def save(self, conn):
-            pass
-
-    # generic empty doc created by the user through the Kibana UI
-    # when it's created that way, the service type is None,
-    # so it's up to the connector to set it back to its value
-    doc = {
-        "status": "created",
-        "service_type": None,
-        "index_name": "test",
-        "configuration": {},
-        "scheduling": {"enabled": False},
-    }
-    connector = BYOConnector(Index(), "1", doc, {})
-
-    config = {
-        "connector_id": "1",
-        "service_type": "banana",
-        "sources": {"banana": "connectors.tests.test_source:Banana"},
-    }
-
-    source = await get_data_source(connector, config)
-    assert str(source) == "Datasource `Banana`"
-    assert connector.status == Status.NEEDS_CONFIGURATION
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Closes  https://github.com/elastic/enterprise-search-team/issues/3420


Regression introduced by https://github.com/elastic/connectors-python/pull/74

the check

```
connector.status in (Status.CREATED, Status.NEEDS_CONFIGURATION )
```

now comes **after** the data source class creation. We need to bypass the creation of the class if we have those states.

The `get_data_source` role became very confusing, I have refactored things.


Changes:

- `connectors.source.get_data_source(connector, config)` becomes `connectors.byoc.BYOConnector.prepare(config)`
- `BYOConnector.prepare()` is always called before `BYOConnector.sync()` and does the config writes in Elasticsearch if needed
- `BYOConnector.sync()` creates the data provider instance if needed.
- `connectors.runner.ConnectorService._one_sync()` becomes much cleaner as it deals with the `connector` instance only

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist

- [x] Covered the changes with automated tests
- [x] Tested the changes locally

#### Cloud Review Checklist

Once the Jenkins artifact is ready, run a local cloud instance:

- [x] Make sure running a custom connector still works
- [x] Make sure running a native connector still works
- [x] Make sure adding a connector and not configuring it doesn't raise an error in Kibana

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
