### PR TITLE
Simplify the __init__ for BaseDataSource

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -543,7 +543,7 @@ class Connector:
                 logger.info("Sync forced")
 
             try:
-                self.data_provider = self.source_klass(self)
+                self.data_provider = self.source_klass(self.configuration)
             except Exception as e:
                 logger.critical(e, exc_info=True)
                 raise DataSourceError(
@@ -585,7 +585,7 @@ class Connector:
             result = await elastic_server.async_bulk(
                 self.index_name,
                 self.prepare_docs(self.data_provider),
-                self.data_provider.connector.pipeline,
+                self.pipeline,
                 options=bulk_options,
             )
             await self._sync_done(job, result)

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -95,10 +95,9 @@ class DataSourceConfiguration:
 class BaseDataSource:
     """Base class, defines a lose contract."""
 
-    def __init__(self, connector):
-        self.connector = connector
-        assert isinstance(self.connector.configuration, DataSourceConfiguration)
-        self.configuration = self.connector.configuration
+    def __init__(self, configuration):
+        self.configuration = configuration
+        assert isinstance(self.configuration, DataSourceConfiguration)
         self.configuration.set_defaults(self.get_default_configuration())
 
     def __str__(self):

--- a/connectors/sources/abs.py
+++ b/connectors/sources/abs.py
@@ -31,13 +31,13 @@ DEFAULT_RETRY_COUNT = 3
 class AzureBlobStorageDataSource(BaseDataSource):
     """Class to fetch documents from Azure Blob Storage"""
 
-    def __init__(self, connector):
+    def __init__(self, configuration):
         """Setup the connection to the azure base client
 
         Args:
             connector (BYOConnector): Object of the BYOConnector class
         """
-        super().__init__(connector=connector)
+        super().__init__(configuration=configuration)
         self.connection_string = None
         self.enable_content_extraction = self.configuration.get(
             "enable_content_extraction", DEFAULT_CONTENT_EXTRACTION

--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -22,8 +22,8 @@ DEFAULT_CONTENT_EXTRACTION = True
 class DirectoryDataSource(BaseDataSource):
     """Directory"""
 
-    def __init__(self, connector):
-        super().__init__(connector)
+    def __init__(self, configuration):
+        super().__init__(configuration=configuration)
         self.directory = self.configuration["directory"]
         self.pattern = self.configuration["pattern"]
         self.enable_content_extraction = self.configuration["enable_content_extraction"]

--- a/connectors/sources/gcs.py
+++ b/connectors/sources/gcs.py
@@ -62,13 +62,13 @@ DEFAULT_PEM_FILE = os.path.join(
 class GoogleCloudStorageDataSource(BaseDataSource):
     """Class to fetch documents from Google Cloud Storage."""
 
-    def __init__(self, connector):
+    def __init__(self, configuration):
         """Setup connection to the Google Cloud Storage Client.
 
         Args:
             connector (Connector): Object of the Connector class.
         """
-        super().__init__(connector=connector)
+        super().__init__(configuration=configuration)
         if not self.configuration["service_account_credentials"]:
             raise Exception("service_account_credentials can't be empty.")
 

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -16,8 +16,8 @@ from connectors.source import BaseDataSource
 class MongoDataSource(BaseDataSource):
     """MongoDB"""
 
-    def __init__(self, connector):
-        super().__init__(connector)
+    def __init__(self, configuration):
+        super().__init__(configuration=configuration)
         self.client = AsyncIOMotorClient(
             self.configuration["host"],
             directConnection=True,

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -33,13 +33,13 @@ DEFAULT_SSL_CA = None
 class MySqlDataSource(BaseDataSource):
     """Class to fetch and modify documents from MySQL server"""
 
-    def __init__(self, connector):
+    def __init__(self, configuration):
         """Setup connection to the MySQL server.
 
         Args:
             connector (Connector): Object of the Connector class
         """
-        super().__init__(connector=connector)
+        super().__init__(configuration=configuration)
         self.retry_count = self.configuration["retry_count"]
         self.connection_pool = None
         self.ssl_disabled = self.configuration["ssl_disabled"]

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -25,13 +25,13 @@ DEFAULT_FILE_SIZE_LIMIT = 10485760
 class NASDataSource(BaseDataSource):
     """Class to fetch documents from Network Drive"""
 
-    def __init__(self, connector):
+    def __init__(self, configuration):
         """Setup the connection to the Network Drive
 
         Args:
             connector (Connector): Object of the Connector class
         """
-        super().__init__(connector)
+        super().__init__(configuration=configuration)
         self.username = self.configuration["username"]
         self.password = self.configuration["password"]
         self.server_ip = self.configuration["server_ip"]

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -36,13 +36,13 @@ else:
 class S3DataSource(BaseDataSource):
     """Amazon S3"""
 
-    def __init__(self, connector):
+    def __init__(self, configuration):
         """Setup connection to the Amazon S3.
 
         Args:
             connector (Connector): Object of the Connector class.
         """
-        super().__init__(connector)
+        super().__init__(configuration=configuration)
         self.session = aioboto3.Session()
         set_extra_logger(aws_logger, log_level=logging.DEBUG, prefix="S3")
         set_extra_logger("aioboto3.resources", log_level=logging.INFO, prefix="S3")

--- a/connectors/sources/tests/support.py
+++ b/connectors/sources/tests/support.py
@@ -6,17 +6,12 @@
 from connectors.source import DataSourceConfiguration
 
 
-class FakeConnector:
-    def __init__(self, config):
-        self.configuration = DataSourceConfiguration(config)
-
-
 def create_source(klass, **extras):
     config = klass.get_default_configuration()
     for k, v in extras.items():
         config[k] = {"value": v}
-    conn = FakeConnector(config)
-    return klass(conn)
+
+    return klass(configuration=DataSourceConfiguration(config))
 
 
 async def assert_basics(klass, field, value):

--- a/connectors/sources/tests/test_gcs.py
+++ b/connectors/sources/tests/test_gcs.py
@@ -5,7 +5,6 @@
 #
 """Tests the Google Cloud Storage source class methods.
 """
-import argparse
 import asyncio
 import json
 from unittest import mock

--- a/connectors/sources/tests/test_gcs.py
+++ b/connectors/sources/tests/test_gcs.py
@@ -29,11 +29,10 @@ def get_mocked_source_object():
     Returns:
         GoogleCloudStorageDataSource: Mocked object of the data source class.
     """
-    connector = argparse.Namespace()
-    connector.configuration = DataSourceConfiguration(
+    configuration = DataSourceConfiguration(
         {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS}
     )
-    mocked_gcs_object = GoogleCloudStorageDataSource(connector=connector)
+    mocked_gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
     return mocked_gcs_object
 
 
@@ -63,14 +62,11 @@ async def test_empty_configuration():
     """Tests the validity of the configurations passed to the Google Cloud source class."""
 
     # Setup
-    connector = argparse.Namespace()
-    connector.configuration = DataSourceConfiguration(
-        {"service_account_credentials": ""}
-    )
+    configuration = DataSourceConfiguration({"service_account_credentials": ""})
 
     # Execute
     with pytest.raises(Exception, match="service_account_credentials can't be empty."):
-        _ = GoogleCloudStorageDataSource(connector=connector)
+        _ = GoogleCloudStorageDataSource(configuration=configuration)
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/fake_sources.py
+++ b/connectors/tests/fake_sources.py
@@ -14,11 +14,11 @@ class FakeSource:
 
     service_type = "fake"
 
-    def __init__(self, connector):
-        self.connector = connector
-        if connector.configuration.has_field("raise"):
+    def __init__(self, configuration):
+        self.configuration = configuration
+        if configuration.has_field("raise"):
             raise Exception("I break on init")
-        self.fail = connector.configuration.has_field("fail")
+        self.fail = configuration.has_field("fail")
 
     async def changed(self):
         return True

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -85,11 +85,10 @@ def test_get_data_sources():
 
 @pytest.mark.asyncio
 async def test_base_class():
-    class Connector:
-        configuration = DataSourceConfiguration({})
+    configuration = DataSourceConfiguration({})
 
     with pytest.raises(NotImplementedError):
-        BaseDataSource(Connector())
+        BaseDataSource(configuration=configuration)
 
     # ABCs
     class DataSource(BaseDataSource):
@@ -118,7 +117,7 @@ async def test_base_class():
                 },
             }
 
-    ds = DataSource(Connector())
+    ds = DataSource(configuration=configuration)
     ds.get_default_configuration()["port"]["value"] == 3306
 
     options = {"a": "1"}


### PR DESCRIPTION
Small refactoring for BaseDataSource:

Before:

```python
def __init__(self, connector):
    self.connector = connector
```

After:

```python
def __init__(self, configuration):
    self.configuration = configuration
```

Idea is - neither `BaseDataSource` nor its children need access to `Connector` class instance - moreover it can be used in a harmful way. This change makes it so that DataSource classes only receive configuration as an argument in the initializer.