### PR TITLE
fixed an intermittent+leftover from a merge

### DIFF
--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -488,7 +488,7 @@ async def test_connector_service_poll_trace_mem(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_with_entsearch(
-    mock_responses, patch_logger, patch_ping, set_env  # , catch_stdout
+    mock_responses, patch_logger, patch_ping, set_env, catch_stdout
 ):
     with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG}):
 

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -23,8 +23,8 @@ from connectors.utils import (
 
 
 def test_next_run():
-
-    assert next_run("1 * * * * *") < 70.0
+    # can run within two minutes
+    assert next_run("1 * * * * *") < 120
     assert next_run("* * * * * *") == 0
 
     # this should get parsed


### PR DESCRIPTION

- The cron test can fail if the time is at the last second of the minute, so we just check it runs under 2 min
- left over from a merge, we do want to catch stdout in that test