### PR TITLE
Tweak perf8 options

### DIFF
--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -109,7 +109,7 @@ class SyncService(BaseService):
                 await connector.close()
 
     async def run(self):
-        if 'PERF8' in os.environ:
+        if "PERF8" in os.environ:
             import perf8
 
             async with perf8.measure():

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -12,6 +12,7 @@ Event loop
 """
 import asyncio
 import time
+import os
 
 from connectors.byoei import ElasticServer
 from connectors.byoc import (
@@ -108,6 +109,15 @@ class SyncService(BaseService):
                 await connector.close()
 
     async def run(self):
+        if 'PERF8' in os.environ:
+            import perf8
+
+            async with perf8.measure():
+                return await self._run()
+        else:
+            return await self._run()
+
+    async def _run(self):
         """Main event loop."""
         one_sync = self.args.one_sync
         sync_now = self.args.sync_now

--- a/connectors/sources/tests/fixtures/mysql/loadsample.py
+++ b/connectors/sources/tests/fixtures/mysql/loadsample.py
@@ -9,8 +9,10 @@ import string
 import os
 
 
+DATA_SIZE = os.environ.get("DATA_SIZE", "small").lower()
 DATABASE_NAME = "customerinfo"
-NUM_TABLES = int(os.environ.get('NUM_TABLES', '30'))
+_SIZES = {"small": 5, "medium": 10, "large": 30}
+NUM_TABLES = _SIZES[DATA_SIZE]
 
 
 def random_text(k=1024 * 20):

--- a/connectors/sources/tests/fixtures/mysql/loadsample.py
+++ b/connectors/sources/tests/fixtures/mysql/loadsample.py
@@ -6,9 +6,11 @@
 from mysql.connector import connect
 import random
 import string
+import os
 
 
 DATABASE_NAME = "customerinfo"
+NUM_TABLES = int(os.environ.get('NUM_TABLES', '30'))
 
 
 def random_text(k=1024 * 20):
@@ -25,7 +27,7 @@ def main():
     cursor.execute(f"DROP DATABASE IF EXISTS {DATABASE_NAME}")
     cursor.execute(f"CREATE DATABASE {DATABASE_NAME}")
     cursor.execute(f"USE {DATABASE_NAME}")
-    for table in range(30):
+    for table in range(NUM_TABLES):
         print(f"Adding data in {table}...")
         sql_query = f"CREATE TABLE IF NOT EXISTS customers_{table} (name VARCHAR(255), age int, description LONGTEXT, PRIMARY KEY (name))"
         cursor.execute(sql_query)

--- a/connectors/sources/tests/fixtures/mysql/remove.py
+++ b/connectors/sources/tests/fixtures/mysql/remove.py
@@ -5,8 +5,11 @@
 #
 from mysql.connector import connect
 import random
+import os
+
 
 DATABASE_NAME = "customerinfo"
+NUM_TABLES = int(os.environ.get('NUM_TABLES', '30'))
 
 
 def main():
@@ -14,7 +17,7 @@ def main():
     database = connect(host="127.0.0.1", port=3306, user="root", password="changeme")
     cursor = database.cursor()
     cursor.execute(f"USE {DATABASE_NAME}")
-    for table in range(15):
+    for table in range(NUM_TABLES):
         print(f"Working on table {table}...")
         rows = [(f"user_{row_id}",) for row_id in random.sample(range(1, 1000), 10)]
         print(rows)

--- a/connectors/sources/tests/fixtures/mysql/remove.py
+++ b/connectors/sources/tests/fixtures/mysql/remove.py
@@ -8,8 +8,10 @@ import random
 import os
 
 
+DATA_SIZE = os.environ.get("DATA_SIZE", "small").lower()
 DATABASE_NAME = "customerinfo"
-NUM_TABLES = int(os.environ.get('NUM_TABLES', '30'))
+_SIZES = {"small": 5, "medium": 10, "large": 30}
+NUM_TABLES = _SIZES[DATA_SIZE]
 
 
 def main():

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -30,9 +30,9 @@ if [[ $PERF8 == "yes" ]]
 then
     if [[ $PLATFORM == "darwin" ]]
     then
-      $ROOT_DIR/bin/perf8 --memray --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
+      $ROOT_DIR/bin/perf8 -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --uvloop --debug
     else
-      $ROOT_DIR/bin/perf8 --memray --pyspy --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
+      $ROOT_DIR/bin/perf8 -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --pyspy --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
     fi
 else
     $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -30,9 +30,9 @@ if [[ $PERF8 == "yes" ]]
 then
     if [[ $PLATFORM == "darwin" ]]
     then
-      $ROOT_DIR/bin/perf8 -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --uvloop --debug
+      $ROOT_DIR/bin/perf8 --refresh-rate 5 -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
     else
-      $ROOT_DIR/bin/perf8 -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --pyspy --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
+      $ROOT_DIR/bin/perf8 --refresh-rate 5 -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --pyspy --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
     fi
 else
     $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -8,6 +8,9 @@ PERF8=$2
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR="$SCRIPT_DIR/../.."
 PLATFORM='unknown'
+export REFRESH_RATE="${REFRESH_RATE:-5}"
+export DATA_SIZE="${DATA_SIZE:-medium}"
+
 unamestr=$(uname)
 if [[ "$unamestr" == 'Linux' ]]; then
    PLATFORM='linux'
@@ -30,9 +33,9 @@ if [[ $PERF8 == "yes" ]]
 then
     if [[ $PLATFORM == "darwin" ]]
     then
-      $ROOT_DIR/bin/perf8 --refresh-rate 5 -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
+      $ROOT_DIR/bin/perf8 --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
     else
-      $ROOT_DIR/bin/perf8 --refresh-rate 5 -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --pyspy --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
+      $ROOT_DIR/bin/perf8 --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-ftest-report --asyncstats --memray --pyspy --psutil -c $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug
     fi
 else
     $ROOT_DIR/bin/elastic-ingest --one-sync --sync-now --debug


### PR DESCRIPTION
- plugged the `--asyncstats` plugin
- exposed `DATA_SIZE` so we can run various sizes of perf tests
- exposed `--refresh-rate` so we can lower the size of the reports on very long runs 