### PR TITLE
Update elasticsearch client to 8.6.0

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,5 +1,5 @@
 aiohttp==3.8.3
-elasticsearch[async]==8.5.0
+elasticsearch[async]==8.6.0
 elastic-transport==8.4.0
 pyyaml==6.0
 envyaml==1.10.211231


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3217

This PR will update `elasticsearch` client to the latest public version 8.6.0

*Note*: I didn't update `elastic-transport` because the latest version is 8.4.0. 
## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally

