### PR TITLE
added convert_to_b64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ autoformat: bin/python bin/black bin/elastic-ingest
 	bin/black scripts
 
 test:	bin/pytest bin/elastic-ingest
-	bin/pytest --cov-report term-missing --cov-report html --cov=connectors -sv connectors/tests connectors/sources/tests
+	bin/pytest --cov-report term-missing --cov-fail-under 92 --cov-report html --cov=connectors -sv connectors/tests connectors/sources/tests
 
 release: install
 	bin/python setup.py sdist

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -174,7 +174,7 @@ def temp_file(converter):
         _SAVED = utils._BASE64
         utils._BASE64 = None
     try:
-        content = binascii.hexlify(os.urandom(32))
+        content = binascii.hexlify(os.urandom(32)).strip()
         with tempfile.NamedTemporaryFile() as fp:
             fp.write(content)
             fp.flush()
@@ -192,7 +192,7 @@ def test_convert_to_b64_inplace(converter):
 
         assert result == source
         with open(result, "rb") as f:
-            assert f.read().strip() == base64.b64encode(content)
+            assert f.read().strip() == base64.b64encode(content).strip()
 
 
 @pytest.mark.parametrize("converter", ["system", "py"])
@@ -203,7 +203,7 @@ def test_convert_to_b64_target(converter):
             target = f"{source}.here"
             result = convert_to_b64(source, target=target)
             with open(result, "rb") as f:
-                assert f.read().strip() == base64.b64encode(content)
+                assert f.read().strip() == base64.b64encode(content).strip()
         finally:
             if os.path.exists(target):
                 os.remove(target)

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -176,7 +176,6 @@ def temp_file(converter):
     try:
         content = binascii.hexlify(os.urandom(32))
         with tempfile.NamedTemporaryFile() as fp:
-            source = fp.name
             fp.write(content)
             fp.flush()
             yield fp.name, content

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -207,3 +207,25 @@ def test_convert_to_b64_target(converter):
         finally:
             if os.path.exists(target):
                 os.remove(target)
+
+
+@pytest.mark.parametrize("converter", ["system", "py"])
+def test_convert_to_b64_no_overwrite(converter):
+    with temp_file(converter) as (source, content):
+        # check overwrite
+        try:
+            target = f"{source}.here"
+            with open(target, "w") as f:
+                f.write("some")
+
+            # if the file exists we should raise an error..
+            with pytest.raises(IOError):
+                convert_to_b64(source, target=target)
+
+            # ..unless we use `overwrite`
+            result = convert_to_b64(source, target=target, overwrite=True)
+            with open(result, "rb") as f:
+                assert f.read().strip() == base64.b64encode(content)
+        finally:
+            if os.path.exists(target):
+                os.remove(target)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -230,7 +230,7 @@ def convert_to_b64(source, target=None, overwrite=False):
             os.remove(target)
         os.rename(temp_target, target)
 
-    return not inplace and target or source
+    return source if inplace else target
 
 
 class MemQueue(asyncio.Queue):

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -9,6 +9,7 @@ import contextlib
 import functools
 import gc
 import os
+import platform
 import shutil
 import subprocess
 import time
@@ -206,7 +207,11 @@ def convert_to_b64(source, target=None, overwrite=False):
         raise IOError(f"{target} already exists.")
 
     if _BASE64 is not None:
-        cmd = f"{_BASE64} {source} > {temp_target}"
+        if platform.system() == "Darwin":
+            cmd = f"{_BASE64} {source} > {temp_target}"
+        else:
+            # In Linuces, avoid line wrapping
+            cmd = f"{_BASE64} -w 0 {source} > {temp_target}"
         subprocess.check_call(cmd, shell=True)
     else:
         with open(source, "rb") as f:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -184,7 +184,7 @@ def get_base64_value(content):
 _BASE64 = shutil.which("base64")
 
 
-def convert_to_b64(source, target=None, overwite=False):
+def convert_to_b64(source, target=None, overwrite=False):
     """Converts a `source` file to base64 using the system's `base64`
 
     When `target` is not provided, done in-place.
@@ -202,7 +202,7 @@ def convert_to_b64(source, target=None, overwite=False):
     """
     inplace = target is None
     temp_target = f"{source}.b64"
-    if not inplace and not overwite and os.path.exists(target):
+    if not inplace and not overwrite and os.path.exists(target):
         raise IOError(f"{target} already exists.")
 
     if _BASE64 is not None:

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -12,3 +12,4 @@ python-dateutil>=2.8.2
 aiogoogle>=4.2.0
 uvloop==0.17.0; sys_platform != 'win32'
 fastjsonschema==2.16.2
+base64io==1.0.3


### PR DESCRIPTION
- Adds a base64 helper that uses the system's `base64` encoder (fast and no memory overhead)
- Falls back to pure Python (win32)
- enforces a lower limit for tests coverage