### PR TITLE
Add pagination and only return supported connectors

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -21,12 +21,12 @@ from connectors.source import DataSourceConfiguration, get_source_klass
 from elasticsearch.exceptions import ApiError
 from connectors.index import defaults_for, DEFAULT_LANGUAGE
 
-
 CONNECTORS_INDEX = ".elastic-connectors"
 JOBS_INDEX = ".elastic-connectors-sync-jobs"
 PIPELINE = "ent-search-generic-ingestion"
 SYNC_DISABLED = -1
 DEFAULT_ANALYSIS_ICU = False
+DEFAULT_PAGE_SIZE = 100
 
 
 def e2str(entry):
@@ -116,31 +116,68 @@ class BYOIndex(ESClient):
             indices=[CONNECTORS_INDEX, JOBS_INDEX], pipelines=[PIPELINE]
         )
 
-    async def get_list(self):
+    async def get_connectors(self, native_service_types=[], connectors_ids=[]):
         await self.client.indices.refresh(index=CONNECTORS_INDEX)
 
-        try:
-            resp = await self.client.search(
-                index=CONNECTORS_INDEX,
-                query={"match_all": {}},
-                size=20,
-                expand_wildcards="hidden",
-            )
-        except ApiError as e:
-            logger.critical(f"The server returned {e.status_code}")
-            logger.critical(e.body, exc_info=True)
-            return
+        query = {
+            "bool": {
+                "should": [
+                    {
+                        "bool": {
+                            "filter": [
+                                {"term": {"is_native": True}},
+                                {"terms": {"service_type": native_service_types}},
+                            ]
+                        }
+                    },
+                    {
+                        "bool": {
+                            "filter": [
+                                {"term": {"is_native": False}},
+                                {"terms": {"_id": connectors_ids}},
+                            ]
+                        }
+                    },
+                ]
+            }
+        }
 
-        logger.debug(f"Found {len(resp['hits']['hits'])} connectors")
-        for hit in resp["hits"]["hits"]:
+        async for connector in self._query_with_pagination(CONNECTORS_INDEX, query):
             yield BYOConnector(
                 self,
-                hit["_id"],
-                hit["_source"],
+                connector["_id"],
+                connector["_source"],
                 bulk_options=self.bulk_options,
                 language_code=self.language_code,
                 analysis_icu=self.analysis_icu,
             )
+
+    async def _query_with_pagination(self, index, query, page_size=DEFAULT_PAGE_SIZE):
+        count = 0
+        offset = 0
+
+        while True:
+            try:
+                resp = await self.client.search(
+                    index=index,
+                    query=query,
+                    from_=offset,
+                    size=page_size,
+                    expand_wildcards="hidden",
+                )
+            except ApiError as e:
+                logger.critical(f"The server returned {e.status_code}")
+                logger.critical(e.body, exc_info=True)
+                return
+
+            hits = resp["hits"]["hits"]
+            total = resp["hits"]["total"]["value"]
+            count += len(hits)
+            for hit in hits:
+                yield hit
+            if count >= total:
+                break
+            offset += len(hits)
 
 
 class SyncJob:

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -180,16 +180,9 @@ class ConnectorService:
             while self.running:
                 try:
                     logger.debug(f"Polling every {self.idling} seconds")
-                    async for connector in self.connectors.get_list():
-                        if (
-                            connector.service_type not in native_service_types
-                            and connector.id not in connectors_ids
-                        ):
-                            logger.debug(
-                                f"Connector {connector.id} of type {connector.service_type} not supported, ignoring"
-                            )
-                            continue
-
+                    async for connector in self.connectors.get_connectors(
+                        native_service_types, connectors_ids
+                    ):
                         await self._one_sync(connector, es, sync_now)
                         if one_sync:
                             self.stop()

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -185,7 +185,6 @@ class ConnectorService:
                     ):
                         await self._one_sync(connector, es, sync_now)
                         if one_sync:
-                            self.stop()
                             break
                 except Exception as e:
                     logger.critical(e, exc_info=True)
@@ -193,9 +192,8 @@ class ConnectorService:
 
                 if not one_sync:
                     await self._sleeps.sleep(self.idling)
-                else:
-                    self.stop()
         finally:
+            self.stop()
             await self.connectors.close()
             await es.close()
 

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -184,8 +184,8 @@ class ConnectorService:
                         native_service_types, connectors_ids
                     ):
                         await self._one_sync(connector, es, sync_now)
-                        if one_sync:
-                            break
+                    if one_sync:
+                        break
                 except Exception as e:
                     logger.critical(e, exc_info=True)
                     self.raise_if_spurious(e)

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -130,7 +130,7 @@ async def test_heartbeat(mock_responses, patch_logger):
 
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_search?expand_wildcards=hidden",
-        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}]}},
+        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}], "total": {"value": 1}}},
         headers=headers,
     )
 
@@ -144,7 +144,7 @@ async def test_heartbeat(mock_responses, patch_logger):
     connectors = BYOIndex(config)
     conns = []
 
-    async for connector in connectors.get_list():
+    async for connector in connectors.get_connectors():
         connector.start_heartbeat(0.2)
         connector.start_heartbeat(1.0)  # NO-OP
         conns.append(connector)
@@ -164,14 +164,14 @@ async def test_connectors_get_list(mock_responses):
 
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_search?expand_wildcards=hidden",
-        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}]}},
+        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}], "total": {"value": 1}}},
         headers=headers,
     )
 
     connectors = BYOIndex(config)
     conns = []
 
-    async for connector in connectors.get_list():
+    async for connector in connectors.get_connectors():
         conns.append(connector)
 
     assert len(conns) == 1
@@ -217,7 +217,7 @@ async def test_sync_mongo(mock_responses, patch_logger):
 
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_search?expand_wildcards=hidden",
-        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}]}},
+        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}], "total": {"value": 1}}},
         headers=headers,
     )
     mock_responses.put(
@@ -295,7 +295,7 @@ async def test_sync_mongo(mock_responses, patch_logger):
     service_config = {"sources": {"mongodb": "connectors.tests.test_byoc:Data"}}
 
     try:
-        async for connector in connectors.get_list():
+        async for connector in connectors.get_connectors():
             await connector.prepare(service_config)
             await connector.sync(es, 0)
             await connector.close()
@@ -356,13 +356,13 @@ async def test_connectors_properties(mock_responses, set_env):
 
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_search?expand_wildcards=hidden",
-        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}]}},
+        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}], "total": {"value": 1}}},
         headers=headers,
     )
 
     connectors = BYOIndex(config["elasticsearch"])
 
-    async for connector in connectors.get_list():
+    async for connector in connectors.get_connectors():
         assert connector.analysis_icu == config["elasticsearch"]["analysis_icu"]
         assert connector.language_code == config["elasticsearch"]["language_code"]
 

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -144,7 +144,7 @@ async def test_heartbeat(mock_responses, patch_logger):
     connectors = BYOIndex(config)
     conns = []
 
-    async for connector in connectors.get_connectors():
+    async for connector in connectors.get_connectors(['mongodb']):
         connector.start_heartbeat(0.2)
         connector.start_heartbeat(1.0)  # NO-OP
         conns.append(connector)
@@ -171,7 +171,7 @@ async def test_connectors_get_list(mock_responses):
     connectors = BYOIndex(config)
     conns = []
 
-    async for connector in connectors.get_connectors():
+    async for connector in connectors.get_connectors(['mongodb']):
         conns.append(connector)
 
     assert len(conns) == 1
@@ -295,7 +295,7 @@ async def test_sync_mongo(mock_responses, patch_logger):
     service_config = {"sources": {"mongodb": "connectors.tests.test_byoc:Data"}}
 
     try:
-        async for connector in connectors.get_connectors():
+        async for connector in connectors.get_connectors(['mongodb']):
             await connector.prepare(service_config)
             await connector.sync(es, 0)
             await connector.close()
@@ -362,7 +362,7 @@ async def test_connectors_properties(mock_responses, set_env):
 
     connectors = BYOIndex(config["elasticsearch"])
 
-    async for connector in connectors.get_connectors():
+    async for connector in connectors.get_connectors(['mongodb']):
         assert connector.analysis_icu == config["elasticsearch"]["analysis_icu"]
         assert connector.language_code == config["elasticsearch"]["language_code"]
 

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -266,7 +266,7 @@ async def set_server_responses(
 
     def _connectors_read(url, **kw):
         return CallbackResult(
-            status=200, payload={"hits": {"hits": [{"_id": "1", "_source": config}]}}
+            status=200, payload={"hits": {"hits": [{"_id": "1", "_source": config}], "total": {"value": 1}}}
         )
 
     if connectors_read is None:
@@ -410,7 +410,6 @@ async def test_connector_service_poll_unconfigured(
     await service.poll()
 
     patch_logger.assert_present("*** Connector 1 HEARTBEAT")
-    patch_logger.assert_present("Found 1 connector")
     patch_logger.assert_present("Can't sync with status `needs_configuration`")
     patch_logger.assert_not_present("Sync done")
 
@@ -436,7 +435,6 @@ async def test_connector_service_poll_no_sync_but_status_updated(
     await service.poll(sync_now=False)
 
     patch_logger.assert_present("*** Connector 1 HEARTBEAT")
-    patch_logger.assert_present("Found 1 connector")
     patch_logger.assert_present("Scheduling is disabled")
     patch_logger.assert_not_present("Sync done")
     assert calls[-1]["status"] == "connected"
@@ -478,7 +476,6 @@ async def test_connector_service_poll_just_created(
     await service.poll()
 
     patch_logger.assert_present("*** Connector 1 HEARTBEAT")
-    patch_logger.assert_present("Found 1 connector")
     patch_logger.assert_present("Can't sync with status `created`")
     patch_logger.assert_not_present("Sync done")
 
@@ -538,17 +535,6 @@ async def test_connector_service_poll_clear_error(
         "job:None",  # second sync
         "connector:None",  # second sync
     ]
-
-
-@pytest.mark.asyncio
-async def test_connector_service_poll_not_native(
-    mock_responses, patch_logger, patch_ping, set_env
-):
-    await set_server_responses(mock_responses, FAKE_CONFIG_NOT_NATIVE)
-    service = ConnectorService(CONFIG_2)
-    asyncio.get_event_loop().call_soon(service.stop)
-    await service.poll()
-    patch_logger.assert_present("Connector 1 of type fake not supported, ignoring")
 
 
 @pytest.mark.asyncio
@@ -727,7 +713,7 @@ async def test_spurious_continue(mock_responses, patch_logger, patch_ping, set_e
 
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_search?expand_wildcards=hidden",
-        payload={"hits": {"hits": [{"_id": "1", "_source": FAKE_CONFIG}]}},
+        payload={"hits": {"hits": [{"_id": "1", "_source": FAKE_CONFIG}], "total": {"value": 1}}},
         headers=headers,
     )
 
@@ -758,7 +744,7 @@ async def test_connector_settings_change(
         current[0] += 1
         source = configs[current[0]]
         return CallbackResult(
-            status=200, payload={"hits": {"hits": [{"_id": "1", "_source": source}]}}
+            status=200, payload={"hits": {"hits": [{"_id": "1", "_source": source}], "total": {"value": 1}}}
         )
 
     indexed = []


### PR DESCRIPTION
This PR introduces 2 changes:

1. Add pagination to `get_connectors` function
2. Make `get_connectors` only return supported connectors.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally