### PR TITLE
[Filtering] Add BasicRuleNoMatchAllRegexValidator

### DIFF
--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -147,6 +147,50 @@ class Policy(Enum):
                 )
 
 
+class BasicRuleValidationResult:
+    def __init__(self, rule_id, is_valid, validation_message):
+        self.rule_id = rule_id
+        self.is_valid = is_valid
+        self.validation_message = validation_message
+
+    @classmethod
+    def valid_result(cls, rule_id):
+        return BasicRuleValidationResult(
+            rule_id=rule_id, is_valid=True, validation_message="Valid rule"
+        )
+
+
+class BasicRuleValidator:
+    @classmethod
+    def validate(cls, rule):
+        raise NotImplementedError
+
+
+class BasicRuleNoMatchAllRegexValidator(BasicRuleValidator):
+    MATCH_ALL_REGEXPS = [".*", "(.*)"]
+
+    @classmethod
+    def validate(cls, basic_rule_json):
+        basic_rule = BasicRule.from_json(basic_rule_json)
+
+        # default rule uses match all regex, which is intended
+        if basic_rule.is_default_rule():
+            return BasicRuleValidationResult.valid_result(rule_id=basic_rule.id_)
+
+        if basic_rule.rule == Rule.REGEX and any(
+            match_all_regex == basic_rule.value
+            for match_all_regex in BasicRuleNoMatchAllRegexValidator.MATCH_ALL_REGEXPS
+        ):
+            return BasicRuleValidationResult(
+                rule_id=basic_rule.id_,
+                is_valid=False,
+                validation_message=f"Match all regexps: '{BasicRuleNoMatchAllRegexValidator.MATCH_ALL_REGEXPS}' are "
+                f"not allowed.",
+            )
+
+        return BasicRuleValidationResult.valid_result(rule_id=basic_rule.id_)
+
+
 class BasicRule:
     DEFAULT_RULE_ID = "DEFAULT"
 

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -1230,7 +1230,6 @@ def basic_rule_json(merge_with=None, delete_keys=None):
         (basic_rule_json(merge_with={"id": BasicRule.DEFAULT_RULE_ID}), True),
         # valid regexps
         (basic_rule_json(merge_with={"rule": "regex", "value": "abc"}), True),
-        (basic_rule_json(merge_with={"rule": "regex", "value": "\*"}), True),
         # for other rule types it should be possible to use values which look like match all regexps
         (basic_rule_json(merge_with={"rule": "contains", "value": ".*"}), True),
         (basic_rule_json(merge_with={"rule": "contains", "value": "(.*)"}), True),

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -10,9 +10,9 @@ import pytest
 
 from connectors.filtering.basic_rule import (
     BasicRule,
-    BasicRuleNoMatchAllRegexValidator,
     BasicRuleAgainstSchemaValidator,
     BasicRuleEngine,
+    BasicRuleNoMatchAllRegexValidator,
     Policy,
     Rule,
     RuleMatchStats,
@@ -1501,6 +1501,7 @@ def test_basic_rule_validate_no_match_all_regex(basic_rule, should_be_valid):
         assert BasicRuleNoMatchAllRegexValidator.validate(basic_rule).is_valid
     else:
         assert not BasicRuleNoMatchAllRegexValidator.validate(basic_rule).is_valid
+
 
 @pytest.mark.parametrize(
     "basic_rule, should_be_valid",


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/3583 ##

This PR adds the `BasicRuleNoMatchAllRegexValidator`. The default rule is excluded from this validation as it intentionally uses a match all regex.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally