### PR TITLE
[8.6] Add perf8 integration (#191)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 PYTHON=python3.10
 ARCH=$(shell uname -m)
+PERF8?=no
 
 bin/python:
 	$(PYTHON) -m venv .
@@ -42,7 +43,7 @@ release: install
 	bin/python setup.py sdist
 
 ftest: bin/pytest bin/elastic-ingest
-	connectors/tests/ftest.sh $(NAME)
+	connectors/tests/ftest.sh $(NAME) $(PERF8)
 
 run: install
 	bin/elastic-ingest --debug

--- a/connectors/sources/tests/fixtures/mysql/fixture.py
+++ b/connectors/sources/tests/fixtures/mysql/fixture.py
@@ -52,7 +52,7 @@ def remove():
     database = connect(host="127.0.0.1", port=3306, user="root", password="changeme")
     cursor = database.cursor()
     cursor.execute(f"USE {DATABASE_NAME}")
-    for table in range(NUM_TABLES):
+    for table in range(30):
         print(f"Working on table {table}...")
         rows = [(f"user_{row_id}",) for row_id in random.sample(range(1, 1000), 10)]
         print(rows)

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -3,6 +3,8 @@ set -exu
 set -o pipefail
 
 NAME=$1
+PERF8=$2
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR="$SCRIPT_DIR/../.."
 PLATFORM='unknown'

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -4,7 +4,6 @@ elastic-transport==8.4.0
 pyyaml==6.0
 envyaml==1.10.211231
 ecs-logging==2.0.0
-envyaml==1.10.211231
 pympler==1.0.1
 guppy3==3.1.2
 cron-schedule-triggers==0.0.11

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,3 +6,4 @@ pytest>=7.1.2
 pytest-cov>=3.0.0
 pytest-asyncio>=0.19.0
 pytest-randomly>=3.12.0
+git+https://github.com/elastic/perf8#egg=perf8


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Add perf8 integration (#191)

tried with 

```
make ftest NAME=mysql
```

in this branch