### PR TITLE
dont send huge sql queries in load()

### DIFF
--- a/connectors/sources/tests/fixtures/mysql/fixture.py
+++ b/connectors/sources/tests/fixtures/mysql/fixture.py
@@ -22,6 +22,18 @@ def random_text(k=1024 * 20):
 BIG_TEXT = random_text()
 
 
+def inject_lines(table, cursor, start, lines):
+    raws = []
+    for raw_id in range(lines):
+        raw_id += start
+        raws.append((f"user_{raw_id}", raw_id, BIG_TEXT))
+    sql_query = (
+        f"INSERT INTO customers_{table}"
+        + "(name, age, description) VALUES (%s, %s, %s)"
+    )
+    cursor.executemany(sql_query, raws)
+
+
 def load():
     """N tables of 10001 rows each. each row is ~ 1024*20 bytes"""
     database = connect(host="127.0.0.1", port=3306, user="root", password="changeme")
@@ -33,14 +45,9 @@ def load():
         print(f"Adding data in {table}...")
         sql_query = f"CREATE TABLE IF NOT EXISTS customers_{table} (name VARCHAR(255), age int, description LONGTEXT, PRIMARY KEY (name))"
         cursor.execute(sql_query)
-        raws = []
-        for raw_id in range(10000):
-            raws.append((f"user_{raw_id}", raw_id, BIG_TEXT))
-        sql_query = (
-            f"INSERT INTO customers_{table}"
-            + "(name, age, description) VALUES (%s, %s, %s)"
-        )
-        cursor.executemany(sql_query, raws)
+        for i in range(10):
+            inject_lines(table, cursor, i * 1000, 1000)
+
     database.commit()
 
 


### PR DESCRIPTION
We had a failure in the e2e test for MySQL

`mysql.connector.errors.OperationalError: 1153 (08S01): Got a packet bigger than 'max_allowed_packet' bytes`

This change updates the table in batches of 1000 lines to avoid hitting that limit

reproduced locally with 

```
make ftest NAME=mysql
```

which passes with the fix 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
