### PR TITLE
Add rule for flake8 to enforce imports order + make autoformat now sorts imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile = black
+skip=lib

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
 profile = black
-skip=lib
+skip=lib,bin

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ clean:
 	rm -rf bin lib include
 
 lint: bin/python bin/black bin/elastic-ingest
+	bin/isort --check . --sp .isort.cfg
 	bin/black --check connectors
 	bin/black --check setup.py
 	bin/flake8 connectors --exclude fixtures
@@ -39,12 +40,10 @@ lint: bin/python bin/black bin/elastic-ingest
 	bin/flake8 scripts
 
 autoformat: bin/python bin/black bin/elastic-ingest
+	bin/isort . --sp .isort.cfg
 	bin/black connectors
 	bin/black setup.py
 	bin/black scripts
-	bin/isort connectors
-	bin/isort setup.py
-	bin/isort scripts
 
 test:	bin/pytest bin/elastic-ingest
 	bin/pytest --cov-report term-missing --cov-report html --cov=connectors -sv connectors/tests connectors/sources/tests

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ autoformat: bin/python bin/black bin/elastic-ingest
 	bin/black connectors
 	bin/black setup.py
 	bin/black scripts
+	bin/isort connectors
+	bin/isort setup.py
+	bin/isort scripts
 
 test:	bin/pytest bin/elastic-ingest
 	bin/pytest --cov-report term-missing --cov-report html --cov=connectors -sv connectors/tests connectors/sources/tests

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -7,17 +7,14 @@
 Implementation of BYOC protocol.
 """
 import asyncio
-from enum import Enum
 import time
 from datetime import datetime, timezone
+from enum import Enum
 
-from connectors.utils import (
-    iso_utc,
-    next_run,
-)
+from connectors.es import DEFAULT_LANGUAGE, ESIndex, defaults_for
 from connectors.logger import logger
 from connectors.source import DataSourceConfiguration, get_source_klass
-from connectors.es import ESIndex, defaults_for, DEFAULT_LANGUAGE
+from connectors.utils import iso_utc, next_run
 
 CONNECTORS_INDEX = ".elastic-connectors"
 JOBS_INDEX = ".elastic-connectors-sync-jobs"

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -19,30 +19,21 @@ Implementation of BYOEI protocol (+some ids collecting)
 Elasticsearch <== Bulker <== queue <== Fetcher <== generator
 
 """
+import asyncio
 import copy
+import functools
 import time
 from collections import defaultdict
-import functools
-import asyncio
 
 from elasticsearch import NotFoundError as ElasticNotFoundError
 from elasticsearch.helpers import async_scan
 
 from connectors.logger import logger
-from connectors.utils import (
-    iso_utc,
-    ESClient,
-    get_size,
-    DEFAULT_CHUNK_SIZE,
-    DEFAULT_QUEUE_SIZE,
-    DEFAULT_QUEUE_MEM_SIZE,
-    DEFAULT_CHUNK_MEM_SIZE,
-    DEFAULT_DISPLAY_EVERY,
-    DEFAULT_MAX_CONCURRENCY,
-    MemQueue,
-    ConcurrentTasks,
-)
-
+from connectors.utils import (DEFAULT_CHUNK_MEM_SIZE, DEFAULT_CHUNK_SIZE,
+                              DEFAULT_DISPLAY_EVERY, DEFAULT_MAX_CONCURRENCY,
+                              DEFAULT_QUEUE_MEM_SIZE, DEFAULT_QUEUE_SIZE,
+                              ConcurrentTasks, ESClient, MemQueue, get_size,
+                              iso_utc)
 
 OP_INDEX = "index"
 OP_UPSERT = "update"

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -29,11 +29,19 @@ from elasticsearch import NotFoundError as ElasticNotFoundError
 from elasticsearch.helpers import async_scan
 
 from connectors.logger import logger
-from connectors.utils import (DEFAULT_CHUNK_MEM_SIZE, DEFAULT_CHUNK_SIZE,
-                              DEFAULT_DISPLAY_EVERY, DEFAULT_MAX_CONCURRENCY,
-                              DEFAULT_QUEUE_MEM_SIZE, DEFAULT_QUEUE_SIZE,
-                              ConcurrentTasks, ESClient, MemQueue, get_size,
-                              iso_utc)
+from connectors.utils import (
+    DEFAULT_CHUNK_MEM_SIZE,
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_DISPLAY_EVERY,
+    DEFAULT_MAX_CONCURRENCY,
+    DEFAULT_QUEUE_MEM_SIZE,
+    DEFAULT_QUEUE_SIZE,
+    ConcurrentTasks,
+    ESClient,
+    MemQueue,
+    get_size,
+    iso_utc,
+)
 
 OP_INDEX = "index"
 OP_UPSERT = "update"

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -8,20 +8,20 @@ Command Line Interface.
 
 Parses arguments and call run() with them.
 """
-from argparse import ArgumentParser
-import os
-import logging
 import asyncio
-import signal
 import functools
+import logging
+import os
+import signal
+from argparse import ArgumentParser
 
 from envyaml import EnvYAML
 
+from connectors import __version__
 from connectors.logger import logger, set_logger
+from connectors.services.sync import SyncService
 from connectors.source import get_data_sources
 from connectors.utils import get_event_loop
-from connectors import __version__
-from connectors.services.sync import SyncService
 
 
 def _parser():

--- a/connectors/conftest.py
+++ b/connectors/conftest.py
@@ -3,11 +3,11 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import io
-import sys
-import os
 import asyncio
+import io
+import os
 import re
+import sys
 import traceback
 
 import pytest

--- a/connectors/es/__init__.py
+++ b/connectors/es/__init__.py
@@ -4,9 +4,5 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 from connectors.es.index import ESIndex  # NOQA
-from connectors.es.settings import (  # NOQA
-    Mappings,
-    Settings,
-    defaults_for,
-    DEFAULT_LANGUAGE,
-)
+from connectors.es.settings import (DEFAULT_LANGUAGE, Mappings,  # NOQA
+                                    Settings, defaults_for)

--- a/connectors/es/__init__.py
+++ b/connectors/es/__init__.py
@@ -4,5 +4,9 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 from connectors.es.index import ESIndex  # NOQA
-from connectors.es.settings import (DEFAULT_LANGUAGE, Mappings,  # NOQA
-                                    Settings, defaults_for)
+from connectors.es.settings import (  # NOQA
+    DEFAULT_LANGUAGE,
+    Mappings,
+    Settings,
+    defaults_for,
+)

--- a/connectors/es/settings.py
+++ b/connectors/es/settings.py
@@ -3,9 +3,10 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from os import path
-import yaml
 import copy
+from os import path
+
+import yaml
 
 ENUM_IGNORE_ABOVE = 2048
 

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -3,10 +3,10 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import sys
-import os
 import asyncio
 import logging
+import os
+import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 
 import elasticsearch
@@ -16,7 +16,6 @@ from connectors.byoei import ElasticServer
 from connectors.logger import logger, set_logger
 from connectors.source import get_source_klass
 from connectors.utils import validate_index_name
-
 
 CONNECTORS_INDEX = ".elastic-connectors"
 JOBS_INDEX = ".elastic-connectors-sync-jobs"

--- a/connectors/logger.py
+++ b/connectors/logger.py
@@ -6,9 +6,11 @@
 """
 Logger -- sets the logging and provides a `logger` global object.
 """
-from datetime import datetime
 import logging
+from datetime import datetime
+
 import ecs_logging
+
 from connectors import __version__
 
 logger = None

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -4,7 +4,9 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import os
+
 from envyaml import EnvYAML
+
 from connectors.logger import logger
 
 

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -11,22 +11,16 @@ Event loop
 - mirrors an Elasticsearch index with a collection of documents
 """
 import asyncio
-import time
 import os
+import time
 
+from connectors.byoc import (BYOIndex, ConnectorUpdateError, DataSourceError,
+                             ServiceTypeNotConfiguredError,
+                             ServiceTypeNotSupportedError, Status, e2str)
 from connectors.byoei import ElasticServer
-from connectors.byoc import (
-    BYOIndex,
-    Status,
-    e2str,
-    ServiceTypeNotConfiguredError,
-    ConnectorUpdateError,
-    ServiceTypeNotSupportedError,
-    DataSourceError,
-)
 from connectors.logger import logger
-from connectors.utils import CancellableSleeps, trace_mem
 from connectors.services.base import BaseService
+from connectors.utils import CancellableSleeps, trace_mem
 
 
 class SyncService(BaseService):

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -14,9 +14,15 @@ import asyncio
 import os
 import time
 
-from connectors.byoc import (BYOIndex, ConnectorUpdateError, DataSourceError,
-                             ServiceTypeNotConfiguredError,
-                             ServiceTypeNotSupportedError, Status, e2str)
+from connectors.byoc import (
+    BYOIndex,
+    ConnectorUpdateError,
+    DataSourceError,
+    ServiceTypeNotConfiguredError,
+    ServiceTypeNotSupportedError,
+    Status,
+    e2str,
+)
 from connectors.byoei import ElasticServer
 from connectors.logger import logger
 from connectors.services.base import BaseService

--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -6,13 +6,13 @@
 """
 Demo of a standalone source
 """
-import os
-from pathlib import Path
-import hashlib
 import functools
+import hashlib
+import os
 from datetime import datetime, timezone
-from connectors.utils import get_base64_value, TIKA_SUPPORTED_FILETYPES
+from pathlib import Path
 
+from connectors.utils import TIKA_SUPPORTED_FILETYPES, get_base64_value
 
 HERE = os.path.dirname(__file__)
 DEFAULT_CONTENT_EXTRACTION = True

--- a/connectors/sources/gcs.py
+++ b/connectors/sources/gcs.py
@@ -16,8 +16,8 @@ from aiogoogle import Aiogoogle
 from aiogoogle.auth.creds import ServiceAccountCreds
 
 from connectors.logger import logger
-from connectors.utils import get_base64_value, TIKA_SUPPORTED_FILETYPES
 from connectors.source import BaseDataSource
+from connectors.utils import TIKA_SUPPORTED_FILETYPES, get_base64_value
 
 CLOUD_STORAGE_READ_ONLY_SCOPE = "https://www.googleapis.com/auth/devstorage.read_only"
 CLOUD_STORAGE_BASE_URL = "https://console.cloud.google.com/storage/browser/_details/"

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -3,13 +3,14 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from datetime import datetime
 import asyncio
+from datetime import datetime
+
 from bson import Decimal128
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from connectors.source import BaseDataSource
 from connectors.logger import logger
+from connectors.source import BaseDataSource
 
 
 class MongoDataSource(BaseDataSource):

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -15,8 +15,7 @@ from smbprotocol.exceptions import SMBException, SMBOSError
 
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.utils import (TIKA_SUPPORTED_FILETYPES, get_base64_value,
-                              iso_utc)
+from connectors.utils import TIKA_SUPPORTED_FILETYPES, get_base64_value, iso_utc
 
 MAX_CHUNK_SIZE = 65536
 DEFAULT_CONTENT_EXTRACTION = True

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -8,14 +8,15 @@
 import asyncio
 import os
 from functools import partial
+from io import BytesIO
 
 import smbclient
-from io import BytesIO
-from connectors.logger import logger
-from connectors.source import BaseDataSource
-from connectors.utils import iso_utc, get_base64_value, TIKA_SUPPORTED_FILETYPES
 from smbprotocol.exceptions import SMBException, SMBOSError
 
+from connectors.logger import logger
+from connectors.source import BaseDataSource
+from connectors.utils import (TIKA_SUPPORTED_FILETYPES, get_base64_value,
+                              iso_utc)
 
 MAX_CHUNK_SIZE = 65536
 DEFAULT_CONTENT_EXTRACTION = True

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -6,21 +6,21 @@
 import asyncio
 import logging
 import os
+from contextlib import asynccontextmanager
 from functools import partial
 from hashlib import md5
+from io import BytesIO
 
 import aioboto3
-from io import BytesIO
-from aiobotocore.response import AioReadTimeoutError
-from aiohttp.client_exceptions import ServerTimeoutError
 from aiobotocore.config import AioConfig
+from aiobotocore.response import AioReadTimeoutError
 from aiobotocore.utils import logger as aws_logger
+from aiohttp.client_exceptions import ServerTimeoutError
 from botocore.exceptions import ClientError
-from contextlib import asynccontextmanager
+
 from connectors.logger import logger, set_extra_logger
 from connectors.source import BaseDataSource
-from connectors.utils import get_base64_value, TIKA_SUPPORTED_FILETYPES
-
+from connectors.utils import TIKA_SUPPORTED_FILETYPES, get_base64_value
 
 MAX_CHUNK_SIZE = 1048576
 DEFAULT_MAX_FILE_SIZE = 10485760

--- a/connectors/sources/tests/fixtures/gcs/loadsample.py
+++ b/connectors/sources/tests/fixtures/gcs/loadsample.py
@@ -7,6 +7,7 @@
 """
 import random
 import string
+
 from google.auth.credentials import AnonymousCredentials
 from google.cloud import storage
 

--- a/connectors/sources/tests/fixtures/mysql/loadsample.py
+++ b/connectors/sources/tests/fixtures/mysql/loadsample.py
@@ -3,11 +3,11 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from mysql.connector import connect
+import os
 import random
 import string
-import os
 
+from mysql.connector import connect
 
 DATA_SIZE = os.environ.get("DATA_SIZE", "small").lower()
 DATABASE_NAME = "customerinfo"

--- a/connectors/sources/tests/fixtures/mysql/remove.py
+++ b/connectors/sources/tests/fixtures/mysql/remove.py
@@ -3,10 +3,10 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from mysql.connector import connect
-import random
 import os
+import random
 
+from mysql.connector import connect
 
 DATA_SIZE = os.environ.get("DATA_SIZE", "small").lower()
 DATABASE_NAME = "customerinfo"

--- a/connectors/sources/tests/fixtures/network_drive/loadsample.py
+++ b/connectors/sources/tests/fixtures/network_drive/loadsample.py
@@ -5,9 +5,10 @@
 #
 """Network Drive module responsible to generate file/folder(s) on Network Drive server.
 """
-import smbclient
 import random
 import string
+
+import smbclient
 
 SERVER = "127.0.0.1"
 NUMBER_OF_SMALL_FILES = 10000

--- a/connectors/sources/tests/fixtures/s3/load_storage.py
+++ b/connectors/sources/tests/fixtures/s3/load_storage.py
@@ -1,7 +1,8 @@
-import boto3
-import sys
 import random
 import string
+import sys
+
+import boto3
 
 BUCKET_NAME = "ent-search-ingest-dev"
 REGION_NAME = "us-west-2"

--- a/connectors/sources/tests/fixtures/s3/remove.py
+++ b/connectors/sources/tests/fixtures/s3/remove.py
@@ -1,5 +1,6 @@
-import boto3
 import sys
+
+import boto3
 
 BUCKET_NAME = "ent-search-ingest-dev"
 REGION_NAME = "us-west-2"

--- a/connectors/sources/tests/test_directory.py
+++ b/connectors/sources/tests/test_directory.py
@@ -4,8 +4,9 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import pytest
-from connectors.sources.directory import DirectoryDataSource, HERE
-from connectors.sources.tests.support import create_source, assert_basics
+
+from connectors.sources.directory import HERE, DirectoryDataSource
+from connectors.sources.tests.support import assert_basics, create_source
 
 
 @pytest.mark.asyncio

--- a/connectors/sources/tests/test_gcs.py
+++ b/connectors/sources/tests/test_gcs.py
@@ -13,7 +13,7 @@ from unittest import mock
 import pytest
 from aiogoogle import Aiogoogle
 from aiogoogle.auth.managers import ServiceAccountManager
-from aiogoogle.models import Response, Request
+from aiogoogle.models import Request, Response
 
 from connectors.source import DataSourceConfiguration
 from connectors.sources.gcs import GoogleCloudStorageDataSource

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -10,7 +10,7 @@ import pytest
 from bson.decimal128 import Decimal128
 
 from connectors.sources.mongo import MongoDataSource
-from connectors.sources.tests.support import create_source, assert_basics
+from connectors.sources.tests.support import assert_basics, create_source
 
 
 @pytest.mark.asyncio

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -5,10 +5,10 @@
 #
 """Tests the MySQL source class methods"""
 import asyncio
-import ssl
 import datetime
 import decimal
 import random
+import ssl
 from decimal import Decimal
 from unittest import mock
 

--- a/connectors/sources/tests/test_network_drive.py
+++ b/connectors/sources/tests/test_network_drive.py
@@ -7,15 +7,16 @@
 """
 import asyncio
 import datetime
+from io import BytesIO
 from unittest import mock
 
 import pytest
 import smbclient
-from io import BytesIO
+from smbprotocol.exceptions import LogonFailure, SMBOSError
+
 from connectors.source import DataSourceConfiguration
 from connectors.sources.network_drive import NASDataSource
 from connectors.sources.tests.support import create_source
-from smbprotocol.exceptions import LogonFailure, SMBOSError
 
 READ_COUNT = 0
 MAX_CHUNK_SIZE = 65536

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import aioboto3
 import pytest
+
 from connectors.sources.s3 import S3DataSource
 from connectors.sources.tests.support import assert_basics, create_source
 

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -6,25 +6,17 @@
 import asyncio
 import json
 import os
-from envyaml import EnvYAML
 from datetime import datetime
 
+import pytest
 from aioresponses import CallbackResult
 from elasticsearch import AsyncElasticsearch
-import pytest
+from envyaml import EnvYAML
 
-from connectors.source import BaseDataSource
+from connectors.byoc import (BYOConnector, BYOIndex, JobStatus, Status,
+                             SyncJob, e2str, iso_utc)
 from connectors.byoei import ElasticServer
-from connectors.byoc import (
-    e2str,
-    Status,
-    iso_utc,
-    SyncJob,
-    JobStatus,
-    BYOIndex,
-    BYOConnector,
-)
-
+from connectors.source import BaseDataSource
 
 CONFIG = os.path.join(os.path.dirname(__file__), "config.yml")
 

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -13,8 +13,15 @@ from aioresponses import CallbackResult
 from elasticsearch import AsyncElasticsearch
 from envyaml import EnvYAML
 
-from connectors.byoc import (BYOConnector, BYOIndex, JobStatus, Status,
-                             SyncJob, e2str, iso_utc)
+from connectors.byoc import (
+    BYOConnector,
+    BYOIndex,
+    JobStatus,
+    Status,
+    SyncJob,
+    e2str,
+    iso_utc,
+)
 from connectors.byoei import ElasticServer
 from connectors.source import BaseDataSource
 

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -4,6 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import datetime
+
 import pytest
 
 from connectors.byoc import PipelineSettings

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -8,9 +8,8 @@ import os
 import signal
 from unittest import mock
 
-from connectors.cli import main, run
 from connectors import __version__
-
+from connectors.cli import main, run
 
 CONFIG = os.path.join(os.path.dirname(__file__), "config.yml")
 

--- a/connectors/tests/test_es_index.py
+++ b/connectors/tests/test_es_index.py
@@ -5,6 +5,7 @@
 #
 
 import pytest
+
 from connectors.es.index import ESIndex
 
 

--- a/connectors/tests/test_es_settings.py
+++ b/connectors/tests/test_es_settings.py
@@ -3,17 +3,14 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import pytest
 import json
-from connectors.es.settings import (
-    Mappings,
-    Settings,
-    UnsupportedLanguageCode,
-    DEFAULT_LANGUAGE,
-    NON_ICU_ANALYSIS_SETTINGS,
-    ICU_ANALYSIS_SETTINGS,
-    defaults_for,
-)
+
+import pytest
+
+from connectors.es.settings import (DEFAULT_LANGUAGE, ICU_ANALYSIS_SETTINGS,
+                                    NON_ICU_ANALYSIS_SETTINGS, Mappings,
+                                    Settings, UnsupportedLanguageCode,
+                                    defaults_for)
 
 EXPECTED_CONNECTORS_PROPS = ["id", "_subextracted_as_of", "_subextracted_version"]
 

--- a/connectors/tests/test_es_settings.py
+++ b/connectors/tests/test_es_settings.py
@@ -7,10 +7,15 @@ import json
 
 import pytest
 
-from connectors.es.settings import (DEFAULT_LANGUAGE, ICU_ANALYSIS_SETTINGS,
-                                    NON_ICU_ANALYSIS_SETTINGS, Mappings,
-                                    Settings, UnsupportedLanguageCode,
-                                    defaults_for)
+from connectors.es.settings import (
+    DEFAULT_LANGUAGE,
+    ICU_ANALYSIS_SETTINGS,
+    NON_ICU_ANALYSIS_SETTINGS,
+    Mappings,
+    Settings,
+    UnsupportedLanguageCode,
+    defaults_for,
+)
 
 EXPECTED_CONNECTORS_PROPS = ["id", "_subextracted_as_of", "_subextracted_version"]
 

--- a/connectors/tests/test_kibana.py
+++ b/connectors/tests/test_kibana.py
@@ -5,8 +5,8 @@
 #
 import os
 from unittest import mock
-from connectors.kibana import main
 
+from connectors.kibana import main
 
 HERE = os.path.dirname(__file__)
 

--- a/connectors/tests/test_logger.py
+++ b/connectors/tests/test_logger.py
@@ -3,8 +3,8 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import logging
 import json
+import logging
 from contextlib import contextmanager
 
 import connectors.logger

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -5,8 +5,13 @@
 #
 import pytest
 
-from connectors.source import (BaseDataSource, DataSourceConfiguration, Field,
-                               get_data_sources, get_source_klass)
+from connectors.source import (
+    BaseDataSource,
+    DataSourceConfiguration,
+    Field,
+    get_data_sources,
+    get_source_klass,
+)
 
 CONFIG = {
     "host": {

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -5,14 +5,8 @@
 #
 import pytest
 
-from connectors.source import (
-    Field,
-    DataSourceConfiguration,
-    get_source_klass,
-    get_data_sources,
-    BaseDataSource,
-)
-
+from connectors.source import (BaseDataSource, DataSourceConfiguration, Field,
+                               get_data_sources, get_source_klass)
 
 CONFIG = {
     "host": {

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -3,19 +3,19 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import copy
-import os
-import pytest
 import asyncio
+import copy
 import json
+import os
 from unittest import mock
+
+import pytest
 from aioresponses import CallbackResult
 
-from connectors.services.sync import SyncService
 from connectors.byoc import DataSourceError
 from connectors.conftest import assert_re
+from connectors.services.sync import SyncService
 from connectors.tests.fake_sources import FakeSourceTS
-
 
 CONFIG = os.path.join(os.path.dirname(__file__), "config.yml")
 ES_CONFIG = os.path.join(os.path.dirname(__file__), "entsearch.yml")

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -4,22 +4,16 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
-import time
-import functools
 import base64
+import functools
+import time
 
 import pytest
 from pympler import asizeof
 
-from connectors.utils import (
-    next_run,
-    validate_index_name,
-    InvalidIndexNameError,
-    ESClient,
-    MemQueue,
-    get_base64_value,
-    ConcurrentTasks,
-)
+from connectors.utils import (ConcurrentTasks, ESClient, InvalidIndexNameError,
+                              MemQueue, get_base64_value, next_run,
+                              validate_index_name)
 
 
 def test_next_run():

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -11,9 +11,15 @@ import time
 import pytest
 from pympler import asizeof
 
-from connectors.utils import (ConcurrentTasks, ESClient, InvalidIndexNameError,
-                              MemQueue, get_base64_value, next_run,
-                              validate_index_name)
+from connectors.utils import (
+    ConcurrentTasks,
+    ESClient,
+    InvalidIndexNameError,
+    MemQueue,
+    get_base64_value,
+    next_run,
+    validate_index_name,
+)
 
 
 def test_next_run():

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -3,29 +3,25 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from datetime import datetime, timezone
-import base64
-import logging
-import time
 import asyncio
-import tracemalloc
-import gc
+import base64
 import contextlib
 import functools
+import gc
+import logging
+import time
+import tracemalloc
+from datetime import datetime, timezone
 
-from elasticsearch import (
-    AsyncElasticsearch,
-    ApiError,
-    ConnectionError as ElasticConnectionError,
-    NotFoundError,
-)
+from cstriggers.core.trigger import QuartzCron
 from elastic_transport.client_utils import url_to_node_config
+from elasticsearch import ApiError, AsyncElasticsearch
+from elasticsearch import ConnectionError as ElasticConnectionError
+from elasticsearch import NotFoundError
 from guppy import hpy
 from pympler import asizeof
-from cstriggers.core.trigger import QuartzCron
 
-from connectors.logger import set_extra_logger, logger
-
+from connectors.logger import logger, set_extra_logger
 
 DEFAULT_CHUNK_SIZE = 500
 DEFAULT_QUEUE_SIZE = 1024

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,8 @@
 # tests
 black>=22.6.0
 flake8>=4.0.1
+flake8-import-order>=0.18.2
+isort>=5.11.3
 aioresponses>=0.7.3
 pytest>=7.1.2
 pytest-cov>=3.0.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,7 +1,6 @@
 # tests
 black>=22.6.0
 flake8>=4.0.1
-flake8-import-order>=0.18.2
 isort>=5.11.3
 aioresponses>=0.7.3
 pytest>=7.1.2

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -3,9 +3,10 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import os
 import asyncio
+import os
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+
 import yaml
 from elasticsearch import AsyncElasticsearch
 

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import sys
 import os
-from setuptools import setup, find_packages
+import sys
+
+from setuptools import find_packages, setup
 from setuptools._vendor.packaging.markers import Marker
 
 try:
@@ -19,7 +20,6 @@ if sys.version_info.minor < 10:
     raise ValueError("Requires Python 3.10 or superior.")
 
 from connectors import __version__  # NOQA
-
 
 # We feed install_requires with `requirements.txt` but we unpin versions so we
 # don't enforce them and trap folks into dependency hell. (only works with `==` here)


### PR DESCRIPTION
Changes in the PR:

1. Add [isort](https://pycqa.github.io/isort/) package.
2. `isort` is used in `make lint` to verify that all imports are sorted in the correct order
3. `isort` is used in `make autoformat` to automatically sort imports
4. `make autoformat` is ran to sort imports correctly.

It's safe to make a github pre-commit hook to do `make autoformat` that will do the sorting for you.