### PR TITLE
Speed up test_preflight_check.py tests

### DIFF
--- a/connectors/tests/test_preflight_check.py
+++ b/connectors/tests/test_preflight_check.py
@@ -17,7 +17,7 @@ config = {
         "username": "elastic",
         "password": "changeme",
         "max_wait_duration": 0.1,
-        "initial_backoff_duration": 0.1
+        "initial_backoff_duration": 0.1,
     },
     "service": {"preflight_max_attempts": 4, "preflight_idle": 0.1},
 }

--- a/connectors/tests/test_preflight_check.py
+++ b/connectors/tests/test_preflight_check.py
@@ -16,9 +16,10 @@ config = {
         "host": host,
         "username": "elastic",
         "password": "changeme",
-        "max_wait_duration": 2,
+        "max_wait_duration": 0.1,
+        "initial_backoff_duration": 0.1
     },
-    "service": {"preflight_max_attempts": 4, "preflight_idle": 1},
+    "service": {"preflight_max_attempts": 4, "preflight_idle": 0.1},
 }
 
 


### PR DESCRIPTION
Speeding up tests in `test_preflight_check.py` - they rely on default timeout times that are a bit too slow (e.g. initial backoff for retrying connector to Elasticsearch is 5 seconds). These tests mock responses, thus no need to keep long times.

```
> bin/pytest -sv --durations=0 connectors/tests/test_preflight_check.py
```

Before change takes ~19 seconds:
```
5.01s call     connectors/tests/test_preflight_check.py::test_es_unavailable
4.06s call     connectors/tests/test_preflight_check.py::test_job_index_missing
4.03s call     connectors/tests/test_preflight_check.py::test_connector_index_missing
4.03s call     connectors/tests/test_preflight_check.py::test_both_indices_missing
2.02s call     connectors/tests/test_preflight_check.py::test_index_exist_transient_error
0.01s call     connectors/tests/test_preflight_check.py::test_pass
0.01s call     connectors/tests/test_preflight_check.py::test_es_transient_error
0.01s setup    connectors/tests/test_preflight_check.py::test_job_index_missing
```

After change takes < 250ms:
```
0.11s call     connectors/tests/test_preflight_check.py::test_es_unavailable
0.05s call     connectors/tests/test_preflight_check.py::test_job_index_missing
0.02s call     connectors/tests/test_preflight_check.py::test_connector_index_missing
0.02s call     connectors/tests/test_preflight_check.py::test_both_indices_missing
0.01s call     connectors/tests/test_preflight_check.py::test_index_exist_transient_error
0.01s call     connectors/tests/test_preflight_check.py::test_pass
0.01s call     connectors/tests/test_preflight_check.py::test_es_transient_error
0.01s setup    connectors/tests/test_preflight_check.py::test_job_index_missing
```