### PR TITLE
[Makefile] Add 'bin/elastic-ingest' command to 'install' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ bin/python:
 	$(PYTHON) -m venv .
 	bin/pip install --upgrade pip
 
-install: bin/python
+install: bin/python bin/elastic-ingest
 	bin/pip install -r requirements/$(ARCH).txt
 
 dev: install

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ bin/python:
 	bin/pip install --upgrade pip
 
 install: bin/python bin/elastic-ingest
-	bin/pip install -r requirements/$(ARCH).txt
 
 dev: install
 	bin/pip install -r requirements/tests.txt


### PR DESCRIPTION
I ran into the problem that the execution of the following commands:

```
make clean
make install
make run
```

lead to the following error: `make: bin/elastic-ingest: No such file or directory`.

I've added `bin/elastic-ingest` command to `install` to be sure that it's also installed. Also removed a redundant installation step (requirements are installed by `bin/python` and by `bin/elastic-ingest`).

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally