### PR TITLE
Add BasicRule class matching documents against a basic rule

### DIFF
--- a/connectors/filtering/__init__.py
+++ b/connectors/filtering/__init__.py
@@ -3,5 +3,3 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-
-from connectors.filtering.basic_rule import BasicRule

--- a/connectors/filtering/__init__.py
+++ b/connectors/filtering/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+from connectors.filtering.basic_rule import BasicRule

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -3,12 +3,11 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import datetime
-import re
-
 from connectors.logger import logger
+import datetime
 from dateutil.parser import *
 from enum import Enum
+import re
 
 
 class BasicRule:
@@ -118,7 +117,8 @@ class BasicRule:
                 case _:
                     return str(self.value)
         except ValueError as e:
-            logger.debug(f"Failed to coerce value '{self.value}' ({type(self.value)}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}")
+            logger.debug(
+                f"Failed to coerce value '{self.value}' ({type(self.value)}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}")
             return str(self.value)
 
     @staticmethod

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -12,21 +12,69 @@ from dateutil.parser import ParserError, parser
 from connectors.logger import logger
 
 
+def to_float(value):
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def to_datetime(value):
+    try:
+        date_parser = parser()
+        parsed_date_or_datetime = date_parser.parse(timestr=value)
+
+        if isinstance(parsed_date_or_datetime, datetime.datetime):
+            return parsed_date_or_datetime
+        elif isinstance(parsed_date_or_datetime, datetime.date):
+            # adds 00:00 to the date and returns datetime
+            return datetime.datetime.combine(parsed_date_or_datetime, datetime.time.min)
+        else:
+            return value
+
+    except ParserError:
+        return value
+
+
+def to_bool(value):
+    if len(value) == 0 or re.match("^(false|f|no|n|off)$", value):
+        return False
+
+    if re.match("^(true|t|yes|y|on)$", value):
+        return True
+
+    return value
+
+
+def try_coerce(value):
+    coerced_value = to_float(value)
+
+    if isinstance(coerced_value, str):
+        coerced_value = to_datetime(value)
+
+    if isinstance(coerced_value, str):
+        coerced_value = to_bool(value)
+
+    return coerced_value
+
+
+class Rule(Enum):
+    EQUALS = 1
+    STARTS_WITH = 2
+    ENDS_WITH = 3
+    CONTAINS = 4
+    REGEX = 5
+    GREATER_THAN = 6
+    LESS_THAN = 7
+
+
+class Policy(Enum):
+    INCLUDE = 1
+    EXCLUDE = 2
+
+
 class BasicRule:
     DEFAULT_RULE_ID = "DEFAULT"
-
-    class Policy(Enum):
-        INCLUDE = 1
-        EXCLUDE = 2
-
-    class Rule(Enum):
-        EQUALS = 1
-        STARTS_WITH = 2
-        ENDS_WITH = 3
-        CONTAINS = 4
-        REGEX = 5
-        GREATER_THAN = 6
-        LESS_THAN = 7
 
     def __init__(self, id_, order, policy, field, rule, value):
         self._id = id_
@@ -36,142 +84,84 @@ class BasicRule:
         self._rule = rule
         self._value = value
 
-    @staticmethod
-    def default_rule():
-        return BasicRule(
+    @classmethod
+    def default_rule(cls):
+        return cls(
             id_=BasicRule.DEFAULT_RULE_ID,
             order=0,
-            policy=BasicRule.Policy.INCLUDE,
+            policy=Policy.INCLUDE,
             field="_",
-            rule=BasicRule.Rule.EQUALS,
+            rule=Rule.EQUALS,
             value=".*",
         )
 
-    def matches_document(self, document):
-        if self.is_default_rule:
+    def matches(self, document):
+        if self.is_default_rule():
             return True
 
-        if self.field not in document:
+        if self.field() not in document:
             return False
 
-        document_value = document[self.field]
+        document_value = document[self.field()]
         coerced_rule_value = self.coerce_rule_value_based_on_document_value(
             document_value
         )
 
-        match self.rule:
-            case BasicRule.Rule.STARTS_WITH:
-                return str(document_value).startswith(self.value)
-            case BasicRule.Rule.ENDS_WITH:
-                return str(document_value).endswith(self.value)
-            case BasicRule.Rule.CONTAINS:
-                return self.value in str(document_value)
-            case BasicRule.Rule.REGEX:
-                return re.match(self.value, str(document_value)) is not None
-            case BasicRule.Rule.LESS_THAN:
+        match self.rule():
+            case Rule.STARTS_WITH:
+                return str(document_value).startswith(self.value())
+            case Rule.ENDS_WITH:
+                return str(document_value).endswith(self.value())
+            case Rule.CONTAINS:
+                return self.value() in str(document_value)
+            case Rule.REGEX:
+                return re.match(self.value(), str(document_value)) is not None
+            case Rule.LESS_THAN:
                 return document_value < coerced_rule_value
-            case BasicRule.Rule.GREATER_THAN:
+            case Rule.GREATER_THAN:
                 return document_value > coerced_rule_value
-            case BasicRule.Rule.EQUALS:
+            case Rule.EQUALS:
                 return document_value == coerced_rule_value
 
-        return False
-
-    @property
     def id_(self):
         return self._id
 
-    @property
     def order(self):
         return self._order
 
-    @property
     def policy(self):
         return self._policy
 
-    @property
     def field(self):
         return self._field
 
-    @property
     def rule(self):
         return self._rule
 
-    @property
     def value(self):
         return self._value
 
-    @property
     def is_default_rule(self):
-        return self.id_ == BasicRule.DEFAULT_RULE_ID
+        return self.id_() == BasicRule.DEFAULT_RULE_ID
 
-    @property
     def is_include(self):
-        return self.policy == BasicRule.Policy.INCLUDE
+        return self.policy() == Policy.INCLUDE
 
     def coerce_rule_value_based_on_document_value(self, doc_value):
         try:
             match doc_value:
                 case str():
-                    return str(self.value)
+                    return str(self.value())
                 case bool():
-                    return str(BasicRule.__to_bool(self.value))
+                    return str(to_bool(self.value()))
                 case float() | int():
-                    return float(self.value)
+                    return float(self.value())
                 case datetime.date() | datetime.datetime:
-                    return BasicRule.__to_datetime(self.value)
+                    return to_datetime(self.value())
                 case _:
-                    return str(self.value)
+                    return str(self.value())
         except ValueError as e:
             logger.debug(
-                f"Failed to coerce value '{self.value}' ({type(self.value)}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}"
+                f"Failed to coerce value '{self.value()}' ({type(self.value())}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}"
             )
-            return str(self.value)
-
-    @staticmethod
-    def try_coerce(value):
-        coerced_value = BasicRule.__to_float(value)
-
-        if isinstance(coerced_value, str):
-            coerced_value = BasicRule.__to_datetime(value)
-
-        if isinstance(coerced_value, str):
-            coerced_value = BasicRule.__to_bool(value)
-
-        return coerced_value
-
-    @staticmethod
-    def __to_float(value):
-        try:
-            return float(value)
-        except ValueError:
-            return value
-
-    @staticmethod
-    def __to_datetime(value):
-        try:
-            date_parser = parser()
-            parsed_date_or_datetime = date_parser.parse(timestr=value)
-
-            if isinstance(parsed_date_or_datetime, datetime.datetime):
-                return parsed_date_or_datetime
-            elif isinstance(parsed_date_or_datetime, datetime.date):
-                # adds 00:00 to the date and returns datetime
-                return datetime.datetime.combine(
-                    parsed_date_or_datetime, datetime.time.min
-                )
-            else:
-                return value
-
-        except ParserError:
-            return value
-
-    @staticmethod
-    def __to_bool(value):
-        if len(value) == 0 or re.match("^(false|f|no|n|off)$", value):
-            return False
-
-        if re.match("^(true|t|yes|y|on)$", value):
-            return True
-
-        return value
+            return str(self.value())

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -11,6 +11,9 @@ from dateutil.parser import ParserError, parser
 
 from connectors.logger import logger
 
+IS_BOOL_FALSE = re.compile("^(false|f|no|n|off)$", re.I)
+IS_BOOL_TRUE = re.compile("^(true|t|yes|y|on)$", re.I)
+
 
 def to_float(value):
     try:
@@ -37,10 +40,10 @@ def to_datetime(value):
 
 
 def to_bool(value):
-    if len(value) == 0 or re.match("^(false|f|no|n|off)$", value):
+    if len(value) == 0 or IS_BOOL_FALSE.match(value):
         return False
 
-    if re.match("^(true|t|yes|y|on)$", value):
+    if IS_BOOL_TRUE.match(value):
         return True
 
     return value

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -32,8 +32,8 @@ def to_datetime(value):
         elif isinstance(parsed_date_or_datetime, datetime.date):
             # adds 00:00 to the date and returns datetime
             return datetime.datetime.combine(parsed_date_or_datetime, datetime.time.min)
-        else:
-            return value
+
+        return value
 
     except ParserError:
         return value

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -16,7 +16,7 @@ class BasicRule:
 
     class Policy(Enum):
         INCLUDE = 1
-        EXCLUDE = 1
+        EXCLUDE = 2
 
     class Rule(Enum):
         EQUALS = 1
@@ -99,6 +99,10 @@ class BasicRule:
     @property
     def is_default_rule(self):
         return self.id_ == BasicRule.DEFAULT_RULE_ID
+
+    @property
+    def is_include(self):
+        return self.policy == BasicRule.Policy.INCLUDE
 
     def coerce_rule_value_based_on_document_value(self, doc_value):
         try:

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -13,7 +13,7 @@ from connectors.logger import logger
 
 
 class BasicRule:
-    DEFAULT_RULE_ID = 'DEFAULT'
+    DEFAULT_RULE_ID = "DEFAULT"
 
     class Policy(Enum):
         INCLUDE = 1
@@ -38,12 +38,14 @@ class BasicRule:
 
     @staticmethod
     def default_rule():
-        return BasicRule(id_=BasicRule.DEFAULT_RULE_ID,
-                         order=0,
-                         policy=BasicRule.Policy.INCLUDE,
-                         field='_',
-                         rule=BasicRule.Rule.EQUALS,
-                         value='.*')
+        return BasicRule(
+            id_=BasicRule.DEFAULT_RULE_ID,
+            order=0,
+            policy=BasicRule.Policy.INCLUDE,
+            field="_",
+            rule=BasicRule.Rule.EQUALS,
+            value=".*",
+        )
 
     def matches_document(self, document):
         if self.is_default_rule:
@@ -53,7 +55,9 @@ class BasicRule:
             return False
 
         document_value = document[self.field]
-        coerced_rule_value = self.coerce_rule_value_based_on_document_value(document_value)
+        coerced_rule_value = self.coerce_rule_value_based_on_document_value(
+            document_value
+        )
 
         match self.rule:
             case BasicRule.Rule.STARTS_WITH:
@@ -120,7 +124,8 @@ class BasicRule:
                     return str(self.value)
         except ValueError as e:
             logger.debug(
-                f"Failed to coerce value '{self.value}' ({type(self.value)}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}")
+                f"Failed to coerce value '{self.value}' ({type(self.value)}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}"
+            )
             return str(self.value)
 
     @staticmethod
@@ -151,7 +156,9 @@ class BasicRule:
                 return parsed_date_or_datetime
             elif isinstance(parsed_date_or_datetime, datetime.date):
                 # adds 00:00 to the date and returns datetime
-                return datetime.datetime.combine(parsed_date_or_datetime, datetime.time.min)
+                return datetime.datetime.combine(
+                    parsed_date_or_datetime, datetime.time.min
+                )
             else:
                 return value
 
@@ -160,10 +167,10 @@ class BasicRule:
 
     @staticmethod
     def __to_bool(value):
-        if len(value) == 0 or re.match('^(false|f|no|n|off)$', value):
+        if len(value) == 0 or re.match("^(false|f|no|n|off)$", value):
             return False
 
-        if re.match('^(true|t|yes|y|on)$', value):
+        if re.match("^(true|t|yes|y|on)$", value):
             return True
 
         return value

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -126,24 +126,6 @@ class BasicRule:
             case Rule.EQUALS:
                 return document_value == coerced_rule_value
 
-    def id_(self):
-        return self._id
-
-    def order(self):
-        return self._order
-
-    def policy(self):
-        return self._policy
-
-    def field(self):
-        return self._field
-
-    def rule(self):
-        return self._rule
-
-    def value(self):
-        return self._value
-
     def is_default_rule(self):
         return self._id == BasicRule.DEFAULT_RULE_ID
 

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -1,0 +1,163 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+import datetime
+import re
+
+from connectors.logger import logger
+from dateutil.parser import *
+from enum import Enum
+
+
+class BasicRule:
+    DEFAULT_RULE_ID = 'DEFAULT'
+
+    class Policy(Enum):
+        INCLUDE = 1
+        EXCLUDE = 1
+
+    class Rule(Enum):
+        EQUALS = 1
+        STARTS_WITH = 2
+        ENDS_WITH = 3
+        CONTAINS = 4
+        REGEX = 5
+        GREATER_THAN = 6
+        LESS_THAN = 7
+
+    def __init__(self, id_, order, policy, field, rule, value):
+        self._id = id_
+        self._order = order
+        self._policy = policy
+        self._field = field
+        self._rule = rule
+        self._value = value
+
+    @staticmethod
+    def default_rule():
+        return BasicRule(id_=BasicRule.DEFAULT_RULE_ID,
+                         order=0,
+                         policy=BasicRule.Policy.INCLUDE,
+                         field='_',
+                         rule=BasicRule.Rule.EQUALS,
+                         value='.*')
+
+    def matches_document(self, document):
+        if self.is_default_rule:
+            return True
+
+        if self.field not in document:
+            return False
+
+        document_value = document[self.field]
+        coerced_rule_value = self.coerce_rule_value_based_on_document_value(document_value)
+
+        match self.rule:
+            case BasicRule.Rule.STARTS_WITH:
+                return str(document_value).startswith(self.value)
+            case BasicRule.Rule.ENDS_WITH:
+                return str(document_value).endswith(self.value)
+            case BasicRule.Rule.CONTAINS:
+                return self.value in str(document_value)
+            case BasicRule.Rule.REGEX:
+                return re.match(self.value, str(document_value)) is not None
+            case BasicRule.Rule.LESS_THAN:
+                return document_value < coerced_rule_value
+            case BasicRule.Rule.GREATER_THAN:
+                return document_value > coerced_rule_value
+            case BasicRule.Rule.EQUALS:
+                return document_value == coerced_rule_value
+
+        return False
+
+    @property
+    def id_(self):
+        return self._id
+
+    @property
+    def order(self):
+        return self._order
+
+    @property
+    def policy(self):
+        return self._policy
+
+    @property
+    def field(self):
+        return self._field
+
+    @property
+    def rule(self):
+        return self._rule
+
+    @property
+    def value(self):
+        return self._value
+
+    @property
+    def is_default_rule(self):
+        return self.id_ == BasicRule.DEFAULT_RULE_ID
+
+    def coerce_rule_value_based_on_document_value(self, doc_value):
+        try:
+            match doc_value:
+                case str():
+                    return str(self.value)
+                case bool():
+                    return str(BasicRule.__to_bool(self.value))
+                case float() | int():
+                    return float(self.value)
+                case datetime.date() | datetime.datetime:
+                    return BasicRule.__to_datetime(self.value)
+                case _:
+                    return str(self.value)
+        except ValueError as e:
+            logger.debug(f"Failed to coerce value '{self.value}' ({type(self.value)}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}")
+            return str(self.value)
+
+    @staticmethod
+    def try_coerce(value):
+        coerced_value = BasicRule.__to_float(value)
+
+        if isinstance(coerced_value, str):
+            coerced_value = BasicRule.__to_datetime(value)
+
+        if isinstance(coerced_value, str):
+            coerced_value = BasicRule.__to_bool(value)
+
+        return coerced_value
+
+    @staticmethod
+    def __to_float(value):
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+    @staticmethod
+    def __to_datetime(value):
+        try:
+            parsed_date_or_datetime = parse(timestr=value)
+
+            if isinstance(parsed_date_or_datetime, datetime.datetime):
+                return parsed_date_or_datetime
+            elif isinstance(parsed_date_or_datetime, datetime.date):
+                # adds 00:00 to the date and returns datetime
+                return datetime.datetime.combine(parsed_date_or_datetime, datetime.time.min)
+            else:
+                return value
+
+        except ParserError:
+            return value
+
+    @staticmethod
+    def __to_bool(value):
+        if len(value) == 0 or re.match('^(false|f|no|n|off)$', value):
+            return False
+
+        if re.match('^(true|t|yes|y|on)$', value):
+            return True
+
+        return value

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -150,7 +150,8 @@ class BasicRule:
     @staticmethod
     def __to_datetime(value):
         try:
-            parsed_date_or_datetime = parser.parse(timestr=value)
+            date_parser = parser()
+            parsed_date_or_datetime = date_parser.parse(timestr=value)
 
             if isinstance(parsed_date_or_datetime, datetime.datetime):
                 return parsed_date_or_datetime

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -3,11 +3,13 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from connectors.logger import logger
 import datetime
-from dateutil.parser import *
-from enum import Enum
 import re
+from enum import Enum
+
+from dateutil.parser import *
+
+from connectors.logger import logger
 
 
 class BasicRule:

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -102,23 +102,23 @@ class BasicRule:
         if self.is_default_rule():
             return True
 
-        if self.field() not in document:
+        if self._field not in document:
             return False
 
-        document_value = document[self.field()]
+        document_value = document[self._field]
         coerced_rule_value = self.coerce_rule_value_based_on_document_value(
             document_value
         )
 
-        match self.rule():
+        match self._rule:
             case Rule.STARTS_WITH:
-                return str(document_value).startswith(self.value())
+                return str(document_value).startswith(self._value)
             case Rule.ENDS_WITH:
-                return str(document_value).endswith(self.value())
+                return str(document_value).endswith(self._value)
             case Rule.CONTAINS:
-                return self.value() in str(document_value)
+                return self._value in str(document_value)
             case Rule.REGEX:
-                return re.match(self.value(), str(document_value)) is not None
+                return re.match(self._value, str(document_value)) is not None
             case Rule.LESS_THAN:
                 return document_value < coerced_rule_value
             case Rule.GREATER_THAN:
@@ -145,26 +145,26 @@ class BasicRule:
         return self._value
 
     def is_default_rule(self):
-        return self.id_() == BasicRule.DEFAULT_RULE_ID
+        return self._id == BasicRule.DEFAULT_RULE_ID
 
     def is_include(self):
-        return self.policy() == Policy.INCLUDE
+        return self._policy == Policy.INCLUDE
 
     def coerce_rule_value_based_on_document_value(self, doc_value):
         try:
             match doc_value:
                 case str():
-                    return str(self.value())
+                    return str(self._value)
                 case bool():
-                    return str(to_bool(self.value()))
+                    return str(to_bool(self._value))
                 case float() | int():
-                    return float(self.value())
+                    return float(self._value)
                 case datetime.date() | datetime.datetime:
-                    return to_datetime(self.value())
+                    return to_datetime(self._value)
                 case _:
-                    return str(self.value())
+                    return str(self._value)
         except ValueError as e:
             logger.debug(
-                f"Failed to coerce value '{self.value()}' ({type(self.value())}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}"
+                f"Failed to coerce value '{self._value}' ({type(self._value)}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}"
             )
-            return str(self.value())
+            return str(self._value)

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -7,7 +7,7 @@ import datetime
 import re
 from enum import Enum
 
-from dateutil.parser import *
+from dateutil.parser import ParserError, parser
 
 from connectors.logger import logger
 
@@ -150,7 +150,7 @@ class BasicRule:
     @staticmethod
     def __to_datetime(value):
         try:
-            parsed_date_or_datetime = parse(timestr=value)
+            parsed_date_or_datetime = parser.parse(timestr=value)
 
             if isinstance(parsed_date_or_datetime, datetime.datetime):
                 return parsed_date_or_datetime

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -581,3 +581,19 @@ def test_do_not_coerce_and_return_original_string():
 
     assert isinstance(coerced_value, str)
     assert coerced_value == value
+
+
+def test_is_include_for_include_policy():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value='something')
+
+    assert basic_rule.is_include
+
+
+def test_is_not_include_for_exclude_policy():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.EXCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value='something')
+
+    assert not basic_rule.is_include

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -1,0 +1,583 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+import datetime
+
+from connectors.filtering.basic_rule import BasicRule
+
+DESCRIPTION_KEY = 'description'
+DESCRIPTION_VALUE = 'abc'
+
+AMOUNT_FLOAT_KEY = 'amount-float'
+AMOUNT_FLOAT_VALUE = 100.0
+AMOUNT_INT_KEY = 'amount-int'
+AMOUNT_INT_VALUE = 100
+
+CREATED_AT_DATE_KEY = 'created_at_date'
+# we expect that the data sources parse their dates to datetime
+CREATED_AT_DATE_VALUE = datetime.datetime(year=2022, month=1, day=1, hour=0, minute=0)
+CREATED_AT_DATETIME_KEY = 'created_at_datetime'
+CREATED_AT_DATETIME_VALUE = datetime.datetime(year=2022, month=1, day=1, hour=5, minute=10, microsecond=5)
+
+DOCUMENT = {
+    DESCRIPTION_KEY: DESCRIPTION_VALUE,
+    AMOUNT_FLOAT_KEY: AMOUNT_FLOAT_VALUE,
+    AMOUNT_INT_KEY: AMOUNT_INT_VALUE,
+    CREATED_AT_DATE_KEY: CREATED_AT_DATE_VALUE,
+    CREATED_AT_DATETIME_KEY: CREATED_AT_DATETIME_VALUE
+}
+
+
+def test_matches_default_rule():
+    assert BasicRule.default_rule().matches_document(DOCUMENT)
+
+
+def test_no_field_leads_to_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field='non existing', rule=BasicRule.Rule.EQUALS, value='')
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_starts_with_string_matches():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.STARTS_WITH, value=DESCRIPTION_VALUE[:1])
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_starts_with_string_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.STARTS_WITH, value='d')
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_ends_with_string_matches():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.ENDS_WITH, value=DESCRIPTION_VALUE[1:])
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_ends_with_string_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.ENDS_WITH, value='d')
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_contains_with_string_matches():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.CONTAINS, value=DESCRIPTION_VALUE[1:2])
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_contains_with_string_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.CONTAINS, value='d')
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_regex_matches():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.REGEX, value='^a')
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_regex_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.REGEX, value='^d')
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_string_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='bcd')
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_string_no_match_string_is_smaller_lexicographically():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='a')
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_string_no_match_string_is_the_same():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='abc')
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_integer_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_INT_VALUE + 5)
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_integer_no_match_numbers_are_the_same():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_INT_VALUE)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_integer_no_match_document_value_is_greater():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_INT_VALUE - 5)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_float_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_FLOAT_VALUE + 5.0)
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_float_no_match_numbers_are_the_same():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_FLOAT_VALUE)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_float_no_match_document_value_is_greater():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_FLOAT_VALUE - 5.0)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_datetime_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value=str(CREATED_AT_DATETIME_VALUE + datetime.timedelta(days=10)))
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_datetime_no_match_same_time():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value=str(CREATED_AT_DATETIME_VALUE))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_datetime_no_match_later_time():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_date_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value=str(CREATED_AT_DATE_VALUE + datetime.timedelta(days=5)))
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_date_no_match_same_time():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value=str(CREATED_AT_DATE_VALUE))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_less_than_date_no_match_later_time():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=5)))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_string_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.GREATER_THAN, value='a')
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_string_no_match_string_is_greater_lexicographically():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.GREATER_THAN, value='bcd')
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_string_no_match_string_is_the_same():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='abc')
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_integer_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_INT_VALUE - 5)
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_integer_no_match_numbers_are_the_same():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_INT_VALUE)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_integer_no_match_document_value_is_less():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_INT_VALUE + 5)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_float_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_FLOAT_VALUE - 10.0)
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_float_no_match_numbers_are_the_same():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_FLOAT_VALUE)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_float_no_match_document_value_is_greater():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_FLOAT_VALUE + 10.0)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_datetime_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.GREATER_THAN,
+                           value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)))
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_datetime_no_match_same_time():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.GREATER_THAN,
+                           value=str(CREATED_AT_DATETIME_VALUE))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_datetime_no_match_earlier_time():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.GREATER_THAN,
+                           value=str(CREATED_AT_DATETIME_VALUE + datetime.timedelta(days=10)))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_date_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.GREATER_THAN,
+                           value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=5)))
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_date_no_match_same_time():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.GREATER_THAN,
+                           value=str(CREATED_AT_DATE_VALUE))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_greater_than_date_no_match_earlier_time():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.GREATER_THAN,
+                           value=str(CREATED_AT_DATE_VALUE + datetime.timedelta(days=5)))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_integer_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=AMOUNT_INT_VALUE)
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_integer_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=AMOUNT_INT_VALUE + 5)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_float_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=AMOUNT_FLOAT_VALUE)
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_float_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=AMOUNT_FLOAT_VALUE + 5.0)
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_string_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=DESCRIPTION_VALUE)
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_string_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=DESCRIPTION_VALUE[1:])
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_datetime_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=str(CREATED_AT_DATETIME_VALUE))
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_datetime_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_date_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=str(CREATED_AT_DATE_VALUE))
+
+    assert basic_rule.matches_document(DOCUMENT)
+
+
+def test_equals_date_no_match():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.EQUALS,
+                           value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=15)))
+
+    assert not basic_rule.matches_document(DOCUMENT)
+
+
+def test_coerce_rule_value_to_str():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='string')
+
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value('also a string')
+
+    assert isinstance(coerced_rule_value, str)
+    assert coerced_rule_value == 'string'
+
+
+def test_coerce_rule_value_to_float():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='1.0')
+
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(2.0)
+
+    assert isinstance(coerced_rule_value, float)
+    assert coerced_rule_value == 1.0
+
+
+def test_coerce_rule_value_to_float_if_it_is_an_int():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='1')
+
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(2)
+
+    assert isinstance(coerced_rule_value, float)
+    assert coerced_rule_value == 1.0
+
+
+def test_coerce_rule_value_to_bool():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='t')
+
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(True)
+
+    assert isinstance(coerced_rule_value, str)
+    assert bool(coerced_rule_value)
+
+
+def test_coerce_rule_value_to_datetime_date_if_it_is_datetime():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value=str(datetime.datetime(year=2022, month=1, day=1)))
+
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(
+        datetime.datetime(year=2023, month=2, day=2))
+
+    assert isinstance(coerced_rule_value, datetime.datetime)
+    assert coerced_rule_value == datetime.datetime(year=2022, month=1, day=1)
+
+
+def test_coerce_rule_value_to_datetime_date_if_it_is_date():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value=str(datetime.date(year=2022, month=1, day=1)))
+
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(
+        datetime.date(year=2023, month=2, day=2))
+
+    assert isinstance(coerced_rule_value, datetime.date)
+    assert coerced_rule_value == datetime.datetime(year=2022, month=1, day=1)
+
+
+def test_coerce_rule_to_default_if_type_is_not_registered():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value='something')
+
+    # dict is not registered as type case in the coerce function
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value({'key': 'value'})
+
+    assert isinstance(coerced_rule_value, str)
+    assert coerced_rule_value == 'something'
+
+
+def test_coerce_rule_to_default_if_doc_value_type_not_matching_rule_value_type():
+    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
+                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
+                           value='something')
+
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(1)
+
+    assert isinstance(coerced_rule_value, str)
+    assert coerced_rule_value == 'something'
+
+
+def test_coerce_to_float():
+    value = "0.001"
+
+    assert isinstance(BasicRule.try_coerce(value), float)
+
+
+def test_coerce_date_string_to_datetime():
+    value = "03-10-2022"
+
+    assert isinstance(BasicRule.try_coerce(value), datetime.datetime)
+
+
+def test_coerce_datetime_string_to_datetime():
+    value = "03-10-2022 10:00"
+
+    assert isinstance(BasicRule.try_coerce(value), datetime.datetime)
+
+
+def test_coerce_to_true():
+    value = "true"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(coerced_value, bool)
+    assert coerced_value
+
+    value = "t"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(coerced_value, bool)
+    assert coerced_value
+
+    value = "yes"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(coerced_value, bool)
+    assert coerced_value
+
+    value = "y"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(coerced_value, bool)
+    assert coerced_value
+
+    value = "on"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(coerced_value, bool)
+    assert coerced_value
+
+
+def test_coerce_to_false():
+    value = ""
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert not coerced_value
+
+    value = "false"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert not coerced_value
+
+    value = "f"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert not coerced_value
+
+    value = "no"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert not coerced_value
+
+    value = "n"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert not coerced_value
+
+    value = "off"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert not coerced_value
+
+
+def test_do_not_coerce_and_return_original_string():
+    value = "value"
+    coerced_value = BasicRule.try_coerce(value)
+
+    assert isinstance(coerced_value, str)
+    assert coerced_value == value

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -8,26 +8,28 @@ import datetime
 
 from connectors.filtering.basic_rule import BasicRule
 
-DESCRIPTION_KEY = 'description'
-DESCRIPTION_VALUE = 'abc'
+DESCRIPTION_KEY = "description"
+DESCRIPTION_VALUE = "abc"
 
-AMOUNT_FLOAT_KEY = 'amount-float'
+AMOUNT_FLOAT_KEY = "amount-float"
 AMOUNT_FLOAT_VALUE = 100.0
-AMOUNT_INT_KEY = 'amount-int'
+AMOUNT_INT_KEY = "amount-int"
 AMOUNT_INT_VALUE = 100
 
-CREATED_AT_DATE_KEY = 'created_at_date'
+CREATED_AT_DATE_KEY = "created_at_date"
 # we expect that the data sources parse their dates to datetime
 CREATED_AT_DATE_VALUE = datetime.datetime(year=2022, month=1, day=1, hour=0, minute=0)
-CREATED_AT_DATETIME_KEY = 'created_at_datetime'
-CREATED_AT_DATETIME_VALUE = datetime.datetime(year=2022, month=1, day=1, hour=5, minute=10, microsecond=5)
+CREATED_AT_DATETIME_KEY = "created_at_datetime"
+CREATED_AT_DATETIME_VALUE = datetime.datetime(
+    year=2022, month=1, day=1, hour=5, minute=10, microsecond=5
+)
 
 DOCUMENT = {
     DESCRIPTION_KEY: DESCRIPTION_VALUE,
     AMOUNT_FLOAT_KEY: AMOUNT_FLOAT_VALUE,
     AMOUNT_INT_KEY: AMOUNT_INT_VALUE,
     CREATED_AT_DATE_KEY: CREATED_AT_DATE_VALUE,
-    CREATED_AT_DATETIME_KEY: CREATED_AT_DATETIME_VALUE
+    CREATED_AT_DATETIME_KEY: CREATED_AT_DATETIME_VALUE,
 }
 
 
@@ -36,383 +38,669 @@ def test_matches_default_rule():
 
 
 def test_no_field_leads_to_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field='non existing', rule=BasicRule.Rule.EQUALS, value='')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field="non existing",
+        rule=BasicRule.Rule.EQUALS,
+        value="",
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_starts_with_string_matches():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.STARTS_WITH, value=DESCRIPTION_VALUE[:1])
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.STARTS_WITH,
+        value=DESCRIPTION_VALUE[:1],
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_starts_with_string_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.STARTS_WITH, value='d')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.STARTS_WITH,
+        value="d",
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_ends_with_string_matches():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.ENDS_WITH, value=DESCRIPTION_VALUE[1:])
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.ENDS_WITH,
+        value=DESCRIPTION_VALUE[1:],
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_ends_with_string_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.ENDS_WITH, value='d')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.ENDS_WITH,
+        value="d",
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_contains_with_string_matches():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.CONTAINS, value=DESCRIPTION_VALUE[1:2])
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.CONTAINS,
+        value=DESCRIPTION_VALUE[1:2],
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_contains_with_string_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.CONTAINS, value='d')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.CONTAINS,
+        value="d",
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_regex_matches():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.REGEX, value='^a')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.REGEX,
+        value="^a",
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_regex_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.REGEX, value='^d')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.REGEX,
+        value="^d",
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_string_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='bcd')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="bcd",
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_string_no_match_string_is_smaller_lexicographically():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='a')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="a",
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_string_no_match_string_is_the_same():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='abc')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="abc",
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_integer_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_INT_VALUE + 5)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_INT_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=AMOUNT_INT_VALUE + 5,
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_integer_no_match_numbers_are_the_same():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_INT_VALUE)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_INT_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=AMOUNT_INT_VALUE,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_integer_no_match_document_value_is_greater():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_INT_VALUE - 5)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_INT_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=AMOUNT_INT_VALUE - 5,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_float_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_FLOAT_VALUE + 5.0)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_FLOAT_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=AMOUNT_FLOAT_VALUE + 5.0,
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_float_no_match_numbers_are_the_same():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_FLOAT_VALUE)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_FLOAT_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=AMOUNT_FLOAT_VALUE,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_float_no_match_document_value_is_greater():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_FLOAT_VALUE - 5.0)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_FLOAT_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=AMOUNT_FLOAT_VALUE - 5.0,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_datetime_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value=str(CREATED_AT_DATETIME_VALUE + datetime.timedelta(days=10)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATETIME_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=str(CREATED_AT_DATETIME_VALUE + datetime.timedelta(days=10)),
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_datetime_no_match_same_time():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value=str(CREATED_AT_DATETIME_VALUE))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATETIME_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=str(CREATED_AT_DATETIME_VALUE),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_datetime_no_match_later_time():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATETIME_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_date_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value=str(CREATED_AT_DATE_VALUE + datetime.timedelta(days=5)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATE_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=str(CREATED_AT_DATE_VALUE + datetime.timedelta(days=5)),
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_date_no_match_same_time():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value=str(CREATED_AT_DATE_VALUE))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATE_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=str(CREATED_AT_DATE_VALUE),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_less_than_date_no_match_later_time():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=5)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATE_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=5)),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_string_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.GREATER_THAN, value='a')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value="a",
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_string_no_match_string_is_greater_lexicographically():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.GREATER_THAN, value='bcd')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value="bcd",
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_string_no_match_string_is_the_same():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='abc')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="abc",
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_integer_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_INT_VALUE - 5)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_INT_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=AMOUNT_INT_VALUE - 5,
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_integer_no_match_numbers_are_the_same():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.LESS_THAN, value=AMOUNT_INT_VALUE)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_INT_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=AMOUNT_INT_VALUE,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_integer_no_match_document_value_is_less():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_INT_VALUE + 5)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_INT_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=AMOUNT_INT_VALUE + 5,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_float_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_FLOAT_VALUE - 10.0)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_FLOAT_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=AMOUNT_FLOAT_VALUE - 10.0,
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_float_no_match_numbers_are_the_same():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_FLOAT_VALUE)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_FLOAT_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=AMOUNT_FLOAT_VALUE,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_float_no_match_document_value_is_greater():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.GREATER_THAN, value=AMOUNT_FLOAT_VALUE + 10.0)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_FLOAT_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=AMOUNT_FLOAT_VALUE + 10.0,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_datetime_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.GREATER_THAN,
-                           value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATETIME_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)),
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_datetime_no_match_same_time():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.GREATER_THAN,
-                           value=str(CREATED_AT_DATETIME_VALUE))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATETIME_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=str(CREATED_AT_DATETIME_VALUE),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_datetime_no_match_earlier_time():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.GREATER_THAN,
-                           value=str(CREATED_AT_DATETIME_VALUE + datetime.timedelta(days=10)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATETIME_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=str(CREATED_AT_DATETIME_VALUE + datetime.timedelta(days=10)),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_date_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.GREATER_THAN,
-                           value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=5)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATE_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=5)),
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_date_no_match_same_time():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.GREATER_THAN,
-                           value=str(CREATED_AT_DATE_VALUE))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATE_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=str(CREATED_AT_DATE_VALUE),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_greater_than_date_no_match_earlier_time():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.GREATER_THAN,
-                           value=str(CREATED_AT_DATE_VALUE + datetime.timedelta(days=5)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATE_KEY,
+        rule=BasicRule.Rule.GREATER_THAN,
+        value=str(CREATED_AT_DATE_VALUE + datetime.timedelta(days=5)),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_integer_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=AMOUNT_INT_VALUE)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_INT_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=AMOUNT_INT_VALUE,
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_integer_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_INT_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=AMOUNT_INT_VALUE + 5)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_INT_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=AMOUNT_INT_VALUE + 5,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_float_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=AMOUNT_FLOAT_VALUE)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_FLOAT_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=AMOUNT_FLOAT_VALUE,
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_float_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=AMOUNT_FLOAT_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=AMOUNT_FLOAT_VALUE + 5.0)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=AMOUNT_FLOAT_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=AMOUNT_FLOAT_VALUE + 5.0,
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_string_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=DESCRIPTION_VALUE)
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=DESCRIPTION_VALUE,
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_string_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=DESCRIPTION_VALUE[1:])
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=DESCRIPTION_VALUE[1:],
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_datetime_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=str(CREATED_AT_DATETIME_VALUE))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATETIME_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=str(CREATED_AT_DATETIME_VALUE),
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_datetime_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATETIME_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATETIME_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_date_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=str(CREATED_AT_DATE_VALUE))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATE_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=str(CREATED_AT_DATE_VALUE),
+    )
 
     assert basic_rule.matches_document(DOCUMENT)
 
 
 def test_equals_date_no_match():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=CREATED_AT_DATE_KEY, rule=BasicRule.Rule.EQUALS,
-                           value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=15)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=CREATED_AT_DATE_KEY,
+        rule=BasicRule.Rule.EQUALS,
+        value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=15)),
+    )
 
     assert not basic_rule.matches_document(DOCUMENT)
 
 
 def test_coerce_rule_value_to_str():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='string')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="string",
+    )
 
-    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value('also a string')
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(
+        "also a string"
+    )
 
     assert isinstance(coerced_rule_value, str)
-    assert coerced_rule_value == 'string'
+    assert coerced_rule_value == "string"
 
 
 def test_coerce_rule_value_to_float():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='1.0')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="1.0",
+    )
 
     coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(2.0)
 
@@ -421,8 +709,14 @@ def test_coerce_rule_value_to_float():
 
 
 def test_coerce_rule_value_to_float_if_it_is_an_int():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='1')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="1",
+    )
 
     coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(2)
 
@@ -431,8 +725,14 @@ def test_coerce_rule_value_to_float_if_it_is_an_int():
 
 
 def test_coerce_rule_value_to_bool():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN, value='t')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="t",
+    )
 
     coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(True)
 
@@ -441,50 +741,74 @@ def test_coerce_rule_value_to_bool():
 
 
 def test_coerce_rule_value_to_datetime_date_if_it_is_datetime():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value=str(datetime.datetime(year=2022, month=1, day=1)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=str(datetime.datetime(year=2022, month=1, day=1)),
+    )
 
     coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(
-        datetime.datetime(year=2023, month=2, day=2))
+        datetime.datetime(year=2023, month=2, day=2)
+    )
 
     assert isinstance(coerced_rule_value, datetime.datetime)
     assert coerced_rule_value == datetime.datetime(year=2022, month=1, day=1)
 
 
 def test_coerce_rule_value_to_datetime_date_if_it_is_date():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value=str(datetime.date(year=2022, month=1, day=1)))
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value=str(datetime.date(year=2022, month=1, day=1)),
+    )
 
     coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(
-        datetime.date(year=2023, month=2, day=2))
+        datetime.date(year=2023, month=2, day=2)
+    )
 
     assert isinstance(coerced_rule_value, datetime.date)
     assert coerced_rule_value == datetime.datetime(year=2022, month=1, day=1)
 
 
 def test_coerce_rule_to_default_if_type_is_not_registered():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value='something')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="something",
+    )
 
     # dict is not registered as type case in the coerce function
-    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value({'key': 'value'})
+    coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(
+        {"key": "value"}
+    )
 
     assert isinstance(coerced_rule_value, str)
-    assert coerced_rule_value == 'something'
+    assert coerced_rule_value == "something"
 
 
 def test_coerce_rule_to_default_if_doc_value_type_not_matching_rule_value_type():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value='something')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="something",
+    )
 
     coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(1)
 
     assert isinstance(coerced_rule_value, str)
-    assert coerced_rule_value == 'something'
+    assert coerced_rule_value == "something"
 
 
 def test_coerce_to_float():
@@ -584,16 +908,26 @@ def test_do_not_coerce_and_return_original_string():
 
 
 def test_is_include_for_include_policy():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.INCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value='something')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.INCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="something",
+    )
 
     assert basic_rule.is_include
 
 
 def test_is_not_include_for_exclude_policy():
-    basic_rule = BasicRule(id_=1, order=1, policy=BasicRule.Policy.EXCLUDE,
-                           field=DESCRIPTION_KEY, rule=BasicRule.Rule.LESS_THAN,
-                           value='something')
+    basic_rule = BasicRule(
+        id_=1,
+        order=1,
+        policy=BasicRule.Policy.EXCLUDE,
+        field=DESCRIPTION_KEY,
+        rule=BasicRule.Rule.LESS_THAN,
+        value="something",
+    )
 
     assert not basic_rule.is_include

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -6,7 +6,7 @@
 
 import datetime
 
-from connectors.filtering.basic_rule import BasicRule
+from connectors.filtering.basic_rule import BasicRule, Policy, Rule, try_coerce
 
 DESCRIPTION_KEY = "description"
 DESCRIPTION_VALUE = "abc"
@@ -34,653 +34,653 @@ DOCUMENT = {
 
 
 def test_matches_default_rule():
-    assert BasicRule.default_rule().matches_document(DOCUMENT)
+    assert BasicRule.default_rule().matches(DOCUMENT)
 
 
 def test_no_field_leads_to_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field="non existing",
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value="",
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_starts_with_string_matches():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.STARTS_WITH,
+        rule=Rule.STARTS_WITH,
         value=DESCRIPTION_VALUE[:1],
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_starts_with_string_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.STARTS_WITH,
+        rule=Rule.STARTS_WITH,
         value="d",
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_ends_with_string_matches():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.ENDS_WITH,
+        rule=Rule.ENDS_WITH,
         value=DESCRIPTION_VALUE[1:],
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_ends_with_string_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.ENDS_WITH,
+        rule=Rule.ENDS_WITH,
         value="d",
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_contains_with_string_matches():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.CONTAINS,
+        rule=Rule.CONTAINS,
         value=DESCRIPTION_VALUE[1:2],
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_contains_with_string_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.CONTAINS,
+        rule=Rule.CONTAINS,
         value="d",
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_regex_matches():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.REGEX,
+        rule=Rule.REGEX,
         value="^a",
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_regex_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.REGEX,
+        rule=Rule.REGEX,
         value="^d",
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_string_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="bcd",
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_string_no_match_string_is_smaller_lexicographically():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="a",
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_string_no_match_string_is_the_same():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="abc",
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_integer_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_INT_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=AMOUNT_INT_VALUE + 5,
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_integer_no_match_numbers_are_the_same():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_INT_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=AMOUNT_INT_VALUE,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_integer_no_match_document_value_is_greater():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_INT_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=AMOUNT_INT_VALUE - 5,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_float_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_FLOAT_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=AMOUNT_FLOAT_VALUE + 5.0,
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_float_no_match_numbers_are_the_same():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_FLOAT_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=AMOUNT_FLOAT_VALUE,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_float_no_match_document_value_is_greater():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_FLOAT_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=AMOUNT_FLOAT_VALUE - 5.0,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_datetime_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATETIME_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=str(CREATED_AT_DATETIME_VALUE + datetime.timedelta(days=10)),
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_datetime_no_match_same_time():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATETIME_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=str(CREATED_AT_DATETIME_VALUE),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_datetime_no_match_later_time():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATETIME_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_date_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATE_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=str(CREATED_AT_DATE_VALUE + datetime.timedelta(days=5)),
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_date_no_match_same_time():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATE_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=str(CREATED_AT_DATE_VALUE),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_less_than_date_no_match_later_time():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATE_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=5)),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_string_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value="a",
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_string_no_match_string_is_greater_lexicographically():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value="bcd",
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_string_no_match_string_is_the_same():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="abc",
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_integer_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_INT_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=AMOUNT_INT_VALUE - 5,
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_integer_no_match_numbers_are_the_same():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_INT_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=AMOUNT_INT_VALUE,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_integer_no_match_document_value_is_less():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_INT_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=AMOUNT_INT_VALUE + 5,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_float_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_FLOAT_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=AMOUNT_FLOAT_VALUE - 10.0,
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_float_no_match_numbers_are_the_same():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_FLOAT_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=AMOUNT_FLOAT_VALUE,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_float_no_match_document_value_is_greater():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_FLOAT_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=AMOUNT_FLOAT_VALUE + 10.0,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_datetime_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATETIME_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)),
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_datetime_no_match_same_time():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATETIME_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=str(CREATED_AT_DATETIME_VALUE),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_datetime_no_match_earlier_time():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATETIME_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=str(CREATED_AT_DATETIME_VALUE + datetime.timedelta(days=10)),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_date_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATE_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=5)),
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_date_no_match_same_time():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATE_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=str(CREATED_AT_DATE_VALUE),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_greater_than_date_no_match_earlier_time():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATE_KEY,
-        rule=BasicRule.Rule.GREATER_THAN,
+        rule=Rule.GREATER_THAN,
         value=str(CREATED_AT_DATE_VALUE + datetime.timedelta(days=5)),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_equals_integer_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_INT_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=AMOUNT_INT_VALUE,
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_equals_integer_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_INT_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=AMOUNT_INT_VALUE + 5,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_equals_float_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_FLOAT_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=AMOUNT_FLOAT_VALUE,
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_equals_float_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=AMOUNT_FLOAT_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=AMOUNT_FLOAT_VALUE + 5.0,
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_equals_string_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=DESCRIPTION_VALUE,
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_equals_string_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=DESCRIPTION_VALUE[1:],
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_equals_datetime_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATETIME_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=str(CREATED_AT_DATETIME_VALUE),
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_equals_datetime_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATETIME_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=str(CREATED_AT_DATETIME_VALUE - datetime.timedelta(days=10)),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_equals_date_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATE_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=str(CREATED_AT_DATE_VALUE),
     )
 
-    assert basic_rule.matches_document(DOCUMENT)
+    assert basic_rule.matches(DOCUMENT)
 
 
 def test_equals_date_no_match():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=CREATED_AT_DATE_KEY,
-        rule=BasicRule.Rule.EQUALS,
+        rule=Rule.EQUALS,
         value=str(CREATED_AT_DATE_VALUE - datetime.timedelta(days=15)),
     )
 
-    assert not basic_rule.matches_document(DOCUMENT)
+    assert not basic_rule.matches(DOCUMENT)
 
 
 def test_coerce_rule_value_to_str():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="string",
     )
 
@@ -696,9 +696,9 @@ def test_coerce_rule_value_to_float():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="1.0",
     )
 
@@ -712,9 +712,9 @@ def test_coerce_rule_value_to_float_if_it_is_an_int():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="1",
     )
 
@@ -728,9 +728,9 @@ def test_coerce_rule_value_to_bool():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="t",
     )
 
@@ -744,9 +744,9 @@ def test_coerce_rule_value_to_datetime_date_if_it_is_datetime():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=str(datetime.datetime(year=2022, month=1, day=1)),
     )
 
@@ -762,9 +762,9 @@ def test_coerce_rule_value_to_datetime_date_if_it_is_date():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value=str(datetime.date(year=2022, month=1, day=1)),
     )
 
@@ -780,9 +780,9 @@ def test_coerce_rule_to_default_if_type_is_not_registered():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="something",
     )
 
@@ -799,9 +799,9 @@ def test_coerce_rule_to_default_if_doc_value_type_not_matching_rule_value_type()
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="something",
     )
 
@@ -814,48 +814,48 @@ def test_coerce_rule_to_default_if_doc_value_type_not_matching_rule_value_type()
 def test_coerce_to_float():
     value = "0.001"
 
-    assert isinstance(BasicRule.try_coerce(value), float)
+    assert isinstance(try_coerce(value), float)
 
 
 def test_coerce_date_string_to_datetime():
     value = "03-10-2022"
 
-    assert isinstance(BasicRule.try_coerce(value), datetime.datetime)
+    assert isinstance(try_coerce(value), datetime.datetime)
 
 
 def test_coerce_datetime_string_to_datetime():
     value = "03-10-2022 10:00"
 
-    assert isinstance(BasicRule.try_coerce(value), datetime.datetime)
+    assert isinstance(try_coerce(value), datetime.datetime)
 
 
 def test_coerce_to_true():
     value = "true"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
     assert isinstance(coerced_value, bool)
     assert coerced_value
 
     value = "t"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
     assert isinstance(coerced_value, bool)
     assert coerced_value
 
     value = "yes"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
     assert isinstance(coerced_value, bool)
     assert coerced_value
 
     value = "y"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
     assert isinstance(coerced_value, bool)
     assert coerced_value
 
     value = "on"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
     assert isinstance(coerced_value, bool)
     assert coerced_value
@@ -863,45 +863,45 @@ def test_coerce_to_true():
 
 def test_coerce_to_false():
     value = ""
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
-    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert isinstance(try_coerce(value), bool)
     assert not coerced_value
 
     value = "false"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
-    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert isinstance(try_coerce(value), bool)
     assert not coerced_value
 
     value = "f"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
-    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert isinstance(try_coerce(value), bool)
     assert not coerced_value
 
     value = "no"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
-    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert isinstance(try_coerce(value), bool)
     assert not coerced_value
 
     value = "n"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
-    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert isinstance(try_coerce(value), bool)
     assert not coerced_value
 
     value = "off"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
-    assert isinstance(BasicRule.try_coerce(value), bool)
+    assert isinstance(try_coerce(value), bool)
     assert not coerced_value
 
 
 def test_do_not_coerce_and_return_original_string():
     value = "value"
-    coerced_value = BasicRule.try_coerce(value)
+    coerced_value = try_coerce(value)
 
     assert isinstance(coerced_value, str)
     assert coerced_value == value
@@ -911,23 +911,23 @@ def test_is_include_for_include_policy():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.INCLUDE,
+        policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="something",
     )
 
-    assert basic_rule.is_include
+    assert basic_rule.is_include()
 
 
 def test_is_not_include_for_exclude_policy():
     basic_rule = BasicRule(
         id_=1,
         order=1,
-        policy=BasicRule.Policy.EXCLUDE,
+        policy=Policy.EXCLUDE,
         field=DESCRIPTION_KEY,
-        rule=BasicRule.Rule.LESS_THAN,
+        rule=Rule.LESS_THAN,
         value="something",
     )
 
-    assert not basic_rule.is_include
+    assert not basic_rule.is_include()

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -8,6 +8,6 @@ pympler==1.0.1
 guppy3==3.1.2
 cron-schedule-triggers==0.0.11
 pytz==2019.3
-python-dateutil~=2.8.2
+python-dateutil>=2.8.2
 aiogoogle>=4.2.0
 uvloop==0.17.0; sys_platform != 'win32'

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -8,5 +8,6 @@ pympler==1.0.1
 guppy3==3.1.2
 cron-schedule-triggers==0.0.11
 pytz==2019.3
+python-dateutil~=2.8.2
 aiogoogle>=4.2.0
 uvloop==0.17.0; sys_platform != 'win32'


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3600 ##

This PR introduces the BasicRule class which can check if a document matches the constraints defined by a basic rule. The BasicRule tries to coerce the type of the rule value to the type of the document value. It also exposes a property to check whether the used policy was `include` or not (will be important for the rules engine and its execution later on during a sync).

The following comparisons are supported:
- Starts with
- Ends with
- Contains
- Regex
- Less than
- Greater than
- Equals

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally