### PR TITLE
fix macOS specific issue

### DIFF
--- a/connectors/sources/abs.py
+++ b/connectors/sources/abs.py
@@ -187,6 +187,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
             logger.debug(f"Calling convert_to_b64 for file : {blob_name}")
             await asyncio.to_thread(convert_to_b64, source=temp_filename)
             async with aiofiles.open(file=temp_filename, mode="r") as async_buffer:
+                # base64 on macOS will add a EOL, so we strip() here
                 document["_attachment"] = (await async_buffer.read()).strip()
             await remove(temp_filename)
         return document

--- a/connectors/sources/abs.py
+++ b/connectors/sources/abs.py
@@ -187,7 +187,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
             logger.debug(f"Calling convert_to_b64 for file : {blob_name}")
             await asyncio.to_thread(convert_to_b64, source=temp_filename)
             async with aiofiles.open(file=temp_filename, mode="r") as async_buffer:
-                document["_attachment"] = await async_buffer.read()
+                document["_attachment"] = (await async_buffer.read()).strip()
             await remove(temp_filename)
         return document
 

--- a/connectors/sources/gcs.py
+++ b/connectors/sources/gcs.py
@@ -327,13 +327,14 @@ class GoogleCloudStorageDataSource(BaseDataSource):
                 )
             )
             source_file_name = async_buffer.name
+
         logger.debug(f"Calling convert_to_b64 for file : {blob_name}")
         await asyncio.to_thread(
             convert_to_b64,
             source=source_file_name,
         )
         async with aiofiles.open(file=source_file_name, mode="r") as target_file:
-            document["_attachment"] = await target_file.read()
+            document["_attachment"] = (await target_file.read()).strip()
         await remove(source_file_name)
         logger.debug(f"Downloaded {blob_name} for {blob_size} bytes ")
         return document

--- a/connectors/sources/gcs.py
+++ b/connectors/sources/gcs.py
@@ -334,6 +334,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
             source=source_file_name,
         )
         async with aiofiles.open(file=source_file_name, mode="r") as target_file:
+            # base64 on macOS will add a EOL, so we strip() here
             document["_attachment"] = (await target_file.read()).strip()
         await remove(source_file_name)
         logger.debug(f"Downloaded {blob_name} for {blob_size} bytes ")

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -214,6 +214,7 @@ def convert_to_b64(source, target=None, overwrite=False):
         else:
             # In Linuces, avoid line wrapping
             cmd = f"{_BASE64} -w 0 {source} > {temp_target}"
+        logger.debug(f"Calling {cmd}")
         subprocess.check_call(cmd, shell=True)
     else:
         # Pure Python version


### PR DESCRIPTION
`base64` on macOs returns `\n` instead of an empty string.  Here, we strip the data before we put it in the attachment key

A better long term fix would be to generate a real 15 bytes files in those tests, but it's still a good idea to strip

cc @praveen-elastic 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
