### PR TITLE
[Filtering] Add BasicRuleSetSemanticValidator

### DIFF
--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -174,7 +174,7 @@ class Policy(Enum):
 
 class BasicRuleValidationResult:
     def __init__(self, rule_id, is_valid, validation_message):
-        self.rule_id = (rule_id,)
+        self.rule_id = rule_id
         self.is_valid = is_valid
         self.validation_message = validation_message
 

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -208,12 +208,7 @@ class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
             if field_rule_value_hash in rules_dict:
                 semantic_duplicate = rules_dict[field_rule_value_hash]
 
-                if semantic_duplicate.policy == basic_rule.policy:
-                    return cls.semantic_duplicates_validation_results(
-                        basic_rule, semantic_duplicate
-                    )
-
-                return cls.semantic_duplicates_conflicting_policies_validation_result(
+                return cls.semantic_duplicates_validation_results(
                     basic_rule, semantic_duplicate
                 )
 
@@ -222,31 +217,6 @@ class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
         return [
             BasicRuleValidationResult.valid_result(rule_id=rule.id_)
             for rule in rules_dict.values()
-        ]
-
-    @classmethod
-    def semantic_duplicates_conflicting_policies_validation_result(
-        cls, basic_rule, semantic_duplicate
-    ):
-        def semantic_duplicate_conflicting_policy_msg(rule_one, rule_two):
-            return f"Rule with id '{rule_one.id_}' is semantically equal to rule with id '{rule_two.id_}' and the rules have conflicting policies."
-
-        return [
-            # We need two error messages to highlight both rules in the UI
-            BasicRuleValidationResult(
-                rule_id=basic_rule.id_,
-                is_valid=False,
-                validation_message=semantic_duplicate_conflicting_policy_msg(
-                    basic_rule, semantic_duplicate
-                ),
-            ),
-            BasicRuleValidationResult(
-                rule_id=semantic_duplicate.id_,
-                is_valid=False,
-                validation_message=semantic_duplicate_conflicting_policy_msg(
-                    semantic_duplicate, basic_rule
-                ),
-            ),
         ]
 
     @classmethod

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -217,6 +217,8 @@ class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
                     basic_rule, semantic_duplicate
                 )
 
+            rules_dict[field_rule_value_hash] = basic_rule
+
         return [
             BasicRuleValidationResult.valid_result(rule_id=rule.id_)
             for rule in rules_dict.values()
@@ -235,14 +237,14 @@ class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
                 rule_id=basic_rule.id_,
                 is_valid=False,
                 validation_message=semantic_duplicate_conflicting_policy_msg(
-                    basic_rule.id_, semantic_duplicate.id_
+                    basic_rule, semantic_duplicate
                 ),
             ),
             BasicRuleValidationResult(
                 rule_id=semantic_duplicate.id_,
                 is_valid=False,
                 validation_message=semantic_duplicate_conflicting_policy_msg(
-                    semantic_duplicate.id_, basic_rule.id_
+                    semantic_duplicate, basic_rule
                 ),
             ),
         ]
@@ -250,7 +252,7 @@ class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
     @classmethod
     def semantic_duplicates_validation_results(cls, basic_rule, semantic_duplicate):
         def semantic_duplicate_msg(rule_one, rule_two):
-            return f"Rule with id '{rule_one.id_}' is semantically equal to rule with id '{rule_two.id_}'"
+            return f"Rule with id '{rule_one}' is semantically equal to rule with id '{rule_two}'"
 
         return [
             # We need two error messages to highlight both rules in the UI

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -185,6 +185,92 @@ class BasicRuleValidationResult:
         )
 
 
+class BasicRulesSetValidator:
+    @classmethod
+    def validate(cls, rules):
+        raise NotImplementedError
+
+
+class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
+    @classmethod
+    def validate(cls, rules):
+        rules_dict = {}
+
+        for rule in rules:
+            basic_rule = BasicRule.from_json(rule)
+
+            # we want to check whether another rule already uses the exact same values for 'field', 'rule' and 'value'
+            # to detect semantic duplicates
+            field_rule_value_hash = hash(
+                (basic_rule.field, basic_rule.rule, basic_rule.value)
+            )
+
+            if field_rule_value_hash in rules_dict:
+                semantic_duplicate = rules_dict[field_rule_value_hash]
+
+                if semantic_duplicate.policy == basic_rule.policy:
+                    return cls.semantic_duplicates_validation_results(
+                        basic_rule, semantic_duplicate
+                    )
+
+                return cls.semantic_duplicates_conflicting_policies_validation_result(
+                    basic_rule, semantic_duplicate
+                )
+
+        return [
+            BasicRuleValidationResult.valid_result(rule_id=rule.id_)
+            for rule in rules_dict.values()
+        ]
+
+    @classmethod
+    def semantic_duplicates_conflicting_policies_validation_result(
+        cls, basic_rule, semantic_duplicate
+    ):
+        def semantic_duplicate_conflicting_policy_msg(rule_one, rule_two):
+            return f"Rule with id '{rule_one.id_}' is semantically equal to rule with id '{rule_two.id_}' and the rules have conflicting policies."
+
+        return [
+            # We need two error messages to highlight both rules in the UI
+            BasicRuleValidationResult(
+                rule_id=basic_rule.id_,
+                is_valid=False,
+                validation_message=semantic_duplicate_conflicting_policy_msg(
+                    basic_rule.id_, semantic_duplicate.id_
+                ),
+            ),
+            BasicRuleValidationResult(
+                rule_id=semantic_duplicate.id_,
+                is_valid=False,
+                validation_message=semantic_duplicate_conflicting_policy_msg(
+                    semantic_duplicate.id_, basic_rule.id_
+                ),
+            ),
+        ]
+
+    @classmethod
+    def semantic_duplicates_validation_results(cls, basic_rule, semantic_duplicate):
+        def semantic_duplicate_msg(rule_one, rule_two):
+            return f"Rule with id '{rule_one.id_}' is semantically equal to rule with id '{rule_two.id_}'"
+
+        return [
+            # We need two error messages to highlight both rules in the UI
+            BasicRuleValidationResult(
+                rule_id=basic_rule.id_,
+                is_valid=False,
+                validation_message=semantic_duplicate_msg(
+                    basic_rule.id_, semantic_duplicate.id_
+                ),
+            ),
+            BasicRuleValidationResult(
+                rule_id=semantic_duplicate.id_,
+                is_valid=False,
+                validation_message=semantic_duplicate_msg(
+                    semantic_duplicate.id_, basic_rule.id_
+                ),
+            ),
+        ]
+
+
 class BasicRuleValidator:
     @classmethod
     def validate(cls, rule):

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -1387,7 +1387,7 @@ def test_basic_rules_set_no_conflicting_policies_validation(
             for result in BasicRulesSetSemanticValidator.validate(basic_rules_set)
         )
     else:
-        assert all(
-            not result.is_valid
+        assert not any(
+            result.is_valid
             for result in BasicRulesSetSemanticValidator.validate(basic_rules_set)
         )

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -11,9 +11,9 @@ import pytest
 from connectors.filtering.basic_rule import (
     BasicRule,
     BasicRuleAgainstSchemaValidator,
-    BasicRulesSetSemanticValidator,
     BasicRuleEngine,
     BasicRuleNoMatchAllRegexValidator,
+    BasicRulesSetSemanticValidator,
     Policy,
     Rule,
     RuleMatchStats,

--- a/connectors/tests/test_basic_rule.py
+++ b/connectors/tests/test_basic_rule.py
@@ -1334,7 +1334,7 @@ def test_basic_rule_against_schema_validation(basic_rule, should_be_valid):
 
 
 @pytest.mark.parametrize(
-    "basic_rules_set, should_be_valid",
+    "basic_rules, should_be_valid",
     [
         (
             [
@@ -1379,15 +1379,19 @@ def test_basic_rule_against_schema_validation(basic_rule, should_be_valid):
     ],
 )
 def test_basic_rules_set_no_conflicting_policies_validation(
-    basic_rules_set, should_be_valid
+    basic_rules, should_be_valid
 ):
+    validation_results = BasicRulesSetSemanticValidator.validate(basic_rules)
+
     if should_be_valid:
-        assert all(
-            result.is_valid
-            for result in BasicRulesSetSemanticValidator.validate(basic_rules_set)
-        )
+        assert all(result.is_valid for result in validation_results)
     else:
-        assert not any(
-            result.is_valid
-            for result in BasicRulesSetSemanticValidator.validate(basic_rules_set)
-        )
+
+        assert not any(result.is_valid for result in validation_results)
+
+    validation_results_rule_ids = set(
+        map(lambda result: result.rule_id, validation_results)
+    )
+    basic_rule_ids = set(map(lambda rule: rule["id"], basic_rules))
+
+    assert validation_results_rule_ids == basic_rule_ids


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/3583 ##

This PR adds two new classes:
- `BasicRuleSetValidator`: this class serves as a base class to validate a whole set of rules, used to validate constraints between different rules as opposed to `BasicRuleValidator` which validates a single rule in isolation. Can also act as a facade later on hiding different basic rule validators keeping code clean (passing all rules to it and calling the appropriate validators).

- `BasicRuleSetSemanticValidator`: this class checks if semantic errors are present in the set of rules like the following:
  - Duplicate rules with the same policy (duplicate in the sense of same `field`, `rule` and `value`)
  - Duplicate rules with different policies (duplicate in the sense of same `field`, `rule` and `value`)
  - (other constraints can be added in the future)

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally