### PR TITLE
Low-memory ingest attachment streamer

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,8 @@
 elasticsearch:
-  host: http://localhost:9200
+  host: http://0.0.0.0:9200
   username: elastic
   password: changeme
+  #api_key: "MFBsaTdvUUItV3hiQW5jQVNCNVI6NkNlZDFKVUJTLXFYaV9SV01jYVNQUQ=="
   ssl: true
   bulk:
     queue_max_size: 1024
@@ -25,6 +26,14 @@ service:
   max_concurrent_syncs: 1
   job_cleanup_interval: 300
   log_level: INFO
+
+attachments:
+  drop_dir: /tmp/attachments/drop
+  logs_dir: /tmp/attachments/logs
+  results_dir: /tmp/attachments/results
+  idling: 30
+  max_disk_size: 250
+  max_concurrency: 5
 
 native_service_types:
   - mongodb

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -36,9 +36,9 @@ def _parser():
         "--action",
         type=str,
         default=["poll", "cleanup"],
-        choices=["poll", "list", "cleanup"],
-        nargs="+",
+        choices=["poll", "list", "cleanup", "streamer"],
         help="What elastic-ingest should do",
+        nargs="+",
     )
 
     parser.add_argument(

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -95,7 +95,7 @@ async def prepare(service_type, index_name, config, filtering=None):
         filtering = []
 
     klass = get_source_klass(config["sources"][service_type])
-    es = ElasticServer(config["elasticsearch"])
+    es = ElasticServer(config)
 
     # add a dummy pipeline
     try:
@@ -174,7 +174,7 @@ async def prepare(service_type, index_name, config, filtering=None):
                 "reduce_whitespace": True,
                 "run_ml_inference": True,
             },
-            "sync_now": False,
+            "sync_now": True,
             "is_native": True,
         }
 

--- a/connectors/services/__init__.py
+++ b/connectors/services/__init__.py
@@ -4,6 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 from connectors.services.base import get_services  # NOQA
+from connectors.services.fstreamer import FileUploadService  # NOQA
 from connectors.services.job_cleanup import JobCleanUpService  # NOQA
 from connectors.services.job_scheduling import JobSchedulingService  # NOQA
-from connectors.services.fstreamer import FileUploadService  # NOQA

--- a/connectors/services/__init__.py
+++ b/connectors/services/__init__.py
@@ -6,3 +6,4 @@
 from connectors.services.base import get_services  # NOQA
 from connectors.services.job_cleanup import JobCleanUpService  # NOQA
 from connectors.services.job_scheduling import JobSchedulingService  # NOQA
+from connectors.services.fstreamer import FileUploadService  # NOQA

--- a/connectors/services/fstreamer/__init__.py
+++ b/connectors/services/fstreamer/__init__.py
@@ -1,0 +1,2 @@
+from connectors.services.fstreamer.dropper import UploadDir  # NOQA
+from connectors.services.fstreamer.uploader import FileUploadService  # NOQA

--- a/connectors/services/fstreamer/dropper.py
+++ b/connectors/services/fstreamer/dropper.py
@@ -1,0 +1,106 @@
+import json
+import os
+import re
+
+import aiofiles
+from aiofiles.os import listdir  # type: ignore
+
+SANITIZER = re.compile("[^0-9a-zA-Z]+")
+
+
+# 250MB max disk size
+ONE_MEG = 1024 * 1024
+DEFAULT_MAX_DIR_SIZE = 250
+
+
+class FileMetadata:
+    def __init__(self, name, target_elastic, target_index, doc_id, filename):
+        self.target_elastic = target_elastic
+        self.target_index = target_index
+        self.doc_id = doc_id
+        self.target_filename = filename
+        self.drop_dir = os.path.dirname(self.target_filename)
+        self.filename = os.path.join(
+            self.drop_dir, os.path.splitext(self.target_filename)[0] + ".metadata"
+        )
+        self.name = name
+
+    async def write(self):
+        desc = {
+            "name": self.name,
+            "filename": self.target_filename,
+            "target_index": self.target_index,
+            "target_elastic": self.target_elastic,
+            # XXX how do we know this value when the initial sync of the doc is
+            # not done yet. we might need to use the source id
+            # and at sync time, query for the corresponding ES doc id
+            # and send it only once it's there..
+            "doc_id": self.doc_id,
+        }
+
+        async with aiofiles.open(self.filename, "w") as f:
+            await f.write(json.dumps(desc))
+
+    @classmethod
+    async def read(cls, filename):
+        async with aiofiles.open(filename, "r") as f:
+            data = json.loads(await f.read())
+
+        return cls(
+            data["name"],
+            data["target_elastic"],
+            data["target_index"],
+            data["doc_id"],
+            data["filename"],
+        )
+
+
+class UploadDir:
+    """Represents the upload dir"""
+
+    def __init__(self, drop_dir, max_disk_size=DEFAULT_MAX_DIR_SIZE * ONE_MEG):
+        self.drop_dir = drop_dir
+        self.max_disk_size = max_disk_size
+        # initial scan to get the size
+        self.current_size = 0
+        for item in os.scandir(self.drop_dir):
+            try:
+                if not item.is_file():
+                    continue
+                self.current_size += item.stat().st_size
+            except Exception:
+                pass
+
+    def __str__(self):
+        return f"<UploadDir {self.drop_dir} {self.current_size}/{self.max_disk_size}>"
+
+    def _sanitize(self, name):
+        return SANITIZER.sub("-", name)
+
+    async def drop_file(self, gen, target_elastic, name, filename, index, doc_id):
+        """Writes a file by chunks using the async generator and then a metadata file"""
+
+        if self.current_size >= self.max_disk_size:
+            raise OSError(
+                f"Limit of {self.max_disk_size} bytes reached: {self.current_size}"
+            )
+
+        key = f"{index}-{doc_id}-{self._sanitize(filename)}.upload"
+        target = os.path.join(self.drop_dir, key)
+        async with aiofiles.open(target, "wb") as f:
+            async for chunk in gen:
+                await f.write(chunk)
+                self.current_size += len(chunk)
+
+        # get size of metadata
+        metadata = FileMetadata(filename, target_elastic, index, doc_id, target)
+
+        # writing this file makes it available for the uploader
+        await metadata.write()
+
+    async def get_files(self):
+        # aiofiles.os.listdir is not really async...
+        for file in await listdir(self.drop_dir):
+            if not file.endswith(".metadata"):
+                continue
+            yield await FileMetadata.read(os.path.join(self.drop_dir, file))

--- a/connectors/services/fstreamer/uploader.py
+++ b/connectors/services/fstreamer/uploader.py
@@ -1,0 +1,175 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+# TODO
+#
+# - harden all requests (catch errors, retries)
+# - if a file keep on failing, put it in a failing dir
+# - add a max file size
+#
+import functools
+import json
+import os
+import re
+
+import aiofiles
+import aiohttp
+
+from connectors.logger import logger
+from connectors.services.base import BaseService
+from connectors.services.fstreamer.dropper import UploadDir
+from connectors.utils import (
+    CancellableSleeps,
+    ConcurrentTasks,
+    convert_to_b64,
+    get_event_loop,
+)
+
+SUPPORTED_TEXT_FILETYPE = [".py", ".rst", ".rb", ".sh", ".md", ".txt"]
+
+# 250MB max disk size
+ONE_MEG = 1024 * 1024
+DEFAULT_MAX_DIR_SIZE = 250
+
+# Program to encode in base64 -- we could compile a SIMD-aware one
+# for an extra performance boost
+BASE64 = "base64"
+SANITIZER = re.compile("[^0-9a-zA-Z]+")
+
+
+class FileUploadService(BaseService):
+    """Watches a directory for files and sends them by chunks
+
+    Uses `Transfer-Encoding: chunked`
+    """
+
+    name = "streamer"
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.elastic_config = self.config["elasticsearch"]
+        self._config = self.config.get("attachments", {})
+        self.max_concurrency = self._config.get("max_concurrency", 5)
+        self.directory = UploadDir(self._prepare_dir("drop"))
+        self.idle_time = self._config.get("idling", 30)
+        self.log_directory = self._prepare_dir("logs")
+        self.results_directory = self._prepare_dir("results")
+        self.running = False
+        self._sleeps = CancellableSleeps()
+
+    def _to_b64(self, filename):
+        """Calls the system base64 utility to create a base64-encoded file
+
+        The base64 utility is a stream encoder, the file will not be fully
+        loaded into memory.
+
+        This is a blocking method.
+        """
+        return convert_to_b64(filename)
+
+    async def _file_to_pipeline(self, filename, chunk_size=1024 * 1024):
+        """Convert a file into a streamable Elasticsearch request.
+
+        - Calls `_to_b64` in a separate thread so we don't block
+        - Reads the base64 file by chunks an provide an async generator
+        """
+        b64_file = await get_event_loop().run_in_executor(None, self._to_b64, filename)
+
+        # XXX adding .txt to all known text files
+        if os.path.splitext(filename)[-1] in SUPPORTED_TEXT_FILETYPE:
+            filename += ".txt"
+
+        try:
+            async with aiofiles.open(b64_file, "rb") as f:
+                yield b'{"filename":"' + filename.encode("utf8") + b'","data":"'
+                while chunk := (await f.read(chunk_size)).strip():
+                    yield chunk
+                yield b'"}'
+        finally:
+            if os.path.exists(b64_file):
+                os.remove(b64_file)
+
+    def _prepare_dir(self, name):
+        default_dir = os.path.join(os.getcwd(), "attachments")
+        path = self._config.get(f"{name}_dir", os.path.join(default_dir, name))
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    async def _send_attachment(self, metadata, session):
+        filename = metadata.target_filename
+        name = metadata.name
+        # single host but we could target multiple
+        gen = functools.partial(self._file_to_pipeline, filename)
+        host = metadata.target_elastic["host"]
+        url = (
+            f"{host}/{metadata.target_index}/_doc/{metadata.doc_id}?pipeline=attachment"
+        )
+        logger.debug(f"[{name}] Sending by chunks to {url}")
+        headers = {"Content-Type": "application/json"}
+        result = os.path.join(self.results_directory, filename + ".json")
+        worked = False
+        resp = None
+
+        async with session.put(url, data=gen(), headers=headers) as resp:
+            async with aiofiles.open(result, "w") as f:
+                resp = await resp.json()
+                logger.debug(f"[{filename}] Done, results in {result}")
+                if resp.get("result") in ("updated", "created"):
+                    logger.debug(f"document was {resp['result']}")
+                    worked = True
+                await f.write(json.dumps(resp))
+
+        return worked, filename, metadata, resp
+
+    async def _process_dir(self):
+        logger.info("Scanning now...")
+
+        sent = 0
+
+        def track_results(result):
+            nonlocal sent
+
+            worked, filename, desc_file, resp = result
+            if worked:
+                os.remove(filename)
+                os.remove(desc_file)
+                sent += 1
+                if sent % 10 == 0:
+                    logger.info(f"Sent {sent} files.")
+            else:
+                logger.error(f"Failed to ingest {filename}")
+                logger.error(json.dumps(resp))
+
+        async with aiohttp.ClientSession(
+            auth=aiohttp.BasicAuth(
+                self.elastic_config["username"], self.elastic_config["password"]
+            )
+        ) as session:
+            runner = ConcurrentTasks(
+                max_concurrency=self.max_concurrency, results_callback=track_results
+            )
+
+            async for metadata in self.directory.get_files():
+                logger.debug(f"Processing {metadata.name}")
+                await runner.put(
+                    functools.partial(self._send_attachment, metadata, session)
+                )
+
+            await runner.join()
+
+    #
+    # public APIS
+    #
+    async def run(self):
+        self.running = True
+        logger.info(f"Watching {self.directory}")
+        while self.running:
+            await self._process_dir()
+            logger.info(f"Sleeping for {self.idle_time}s")
+            await self._sleeps.sleep(self.idle_time)
+
+    def shutdown(self, *args, **kw):
+        self.running = False
+        self._sleeps.cancel()

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -138,7 +138,7 @@ class JobSchedulingService(BaseService):
             f"Service started, listening to events from {self.es_config['host']}"
         )
 
-        es = ElasticServer(self.es_config)
+        es = ElasticServer(self.config)
         try:
             while self.running:
                 # creating a pool of task for every round

--- a/connectors/sources/tests/test_directory.py
+++ b/connectors/sources/tests/test_directory.py
@@ -22,10 +22,10 @@ async def test_get_docs(patch_logger, catch_stdout):
         num += 1
         if doc["path"].endswith("__init__.py"):
             continue
-        data = await dl(doit=True, timestamp="xx")
-        if data is not None:
-            assert len(data["_attachment"]) > 0
-        if num > 100:
-            break
+        # consuming the generator
+        data = b""
+        async for chunk in doc["_attachment"]:
+            data += chunk
+        assert len(data) > 0, doc
 
     assert num > 3

--- a/connectors/sources/tests/test_directory.py
+++ b/connectors/sources/tests/test_directory.py
@@ -3,6 +3,8 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import os
+
 import pytest
 
 from connectors.sources.directory import DEFAULT_DIR, DirectoryDataSource
@@ -17,6 +19,9 @@ async def test_basics():
 @pytest.mark.asyncio
 async def test_get_docs(patch_logger, catch_stdout):
     source = create_source(DirectoryDataSource)
+    source.directory = os.path.dirname(__file__)
+    source.pattern = '*.py'
+
     num = 0
     async for (doc, dl) in source.get_docs():
         num += 1

--- a/connectors/sources/tests/test_directory.py
+++ b/connectors/sources/tests/test_directory.py
@@ -20,7 +20,7 @@ async def test_basics():
 async def test_get_docs(patch_logger, catch_stdout):
     source = create_source(DirectoryDataSource)
     source.directory = os.path.dirname(__file__)
-    source.pattern = '*.py'
+    source.pattern = "*.py"
 
     num = 0
     async for (doc, dl) in source.get_docs():

--- a/connectors/tests/commons.py
+++ b/connectors/tests/commons.py
@@ -41,7 +41,13 @@ class AsyncIterator:
         return self
 
 
-def create_service(name, config_file, env):
-    os.environ.update(env)
+def create_service(name, config_file, env=None):
+    defaults = {
+        "root_attachments": "/tmp/attachements",
+        "elasticsearch.password": "changeme",
+    }
+    if env is not None:
+        defaults.update(env)
+    os.environ.update(defaults)
     config = load_config(config_file)
     return get_service(name, config)

--- a/connectors/tests/commons.py
+++ b/connectors/tests/commons.py
@@ -1,3 +1,14 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+import os
+
+from connectors.config import load_config
+from connectors.services.base import get_service
+
+
 class AsyncIterator:
     """
     Async documents generator fake class, which records the args and kwargs it was called with.
@@ -28,3 +39,9 @@ class AsyncIterator:
             self.call_kwargs.append(kwargs)
 
         return self
+
+
+def create_service(name, config_file, env):
+    os.environ.update(env)
+    config = load_config(config_file)
+    return get_service(name, config)

--- a/connectors/tests/config.yml
+++ b/connectors/tests/config.yml
@@ -9,6 +9,14 @@ elasticsearch:
   initial_backoff_duration: 0
   backoff_multiplier: 0
 
+attachments:
+  drop_dir: /tmp/attachments/drop
+  logs_dir: /tmp/attachments/logs
+  results_dir: /tmp/attachments/results
+  idling: 30
+  max_disk_size: 250
+  max_concurrency: 5
+
 service:
   idling: 0.5
   heartbeat: 300

--- a/connectors/tests/config.yml
+++ b/connectors/tests/config.yml
@@ -1,6 +1,6 @@
 elasticsearch:
   host: http://nowhere.com:9200
-  user: elastic
+  username: elastic
   password: ${elasticsearch.password}
   bulk:
     queue_max_size: 1024
@@ -10,9 +10,9 @@ elasticsearch:
   backoff_multiplier: 0
 
 attachments:
-  drop_dir: /tmp/attachments/drop
-  logs_dir: /tmp/attachments/logs
-  results_dir: /tmp/attachments/results
+  drop_dir: ${root_attachments}/drop
+  logs_dir: ${root_attachments}/logs
+  results_dir: ${root_attachments}/results
   idling: 30
   max_disk_size: 250
   max_concurrency: 5

--- a/connectors/tests/config_https.yml
+++ b/connectors/tests/config_https.yml
@@ -9,6 +9,14 @@ elasticsearch:
   initial_backoff_duration: 0
   backoff_multiplier: 0
 
+attachments:
+  drop_dir: /tmp/attachments/drop
+  logs_dir: /tmp/attachments/logs
+  results_dir: /tmp/attachments/results
+  idling: 30
+  max_disk_size: 250
+  max_concurrency: 5
+
 service:
   idling: 0.5
   heartbeat: 300

--- a/connectors/tests/config_mem.yml
+++ b/connectors/tests/config_mem.yml
@@ -9,6 +9,14 @@ elasticsearch:
   initial_backoff_duration: 0
   backoff_multiplier: 0
 
+attachments:
+  drop_dir: /tmp/attachments/drop
+  logs_dir: /tmp/attachments/logs
+  results_dir: /tmp/attachments/results
+  idling: 30
+  max_disk_size: 250
+  max_concurrency: 5
+
 service:
   idling: 0.5
   heartbeat: 300

--- a/connectors/tests/memconfig.yml
+++ b/connectors/tests/memconfig.yml
@@ -11,6 +11,14 @@ elasticsearch:
   initial_backoff_duration: 0
   backoff_multiplier: 0
 
+attachments:
+  drop_dir: /tmp/attachments/drop
+  logs_dir: /tmp/attachments/logs
+  results_dir: /tmp/attachments/results
+  idling: 30
+  max_disk_size: 250
+  max_concurrency: 5
+
 service:
   idling: 0.5
   heartbeat: 300

--- a/connectors/tests/test_fstreamer_uploader.py
+++ b/connectors/tests/test_fstreamer_uploader.py
@@ -1,0 +1,40 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+import asyncio
+import functools
+import os
+import shutil
+from collections import defaultdict
+from tempfile import mkdtemp
+
+import pytest
+
+from connectors.services.fstreamer.uploader import FileUploadService
+from connectors.tests.commons import create_service
+
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.yml")
+
+
+@pytest.mark.asyncio
+async def test_run_upload_service(mock_responses):
+    root = mkdtemp()
+
+    headers = {"X-Elastic-Product": "Elasticsearch"}
+    # mock_responses.put(
+    #        "http://nowhere:9200/search-dir/_doc/e38117cc6d8183deeed85a9a9d7d0341?pipeline=attachment",
+    #        payload={"result": "created"},
+    #        headers=headers
+    # )
+
+    service = create_service(
+        "streamer",
+        CONFIG_FILE,
+        {"root_attachments": root, "elasticsearch.password": "changeme"},
+    )
+
+    asyncio.get_running_loop().call_later(0.5, service.shutdown)
+    await service.run()
+    shutil.rmtree(root)

--- a/connectors/tests/test_job_scheduling.py
+++ b/connectors/tests/test_job_scheduling.py
@@ -18,20 +18,11 @@ from connectors.byoc import (
     ServiceTypeNotSupportedError,
     Status,
 )
-from connectors.config import load_config
 from connectors.services.job_scheduling import JobSchedulingService
 from connectors.source import DataSourceConfiguration
-from connectors.tests.commons import AsyncIterator
+from connectors.tests.commons import AsyncIterator, create_service
 
 CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.yml")
-
-
-def create_service(config_file):
-    config = load_config(config_file)
-    service = JobSchedulingService(config)
-    service.idling = 0.05
-
-    return service
 
 
 async def run_service_with_stop_after(service, stop_after=0):
@@ -55,7 +46,7 @@ async def run_service_with_stop_after(service, stop_after=0):
 
 
 async def create_and_run_service(config_file=CONFIG_FILE, stop_after=0):
-    service = create_service(config_file)
+    service = create_service("poll", config_file)
     await run_service_with_stop_after(service, stop_after)
 
 

--- a/connectors/tests/test_kibana.py
+++ b/connectors/tests/test_kibana.py
@@ -72,7 +72,13 @@ def test_main(patch_logger, mock_responses):
 
 @pytest.mark.asyncio
 async def test_upsert_index(mock_responses):
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
+    config = {
+        "elasticsearch": {
+            "host": "http://nowhere.com:9200",
+            "user": "tarek",
+            "password": "blah",
+        }
+    }
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -17,3 +17,4 @@ SQLAlchemy==2.0.1
 oracledb==1.2.2
 asyncpg==0.27.0
 pyodbc==4.0.34 # Latest version is v4.0.35. However it is not compatible with MAC M1 chip so pining this version
+aiofiles==22.1.0


### PR DESCRIPTION
Implements a disk-based file streamer. The streamer will be running on its separate process because:

- files operations will add more pressure on the event loop (CPU)
- we can tweak the max RSS allowed specifically for this attachments service
- the service will be very small in memory - as long as we don't import all libs
- the service can also process files from the crawler or the ruby service

**Refactorings**

- [x] Moved the sync service to its own module (`syncer.py`)
- [x] Created a `services` subdir
- [x] Created a base `Service` class
- [x] `cli.py` is now just focusing on starting the loop with the right service, `runner.py` is gone
- [x] Refactor tests
- [ ] make sure we don't import all connectors lib when we run just the file streamer


**New features**

- [x] Defined a disk-based standard 
- [x] Added `fstreamer.py` with the Stream service and the function to drop files for that service to grab
- [x] Use `ConcurrentRunner` in `byoei.py`
- [ ] Implement all tests
- [ ] Surface all options in the YAML file to configure the disk-based service
- [x] Allow connectors to pass an async generator for the `_attachment` field to stream a file. When it's detected, it's plugged into `FileDrop.drop_file` to the file is dumped on disk
- [x] use a source doc id in the json desc. the es doc is queried and the file is sent only of we find it
- [ ] Cloud support 
  - [ ] Add a program section in supervisord
  - [ ] Surface the max disk size option in the supervisor start script in the cloud so we can tweak it depending on the VM size
  - [ ] Add memmon support 
  

