### PR TITLE
[8.6] Fix makefile errors (#233)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint run ftest install dev
+.PHONY: test lint run ftest install dev release
 
 PYTHON=python3.10
 ARCH=$(shell uname -m)
@@ -38,13 +38,11 @@ lint: bin/python bin/black bin/elastic-ingest
 test:	bin/pytest bin/elastic-ingest
 	bin/pytest --cov-report term-missing --cov-report html --cov=connectors -sv connectors/tests connectors/sources/tests
 
-release:
-	install
+release: install
 	bin/python setup.py sdist
 
 ftest: bin/pytest bin/elastic-ingest
 	connectors/tests/ftest.sh $(NAME)
 
-run: 
-	install
+run: install
 	bin/elastic-ingest --debug


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix makefile errors (#233)