### PR TITLE
[8.6] the conversion for bool=false is broken (#319)

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -36,7 +36,7 @@ class Field:
         elif type_ == "float":
             return float(value)
         elif type_ == "bool":
-            return value.lower() in "y", "yes", "true", "1"
+            return value.lower() in ("y", "yes", "true", "1")
         elif type_ == "list":
             return [item.strip() for item in value.split(",")]
         return value

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -45,6 +45,7 @@ def test_field_convert():
     assert Field("name", value="1.2", type="float").value == 1.2
     assert Field("name", value="YeS", type="bool").value
     assert Field("name", value="1,2,3", type="list").value == ["1", "2", "3"]
+    assert not Field("name", value="false", type="bool").value
 
 
 def test_data_source_configuration():


### PR DESCRIPTION
Backports the following commits to 8.6:
 - the conversion for bool=false is broken (#319)