### PR TITLE
[Filtering] Add BasicRule parse method

### DIFF
--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+
 import datetime
 import re
 from enum import Enum
@@ -13,6 +14,38 @@ from connectors.logger import logger
 
 IS_BOOL_FALSE = re.compile("^(false|f|no|n|off)$", re.I)
 IS_BOOL_TRUE = re.compile("^(true|t|yes|y|on)$", re.I)
+
+
+def parse(basic_rules_json):
+    """
+
+    *basic_rules_json*, an array of dicts or an empty array
+
+    The parser works in the following way:
+      - Map every raw basic rule in the json to the corresponding BasicRule object
+      - Filter out every basic rule, which matches the default rule
+      - Sort the result in descending order according to their basic rule order (rules are executed in descending order)
+    """
+    if not basic_rules_json:
+        return []
+
+    map_to_basic_rules_list = list(
+        map(
+            lambda basic_rule_json: BasicRule.from_json(basic_rule_json),
+            basic_rules_json,
+        )
+    )
+
+    return sorted(
+        list(
+            filter(
+                lambda basic_rule: not basic_rule.is_default_rule(),
+                map_to_basic_rules_list,
+            )
+        ),
+        key=lambda basic_rule: basic_rule.order,
+        reverse=True,
+    )
 
 
 def to_float(value):
@@ -70,22 +103,71 @@ class Rule(Enum):
     GREATER_THAN = 6
     LESS_THAN = 7
 
+    RULES = [EQUALS, STARTS_WITH, ENDS_WITH, CONTAINS, REGEX, GREATER_THAN, LESS_THAN]
+
+    @classmethod
+    def from_string(cls, string):
+        match string.casefold():
+            case "equals":
+                return Rule.EQUALS
+            case "contains":
+                return Rule.CONTAINS
+            case "ends_with":
+                return Rule.ENDS_WITH
+            case ">":
+                return Rule.GREATER_THAN
+            case "<":
+                return Rule.LESS_THAN
+            case "regex":
+                return Rule.REGEX
+            case "starts_with":
+                return Rule.STARTS_WITH
+            case _:
+                raise ValueError(
+                    f"'{string}' is an unknown value for the enum Rule. Allowed rules: {Rule.RULES}."
+                )
+
 
 class Policy(Enum):
     INCLUDE = 1
     EXCLUDE = 2
+
+    POLICIES = [INCLUDE, EXCLUDE]
+
+    @classmethod
+    def from_string(cls, string):
+        match string.casefold():
+            case "include":
+                return Policy.INCLUDE
+            case "exclude":
+                return Policy.EXCLUDE
+            case _:
+                raise ValueError(
+                    f"'{string}' is an unknown value for a Policy. Allowed policies: {Policy.POLICIES}"
+                )
 
 
 class BasicRule:
     DEFAULT_RULE_ID = "DEFAULT"
 
     def __init__(self, id_, order, policy, field, rule, value):
-        self._id = id_
-        self._order = order
-        self._policy = policy
-        self._field = field
-        self._rule = rule
-        self._value = value
+        self.id_ = id_
+        self.order = order
+        self.policy = policy
+        self.field = field
+        self.rule = rule
+        self.value = value
+
+    @classmethod
+    def from_json(cls, basic_rule_json):
+        return cls(
+            id_=basic_rule_json["id"],
+            order=basic_rule_json["order"],
+            policy=Policy.from_string(basic_rule_json["policy"]),
+            field=basic_rule_json["field"],
+            rule=Rule.from_string(basic_rule_json["rule"]),
+            value=basic_rule_json["value"],
+        )
 
     @classmethod
     def default_rule(cls):
@@ -102,23 +184,23 @@ class BasicRule:
         if self.is_default_rule():
             return True
 
-        if self._field not in document:
+        if self.field not in document:
             return False
 
-        document_value = document[self._field]
+        document_value = document[self.field]
         coerced_rule_value = self.coerce_rule_value_based_on_document_value(
             document_value
         )
 
-        match self._rule:
+        match self.rule:
             case Rule.STARTS_WITH:
-                return str(document_value).startswith(self._value)
+                return str(document_value).startswith(self.value)
             case Rule.ENDS_WITH:
-                return str(document_value).endswith(self._value)
+                return str(document_value).endswith(self.value)
             case Rule.CONTAINS:
-                return self._value in str(document_value)
+                return self.value in str(document_value)
             case Rule.REGEX:
-                return re.match(self._value, str(document_value)) is not None
+                return re.match(self.value, str(document_value)) is not None
             case Rule.LESS_THAN:
                 return document_value < coerced_rule_value
             case Rule.GREATER_THAN:
@@ -127,26 +209,26 @@ class BasicRule:
                 return document_value == coerced_rule_value
 
     def is_default_rule(self):
-        return self._id == BasicRule.DEFAULT_RULE_ID
+        return self.id_ == BasicRule.DEFAULT_RULE_ID
 
     def is_include(self):
-        return self._policy == Policy.INCLUDE
+        return self.policy == Policy.INCLUDE
 
     def coerce_rule_value_based_on_document_value(self, doc_value):
         try:
             match doc_value:
                 case str():
-                    return str(self._value)
+                    return str(self.value)
                 case bool():
-                    return str(to_bool(self._value))
+                    return str(to_bool(self.value))
                 case float() | int():
-                    return float(self._value)
+                    return float(self.value)
                 case datetime.date() | datetime.datetime:
-                    return to_datetime(self._value)
+                    return to_datetime(self.value)
                 case _:
-                    return str(self._value)
+                    return str(self.value)
         except ValueError as e:
             logger.debug(
-                f"Failed to coerce value '{self._value}' ({type(self._value)}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}"
+                f"Failed to coerce value '{self.value}' ({type(self.value)}) based on document value '{doc_value}' ({type(doc_value)}) due to error: {type(e)}: {e}"
             )
-            return str(self._value)
+            return str(self.value)

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -22,8 +22,8 @@ def parse(basic_rules_json):
     *basic_rules_json*, an array of dicts or an empty array
 
     The parser works in the following way:
-      - Map every raw basic rule in the json to the corresponding BasicRule object
-      - Filter out every basic rule, which matches the default rule
+      - Map every raw basic rule in the json array to the corresponding BasicRule object
+      - Filter out every basic rule, which returns true for is_default_rule()
       - Sort the result in descending order according to their basic rule order (rules are executed in descending order)
     """
     if not basic_rules_json:

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -143,7 +143,7 @@ class Policy(Enum):
                 return Policy.EXCLUDE
             case _:
                 raise ValueError(
-                    f"'{string}' is an unknown value for a Policy. Allowed policies: {Policy.POLICIES}"
+                    f"'{string}' is an unknown value for the enum Policy. Allowed policies: {Policy.POLICIES}"
                 )
 
 

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -6,7 +6,73 @@
 
 import datetime
 
-from connectors.filtering.basic_rule import BasicRule, Policy, Rule, try_coerce
+import pytest
+
+from connectors.filtering.basic_rule import BasicRule, Policy, Rule, parse, try_coerce
+
+BASIC_RULE_ONE_ID = "1"
+BASIC_RULE_ONE_ORDER = 1
+BASIC_RULE_ONE_POLICY = "include"
+BASIC_RULE_ONE_FIELD = "field one"
+BASIC_RULE_ONE_RULE = "equals"
+BASIC_RULE_ONE_VALUE = "value one"
+
+BASIC_RULE_ONE_JSON = {
+    "id": BASIC_RULE_ONE_ID,
+    "order": BASIC_RULE_ONE_ORDER,
+    "policy": BASIC_RULE_ONE_POLICY,
+    "field": BASIC_RULE_ONE_FIELD,
+    "rule": BASIC_RULE_ONE_RULE,
+    "value": BASIC_RULE_ONE_VALUE,
+}
+
+BASIC_RULE_TWO_ID = "2"
+BASIC_RULE_TWO_ORDER = 2
+BASIC_RULE_TWO_POLICY = "exclude"
+BASIC_RULE_TWO_FIELD = "field two"
+BASIC_RULE_TWO_RULE = "contains"
+BASIC_RULE_TWO_VALUE = "value two"
+
+BASIC_RULE_TWO_JSON = {
+    "id": BASIC_RULE_TWO_ID,
+    "order": BASIC_RULE_TWO_ORDER,
+    "policy": BASIC_RULE_TWO_POLICY,
+    "field": BASIC_RULE_TWO_FIELD,
+    "rule": BASIC_RULE_TWO_RULE,
+    "value": BASIC_RULE_TWO_VALUE,
+}
+
+BASIC_RULE_THREE_ID = "3"
+BASIC_RULE_THREE_ORDER = 3
+BASIC_RULE_THREE_POLICY = "include"
+BASIC_RULE_THREE_FIELD = "field three"
+BASIC_RULE_THREE_RULE = "contains"
+BASIC_RULE_THREE_VALUE = "value three"
+
+BASIC_RULE_THREE_JSON = {
+    "id": BASIC_RULE_THREE_ID,
+    "order": BASIC_RULE_THREE_ORDER,
+    "policy": BASIC_RULE_THREE_POLICY,
+    "field": BASIC_RULE_THREE_FIELD,
+    "rule": BASIC_RULE_THREE_RULE,
+    "value": BASIC_RULE_THREE_VALUE,
+}
+
+BASIC_RULE_DEFAULT_ID = "DEFAULT"
+BASIC_RULE_DEFAULT_ORDER = 0
+BASIC_RULE_DEFAULT_POLICY = "include"
+BASIC_RULE_DEFAULT_FIELD = "_"
+BASIC_RULE_DEFAULT_RULE = "equals"
+BASIC_RULE_DEFAULT_VALUE = ".*"
+
+BASIC_RULE_DEFAULT_JSON = {
+    "id": BASIC_RULE_DEFAULT_ID,
+    "order": BASIC_RULE_DEFAULT_ORDER,
+    "policy": BASIC_RULE_DEFAULT_POLICY,
+    "field": BASIC_RULE_DEFAULT_FIELD,
+    "rule": BASIC_RULE_DEFAULT_RULE,
+    "value": BASIC_RULE_DEFAULT_VALUE,
+}
 
 DESCRIPTION_KEY = "description"
 DESCRIPTION_VALUE = "abc"
@@ -31,6 +97,219 @@ DOCUMENT = {
     CREATED_AT_DATE_KEY: CREATED_AT_DATE_VALUE,
     CREATED_AT_DATETIME_KEY: CREATED_AT_DATETIME_VALUE,
 }
+
+
+def basic_rule_one_policy_and_rule_uppercase():
+    basic_rule_uppercase = BASIC_RULE_ONE_JSON
+
+    basic_rule_uppercase["rule"] = basic_rule_uppercase["rule"].upper()
+    basic_rule_uppercase["policy"] = basic_rule_uppercase["policy"].upper()
+
+    return basic_rule_uppercase
+
+
+def contains_rule_one(basic_rules):
+    return any(is_rule_one(basic_rule) for basic_rule in basic_rules)
+
+
+def contains_rule_two(basic_rules):
+    return any(is_rule_two(basic_rule) for basic_rule in basic_rules)
+
+
+def contains_rule_three(basic_rules):
+    return any(is_rule_three(basic_rule) for basic_rule in basic_rules)
+
+
+def contains_default_rule(basic_rules):
+    return any(is_default_rule(basic_rule) for basic_rule in basic_rules)
+
+
+def is_rule_one(basic_rule):
+    return (
+            basic_rule.id_ == BASIC_RULE_ONE_ID
+            and basic_rule.order == BASIC_RULE_ONE_ORDER
+            and basic_rule.policy == Policy.from_string(BASIC_RULE_ONE_POLICY)
+            and basic_rule.field == BASIC_RULE_ONE_FIELD
+            and basic_rule.rule == Rule.from_string(BASIC_RULE_ONE_RULE)
+            and basic_rule.value == BASIC_RULE_ONE_VALUE
+    )
+
+
+def is_rule_two(basic_rule):
+    return (
+            basic_rule.id_ == BASIC_RULE_TWO_ID
+            and basic_rule.order == BASIC_RULE_TWO_ORDER
+            and basic_rule.policy == Policy.from_string(BASIC_RULE_TWO_POLICY)
+            and basic_rule.field == BASIC_RULE_TWO_FIELD
+            and basic_rule.rule == Rule.from_string(BASIC_RULE_TWO_RULE)
+            and basic_rule.value == BASIC_RULE_TWO_VALUE
+    )
+
+
+def is_rule_three(basic_rule):
+    return (
+            basic_rule.id_ == BASIC_RULE_THREE_ID
+            and basic_rule.order == BASIC_RULE_THREE_ORDER
+            and basic_rule.policy == Policy.from_string(BASIC_RULE_THREE_POLICY)
+            and basic_rule.field == BASIC_RULE_THREE_FIELD
+            and basic_rule.rule == Rule.from_string(BASIC_RULE_THREE_RULE)
+            and basic_rule.value == BASIC_RULE_THREE_VALUE
+    )
+
+
+def is_default_rule(basic_rule):
+    return (
+            basic_rule.id_ == BASIC_RULE_DEFAULT_ID
+            and basic_rule.order == BASIC_RULE_DEFAULT_ORDER
+            and basic_rule.policy == Policy.from_string(BASIC_RULE_DEFAULT_POLICY)
+            and basic_rule.field == BASIC_RULE_DEFAULT_FIELD
+            and basic_rule.rule == Rule.from_string(BASIC_RULE_DEFAULT_RULE)
+            and basic_rule.value == BASIC_RULE_DEFAULT_VALUE
+    )
+
+
+def test_include_lowercase_should_return_policy_include():
+    assert Policy.from_string("include") == Policy.INCLUDE
+
+
+def test_include_uppercase_should_return_policy_include():
+    assert Policy.from_string("INCLUDE") == Policy.INCLUDE
+
+
+def test_exclude_lowercase_should_return_policy_exclude():
+    assert Policy.from_string("exclude") == Policy.EXCLUDE
+
+
+def test_exclude_uppercase_should_return_policy_exclude():
+    assert Policy.from_string("EXCLUDE") == Policy.EXCLUDE
+
+
+def test_equals_lowercase_should_return_rule_equals():
+    assert Rule.from_string("equals") == Rule.EQUALS
+
+
+def test_equals_uppercase_should_return_rule_equals():
+    assert Rule.from_string("EQUALS") == Rule.EQUALS
+
+
+def test_contains_lowercase_should_return_rule_contains():
+    assert Rule.from_string("contains") == Rule.CONTAINS
+
+
+def test_contains_uppercase_should_return_rule_contains():
+    assert Rule.from_string("CONTAINS") == Rule.CONTAINS
+
+
+def test_ends_with_lowercase_should_return_rule_ends_with():
+    assert Rule.from_string("ends_with") == Rule.ENDS_WITH
+
+
+def test_ends_with_uppercase_should_return_rule_ends_with():
+    assert Rule.from_string("ENDS_WITH") == Rule.ENDS_WITH
+
+
+def test_greater_than_sign_should_return_rule_greater_than():
+    assert Rule.from_string(">") == Rule.GREATER_THAN
+
+
+def test_less_than_sign_should_return_rule_less_than():
+    assert Rule.from_string("<") == Rule.LESS_THAN
+
+
+def test_regex_lowercase_should_return_rule_regex():
+    assert Rule.from_string("regex") == Rule.REGEX
+
+
+def test_regex_uppercase_should_return_rule_regex():
+    assert Rule.from_string("REGEX") == Rule.REGEX
+
+
+def test_starts_with_lowercase_should_return_rule_starts_with():
+    assert Rule.from_string("starts_with") == Rule.STARTS_WITH
+
+
+def test_starts_with_uppercase_should_return_rule_starts_with():
+    assert Rule.from_string("STARTS_WITH") == Rule.STARTS_WITH
+
+
+def test_raise_value_error_if_argument_cannot_be_parsed_to_policy():
+    with pytest.raises(ValueError):
+        Policy.from_string("unknown")
+
+
+def test_raise_value_error_if_argument_cannot_be_parsed_to_rule():
+    with pytest.raises(ValueError):
+        Rule.from_string("unknown")
+
+
+def test_from_json():
+    basic_rule = BasicRule.from_json(BASIC_RULE_ONE_JSON)
+
+    assert is_rule_one(basic_rule)
+
+
+def test_parse_none_to_empty_array():
+    raw_basic_rules = None
+
+    assert len(parse(raw_basic_rules)) == 0
+
+
+def test_parse_empty_basic_rules_to_empty_array():
+    raw_basic_rules = []
+
+    assert len(parse(raw_basic_rules)) == 0
+
+
+def test_parse_one_raw_basic_rule_with_policy_and_rule_lowercase():
+    raw_basic_rules = [BASIC_RULE_ONE_JSON]
+
+    parsed_basic_rules = parse(raw_basic_rules)
+
+    assert len(parsed_basic_rules) == 1
+    assert contains_rule_one(parsed_basic_rules)
+
+
+def test_parse_one_raw_basic_rule_with_policy_and_rule_uppercase():
+    raw_basic_rules = [basic_rule_one_policy_and_rule_uppercase()]
+
+    parsed_basic_rules = parse(raw_basic_rules)
+
+    assert len(parsed_basic_rules) == 1
+    assert contains_rule_one(parsed_basic_rules)
+
+
+def test_parses_multiple_rules_correctly():
+    raw_basic_rules = [BASIC_RULE_ONE_JSON, BASIC_RULE_TWO_JSON]
+
+    parsed_basic_rules = parse(raw_basic_rules)
+
+    assert len(parsed_basic_rules) == 2
+    assert contains_rule_one(parsed_basic_rules)
+    assert contains_rule_two(parsed_basic_rules)
+
+
+def test_parser_rejects_default_rule():
+    raw_basic_rules = [BASIC_RULE_DEFAULT_JSON, BASIC_RULE_ONE_JSON]
+
+    parsed_basic_rules = parse(raw_basic_rules)
+
+    assert len(parsed_basic_rules) == 1
+    assert contains_rule_one(parsed_basic_rules)
+    assert not contains_default_rule(parsed_basic_rules)
+
+
+def test_rules_are_ordered_descending_with_respect_to_the_order_property():
+    raw_basic_rules = [BASIC_RULE_ONE_JSON, BASIC_RULE_THREE_JSON, BASIC_RULE_TWO_JSON]
+
+    parsed_basic_rules = parse(raw_basic_rules)
+    first_rule = parsed_basic_rules[0]
+    second_rule = parsed_basic_rules[1]
+    third_rule = parsed_basic_rules[2]
+
+    assert len(parsed_basic_rules) == 3
+    assert is_rule_three(first_rule)
+    assert is_rule_two(second_rule)
+    assert is_rule_one(third_rule)
 
 
 def test_matches_default_rule():

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -126,45 +126,45 @@ def contains_default_rule(basic_rules):
 
 def is_rule_one(basic_rule):
     return (
-            basic_rule.id_ == BASIC_RULE_ONE_ID
-            and basic_rule.order == BASIC_RULE_ONE_ORDER
-            and basic_rule.policy == Policy.from_string(BASIC_RULE_ONE_POLICY)
-            and basic_rule.field == BASIC_RULE_ONE_FIELD
-            and basic_rule.rule == Rule.from_string(BASIC_RULE_ONE_RULE)
-            and basic_rule.value == BASIC_RULE_ONE_VALUE
+        basic_rule.id_ == BASIC_RULE_ONE_ID
+        and basic_rule.order == BASIC_RULE_ONE_ORDER
+        and basic_rule.policy == Policy.from_string(BASIC_RULE_ONE_POLICY)
+        and basic_rule.field == BASIC_RULE_ONE_FIELD
+        and basic_rule.rule == Rule.from_string(BASIC_RULE_ONE_RULE)
+        and basic_rule.value == BASIC_RULE_ONE_VALUE
     )
 
 
 def is_rule_two(basic_rule):
     return (
-            basic_rule.id_ == BASIC_RULE_TWO_ID
-            and basic_rule.order == BASIC_RULE_TWO_ORDER
-            and basic_rule.policy == Policy.from_string(BASIC_RULE_TWO_POLICY)
-            and basic_rule.field == BASIC_RULE_TWO_FIELD
-            and basic_rule.rule == Rule.from_string(BASIC_RULE_TWO_RULE)
-            and basic_rule.value == BASIC_RULE_TWO_VALUE
+        basic_rule.id_ == BASIC_RULE_TWO_ID
+        and basic_rule.order == BASIC_RULE_TWO_ORDER
+        and basic_rule.policy == Policy.from_string(BASIC_RULE_TWO_POLICY)
+        and basic_rule.field == BASIC_RULE_TWO_FIELD
+        and basic_rule.rule == Rule.from_string(BASIC_RULE_TWO_RULE)
+        and basic_rule.value == BASIC_RULE_TWO_VALUE
     )
 
 
 def is_rule_three(basic_rule):
     return (
-            basic_rule.id_ == BASIC_RULE_THREE_ID
-            and basic_rule.order == BASIC_RULE_THREE_ORDER
-            and basic_rule.policy == Policy.from_string(BASIC_RULE_THREE_POLICY)
-            and basic_rule.field == BASIC_RULE_THREE_FIELD
-            and basic_rule.rule == Rule.from_string(BASIC_RULE_THREE_RULE)
-            and basic_rule.value == BASIC_RULE_THREE_VALUE
+        basic_rule.id_ == BASIC_RULE_THREE_ID
+        and basic_rule.order == BASIC_RULE_THREE_ORDER
+        and basic_rule.policy == Policy.from_string(BASIC_RULE_THREE_POLICY)
+        and basic_rule.field == BASIC_RULE_THREE_FIELD
+        and basic_rule.rule == Rule.from_string(BASIC_RULE_THREE_RULE)
+        and basic_rule.value == BASIC_RULE_THREE_VALUE
     )
 
 
 def is_default_rule(basic_rule):
     return (
-            basic_rule.id_ == BASIC_RULE_DEFAULT_ID
-            and basic_rule.order == BASIC_RULE_DEFAULT_ORDER
-            and basic_rule.policy == Policy.from_string(BASIC_RULE_DEFAULT_POLICY)
-            and basic_rule.field == BASIC_RULE_DEFAULT_FIELD
-            and basic_rule.rule == Rule.from_string(BASIC_RULE_DEFAULT_RULE)
-            and basic_rule.value == BASIC_RULE_DEFAULT_VALUE
+        basic_rule.id_ == BASIC_RULE_DEFAULT_ID
+        and basic_rule.order == BASIC_RULE_DEFAULT_ORDER
+        and basic_rule.policy == Policy.from_string(BASIC_RULE_DEFAULT_POLICY)
+        and basic_rule.field == BASIC_RULE_DEFAULT_FIELD
+        and basic_rule.rule == Rule.from_string(BASIC_RULE_DEFAULT_RULE)
+        and basic_rule.value == BASIC_RULE_DEFAULT_VALUE
     )
 
 

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -168,68 +168,45 @@ def is_default_rule(basic_rule):
     )
 
 
-def test_include_lowercase_should_return_policy_include():
-    assert Policy.from_string("include") == Policy.INCLUDE
+@pytest.mark.parametrize(
+    "policy_string, expected_parsed_policy",
+    [
+        ("include", Policy.INCLUDE),
+        ("INCLUDE", Policy.INCLUDE),
+        ("iNcLuDe", Policy.INCLUDE),
+        ("exclude", Policy.EXCLUDE),
+        ("EXCLUDE", Policy.EXCLUDE),
+        ("eXcLuDe", Policy.EXCLUDE),
+    ],
+)
+def test_from_string_policy_factory_method(policy_string, expected_parsed_policy):
+    assert Policy.from_string(policy_string) == expected_parsed_policy
 
 
-def test_include_uppercase_should_return_policy_include():
-    assert Policy.from_string("INCLUDE") == Policy.INCLUDE
-
-
-def test_exclude_lowercase_should_return_policy_exclude():
-    assert Policy.from_string("exclude") == Policy.EXCLUDE
-
-
-def test_exclude_uppercase_should_return_policy_exclude():
-    assert Policy.from_string("EXCLUDE") == Policy.EXCLUDE
-
-
-def test_equals_lowercase_should_return_rule_equals():
-    assert Rule.from_string("equals") == Rule.EQUALS
-
-
-def test_equals_uppercase_should_return_rule_equals():
-    assert Rule.from_string("EQUALS") == Rule.EQUALS
-
-
-def test_contains_lowercase_should_return_rule_contains():
-    assert Rule.from_string("contains") == Rule.CONTAINS
-
-
-def test_contains_uppercase_should_return_rule_contains():
-    assert Rule.from_string("CONTAINS") == Rule.CONTAINS
-
-
-def test_ends_with_lowercase_should_return_rule_ends_with():
-    assert Rule.from_string("ends_with") == Rule.ENDS_WITH
-
-
-def test_ends_with_uppercase_should_return_rule_ends_with():
-    assert Rule.from_string("ENDS_WITH") == Rule.ENDS_WITH
-
-
-def test_greater_than_sign_should_return_rule_greater_than():
-    assert Rule.from_string(">") == Rule.GREATER_THAN
-
-
-def test_less_than_sign_should_return_rule_less_than():
-    assert Rule.from_string("<") == Rule.LESS_THAN
-
-
-def test_regex_lowercase_should_return_rule_regex():
-    assert Rule.from_string("regex") == Rule.REGEX
-
-
-def test_regex_uppercase_should_return_rule_regex():
-    assert Rule.from_string("REGEX") == Rule.REGEX
-
-
-def test_starts_with_lowercase_should_return_rule_starts_with():
-    assert Rule.from_string("starts_with") == Rule.STARTS_WITH
-
-
-def test_starts_with_uppercase_should_return_rule_starts_with():
-    assert Rule.from_string("STARTS_WITH") == Rule.STARTS_WITH
+@pytest.mark.parametrize(
+    "rule_string, expected_parsed_rule",
+    [
+        ("equals", Rule.EQUALS),
+        ("EQUALS", Rule.EQUALS),
+        ("eQuAlS", Rule.EQUALS),
+        ("contains", Rule.CONTAINS),
+        ("CONTAINS", Rule.CONTAINS),
+        ("cOnTaInS", Rule.CONTAINS),
+        ("ends_with", Rule.ENDS_WITH),
+        ("ENDS_WITH", Rule.ENDS_WITH),
+        ("eNdS_wItH", Rule.ENDS_WITH),
+        (">", Rule.GREATER_THAN),
+        ("<", Rule.LESS_THAN),
+        ("regex", Rule.REGEX),
+        ("REGEX", Rule.REGEX),
+        ("rEgEx", Rule.REGEX),
+        ("starts_with", Rule.STARTS_WITH),
+        ("STARTS_WITH", Rule.STARTS_WITH),
+        ("sTaRtS_wItH", Rule.STARTS_WITH),
+    ],
+)
+def test_from_string_rule_factory_method(rule_string, expected_parsed_rule):
+    assert Rule.from_string(rule_string) == expected_parsed_rule
 
 
 def test_raise_value_error_if_argument_cannot_be_parsed_to_policy():


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3573 ##

This PR adds a parse method to the `BasicRule` class to parse an array of dicts representing raw basic rules in the following way:

  - Map every raw basic rule in the json array to the corresponding BasicRule object
  - Filter out every basic rule, which matches the default rule
  - Sort the result in descending order according to their basic rule order (rules are executed in descending order)

Also add `from_string` factory methods for the `Policy`, `Rule` and a `from_json` factory method for `BasicRule`.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally