### PR TITLE
[Filtering] Integrate the BasicRuleEngine into the sync

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -236,8 +236,11 @@ class SyncJob:
 class Filtering:
     DEFAULT_DOMAIN = "DEFAULT"
 
-    def __init__(self, filtering):
-        self.filtering = filtering if filtering else []
+    def __init__(self, filtering=None):
+        if filtering is None:
+            filtering = []
+
+        self.filtering = filtering
 
     def get_active_filter(self, domain=DEFAULT_DOMAIN):
         return next(
@@ -586,6 +589,7 @@ class Connector:
                 self.index_name,
                 self.prepare_docs(self.data_provider),
                 self.pipeline,
+                filtering=self.filtering,
                 options=bulk_options,
             )
             await self._sync_done(job, result)

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -28,7 +28,9 @@ from collections import defaultdict
 from elasticsearch import NotFoundError as ElasticNotFoundError
 from elasticsearch.helpers import async_scan
 
+from connectors.byoc import Filtering
 from connectors.es import ESClient
+from connectors.filtering.basic_rule import BasicRuleEngine, parse
 from connectors.logger import logger
 from connectors.utils import (
     DEFAULT_CHUNK_MEM_SIZE,
@@ -175,10 +177,13 @@ class Fetcher:
         queue,
         index,
         existing_ids,
+        filtering=None,
         queue_size=DEFAULT_QUEUE_SIZE,
         display_every=DEFAULT_DISPLAY_EVERY,
         concurrent_downloads=DEFAULT_CONCURRENT_DOWNLOADS,
     ):
+        if filtering is None:
+            filtering = Filtering()
         self.client = client
         self.queue = queue
         self.bulk_time = 0
@@ -192,6 +197,10 @@ class Fetcher:
         self.total_docs_created = 0
         self.total_docs_deleted = 0
         self.fetch_error = None
+        self.filtering = filtering
+        self.basic_rule_engine = BasicRuleEngine(
+            parse(filtering.get_active_filter().get("rules", []))
+        )
         self.display_every = display_every
         self.concurrent_downloads = concurrent_downloads
 
@@ -237,6 +246,9 @@ class Fetcher:
                     logger.info(str(self))
 
                 doc_id = doc["id"] = doc.pop("_id")
+
+                if not self.basic_rule_engine.should_ingest(doc):
+                    continue
 
                 if doc_id in self.existing_ids:
                     # pop out of self.existing_ids
@@ -414,8 +426,11 @@ class ElasticServer(ESClient):
         index,
         generator,
         pipeline,
+        filtering=None,
         options=None,
     ):
+        if filtering is None:
+            filtering = Filtering()
         if options is None:
             options = {}
         queue_size = options.get("queue_max_size", DEFAULT_QUEUE_SIZE)
@@ -443,6 +458,7 @@ class ElasticServer(ESClient):
             stream,
             index,
             existing_ids,
+            filtering=filtering,
             queue_size=queue_size,
             display_every=display_every,
             concurrent_downloads=concurrent_downloads,

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -3,12 +3,30 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import asyncio
 import datetime
+from copy import deepcopy
+from unittest import mock
+from unittest.mock import Mock, call
 
 import pytest
 
 from connectors.byoc import PipelineSettings
-from connectors.byoei import ElasticServer
+from connectors.byoei import ElasticServer, Fetcher
+
+INDEX = "some-index"
+TIMESTAMP = datetime.datetime(year=2023, month=1, day=1)
+NO_FILTERING = ()
+DOC_ONE_ID = 1
+
+DOC_ONE = {"_id": DOC_ONE_ID, "_timestamp": TIMESTAMP}
+
+DOC_ONE_DIFFERENT_TIMESTAMP = {
+    "_id": DOC_ONE_ID,
+    "_timestamp": TIMESTAMP + datetime.timedelta(days=1),
+}
+
+DOC_TWO = {"_id": 2, "_timestamp": TIMESTAMP}
 
 
 @pytest.mark.asyncio
@@ -211,7 +229,6 @@ async def test_async_bulk(mock_responses, patch_logger):
 
 @pytest.mark.asyncio
 async def test_async_bulk_same_ts(mock_responses, patch_logger):
-
     ts = datetime.datetime.now().isoformat()
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     set_responses(mock_responses, ts)
@@ -251,3 +268,301 @@ async def test_async_bulk_same_ts(mock_responses, patch_logger):
     }
 
     await es.close()
+
+
+def index_operation(doc):
+    copy = deepcopy(doc)
+    doc_id = copy["id"] = copy.pop("_id")
+
+    return {"_op_type": "index", "_index": INDEX, "_id": doc_id, "doc": copy}
+
+
+def delete_operation(doc):
+    return {"_op_type": "delete", "_index": INDEX, "_id": doc["_id"]}
+
+
+def end_docs_operation():
+    return "END_DOCS"
+
+
+def created(doc_count):
+    """Used for test readability."""
+    return doc_count
+
+
+def updated(doc_count):
+    """Used for test readability."""
+    return doc_count
+
+
+def deleted(doc_count):
+    """Used for test readability."""
+    return doc_count
+
+
+def total_downloads(count):
+    """Used for test readability."""
+    return count
+
+
+async def queue_mock():
+    queue = Mock()
+    future = asyncio.Future()
+    future.set_result(1)
+    queue.put = Mock(return_value=future)
+    return queue
+
+
+def lazy_download_fake(doc):
+    async def lazy_download(**kwargs):
+        # also deepcopy to prevent side effects as docs get mutated in get_docs
+        return deepcopy(doc)
+
+    return lazy_download
+
+
+class AsyncDocsGeneratorFake:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def __aiter__(self):
+        self.i = 0
+        return self
+
+    async def __anext__(self):
+        if self.i >= len(self.docs):
+            raise StopAsyncIteration
+
+        doc = self.docs[self.i]
+        self.i += 1
+        return doc
+
+
+def queue_called_with_operations(queue, operations):
+    expected_calls = [call(operation) for operation in operations]
+    actual_calls = queue.put.call_args_list
+
+    return actual_calls == expected_calls and queue.put.call_count == len(
+        expected_calls
+    )
+
+
+async def basic_rule_engine_mock(return_values):
+    basic_rule_engine = Mock()
+    basic_rule_engine.should_ingest = (
+        Mock(side_effect=list(return_values))
+        if len(return_values)
+        else Mock(return_value=True)
+    )
+    return basic_rule_engine
+
+
+async def lazy_downloads_mock():
+    lazy_downloads = Mock()
+    future = asyncio.Future()
+    future.set_result(1)
+    lazy_downloads.put = Mock(return_value=future)
+    return lazy_downloads
+
+
+async def setup_fetcher(basic_rule_engine, existing_docs, queue):
+    client = Mock()
+    existing_ids = {doc["_id"]: doc["_timestamp"] for doc in existing_docs}
+
+    # filtering content doesn't matter as the BasicRuleEngine behavior is mocked
+    filtering_mock = Mock()
+    filtering_mock.get_active_filter = Mock(return_value={})
+    fetcher = Fetcher(client, queue, INDEX, existing_ids, filtering=filtering_mock)
+    fetcher.basic_rule_engine = basic_rule_engine
+    return fetcher
+
+
+@pytest.mark.parametrize(
+    "existing_docs, docs_from_source, doc_should_ingest, expected_queue_operations, expected_total_docs_updated, "
+    "expected_total_docs_created, expected_total_docs_deleted, expected_total_downloads",
+    [
+        (
+            # no docs exist, data source has doc 1 -> ingest doc 1
+            [],
+            [(DOC_ONE, None)],
+            NO_FILTERING,
+            [index_operation(DOC_ONE), end_docs_operation()],
+            updated(0),
+            created(1),
+            deleted(0),
+            total_downloads(0),
+        ),
+        (
+            # doc 1 is present, nothing in source -> delete one doc
+            [DOC_ONE],
+            [],
+            NO_FILTERING,
+            [delete_operation(DOC_ONE), end_docs_operation()],
+            updated(0),
+            created(0),
+            deleted(1),
+            total_downloads(0),
+        ),
+        (
+            # doc 2 is present, data source only returns doc 1 -> delete doc 2 and ingest doc 1
+            [DOC_TWO],
+            [(DOC_ONE, None)],
+            NO_FILTERING,
+            [index_operation(DOC_ONE), delete_operation(DOC_TWO), end_docs_operation()],
+            updated(0),
+            created(1),
+            deleted(1),
+            total_downloads(0),
+        ),
+        (
+            # doc 1 is present, data source also has doc 1 with the same timestamp -> nothing happens
+            [DOC_ONE],
+            [(DOC_ONE, None)],
+            NO_FILTERING,
+            [end_docs_operation()],
+            updated(0),
+            created(0),
+            deleted(0),
+            total_downloads(0),
+        ),
+        (
+            # doc 1 is present, data source has doc 1 with different timestamp -> doc is updated
+            [DOC_ONE],
+            [(DOC_ONE_DIFFERENT_TIMESTAMP, None)],
+            NO_FILTERING,
+            [
+                # update happens through overwriting
+                index_operation(DOC_ONE_DIFFERENT_TIMESTAMP),
+                end_docs_operation(),
+            ],
+            updated(1),
+            created(0),
+            deleted(0),
+            total_downloads(0),
+        ),
+        (
+            [],
+            [(DOC_ONE, None)],
+            # filter out doc 1
+            (False,),
+            [
+                # should not ingest doc 1
+                end_docs_operation()
+            ],
+            updated(0),
+            created(0),
+            deleted(0),
+            total_downloads(0),
+        ),
+        (
+            # doc 1 is present, data source has doc 1, doc 1 should be filtered -> delete doc 1
+            [DOC_ONE],
+            [(DOC_ONE, None)],
+            # filter out doc 1
+            (False,),
+            [
+                delete_operation(DOC_ONE),
+                end_docs_operation(),
+            ],
+            updated(0),
+            created(0),
+            deleted(1),
+            total_downloads(0),
+        ),
+        (
+            # doc 1 is present, data source has doc 1 (different timestamp), doc 1 should be filtered -> delete doc 1
+            [DOC_ONE],
+            [(DOC_ONE_DIFFERENT_TIMESTAMP, None)],
+            # still filter out doc 1
+            (False,),
+            [delete_operation(DOC_ONE), end_docs_operation()],
+            updated(0),
+            created(0),
+            deleted(1),
+            total_downloads(0),
+        ),
+        (
+            [],
+            [(DOC_ONE, None)],
+            # filtering throws exception
+            [Exception()],
+            ["FETCH_ERROR"],
+            updated(0),
+            created(0),
+            deleted(0),
+            total_downloads(0),
+        ),
+        (
+            [],
+            # no doc present, lazy download for doc 1 specified -> index and increment the downloads counter
+            [(DOC_ONE, lazy_download_fake(DOC_ONE))],
+            NO_FILTERING,
+            [index_operation(DOC_ONE), end_docs_operation()],
+            updated(0),
+            created(1),
+            deleted(0),
+            total_downloads(1),
+        ),
+        (
+            # doc 1 present, data source has doc 1 -> no lazy download if timestamps are the same for the docs
+            [DOC_ONE],
+            [(DOC_ONE, lazy_download_fake(DOC_ONE))],
+            NO_FILTERING,
+            [end_docs_operation()],
+            updated(0),
+            created(0),
+            deleted(0),
+            total_downloads(0),
+        ),
+        (
+            # doc 1 present, data source has doc 1 with different timestamp
+            # lazy download coroutine present -> execute lazy download
+            [DOC_ONE],
+            [
+                (
+                    DOC_ONE_DIFFERENT_TIMESTAMP,
+                    lazy_download_fake(DOC_ONE_DIFFERENT_TIMESTAMP),
+                )
+            ],
+            NO_FILTERING,
+            [index_operation(DOC_ONE_DIFFERENT_TIMESTAMP), end_docs_operation()],
+            updated(1),
+            created(0),
+            deleted(0),
+            total_downloads(1),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_docs(
+    existing_docs,
+    docs_from_source,
+    doc_should_ingest,
+    expected_queue_operations,
+    expected_total_docs_updated,
+    expected_total_docs_created,
+    expected_total_docs_deleted,
+    expected_total_downloads,
+):
+    lazy_downloads = await lazy_downloads_mock()
+
+    with mock.patch("connectors.utils.ConcurrentTasks", return_value=lazy_downloads):
+        queue = await queue_mock()
+        basic_rule_engine = await basic_rule_engine_mock(doc_should_ingest)
+
+        # deep copying docs is needed as get_docs mutates the document ids which has side effects on other test
+        # instances
+        doc_generator = AsyncDocsGeneratorFake(
+            [deepcopy(doc) for doc in docs_from_source]
+        )
+
+        fetcher = await setup_fetcher(basic_rule_engine, existing_docs, queue)
+
+        await fetcher.get_docs(doc_generator)
+
+        assert fetcher.total_docs_updated == expected_total_docs_updated
+        assert fetcher.total_docs_created == expected_total_docs_created
+        assert fetcher.total_docs_deleted == expected_total_docs_deleted
+        assert fetcher.total_downloads == expected_total_downloads
+
+        assert queue_called_with_operations(queue, expected_queue_operations)


### PR DESCRIPTION
### Closes https://github.com/elastic/enterprise-search-team/issues/3581

Integrate the `BasicRuleEngine` into the sync. Also add the missing `Fetcher` tests for `get_docs` as this is one of the key places for syncs to actually work.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes