### PR TITLE
Remove query param from fetch_documents

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -234,12 +234,8 @@ class MySqlDataSource(BaseDataSource):
                 table_name = table[0]
                 logger.debug(f"Found table: {table_name} in database: {database}.")
 
-                # Query to get table's data
-                query = QUERIES["TABLE_DATA"].format(
-                    database=database, table=table_name
-                )
                 async for row in self.fetch_documents(
-                    database=database, table=table_name, query=query
+                    database=database, table=table_name
                 ):
                     yield row
         else:
@@ -286,13 +282,12 @@ class MySqlDataSource(BaseDataSource):
 
         return doc
 
-    async def fetch_documents(self, database, table, query):
+    async def fetch_documents(self, database, table):
         """Fetches all the table entries and format them in Elasticsearch documents
 
         Args:
             database (str): Name of database
             table (str): Name of table
-            query (str): Query to execute
 
         Yields:
             Dict: Document to be index

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -245,8 +245,6 @@ async def test_fetch_documents():
     source.connection_pool.acquire.cursor = Cursor
     source.connection_pool.acquire.cursor.is_connection_lost = False
 
-    query = "select * from table"
-
     # Execute
     with mock.patch.object(
         aiomysql, "create_pool", return_value=(await mock_mysql_response())
@@ -256,7 +254,7 @@ async def test_fetch_documents():
         mock.patch("source._connect", return_value=response)
 
     response = source.fetch_documents(
-        database="database_name", table="table_name", query=query
+        database="database_name", table="table_name"
     )
 
     # Assert


### PR DESCRIPTION
Noticed that `query` is passed into the method but never used, instead on the first line it's already overridden:

```python
 query = QUERIES["TABLE_PRIMARY_KEY"].format(database=database, table=table)
```

It looks like the `query` argument is not needed at all and is a leftover from recent refactorings.

Small additional note:

The method first assigns to `query` here:

```python
 query = QUERIES["TABLE_PRIMARY_KEY"].format(database=database, table=table)
```

And then reassigns it with:

```python
query = QUERIES["TABLE_DATA"].format(database=database, table=table)
```

It looks like a dangerous practice, should we rename them to respectively `table_primary_key_query` and `table_data_query`?