### PR TITLE
reimplemented the put function to avoid a race condition

### DIFF
--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -91,7 +91,7 @@ async def test_mem_queue(patch_logger):
 @pytest.mark.asyncio
 async def test_mem_queue_speed(patch_logger):
     # with memqueue
-    queue = MemQueue(maxmemsize=1024*1024, refresh_interval=0.1, refresh_timeout=2)
+    queue = MemQueue(maxmemsize=1024 * 1024, refresh_interval=0.1, refresh_timeout=2)
     start = time.time()
     for i in range(1000):
         await queue.put("x" * 100)

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -88,6 +88,27 @@ async def test_mem_queue(patch_logger):
     assert when[1] - when[0] > 0.1
 
 
+@pytest.mark.asyncio
+async def test_mem_queue_speed(patch_logger):
+    # with memqueue
+    queue = MemQueue(maxmemsize=1024*1024, refresh_interval=0.1, refresh_timeout=2)
+    start = time.time()
+    for i in range(1000):
+        await queue.put("x" * 100)
+    mem_queue_duration = time.time() - start
+
+    # vanilla queue
+    queue = asyncio.Queue()
+    start = time.time()
+    for i in range(1000):
+        await queue.put("x" * 100)
+    queue_duration = time.time() - start
+
+    # mem queue should be 30 times slower at the most
+    quotient, _ = divmod(mem_queue_duration, queue_duration)
+    assert quotient < 30
+
+
 def test_get_base64_value():
     """This test verify get_base64_value method and convert encoded data into base64"""
     expected_result = get_base64_value("dummy".encode("utf-8"))

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -57,7 +57,7 @@ async def test_mem_queue(patch_logger):
     queue = MemQueue(maxmemsize=1024, refresh_interval=0, refresh_timeout=2)
     await queue.put("small stuff")
 
-    assert not queue.mem_full()
+    assert not queue.full()
     assert queue.qmemsize() == asizeof.asizeof("small stuff")
 
     # let's pile up until it can't accept anymore stuff
@@ -82,7 +82,7 @@ async def test_mem_queue(patch_logger):
         assert (size, item) == (64, "small stuff")
         await asyncio.sleep(0)
         await queue.get()  # removes the 2kb
-        assert not queue.mem_full()
+        assert not queue.full()
 
     await asyncio.gather(remove_data(), add_data())
     assert when[1] - when[0] > 0.1

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -308,13 +308,13 @@ class MemQueue(asyncio.Queue):
 
             await putter_timeout
 
-        super().put_nowait(item_size, item))
+        super().put_nowait((item_size, item))
 
     def put_nowait(self, item):
         item_size = get_size(item)
         if self.full(item_size):
             raise asyncio.QueueFull
-        super().put_nowait(item_size, item))
+        super().put_nowait((item_size, item))
 
 
 class ConcurrentTasks:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -291,7 +291,7 @@ class MemQueue(asyncio.Queue):
                 result = await putter
                 if isinstance(result, asyncio.QueueFull):
                     raise result
-            except:
+            except:  # NOQA
                 putter.cancel()  # Just in case putter is not done yet.
                 try:
                     # Clean self._putters from canceled putters.

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -308,20 +308,13 @@ class MemQueue(asyncio.Queue):
 
             await putter_timeout
 
-        self._put((item_size, item))
-        self._unfinished_tasks += 1
-        self._finished.clear()
-        self._wakeup_next(self._getters)
+        super().put_nowait(item_size, item))
 
     def put_nowait(self, item):
         item_size = get_size(item)
         if self.full(item_size):
             raise asyncio.QueueFull
-
-        self._put((item_size, item))
-        self._unfinished_tasks += 1
-        self._finished.clear()
-        self._wakeup_next(self._getters)
+        super().put_nowait(item_size, item))
 
 
 class ConcurrentTasks:


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/###

First draft at avoiding race condition (from blog post feedback by Quentin and Chenhui)

Quentin:

 it's indeed possible to get a time-of-check to time-of-use race condition. When calling await super.put(), it's possible for another task to enter into _wait_for_room() and it can succeed since `self.current_memsize` will only be updated in `_put()`.



#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
