### PR TITLE
Add SyncJobIndex

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -628,12 +628,11 @@ class SyncJobIndex(ESIndex):
     Represents Elasticsearch index for sync jobs
 
     Args:
-        index_name (str): Name of an Elasticsearch index
         elastic_config (dict): Elasticsearch configuration and credentials
     """
 
-    def __init__(self, index_name, elastic_config):
-        super().__init__(index_name=index_name, elastic_config=elastic_config)
+    def __init__(self, elastic_config):
+        super().__init__(index_name=JOBS_INDEX, elastic_config=elastic_config)
 
     def _create_object(self, doc_source):
         """

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -172,7 +172,7 @@ class ConnectorIndex(ESIndex):
 
 
 class SyncJob:
-    def __init__(self, elastic_index, connector_id, doc_source=None):
+    def __init__(self, elastic_index, connector_id, doc_source=dict()):
         self.connector_id = connector_id
         self.elastic_index = elastic_index
         self.created_at = datetime.now(timezone.utc)

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -690,8 +690,15 @@ class SyncJobIndex(ESIndex):
             "bool": {
                 "filter": [
                     {"terms": {"connector.id": connectors_ids}},
-                    {"terms": {"status": [JobStatus.IN_PROGRESS, JobStatus.CANCELING]}},
-                    {"range": {"last_seen": {"lte": "now-#{STUCK_JOBS_THRESHOLD}s"}}},
+                    {
+                        "terms": {
+                            "status": [
+                                e2str(JobStatus.IN_PROGRESS),
+                                e2str(JobStatus.CANCELING),
+                            ]
+                        }
+                    },
+                    {"range": {"last_seen": {"lte": f"now-{STUCK_JOBS_THRESHOLD}s"}}},
                 ]
             }
         }

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -170,7 +170,6 @@ class ConnectorIndex(ESIndex):
             bulk_options=self.bulk_options,
         )
 
-
 class SyncJob:
     def __init__(self, connector_id, elastic_client):
         self.connector_id = connector_id
@@ -616,3 +615,14 @@ class Connector:
         finally:
             self._syncing = False
             self._start_time = None
+
+
+class SyncJobIndex(ESIndex):
+    def __init__(self, index_name, elastic_config):
+        super().__init__(index_name, elastic_config)
+
+    def _create_object(self, doc):
+        return super()._create_object(doc)
+
+    def build_docs_query(self):
+        return dict()

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -172,15 +172,18 @@ class ConnectorIndex(ESIndex):
 
 
 class SyncJob:
-    def __init__(self, elastic_index, connector_id, doc_source=dict()):
+    def __init__(self, elastic_index, connector_id, doc_source=None):
         self.connector_id = connector_id
         self.elastic_index = elastic_index
         self.created_at = datetime.now(timezone.utc)
         self.completed_at = None
         self.job_id = None
         self.status = None
-        self.doc_source = doc_source
         self.client = elastic_index.client
+        if doc_source is None:
+            doc_source = dict()
+
+        self.doc_source = doc_source
 
     @property
     def duration(self):

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -171,7 +171,7 @@ class ConnectorIndex(ESIndex):
         )
 
 class SyncJob:
-    def __init__(self, elastic_index, connector_id, doc_source):
+    def __init__(self, elastic_index, connector_id, doc_source=None):
         self.connector_id = connector_id
         self.elastic_index = elastic_index
         self.created_at = datetime.now(timezone.utc)
@@ -179,6 +179,7 @@ class SyncJob:
         self.job_id = None
         self.status = None
         self.doc_source = doc_source
+        self.client = elastic_index.client
 
     @property
     def duration(self):
@@ -424,7 +425,7 @@ class Connector:
         return next_run(self.scheduling["interval"])
 
     async def _sync_starts(self):
-        job = SyncJob(self.id, self.client)
+        job = SyncJob(connector_id=self.id, elastic_index=self.index)
         trigger_method = (
             JobTriggerMethod.ON_DEMAND if self.sync_now else JobTriggerMethod.SCHEDULED
         )

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -171,13 +171,14 @@ class ConnectorIndex(ESIndex):
         )
 
 class SyncJob:
-    def __init__(self, connector_id, elastic_client):
+    def __init__(self, elastic_index, connector_id, doc_source):
         self.connector_id = connector_id
-        self.client = elastic_client
+        self.elastic_index = elastic_index
         self.created_at = datetime.now(timezone.utc)
         self.completed_at = None
         self.job_id = None
         self.status = None
+        self.doc_source = doc_source
 
     @property
     def duration(self):
@@ -616,13 +617,76 @@ class Connector:
             self._syncing = False
             self._start_time = None
 
+STUCK_JOBS_THRESHOLD = 60 # 60 seconds
 
 class SyncJobIndex(ESIndex):
+    """
+    Represents Elasticsearch index for sync jobs
+
+    Args:
+        index_name (str): Name of an Elasticsearch index
+        elastic_config (dict): Elasticsearch configuration and credentials
+    """
     def __init__(self, index_name, elastic_config):
-        super().__init__(index_name, elastic_config)
+        super().__init__(index_name=index_name, elastic_config=elastic_config)
 
-    def _create_object(self, doc):
-        return super()._create_object(doc)
+    def _create_object(self, doc_source):
+        """
+        Args:
+            doc_source (dict): A raw Elasticsearch document
+        Returns:
+            SyncJob
+        """
+        return SyncJob(
+            self,
+            connector_id=doc_source['_source']["connector"]["id"],
+            doc_source=doc_source['_source'],
+        )
 
-    def build_docs_query(self):
-        return dict()
+    def pending_job_query(self, connectors_ids=[]):
+        """
+        Args:
+            connectors_ids (list of int): A list of connectors IDs
+        Returns:
+            dict
+        """
+        status_term = { "status":  [e2str(JobStatus.PENDING)] }
+
+        query = { "bool": { "must": [{ "terms": status_term }] } }
+
+        if len(connectors_ids) == 0:
+            return query
+        else:
+            query["bool"]["must"].append( { "terms": { "connector.id": connectors_ids } } )
+
+        return query
+
+    def orphaned_jobs_query(self, connectors_ids):
+        """
+        Args:
+            connectors_ids (list of int): A list of connectors IDs
+        Returns:
+            dict
+        """
+        query = { "bool": { "must_not": { "terms": { "connector.id": connectors_ids } } } }
+
+        return query
+
+    def stuck_jobs_query(self, connectors_ids):
+        """
+        Args:
+            connectors_ids (list of int): A list of connectors IDs
+        Returns:
+            dict
+        """
+        query = {
+            "bool": {
+                "filter": [
+                    { "terms": { "connector.id": connectors_ids } },
+                    { "terms": { "status": [JobStatus.IN_PROGRESS, JobStatus.CANCELING] } },
+                    { "range": { "last_seen": { "lte": "now-#{STUCK_JOBS_THRESHOLD}s" } } }
+                ]
+            }
+        }
+
+        return query

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -186,8 +186,8 @@ def test_utc():
 @pytest.mark.asyncio
 async def test_sync_job(mock_responses):
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
-    connectors_index = BYOIndex(config)
-    client = connectors_index.client
+    jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config)
+    client = jobs_index.client
 
     expected_filtering = {
         "advanced_snippet": {
@@ -198,7 +198,7 @@ async def test_sync_job(mock_responses):
         "validation": FILTERING_VALIDATION_VALID,
     }
 
-    job = SyncJob(connector_id="connector-id", elastic_index=connectors_index)
+    job = SyncJob(connector_id="connector-id", elastic_index=jobs_index)
 
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.post(

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -705,48 +705,61 @@ async def test_update_filtering_validation(
     ]
 
 
-def test_pending_job_query_without_connectors_ids(mock_responses, set_env):
+def test_pending_job_query_with_connectors_ids(mock_responses, set_env):
     config = EnvYAML(CONFIG)
 
-    sync_jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config["elasticsearch"])
-    pending_jobs_query = sync_jobs_index.pending_job_query()
+    connectors_ids = [1, 2]
+    sync_jobs_index = SyncJobIndex(
+        index_name=JOBS_INDEX, elastic_config=config["elasticsearch"]
+    )
+    pending_jobs_query = sync_jobs_index.pending_job_query(
+        connectors_ids=connectors_ids
+    )
 
     # validate the query
     assert "bool" in pending_jobs_query
-    assert pending_jobs_query["bool"] == { "must": [ { "terms": { "status":  ['pending'] } }] }
-
-
-def test_pending_job_query_with_connectors_ids_and_page_size(mock_responses, set_env):
-    config = EnvYAML(CONFIG)
-
-    connectors_ids = [1,2]
-    sync_jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config["elasticsearch"])
-    pending_jobs_query = sync_jobs_index.pending_job_query(connectors_ids=connectors_ids)
-
-    # validate the query
-    assert "bool" in pending_jobs_query
-    assert pending_jobs_query["bool"] == { "must": [ { "terms": { "status":  ['pending'] } }, {'terms': {'connector.id': connectors_ids}}] }
+    assert pending_jobs_query["bool"] == {
+        "must": [
+            {"terms": {"status": ["pending"]}},
+            {"terms": {"connector.id": connectors_ids}},
+        ]
+    }
 
 
 def test_orphaned_jobs_query(mock_responses, set_env):
     config = EnvYAML(CONFIG)
 
-    connectors_ids = [1,2]
-    sync_jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config["elasticsearch"])
-    orphaned_jobs_query = sync_jobs_index.orphaned_jobs_query(connectors_ids=connectors_ids)
+    connectors_ids = [1, 2]
+    sync_jobs_index = SyncJobIndex(
+        index_name=JOBS_INDEX, elastic_config=config["elasticsearch"]
+    )
+    orphaned_jobs_query = sync_jobs_index.orphaned_jobs_query(
+        connectors_ids=connectors_ids
+    )
 
-    assert orphaned_jobs_query == {"bool": {"must_not": { "terms": {"connector.id": connectors_ids}} } }
+    assert orphaned_jobs_query == {
+        "bool": {"must_not": {"terms": {"connector.id": connectors_ids}}}
+    }
+
 
 
 def test_stuck_jobs_query(mock_responses, set_env):
     config = EnvYAML(CONFIG)
 
-    connectors_ids = [1,2]
-    sync_jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config["elasticsearch"])
+    connectors_ids = [1, 2]
+    sync_jobs_index = SyncJobIndex(
+        index_name=JOBS_INDEX, elastic_config=config["elasticsearch"]
+    )
     stuck_jobs_query = sync_jobs_index.stuck_jobs_query(connectors_ids=connectors_ids)
 
     assert "bool" in stuck_jobs_query
     assert len(stuck_jobs_query["bool"]["filter"]) == 3
-    assert { "terms": { "connector.id": connectors_ids } } in stuck_jobs_query["bool"]["filter"]
-    assert { "terms": { "status": [JobStatus.IN_PROGRESS, JobStatus.CANCELING] } } in stuck_jobs_query["bool"]["filter"]
-    assert { "range": { "last_seen": { "lte": "now-#{STUCK_JOBS_THRESHOLD}s" } } } in stuck_jobs_query["bool"]["filter"]
+    assert {"terms": {"connector.id": connectors_ids}} in stuck_jobs_query["bool"][
+        "filter"
+    ]
+    assert {
+        "terms": {"status": [JobStatus.IN_PROGRESS, JobStatus.CANCELING]}
+    } in stuck_jobs_query["bool"]["filter"]
+    assert {
+        "range": {"last_seen": {"lte": "now-#{STUCK_JOBS_THRESHOLD}s"}}
+    } in stuck_jobs_query["bool"]["filter"]

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -24,6 +24,8 @@ from connectors.byoc import (
     SyncJob,
     e2str,
     iso_utc,
+    SyncJobIndex,
+    STUCK_JOBS_THRESHOLD,
 )
 from connectors.byoei import ElasticServer
 from connectors.filtering.validation import ValidationTarget
@@ -697,3 +699,50 @@ async def test_update_filtering_validation(
             retry_on_conflict=ANY,
         )
     ]
+
+
+def test_pending_job_query_without_connectors_ids(mock_responses, set_env):
+    config = EnvYAML(CONFIG)
+
+    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    pending_jobs_query = sync_jobs_index.pending_job_query()
+
+    # validate the query
+    assert "bool" in pending_jobs_query
+    assert pending_jobs_query["bool"] == { "must": [ { "terms": { "status":  'pending' } }] }
+
+
+def test_pending_job_query_with_connectors_ids_and_page_size(mock_responses, set_env):
+    config = EnvYAML(CONFIG)
+
+    connectors_ids = [1,2]
+    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    pending_jobs_query = sync_jobs_index.pending_job_query(connectors_ids=connectors_ids)
+
+    # validate the query
+    assert "bool" in pending_jobs_query
+    assert pending_jobs_query["bool"] == { "must": [ { "terms": { "status":  'pending' } }, {'terms': {'connector.id': connectors_ids}}] }
+
+
+def test_orphaned_jobs_query(mock_responses, set_env):
+    config = EnvYAML(CONFIG)
+
+    connectors_ids = [1,2]
+    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    orphaned_jobs_query = sync_jobs_index.orphaned_jobs_query(connectors_ids=connectors_ids)
+
+    assert orphaned_jobs_query == {"bool": {"must_not": { "terms": {"connector.id": connectors_ids}} } }
+
+
+def test_stuck_jobs_query(mock_responses, set_env):
+    config = EnvYAML(CONFIG)
+
+    connectors_ids = [1,2]
+    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    stuck_jobs_query = sync_jobs_index.stuck_jobs_query(connectors_ids=connectors_ids)
+
+    assert "bool" in stuck_jobs_query
+    assert len(stuck_jobs_query["bool"]["filter"]) == 3
+    assert { "terms": { "connector.id": connectors_ids } } in stuck_jobs_query["bool"]["filter"]
+    assert { "terms": { "status": [JobStatus.IN_PROGRESS, JobStatus.CANCELING] } } in stuck_jobs_query["bool"]["filter"]
+    assert { "range": { "last_seen": { "lte": "now-#{STUCK_JOBS_THRESHOLD}s" } } } in stuck_jobs_query["bool"]["filter"]

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -12,7 +12,6 @@ from unittest.mock import ANY, AsyncMock, Mock, call
 
 import pytest
 from aioresponses import CallbackResult
-from elasticsearch import AsyncElasticsearch
 
 from connectors.byoc import (
     CONNECTORS_INDEX,

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -16,18 +16,19 @@ from elasticsearch import AsyncElasticsearch
 
 from connectors.byoc import (
     CONNECTORS_INDEX,
+    JOBS_INDEX,
+    STUCK_JOBS_THRESHOLD,
     Connector,
     ConnectorIndex,
     Filtering,
     JobStatus,
     Status,
     SyncJob,
+    SyncJobIndex,
     e2str,
     iso_utc,
-    SyncJobIndex,
-    STUCK_JOBS_THRESHOLD,
-    JOBS_INDEX
 )
+
 from connectors.byoei import ElasticServer
 from connectors.filtering.validation import ValidationTarget
 from connectors.logger import logger

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -31,9 +31,9 @@ from connectors.byoc import (
 
 from connectors.byoei import ElasticServer
 from connectors.filtering.validation import ValidationTarget
+from connectors.config import load_config
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.config import load_config
 
 CONFIG = os.path.join(os.path.dirname(__file__), "config.yml")
 

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -758,8 +758,9 @@ def test_stuck_jobs_query(mock_responses, set_env):
         "filter"
     ]
     assert {
-        "terms": {"status": [JobStatus.IN_PROGRESS, JobStatus.CANCELING]}
+        "terms": {"status": [e2str(JobStatus.IN_PROGRESS), e2str(JobStatus.CANCELING)]}
     } in stuck_jobs_query["bool"]["filter"]
+
     assert {
-        "range": {"last_seen": {"lte": "now-#{STUCK_JOBS_THRESHOLD}s"}}
+        "range": {"last_seen": {"lte": f"now-{STUCK_JOBS_THRESHOLD}s"}}
     } in stuck_jobs_query["bool"]["filter"]

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -15,7 +15,6 @@ from aioresponses import CallbackResult
 
 from connectors.byoc import (
     CONNECTORS_INDEX,
-    JOBS_INDEX,
     STUCK_JOBS_THRESHOLD,
     Connector,
     ConnectorIndex,
@@ -28,8 +27,8 @@ from connectors.byoc import (
     iso_utc,
 )
 from connectors.byoei import ElasticServer
-from connectors.filtering.validation import ValidationTarget
 from connectors.config import load_config
+from connectors.filtering.validation import ValidationTarget
 from connectors.logger import logger
 from connectors.source import BaseDataSource
 
@@ -733,7 +732,6 @@ def test_orphaned_jobs_query(mock_responses, set_env):
     assert orphaned_jobs_query == {
         "bool": {"must_not": {"terms": {"connector.id": connectors_ids}}}
     }
-
 
 
 def test_stuck_jobs_query(mock_responses, set_env):

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -185,7 +185,7 @@ def test_utc():
 @pytest.mark.asyncio
 async def test_sync_job(mock_responses):
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
-    jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config)
+    jobs_index = SyncJobIndex(elastic_config=config)
     client = jobs_index.client
 
     expected_filtering = {
@@ -708,9 +708,7 @@ def test_pending_job_query_with_connectors_ids(mock_responses, set_env):
     config = load_config(CONFIG)
 
     connectors_ids = [1, 2]
-    sync_jobs_index = SyncJobIndex(
-        index_name=JOBS_INDEX, elastic_config=config["elasticsearch"]
-    )
+    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
     pending_jobs_query = sync_jobs_index.pending_job_query(
         connectors_ids=connectors_ids
     )
@@ -729,9 +727,7 @@ def test_orphaned_jobs_query(mock_responses, set_env):
     config = load_config(CONFIG)
 
     connectors_ids = [1, 2]
-    sync_jobs_index = SyncJobIndex(
-        index_name=JOBS_INDEX, elastic_config=config["elasticsearch"]
-    )
+    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
     orphaned_jobs_query = sync_jobs_index.orphaned_jobs_query(
         connectors_ids=connectors_ids
     )
@@ -746,9 +742,7 @@ def test_stuck_jobs_query(mock_responses, set_env):
     config = load_config(CONFIG)
 
     connectors_ids = [1, 2]
-    sync_jobs_index = SyncJobIndex(
-        index_name=JOBS_INDEX, elastic_config=config["elasticsearch"]
-    )
+    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
     stuck_jobs_query = sync_jobs_index.stuck_jobs_query(connectors_ids=connectors_ids)
 
     assert "bool" in stuck_jobs_query

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -27,7 +27,6 @@ from connectors.byoc import (
     e2str,
     iso_utc,
 )
-
 from connectors.byoei import ElasticServer
 from connectors.filtering.validation import ValidationTarget
 from connectors.config import load_config

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -26,6 +26,7 @@ from connectors.byoc import (
     iso_utc,
     SyncJobIndex,
     STUCK_JOBS_THRESHOLD,
+    JOBS_INDEX
 )
 from connectors.byoei import ElasticServer
 from connectors.filtering.validation import ValidationTarget
@@ -183,7 +184,9 @@ def test_utc():
 
 @pytest.mark.asyncio
 async def test_sync_job(mock_responses):
-    client = AsyncElasticsearch(hosts=["http://nowhere.com:9200"])
+    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
+    connectors_index = BYOIndex(config)
+    client = connectors_index.client
 
     expected_filtering = {
         "advanced_snippet": {
@@ -194,7 +197,7 @@ async def test_sync_job(mock_responses):
         "validation": FILTERING_VALIDATION_VALID,
     }
 
-    job = SyncJob("connector-id", client)
+    job = SyncJob(connector_id="connector-id", elastic_index=connectors_index)
 
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.post(
@@ -704,31 +707,31 @@ async def test_update_filtering_validation(
 def test_pending_job_query_without_connectors_ids(mock_responses, set_env):
     config = EnvYAML(CONFIG)
 
-    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    sync_jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config["elasticsearch"])
     pending_jobs_query = sync_jobs_index.pending_job_query()
 
     # validate the query
     assert "bool" in pending_jobs_query
-    assert pending_jobs_query["bool"] == { "must": [ { "terms": { "status":  'pending' } }] }
+    assert pending_jobs_query["bool"] == { "must": [ { "terms": { "status":  ['pending'] } }] }
 
 
 def test_pending_job_query_with_connectors_ids_and_page_size(mock_responses, set_env):
     config = EnvYAML(CONFIG)
 
     connectors_ids = [1,2]
-    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    sync_jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config["elasticsearch"])
     pending_jobs_query = sync_jobs_index.pending_job_query(connectors_ids=connectors_ids)
 
     # validate the query
     assert "bool" in pending_jobs_query
-    assert pending_jobs_query["bool"] == { "must": [ { "terms": { "status":  'pending' } }, {'terms': {'connector.id': connectors_ids}}] }
+    assert pending_jobs_query["bool"] == { "must": [ { "terms": { "status":  ['pending'] } }, {'terms': {'connector.id': connectors_ids}}] }
 
 
 def test_orphaned_jobs_query(mock_responses, set_env):
     config = EnvYAML(CONFIG)
 
     connectors_ids = [1,2]
-    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    sync_jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config["elasticsearch"])
     orphaned_jobs_query = sync_jobs_index.orphaned_jobs_query(connectors_ids=connectors_ids)
 
     assert orphaned_jobs_query == {"bool": {"must_not": { "terms": {"connector.id": connectors_ids}} } }
@@ -738,7 +741,7 @@ def test_stuck_jobs_query(mock_responses, set_env):
     config = EnvYAML(CONFIG)
 
     connectors_ids = [1,2]
-    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    sync_jobs_index = SyncJobIndex(index_name=JOBS_INDEX, elastic_config=config["elasticsearch"])
     stuck_jobs_query = sync_jobs_index.stuck_jobs_query(connectors_ids=connectors_ids)
 
     assert "bool" in stuck_jobs_query

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -708,10 +708,8 @@ def test_pending_job_query_with_connectors_ids(mock_responses, set_env):
     config = load_config(CONFIG)
 
     connectors_ids = [1, 2]
-    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
-    pending_jobs_query = sync_jobs_index.pending_job_query(
-        connectors_ids=connectors_ids
-    )
+    sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    pending_jobs_query = sync_job_index.pending_job_query(connectors_ids=connectors_ids)
 
     # validate the query
     assert "bool" in pending_jobs_query
@@ -727,8 +725,8 @@ def test_orphaned_jobs_query(mock_responses, set_env):
     config = load_config(CONFIG)
 
     connectors_ids = [1, 2]
-    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
-    orphaned_jobs_query = sync_jobs_index.orphaned_jobs_query(
+    sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    orphaned_jobs_query = sync_job_index.orphaned_jobs_query(
         connectors_ids=connectors_ids
     )
 
@@ -742,8 +740,8 @@ def test_stuck_jobs_query(mock_responses, set_env):
     config = load_config(CONFIG)
 
     connectors_ids = [1, 2]
-    sync_jobs_index = SyncJobIndex(elastic_config=config["elasticsearch"])
-    stuck_jobs_query = sync_jobs_index.stuck_jobs_query(connectors_ids=connectors_ids)
+    sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    stuck_jobs_query = sync_job_index.stuck_jobs_query(connectors_ids=connectors_ids)
 
     assert "bool" in stuck_jobs_query
     assert len(stuck_jobs_query["bool"]["filter"]) == 3

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -33,6 +33,7 @@ from connectors.byoei import ElasticServer
 from connectors.filtering.validation import ValidationTarget
 from connectors.logger import logger
 from connectors.source import BaseDataSource
+from connectors.config import load_config
 
 CONFIG = os.path.join(os.path.dirname(__file__), "config.yml")
 
@@ -706,7 +707,7 @@ async def test_update_filtering_validation(
 
 
 def test_pending_job_query_with_connectors_ids(mock_responses, set_env):
-    config = EnvYAML(CONFIG)
+    config = load_config(CONFIG)
 
     connectors_ids = [1, 2]
     sync_jobs_index = SyncJobIndex(
@@ -727,7 +728,7 @@ def test_pending_job_query_with_connectors_ids(mock_responses, set_env):
 
 
 def test_orphaned_jobs_query(mock_responses, set_env):
-    config = EnvYAML(CONFIG)
+    config = load_config(CONFIG)
 
     connectors_ids = [1, 2]
     sync_jobs_index = SyncJobIndex(
@@ -744,7 +745,7 @@ def test_orphaned_jobs_query(mock_responses, set_env):
 
 
 def test_stuck_jobs_query(mock_responses, set_env):
-    config = EnvYAML(CONFIG)
+    config = load_config(CONFIG)
 
     connectors_ids = [1, 2]
     sync_jobs_index = SyncJobIndex(


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3252

This PR will add a new SyncJobIndex class which represents sync job index.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

