### PR TITLE
Refactor services

### DIFF
--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -3,19 +3,45 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from connectors.logger import logger
+import time
+
+from connectors.utils import CancellableSleeps
+
+
+class ServiceAlreadyRunningError(Exception):
+    pass
 
 
 class BaseService:
     def __init__(self, config):
         self.config = config
+        self.service_config = self.config["service"]
+        self.es_config = self.config["elasticsearch"]
+        self.running = False
+        self._sleeps = CancellableSleeps()
+        self.errors = [0, time.time()]
 
     def stop(self):
         raise NotImplementedError()
 
     async def run(self):
-        raise NotImplementedError()
+        if self.running:
+            raise ServiceAlreadyRunningError(
+                f"{self.__class__.__name__} is already running."
+            )
 
-    def shutdown(self, sig):
-        logger.info(f"Caught {sig.name}. Graceful shutdown.")
-        self.stop()
+    def raise_if_spurious(self, exception):
+        errors, first = self.errors
+        errors += 1
+
+        # if we piled up too many errors we raise and quit
+        if errors > self.service_config["max_errors"]:
+            raise exception
+
+        # we re-init every ten minutes
+        if time.time() - first > self.service_config["max_errors_span"]:
+            first = time.time()
+            errors = 0
+
+        self.errors[0] = errors
+        self.errors[1] = first

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -33,6 +33,7 @@ class BaseService:
                 f"{self.__class__.__name__} is already running."
             )
 
+        self.running = True
         await self._run()
 
     def raise_if_spurious(self, exception):

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -24,11 +24,16 @@ class BaseService:
     def stop(self):
         raise NotImplementedError()
 
+    async def _run(self):
+        raise NotImplementedError()
+
     async def run(self):
         if self.running:
             raise ServiceAlreadyRunningError(
                 f"{self.__class__.__name__} is already running."
             )
+
+        await self._run()
 
     def raise_if_spurious(self, exception):
         errors, first = self.errors

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -107,13 +107,9 @@ class SyncService(BaseService):
         finally:
             await connector.close()
 
-    async def run(self):
+    async def _run(self):
         """Main event loop."""
-
-        await super().run()
-
         self.connectors = ConnectorIndex(self.es_config)
-        self.running = True
 
         one_sync = self.args.one_sync
         sync_now = self.args.sync_now

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -50,10 +50,6 @@ class SyncService(BaseService):
         self.args = args
         self.idling = self.service_config["idling"]
         self.hb = self.service_config["heartbeat"]
-        self.preflight_max_attempts = int(
-            self.service_config.get("preflight_max_attempts", 10)
-        )
-        self.preflight_idle = int(self.service_config.get("preflight_idle", 30))
         self.connectors = None
 
     async def _one_sync(self, connector, es, sync_now):


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3639

This PR made the following changes:
1. The CLI will be able to run multiple services.
2. Move `perf8` to the application level.
3. Move some common attributes to `BaseService`
4. Make one service only run once.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference