### PR TITLE
Fix configuration values sent to Kibana

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -448,7 +448,12 @@ class BYOConnector:
             source_klass = get_source_klass(fqn)
 
             if self.configuration.is_empty():
-                self.configuration = source_klass.get_simple_configuration()
+                # sets the defaults and the flag to NEEDS_CONFIGURATION
+                self.doc_source[
+                    "configuration"
+                ] = source_klass.get_simple_configuration()
+                self.doc_source["status"] = e2str(Status.NEEDS_CONFIGURATION)
+                self._update_config(self.doc_source)
                 logger.debug(f"Populated configuration for connector {self.id}")
 
             # sync state if needed (when service type or configuration is updated)

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -447,7 +447,7 @@ class BYOConnector:
         try:
             source_klass = get_source_klass(fqn)
             if self.configuration.is_empty():
-                self.configuration = source_klass.get_default_configuration()
+                self.configuration = source_klass.get_simple_configuration()
                 logger.debug(f"Populated configuration for connector {self.id}")
 
             # sync state if needed (when service type or configuration is updated)

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -446,6 +446,7 @@ class BYOConnector:
         fqn = config["sources"][service_type]
         try:
             source_klass = get_source_klass(fqn)
+
             if self.configuration.is_empty():
                 self.configuration = source_klass.get_simple_configuration()
                 logger.debug(f"Populated configuration for connector {self.id}")

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -97,6 +97,8 @@ class SyncService(BaseService):
                 # the heartbeat is always triggered
                 connector.start_heartbeat(self.hb)
 
+                logger.debug(f"Connector status is {connector.status}")
+
                 # we trigger a sync
                 if connector.status in (Status.CREATED, Status.NEEDS_CONFIGURATION):
                     # we can't sync in that state

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -14,8 +14,23 @@ class Field:
             label = name
         self.name = name
         self.label = label
-        self.value = value
         self.type = type
+        self.value = self._convert(value, type)
+
+    def _convert(self, value, type_):
+        if not isinstance(value, str):
+            # we won't convert the value if it's not a str
+            return value
+
+        if type_ == "int":
+            return int(value)
+        elif type_ == "float":
+            return float(value)
+        elif type_ == "bool":
+            return value.lower() in "y", "yes", "true", "1"
+        elif type_ == "list":
+            return [item.strip() for item in value.split(",")]
+        return value
 
 
 class DataSourceConfiguration:
@@ -23,21 +38,32 @@ class DataSourceConfiguration:
 
     def __init__(self, config):
         self._config = {}
+        self._defaults = {}
         if config is not None:
             for key, value in config.items():
-                self.set_field(
-                    key,
-                    value.get("label"),
-                    value.get("value", ""),
-                    value.get("type", "str"),
-                )
+                if isinstance(value, dict):
+                    self.set_field(
+                        key,
+                        value.get("label"),
+                        value.get("value", ""),
+                        value.get("type", "str"),
+                    )
+                else:
+                    self.set_field(key, label=key.capitalize(), value=str(value))
+
+    def set_defaults(self, default_config):
+        self._defaults = {
+            name: item["value"] for (name, item) in default_config.items()
+        }
 
     def __getitem__(self, key):
+        if key not in self._config and key in self._defaults:
+            return self._defaults[key]
         return self._config[key].value
 
     def get(self, key, default=None):
         if key not in self._config:
-            return default
+            return self._defaults.get(key, default)
         return self._config[key].value
 
     def has_field(self, name):
@@ -61,37 +87,29 @@ class BaseDataSource:
 
     def __init__(self, connector):
         self.connector = connector
-        # convert all fields to the expected types
-        self.connector.configuration = self.configuration = self._convert_configuration(
-            connector.configuration
-        )
-
-    def _convert(self, value, type_):
-        if type_ == "int":
-            return int(value)
-        elif type_ == "float":
-            return float(value)
-        elif type_ == "bool":
-            return value.lower() in "y", "yes", "true", "1"
-        elif type_ == "list":
-            return [item.strip() for item in value.split(",")]
-        return value
-
-    def _convert_configuration(self, configuration):
-        return {
-            name: self._convert(configuration.get(name, item["value"]), item["type"])
-            for (name, item) in self.get_default_configuration().items()
-        }
-
-    def get_simple_configuration(self):
-        """Used to return the default config to Kibana"""
-        return {
-            name: {"label": item["label"], "value": str(item["value"])}
-            for (name, item) in self.get_default_configuration().items()
-        }
+        if isinstance(self.connector.configuration, dict):
+            self.connector.configuration = DataSourceConfiguration(
+                self.connector.configuration
+            )
+        self.configuration = self.connector.configuration
+        self.configuration.set_defaults(self.get_default_configuration())
 
     def __str__(self):
         return f"Datasource `{self.__class__.__doc__}`"
+
+    @classmethod
+    def get_simple_configuration(cls):
+        """Used to return the default config to Kibana"""
+        res = {}
+        for name, item in cls.get_default_configuration().items():
+            entry = {"label": item.get("label", name.upper())}
+            if item["value"] is None:
+                entry["value"] = None
+            else:
+                entry["value"] = str(item["value"])
+
+            res[name] = entry
+        return res
 
     @classmethod
     def get_default_configuration(cls):

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -61,7 +61,34 @@ class BaseDataSource:
 
     def __init__(self, connector):
         self.connector = connector
-        self.configuration = connector.configuration
+        # convert all fields to the expected types
+        self.connector.configuration = self.configuration = self._convert_configuration(
+            connector.configuration
+        )
+
+    def _convert(self, value, type_):
+        if type_ == "int":
+            return int(value)
+        elif type_ == "float":
+            return float(value)
+        elif type_ == "bool":
+            return value.lower() in "y", "yes", "true", "1"
+        elif type_ == "list":
+            return [item.strip() for item in value.split(",")]
+        return value
+
+    def _convert_configuration(self, configuration):
+        return {
+            name: self._convert(configuration.get(name, item["value"]), item["type"])
+            for (name, item) in self.get_default_configuration().items()
+        }
+
+    def get_simple_configuration(self):
+        """Used to return the default config to Kibana"""
+        return {
+            name: {"label": item["label"], "value": str(item["value"])}
+            for (name, item) in self.get_default_configuration().items()
+        }
 
     def __str__(self):
         return f"Datasource `{self.__class__.__doc__}`"

--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -12,21 +12,21 @@ import os
 from datetime import datetime, timezone
 from pathlib import Path
 
+from connectors.source import BaseDataSource
 from connectors.utils import TIKA_SUPPORTED_FILETYPES, get_base64_value
 
 HERE = os.path.dirname(__file__)
 DEFAULT_CONTENT_EXTRACTION = True
 
 
-class DirectoryDataSource:
+class DirectoryDataSource(BaseDataSource):
     """Directory"""
 
     def __init__(self, connector):
-        self.directory = connector.configuration["directory"]
-        self.pattern = connector.configuration["pattern"]
-        self.enable_content_extraction = connector.configuration.get(
-            "enable_content_extraction", DEFAULT_CONTENT_EXTRACTION
-        )
+        super().__init__(connector)
+        self.directory = self.configuration["directory"]
+        self.pattern = self.configuration["pattern"]
+        self.enable_content_extraction = self.configuration["enable_content_extraction"]
 
     @classmethod
     def get_default_configuration(cls):

--- a/connectors/sources/gcs.py
+++ b/connectors/sources/gcs.py
@@ -85,12 +85,8 @@ class GoogleCloudStorageDataSource(BaseDataSource):
             ),
         )
         self.user_project_id = self.service_account_credentials.project_id
-        self.retry_count = int(
-            self.configuration.get("retry_count", DEFAULT_RETRY_COUNT)
-        )
-        self.enable_content_extraction = self.configuration.get(
-            "enable_content_extraction", DEFAULT_CONTENT_EXTRACTION
-        )
+        self.retry_count = self.configuration["retry_count"]
+        self.enable_content_extraction = self.configuration["enable_content_extraction"]
 
     @classmethod
     def get_default_configuration(cls):

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -40,12 +40,10 @@ class MySqlDataSource(BaseDataSource):
             connector (BYOConnector): Object of the BYOConnector class
         """
         super().__init__(connector=connector)
-        self.retry_count = int(
-            self.configuration.get("retry_count", DEFAULT_RETRY_COUNT)
-        )
+        self.retry_count = self.configuration["retry_count"]
         self.connection_pool = None
-        self.ssl_disabled = self.configuration.get("ssl_disabled", DEFAULT_SSL_DISABLED)
-        self.certificate = self.configuration.get("ssl_ca", DEFAULT_SSL_CA)
+        self.ssl_disabled = self.configuration["ssl_disabled"]
+        self.certificate = self.configuration["ssl_ca"]
 
     @classmethod
     def get_default_configuration(cls):
@@ -76,7 +74,7 @@ class MySqlDataSource(BaseDataSource):
                 "type": "str",
             },
             "database": {
-                "value": ["customerinfo"],
+                "value": "customerinfo",
                 "label": "Databases",
                 "type": "list",
             },

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -37,9 +37,7 @@ class NASDataSource(BaseDataSource):
         self.server_ip = self.configuration["server_ip"]
         self.port = self.configuration["server_port"]
         self.drive_path = self.configuration["drive_path"]
-        self.enable_content_extraction = self.configuration.get(
-            "enable_content_extraction", DEFAULT_CONTENT_EXTRACTION
-        )
+        self.enable_content_extraction = self.configuration["enable_content_extraction"]
 
     @classmethod
     def get_default_configuration(cls):

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -52,9 +52,7 @@ class S3DataSource(BaseDataSource):
             connect_timeout=self.configuration["connect_timeout"],
             retries={"max_attempts": self.configuration["max_attempts"]},
         )
-        self.enable_content_extraction = self.configuration.get(
-            "enable_content_extraction", DEFAULT_CONTENT_EXTRACTION
-        )
+        self.enable_content_extraction = self.configuration["enable_content_extraction"]
 
     @asynccontextmanager
     async def client(self, **kwargs):

--- a/connectors/sources/tests/test_gcs.py
+++ b/connectors/sources/tests/test_gcs.py
@@ -30,9 +30,9 @@ def get_mocked_source_object():
         GoogleCloudStorageDataSource: Mocked object of the data source class.
     """
     connector = argparse.Namespace()
-    connector.configuration = {
-        "service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS
-    }
+    connector.configuration = DataSourceConfiguration(
+        {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS}
+    )
     mocked_gcs_object = GoogleCloudStorageDataSource(connector=connector)
     return mocked_gcs_object
 
@@ -64,7 +64,9 @@ async def test_empty_configuration():
 
     # Setup
     connector = argparse.Namespace()
-    connector.configuration = {"service_account_credentials": ""}
+    connector.configuration = DataSourceConfiguration(
+        {"service_account_credentials": ""}
+    )
 
     # Execute
     with pytest.raises(Exception, match="service_account_credentials can't be empty."):

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -195,10 +195,14 @@ doc = {"_id": 1}
 max_concurrency = 0
 
 
-class Data:
+class Data(BaseDataSource):
     def __init__(self, connector):
-        self.connector = connector
+        super().__init__(connector)
         self.concurrency = 0
+
+    @classmethod
+    def get_default_configuration(cls):
+        return {}
 
     async def ping(self):
         pass
@@ -433,7 +437,6 @@ async def test_prepare(mock_responses):
         "scheduling": {"enabled": False},
     }
     connector = BYOConnector(Index(), "1", doc, {})
-
     config = {
         "connector_id": "1",
         "service_type": "mongodb",

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -38,6 +38,13 @@ def test_field():
     assert f.label == "name"
 
 
+def test_field_convert():
+    assert Field("name", value="1", type="int").value == 1
+    assert Field("name", value="1.2", type="float").value == 1.2
+    assert Field("name", value="YeS", type="bool").value
+    assert Field("name", value="1,2,3", type="list").value == ["1", "2", "3"]
+
+
 def test_data_source_configuration():
 
     c = DataSourceConfiguration(CONFIG)
@@ -107,6 +114,19 @@ async def test_base_class():
 
     ds = DataSource(Connector())
     ds.get_default_configuration()["port"]["value"] == 3306
+
+    options = {"a": "1"}
+    ds.tweak_bulk_options(options)
+    assert options == {"a": "1"}
+
+    # data we send back to kibana
+    # we want to make sure we only send back label+value
+    expected = {
+        "host": {"label": "Host", "value": "127.0.0.1"},
+        "port": {"label": "Port", "value": "3306"},
+        "user": {"label": "Username", "value": "root"},
+    }
+    assert ds.get_simple_configuration() == expected
 
     with pytest.raises(NotImplementedError):
         await ds.ping()

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -36,6 +36,7 @@ def test_field():
     # stupid holder
     f = Field("name")
     assert f.label == "name"
+    assert f.type == 'str'
 
 
 def test_field_convert():
@@ -105,6 +106,12 @@ async def test_base_class():
                     "label": "Port",
                     "type": "int",
                 },
+                "direct": {
+                    "value": True,
+                    "label": "Direct connect",
+                    "type": "bool",
+                },
+
                 "user": {
                     "value": "root",
                     "label": "Username",
@@ -124,6 +131,7 @@ async def test_base_class():
     expected = {
         "host": {"label": "Host", "value": "127.0.0.1"},
         "port": {"label": "Port", "value": "3306"},
+        "direct": {"label": "Direct connect", "value": "true"},
         "user": {"label": "Username", "value": "root"},
     }
     assert ds.get_simple_configuration() == expected

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -85,7 +85,7 @@ def test_get_data_sources():
 @pytest.mark.asyncio
 async def test_base_class():
     class Connector:
-        configuration = {}
+        configuration = DataSourceConfiguration({})
 
     with pytest.raises(NotImplementedError):
         BaseDataSource(Connector())

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -80,16 +80,38 @@ async def test_base_class():
     class Connector:
         configuration = {}
 
-    base = BaseDataSource(Connector())
+    with pytest.raises(NotImplementedError):
+        BaseDataSource(Connector())
 
     # ABCs
-    with pytest.raises(NotImplementedError):
-        BaseDataSource.get_default_configuration()
+    class DataSource(BaseDataSource):
+        @classmethod
+        def get_default_configuration(cls):
+            return {
+                "host": {
+                    "value": "127.0.0.1",
+                    "label": "Host",
+                    "type": "str",
+                },
+                "port": {
+                    "value": 3306,
+                    "label": "Port",
+                    "type": "int",
+                },
+                "user": {
+                    "value": "root",
+                    "label": "Username",
+                    "type": "str",
+                },
+            }
+
+    ds = DataSource(Connector())
+    ds.get_default_configuration()["port"]["value"] == 3306
 
     with pytest.raises(NotImplementedError):
-        await base.ping()
+        await ds.ping()
 
-    await base.close()
+    await ds.close()
 
     with pytest.raises(NotImplementedError):
-        await base.get_docs()
+        await ds.get_docs()

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -36,7 +36,7 @@ def test_field():
     # stupid holder
     f = Field("name")
     assert f.label == "name"
-    assert f.type == 'str'
+    assert f.type == "str"
 
 
 def test_field_convert():
@@ -111,7 +111,6 @@ async def test_base_class():
                     "label": "Direct connect",
                     "type": "bool",
                 },
-
                 "user": {
                     "value": "root",
                     "label": "Username",


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/282

The Python framework uses type definitions, which are not part of the connectors protocol.
We're sending back the default configuration to Kibana with this extra field, and it chokes.

This change ensures we respect the standard by sending back only `label` and `value`.

We're keeping the `type` value because it allows us to automatically convert the value we get back from Kibana into the right type. The patch also automates the conversion in the `Field` class.

- [x] try out the branch against a cloud deployment to check that it works as expected (tested on 8.7.0-SNAPSHOT)

The changes will be tested once ent-search main picks the main snapshot 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
