### PR TITLE
Remove pipeline check

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -112,9 +112,7 @@ class BYOIndex(ESClient):
         )
 
     async def preflight(self):
-        await self.check_exists(
-            indices=[CONNECTORS_INDEX, JOBS_INDEX], pipelines=[PIPELINE]
-        )
+        await self.check_exists(indices=[CONNECTORS_INDEX, JOBS_INDEX])
 
     async def get_connectors(self, native_service_types=[], connectors_ids=[]):
         if len(native_service_types) == 0 and len(connectors_ids) == 0:

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -185,12 +185,12 @@ class ConnectorService:
                         native_service_types, connectors_ids
                     ):
                         await self._one_sync(connector, es, sync_now)
+                    if one_sync:
+                        break
                 except Exception as e:
                     logger.critical(e, exc_info=True)
                     self.raise_if_spurious(e)
-                finally:
-                    if one_sync:
-                        break
+
                 if not one_sync:
                     await self._sleeps.sleep(self.idling)
         finally:

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -180,7 +180,6 @@ class ConnectorService:
             while self.running:
                 try:
                     logger.debug(f"Polling every {self.idling} seconds")
-
                     async for connector in self.connectors.get_connectors(
                         native_service_types, connectors_ids
                     ):

--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -180,16 +180,17 @@ class ConnectorService:
             while self.running:
                 try:
                     logger.debug(f"Polling every {self.idling} seconds")
+
                     async for connector in self.connectors.get_connectors(
                         native_service_types, connectors_ids
                     ):
                         await self._one_sync(connector, es, sync_now)
-                    if one_sync:
-                        break
                 except Exception as e:
                     logger.critical(e, exc_info=True)
                     self.raise_if_spurious(e)
-
+                finally:
+                    if one_sync:
+                        break
                 if not one_sync:
                     await self._sleeps.sleep(self.idling)
         finally:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -120,7 +120,12 @@ class ESClient:
         await self.close()
         return False
 
-    async def check_exists(self, indices, pipelines):
+    async def check_exists(self, indices=None, pipelines=None):
+        if indices is None:
+            indices = []
+        if pipelines is None:
+            pipelines = []
+
         for index in indices:
             logger.debug(f"Checking for index {index} presence")
             if not await self.client.indices.exists(index=index):


### PR DESCRIPTION
## Closes  https://github.com/elastic/enterprise-search-team/issues/3425

Stop checking for the `pipeline` presence -- puts the Py service on par with the Ruby one
