### PR TITLE
Extract pre-flight check to a function + rearrange arguments in _run function

### DIFF
--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -119,13 +119,15 @@ class SyncService(BaseService):
 
     async def _run(self):
         """Main event loop."""
+        self.running = True
+
         one_sync = self.args.one_sync
         sync_now = self.args.sync_now
-        self.connectors = BYOIndex(self.config["elasticsearch"])
         es_host = self.config["elasticsearch"]["host"]
-        self.running = True
         native_service_types = self.config.get("native_service_types", [])
         logger.debug(f"Native support for {', '.join(native_service_types)}")
+
+        self.connectors = BYOIndex(self.config["elasticsearch"])
 
         # XXX we can support multiple connectors but Ruby can't so let's use a
         # single id
@@ -135,32 +137,11 @@ class SyncService(BaseService):
         else:
             connectors_ids = []
 
-        if not (await self.connectors.wait()):
-            logger.critical(f"{es_host} seem down. Bye!")
-            return -1
-
-        es = ElasticServer(self.config["elasticsearch"])
-
-        # pre-flight check
-        attempts = 0
-        while self.running:
-            logger.info("Preflight checks...")
-            try:
-                # Checking the indices/pipeline in the loop to be less strict about the boot ordering
-                await self.connectors.preflight()
-                break
-            except Exception as e:
-                if attempts > self.preflight_max_attempts:
-                    raise
-                else:
-                    logger.warn(
-                        f"Attempt {attempts+1}/{self.preflight_max_attempts} failed. Retrying..."
-                    )
-                    logger.warn(str(e))
-                    attempts += 1
-                    await asyncio.sleep(self.preflight_idle)
+        await self._pre_flight_check()
 
         logger.info(f"Service started, listening to events from {es_host}")
+
+        es = ElasticServer(self.config["elasticsearch"])
         try:
             while self.running:
                 try:
@@ -185,3 +166,27 @@ class SyncService(BaseService):
             await self.connectors.close()
             await es.close()
         return 0
+
+    async def _pre_flight_check(self):
+        if not (await self.connectors.wait()):
+            logger.critical(f"{es_host} seem down. Bye!")
+            return -1
+
+        # pre-flight check
+        attempts = 0
+        while self.running:
+            logger.info("Preflight checks...")
+            try:
+                # Checking the indices/pipeline in the loop to be less strict about the boot ordering
+                await self.connectors.preflight()
+                break
+            except Exception as e:
+                if attempts > self.preflight_max_attempts:
+                    raise
+                else:
+                    logger.warn(
+                        f"Attempt {attempts+1}/{self.preflight_max_attempts} failed. Retrying..."
+                    )
+                    logger.warn(str(e))
+                    attempts += 1
+                    await asyncio.sleep(self.preflight_idle)

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -119,6 +119,8 @@ class SyncService(BaseService):
 
     async def _run(self):
         """Main event loop."""
+
+        self.connectors = BYOIndex(self.config["elasticsearch"])
         self.running = True
 
         one_sync = self.args.one_sync
@@ -126,8 +128,6 @@ class SyncService(BaseService):
         es_host = self.config["elasticsearch"]["host"]
         native_service_types = self.config.get("native_service_types", [])
         logger.debug(f"Native support for {', '.join(native_service_types)}")
-
-        self.connectors = BYOIndex(self.config["elasticsearch"])
 
         # XXX we can support multiple connectors but Ruby can't so let's use a
         # single id

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -125,7 +125,6 @@ class SyncService(BaseService):
 
         one_sync = self.args.one_sync
         sync_now = self.args.sync_now
-        es_host = self.config["elasticsearch"]["host"]
         native_service_types = self.config.get("native_service_types", [])
         logger.debug(f"Native support for {', '.join(native_service_types)}")
 
@@ -138,8 +137,6 @@ class SyncService(BaseService):
             connectors_ids = []
 
         await self._pre_flight_check()
-
-        logger.info(f"Service started, listening to events from {es_host}")
 
         es = ElasticServer(self.config["elasticsearch"])
         try:
@@ -168,6 +165,8 @@ class SyncService(BaseService):
         return 0
 
     async def _pre_flight_check(self):
+        es_host = self.config["elasticsearch"]["host"]
+
         if not (await self.connectors.wait()):
             logger.critical(f"{es_host} seem down. Bye!")
             return -1
@@ -190,3 +189,5 @@ class SyncService(BaseService):
                     logger.warn(str(e))
                     attempts += 1
                     await asyncio.sleep(self.preflight_idle)
+
+        logger.info(f"Service started, listening to events from {es_host}")


### PR DESCRIPTION
A couple small changes:

1. Rearranged arguments in `_run` function to group them more logically (same things happen together)
2. Moved all preflight check logic to a separate method