### PR TITLE
Fix test_config.py

### DIFF
--- a/connectors/tests/test_config.py
+++ b/connectors/tests/test_config.py
@@ -28,6 +28,12 @@ def test_config():
 
 
 def test_config_with_ent_search():
-    with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG_FILE, "elasticsearch.password": "changeme"}):
+    with mock.patch.dict(
+        os.environ,
+        {
+            "ENT_SEARCH_CONFIG_PATH": ES_CONFIG_FILE,
+            "elasticsearch.password": "changeme",
+        },
+    ):
         config = load_config(CONFIG_FILE)
         assert config["elasticsearch"]["headers"]["X-Elastic-Auth"] == "SomeYeahValue"

--- a/connectors/tests/test_config.py
+++ b/connectors/tests/test_config.py
@@ -22,11 +22,12 @@ def test_bad_config_file():
 
 
 def test_config():
-    config = load_config(CONFIG_FILE)
-    assert isinstance(config, EnvYAML)
+    with mock.patch.dict(os.environ, {"elasticsearch.password": "changeme"}):
+        config = load_config(CONFIG_FILE)
+        assert isinstance(config, EnvYAML)
 
 
 def test_config_with_ent_search():
-    with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG_FILE}):
+    with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG_FILE, "elasticsearch.password": "changeme"}):
         config = load_config(CONFIG_FILE)
         assert config["elasticsearch"]["headers"]["X-Elastic-Auth"] == "SomeYeahValue"


### PR DESCRIPTION
Seems like `test_config.py` is broken, see: https://buildkite.com/elastic/connectors-python/builds/1452#0185bb48-cb87-4632-81bb-0ec9f96a36a9

Running `bin/pytest connectors/tests/test_config.py` produces the following output:

```
E           ValueError: Strict mode enabled, variables $elasticsearch.password are not defined!

lib/python3.10/site-packages/envyaml/envyaml.py:270: ValueError
---------------------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------------------
[FMWK][17:33:25][INFO] Loading config from /Users/artemshelkovnikov/git_tree/connectors-py/connectors/tests/config.yml
============================================================================================= short test summary info =============================================================================================
FAILED connectors/tests/test_config.py::test_config_with_ent_search - ValueError: Strict mode enabled, variables $elasticsearch.password are not defined!
FAILED connectors/tests/test_config.py::test_config - ValueError: Strict mode enabled, variables $elasticsearch.password are not defined!
=========================================================================================== 2 failed, 1 passed in 0.22s ===========================================================================================
```

This seems to happen because of the substitution defined in the config file https://github.com/elastic/connectors-python/blob/main/connectors/tests/config.yml, see:

```
elasticsearch:
  host: http://nowhere.com:9200
  user: elastic
  password: ${elasticsearch.password} <<< this
# ...
```

Since there's nothing to substitute from, password becomes empty and YAML reader in strict mode does not like it.

Fixing it by mocking environment variable `elasticsearch.password`.