### PR TITLE
Extract preflight check from SyncService

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -107,10 +107,6 @@ class BYOIndex(ESIndex):
             doc=document,
         )
 
-    # @TODO move to ESIndex?
-    async def preflight(self):
-        await self.check_exists(indices=[CONNECTORS_INDEX, JOBS_INDEX])
-
     def build_docs_query(self, native_service_types=None, connectors_ids=None):
         if native_service_types is None:
             native_service_types = []

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -92,8 +92,13 @@ async def _start_service(config, args, loop):
     preflight = PreflightCheck(config)
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, functools.partial(preflight.shutdown, sig))
-    if not await preflight.run():
-        return -1
+    try:
+        if not await preflight.run():
+            return -1
+    finally:
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.remove_signal_handler(sig)
+
     service = SyncService(config, args)
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, functools.partial(service.shutdown, sig))

--- a/connectors/conftest.py
+++ b/connectors/conftest.py
@@ -73,21 +73,6 @@ def set_env():
 
 
 @pytest.fixture
-def patch_ping():
-    from connectors.byoc import BYOIndex
-
-    async def _ping(*args):
-        return True
-
-    old = BYOIndex.ping
-    BYOIndex.ping = _ping
-    try:
-        yield
-    finally:
-        BYOIndex.ping = old
-
-
-@pytest.fixture
 def catch_stdout():
     old = sys.stdout
     new = sys.stdout = io.StringIO()

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -1,0 +1,49 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+import asyncio
+
+from connectors.byoc import CONNECTORS_INDEX, JOBS_INDEX
+from connectors.es import ESClient
+from connectors.logger import logger
+
+
+async def pre_flight_check(config):
+    elastic_config = config["elasticsearch"]
+    es_host = elastic_config["host"]
+
+    es_client = ESClient(elastic_config)
+
+    if not (await es_client.wait()):
+        logger.critical(f"{es_host} seem down. Bye!")
+        return -1
+
+    service_config = config["service"]
+    preflight_max_attempts = int(service_config.get("preflight_max_attempts", 10))
+    preflight_idle = int(service_config.get("preflight_idle", 30))
+
+    try:
+        attempts = 0
+        while True:
+            logger.info("Preflight checks...")
+            try:
+                # Checking the indices/pipeline in the loop to be less strict about the boot ordering
+                await es_client.check_exists(indices=[CONNECTORS_INDEX, JOBS_INDEX])
+                break
+            except Exception as e:
+                if attempts > preflight_max_attempts:
+                    raise
+                else:
+                    logger.warn(
+                        f"Attempt {attempts + 1}/{preflight_max_attempts} failed. Retrying..."
+                    )
+                    logger.warn(str(e))
+                    attempts += 1
+                    await asyncio.sleep(preflight_idle)
+    finally:
+        if es_client is not None:
+            es_client.stop_waiting()
+            await es_client.close()

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -18,7 +18,7 @@ class PreflightCheck:
         self.preflight_max_attempts = int(
             self.service_config.get("preflight_max_attempts", 10)
         )
-        self.preflight_idle = int(self.service_config.get("preflight_idle", 2))
+        self.preflight_idle = int(self.service_config.get("preflight_idle", 30))
         self._sleeps = CancellableSleeps()
         self.running = False
 

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -18,7 +18,7 @@ class PreflightCheck:
         self.preflight_max_attempts = int(
             self.service_config.get("preflight_max_attempts", 10)
         )
-        self.preflight_idle = int(self.service_config.get("preflight_idle", 30))
+        self.preflight_idle = int(self.service_config.get("preflight_idle", 2))
         self._sleeps = CancellableSleeps()
         self.running = False
 
@@ -68,5 +68,4 @@ class PreflightCheck:
                     logger.warn(str(e))
                     attempts += 1
                     await self._sleeps.sleep(self.preflight_idle)
-        logger.warn("Preflight check is interrupted.")
         return False

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -32,6 +32,7 @@ def test_main_and_kill(patch_logger, mock_responses):
     )
 
     async def kill():
+        await asyncio.sleep(0.2)
         os.kill(os.getpid(), signal.SIGTERM)
 
     loop = asyncio.new_event_loop()

--- a/connectors/tests/test_preflight_check.py
+++ b/connectors/tests/test_preflight_check.py
@@ -61,7 +61,7 @@ async def test_job_index_missing(mock_responses):
 
 
 @pytest.mark.asyncio
-async def test_both_missing(mock_responses):
+async def test_both_indices_missing(mock_responses):
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=False)
     mock_index_exists(mock_responses, JOBS_INDEX, exist=False)

--- a/connectors/tests/test_preflight_check.py
+++ b/connectors/tests/test_preflight_check.py
@@ -1,0 +1,103 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+import pytest
+
+from connectors.byoc import CONNECTORS_INDEX, JOBS_INDEX
+from connectors.preflight_check import PreflightCheck
+
+headers = {"X-Elastic-Product": "Elasticsearch"}
+host = "http://localhost:9200"
+config = {
+    "elasticsearch": {
+        "host": host,
+        "username": "elastic",
+        "password": "changeme",
+        "max_wait_duration": 2,
+    },
+    "service": {"preflight_max_attempts": 4, "preflight_idle": 1},
+}
+
+
+def mock_es_info(mock_responses, healthy=True, repeat=False):
+    status = 200 if healthy else 503
+    mock_responses.get(host, status=status, headers=headers, repeat=repeat)
+
+
+def mock_index_exists(mock_responses, index, exist=True, repeat=False):
+    status = 200 if exist else 404
+    mock_responses.head(f"{host}/{index}", status=status, repeat=repeat)
+
+
+@pytest.mark.asyncio
+async def test_es_unavailable(mock_responses):
+    mock_es_info(mock_responses, healthy=False, repeat=True)
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_connector_index_missing(mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=False)
+    mock_index_exists(mock_responses, JOBS_INDEX, exist=True)
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_job_index_missing(mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=True)
+    mock_index_exists(mock_responses, JOBS_INDEX, exist=False)
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_both_missing(mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=False)
+    mock_index_exists(mock_responses, JOBS_INDEX, exist=False)
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_pass(mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_es_transient_error(mock_responses):
+    mock_es_info(mock_responses, healthy=False)
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_index_exist_transient_error(mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=False)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX, repeat=True)
+    mock_index_exists(mock_responses, JOBS_INDEX, exist=False)
+    mock_index_exists(mock_responses, JOBS_INDEX, repeat=True)
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is True

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -186,11 +186,6 @@ async def set_server_responses(
 ):
     headers = {"X-Elastic-Product": "Elasticsearch"}
 
-    mock_responses.head(f"{host}/.elastic-connectors", headers=headers, repeat=True)
-    mock_responses.head(
-        f"{host}/.elastic-connectors-sync-jobs", headers=headers, repeat=True
-    )
-
     mock_responses.get(
         f"{host}/_ingest/pipeline/ent-search-generic-ingestion",
         headers=headers,
@@ -594,21 +589,6 @@ async def test_connector_service_poll_buggy_service(
             return
 
     raise AssertionError
-
-
-@pytest.mark.asyncio
-async def test_ping_fails(mock_responses, patch_logger, set_env):
-    from connectors.byoc import BYOIndex
-
-    async def _ping(*args):
-        return False
-
-    BYOIndex.ping = _ping
-
-    service = create_service(CONFIG_FILE)
-    asyncio.get_event_loop().call_soon(service.stop)
-    await service.run()
-    patch_logger.assert_present("http://nowhere.com:9200 seem down. Bye!")
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -322,9 +322,7 @@ async def set_server_responses(
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll(
-    mock_responses, patch_logger, patch_ping, set_env
-):
+async def test_connector_service_poll(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses)
     service = create_service(CONFIG_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
@@ -336,7 +334,7 @@ async def test_connector_service_poll(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_unconfigured(
-    mock_responses, patch_logger, patch_ping, set_env
+    mock_responses, patch_logger, set_env
 ):
     # we should not sync a connector that is not configured
     # but still send out a heartbeat
@@ -353,7 +351,7 @@ async def test_connector_service_poll_unconfigured(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_no_sync_but_status_updated(
-    mock_responses, patch_logger, patch_ping, set_env
+    mock_responses, patch_logger, set_env
 ):
     calls = []
 
@@ -378,7 +376,7 @@ async def test_connector_service_poll_no_sync_but_status_updated(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_cron_broken(
-    mock_responses, patch_logger, patch_ping, set_env
+    mock_responses, patch_logger, set_env
 ):
     calls = []
 
@@ -401,7 +399,7 @@ async def test_connector_service_poll_cron_broken(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_just_created(
-    mock_responses, patch_logger, patch_ping, set_env
+    mock_responses, patch_logger, set_env
 ):
     # we should not sync a connector that is not configured
     # but still send out an heartbeat
@@ -416,9 +414,7 @@ async def test_connector_service_poll_just_created(
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_https(
-    mock_responses, patch_logger, patch_ping, set_env
-):
+async def test_connector_service_poll_https(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, host="https://safenowhere.com:443")
     service = create_service(CONFIG_HTTPS_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
@@ -427,9 +423,7 @@ async def test_connector_service_poll_https(
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_large(
-    mock_responses, patch_logger, patch_ping, set_env
-):
+async def test_connector_service_poll_large(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, LARGE_FAKE_CONFIG)
     service = create_service(MEM_CONFIG_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
@@ -444,7 +438,7 @@ async def test_connector_service_poll_large(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_clear_error(
-    mock_responses, patch_logger, patch_ping, set_env
+    mock_responses, patch_logger, set_env
 ):
     service = create_service(CONFIG_FILE, one_sync=True)
     calls = []
@@ -474,9 +468,7 @@ async def test_connector_service_poll_clear_error(
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_sync_now(
-    mock_responses, patch_logger, patch_ping, set_env
-):
+async def test_connector_service_poll_sync_now(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, FAKE_CONFIG_NO_SYNC)
     service = create_service(CONFIG_FILE, sync_now=True, one_sync=True)
     # one_sync means it won't loop forever
@@ -485,9 +477,7 @@ async def test_connector_service_poll_sync_now(
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_sync_ts(
-    mock_responses, patch_logger, patch_ping, set_env
-):
+async def test_connector_service_poll_sync_ts(mock_responses, patch_logger, set_env):
     indexed = []
 
     def bulk_call(url, **kw):
@@ -505,9 +495,7 @@ async def test_connector_service_poll_sync_ts(
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_sync_fails(
-    mock_responses, patch_logger, patch_ping, set_env
-):
+async def test_connector_service_poll_sync_fails(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, FAKE_CONFIG_FAIL_SERVICE)
     service = create_service(CONFIG_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
@@ -517,7 +505,7 @@ async def test_connector_service_poll_sync_fails(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_unknown_service(
-    mock_responses, patch_logger, patch_ping, set_env
+    mock_responses, patch_logger, set_env
 ):
     await set_server_responses(mock_responses, FAKE_CONFIG_UNKNOWN_SERVICE)
     service = create_service(CONFIG_FILE)
@@ -549,7 +537,6 @@ async def test_connector_service_filtering(
     should_raise_filtering_error,
     mock_responses,
     patch_logger,
-    patch_ping,
     set_env,
 ):
     service = await service_with_max_errors(mock_responses, config, 0)
@@ -567,7 +554,7 @@ async def test_connector_service_filtering(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_buggy_service(
-    mock_responses, patch_logger, patch_ping, set_env
+    mock_responses, patch_logger, set_env
 ):
     def connectors_update(url, **kw):
         doc = json.loads(kw["data"])["doc"]
@@ -592,7 +579,7 @@ async def test_connector_service_poll_buggy_service(
 
 
 @pytest.mark.asyncio
-async def test_spurious(mock_responses, patch_logger, patch_ping, set_env):
+async def test_spurious(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses)
 
     from connectors.byoc import Connector
@@ -619,7 +606,7 @@ async def test_spurious(mock_responses, patch_logger, patch_ping, set_env):
 
 
 @pytest.mark.asyncio
-async def test_spurious_continue(mock_responses, patch_logger, patch_ping, set_env):
+async def test_spurious_continue(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses)
 
     from connectors.byoc import Connector
@@ -657,9 +644,7 @@ async def test_spurious_continue(mock_responses, patch_logger, patch_ping, set_e
 
 
 @pytest.mark.asyncio
-async def test_connector_settings_change(
-    mock_responses, patch_logger, patch_ping, set_env
-):
+async def test_connector_settings_change(mock_responses, patch_logger, set_env):
     service = create_service(CONFIG_FILE, one_sync=True)
 
     configs = [FAKE_CONFIG, FAKE_CONFIG_PIPELINE_CHANGED]


### PR DESCRIPTION
This PR extracts preflight check to a separate module.

The preflight check should not be run in any service (in this case, `SyncService`), but should be done (blocking) before any service can be started.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally