### PR TITLE
Added the `--uvloop` option

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -78,6 +78,13 @@ def _parser():
         help="Runs a single sync and exits.",
     )
 
+    parser.add_argument(
+        "--uvloop",
+        action="store_true",
+        default=False,
+        help="Use uvloop if possible",
+    )
+
     return parser
 
 
@@ -94,7 +101,7 @@ def run(args):
 
     service = SyncService(args)
     coro = service.run()
-    loop = get_event_loop()
+    loop = get_event_loop(args.uvloop)
 
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, functools.partial(service.shutdown, sig))

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -12,16 +12,6 @@ Event loop
 """
 import asyncio
 import time
-import functools
-
-# activate uvloop if present
-try:
-    import uvloop
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-except Exception:
-    pass
-
-from envyaml import EnvYAML
 
 from connectors.byoei import ElasticServer
 from connectors.byoc import (

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -12,6 +12,16 @@ Event loop
 """
 import asyncio
 import time
+import functools
+
+# activate uvloop if present
+try:
+    import uvloop
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+except Exception:
+    pass
+
+from envyaml import EnvYAML
 
 from connectors.byoei import ElasticServer
 from connectors.byoc import (

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -396,7 +396,15 @@ class ConcurrentTasks:
         await asyncio.gather(*self.tasks)
 
 
-def get_event_loop():
+def get_event_loop(uvloop=False):
+    if uvloop:
+        # activate uvloop if lib is present
+        try:
+            import uvloop
+
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        except Exception:
+            pass
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -8,3 +8,4 @@ pympler==1.0.1
 guppy3==3.1.2
 cron-schedule-triggers==0.0.11
 pytz==2019.3
+uvloop==0.17.0

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -8,4 +8,4 @@ pympler==1.0.1
 guppy3==3.1.2
 cron-schedule-triggers==0.0.11
 pytz==2019.3
-uvloop==0.17.0
+uvloop==0.17.0; sys_platform != 'win32'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 import sys
 import os
 from setuptools import setup, find_packages
-
+from setuptools._vendor.packaging.markers import Marker
 
 try:
     ARCH = os.uname().machine
@@ -36,17 +36,10 @@ from connectors import __version__  # NOQA
 def extract_req(req):
     req = req.strip().split(";")
     if len(req) > 1:
-        env_marker = req[-1]
-        env_marker = env_marker.replace(" ", "").strip()
-        # for now we just recognize sys_platform
-        if "sys_platform==" in env_marker:
-            target = env_marker.split("!=")[-1].strip()
-            target = target.strip('"').strip("'")
-            import pdb
-
-            pdb.set_trace()
-            if sys.platform == target:
-                return None
+        env_marker = req[-1].strip()
+        marker = Marker(env_marker)
+        if not marker.evaluate():
+            return None
     req = req[0]
     req = req.split("=")
     return req[0]

--- a/setup.py
+++ b/setup.py
@@ -32,16 +32,19 @@ from connectors import __version__  # NOQA
 # Because the *pinned* dependencies is what we tested
 #
 
+
 def extract_req(req):
-    req = req.strip().split(';')
+    req = req.strip().split(";")
     if len(req) > 1:
         env_marker = req[-1]
-        env_marker = env_marker.replace(' ', '').strip()
+        env_marker = env_marker.replace(" ", "").strip()
         # for now we just recognize sys_platform
-        if 'sys_platform==' in env_marker:
-            target = env_marker.split('!=')[-1].strip()
+        if "sys_platform==" in env_marker:
+            target = env_marker.split("!=")[-1].strip()
             target = target.strip('"').strip("'")
-            import pdb; pdb.set_trace()
+            import pdb
+
+            pdb.set_trace()
             if sys.platform == target:
                 return None
     req = req[0]

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,22 @@ from connectors import __version__  # NOQA
 # Because the *pinned* dependencies is what we tested
 #
 
+def extract_req(req):
+    req = req.strip().split(';')
+    if len(req) > 1:
+        env_marker = req[-1]
+        env_marker = env_marker.replace(' ', '').strip()
+        # for now we just recognize sys_platform
+        if 'sys_platform==' in env_marker:
+            target = env_marker.split('!=')[-1].strip()
+            target = target.strip('"').strip("'")
+            import pdb; pdb.set_trace()
+            if sys.platform == target:
+                return None
+    req = req[0]
+    req = req.split("=")
+    return req[0]
+
 
 def read_reqs(req_file):
     deps = []
@@ -47,12 +63,13 @@ def read_reqs(req_file):
                 subreq_file = req.split("-r")[-1].strip()
                 subreq_file = os.path.join(reqs_dir, subreq_file)
                 for subreq in read_reqs(subreq_file):
-                    dep = subreq.split("=")[0]
-                    if dep not in deps:
+
+                    dep = extract_req(subreq)
+                    if dep is not None and dep not in deps:
                         deps.append(dep)
             else:
-                dep = req.split("=")[0]
-                if dep not in deps:
+                dep = extract_req(req)
+                if dep is not None and dep not in deps:
                     deps.append(dep)
     return deps
 


### PR DESCRIPTION
On Linux or macOS, `--uvloop` will use the uvloop (NodeJS) eventloop instead of the system's queue/kqueue. 

Deactivated by default.