### PR TITLE
[MySQL] Update document key as database_table_column

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -213,7 +213,10 @@ class MySqlDataSource(BaseDataSource):
                         if fetch_many:
                             # sending back column names only once
                             if yield_once:
-                                yield [column[0] for column in cursor.description]
+                                yield [
+                                    f"{query_kwargs['database']}_{query_kwargs['table']}_{column[0]}"
+                                    for column in cursor.description
+                                ]
                                 yield_once = False
 
                             # setting cursor position where it was failed
@@ -340,7 +343,7 @@ class MySqlDataSource(BaseDataSource):
 
         keys = []
         for column_name in response:
-            keys.append(column_name[0])
+            keys.append(f"{database}_{table}_{column_name[0]}")
 
         if keys:
 

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -267,13 +267,17 @@ async def test_fetch_documents():
     response = source.fetch_documents(database="database_name", table="table_name")
 
     # Assert
+    document_list = []
     async for document in response:
-        assert document == {
-            "Database": "database_name",
-            "Table": "table_name",
-            "_id": "database_name_table_name_",
-            "_timestamp": "table1",
-        }
+        document_list.append(document)
+
+    assert {
+        "Database": "database_name",
+        "Table": "table_name",
+        "_id": "database_name_table_name_",
+        "_timestamp": "table1",
+        "database_name_table_name_Database": "table1",
+    } in document_list
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Updated document key as `database_table_column` to avoid the parsing error from elastic

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
