### PR TITLE
[8.5] Merge the headers from `elasticsearch:headers` (#243)

### DIFF
--- a/connectors/runner.py
+++ b/connectors/runner.py
@@ -63,6 +63,7 @@ class ConnectorService:
             "elasticsearch.host",
             "elasticsearch.username",
             "elasticsearch.password",
+            "elasticsearch.headers",
         ):
             sub = field.split(".")[-1]
             if field not in ent_search_config:

--- a/connectors/tests/entsearch.yml
+++ b/connectors/tests/entsearch.yml
@@ -2,4 +2,6 @@ elasticsearch:
   host: http://nowhere.com:9200
   user: elastic
   password: ${elasticsearch.password}
-
+  headers:
+    X-Elastic-Auth: SomeYeahValue
+    X-Something: 1

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -565,7 +565,7 @@ async def test_connector_service_poll_trace_mem(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_with_entsearch(
-    mock_responses, patch_logger, patch_ping, set_env  # , catch_stdout
+    mock_responses, patch_logger, patch_ping, set_env, catch_stdout
 ):
     with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG}):
         def connectors_read(url, **kw):
@@ -574,7 +574,7 @@ async def test_connector_service_poll_with_entsearch(
             return CallbackResult(status=200, payload={})
 
         await set_server_responses(mock_responses, connectors_update=connectors_read)
-        service = create_service(CONFIG)
+        service = ConnectorService(CONFIG)
         asyncio.get_event_loop().call_soon(service.stop)
         await service.poll()
         for log in patch_logger.logs:

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -565,11 +565,16 @@ async def test_connector_service_poll_trace_mem(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_with_entsearch(
-    mock_responses, patch_logger, patch_ping, set_env, catch_stdout
+    mock_responses, patch_logger, patch_ping, set_env  # , catch_stdout
 ):
     with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG}):
-        await set_server_responses(mock_responses)
-        service = ConnectorService(CONFIG)
+        def connectors_read(url, **kw):
+            assert kw["headers"]["x-elastic-auth"] == "SomeYeahValue"
+
+            return CallbackResult(status=200, payload={})
+
+        await set_server_responses(mock_responses, connectors_update=connectors_read)
+        service = create_service(CONFIG)
         asyncio.get_event_loop().call_soon(service.stop)
         await service.poll()
         for log in patch_logger.logs:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -74,6 +74,8 @@ class ESClient:
         self.max_wait_duration = config.get("max_wait_duration", 60)
         self.initial_backoff_duration = config.get("initial_backoff_duration", 5)
         self.backoff_multiplier = config.get("backoff_multiplier", 2)
+        if "headers" in config:
+            options["headers"] = config["headers"]
         self.client = AsyncElasticsearch(**options)
         self._keep_waiting = True
 


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Merge the headers from `elasticsearch:headers` (#243)