### PR TITLE
Speed up test_es_client.py and test_utils.py slow tests

### DIFF
--- a/connectors/tests/test_es_client.py
+++ b/connectors/tests/test_es_client.py
@@ -4,12 +4,12 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import base64
+from unittest import mock
 
 import pytest
+from elasticsearch import ConnectionError
 
 from connectors.es.client import ESClient
-from elasticsearch import ConnectionError
-from unittest import mock
 
 
 def test_esclient():
@@ -92,7 +92,11 @@ async def test_es_client_no_server(patch_logger):
     }
     es_client = ESClient(config)
 
-    with mock.patch.object(es_client.client, "info", side_effect=ConnectionError("Cannot connect - no route to host.")):
+    with mock.patch.object(
+        es_client.client,
+        "info",
+        side_effect=ConnectionError("Cannot connect - no route to host."),
+    ):
         # Execute
         assert not await es_client.ping()
         await es_client.close()

--- a/connectors/tests/test_es_client.py
+++ b/connectors/tests/test_es_client.py
@@ -81,7 +81,9 @@ async def test_es_client_auth_error(mock_responses, patch_logger):
 @pytest.mark.asyncio
 async def test_es_client_no_server(mock_responses, patch_logger):
     host = "http://nowhere.com:9200"
-    mock_responses.get(host, status=503, headers={"X-Elastic-Product": "Elasticsearch"}, repeat=True)
+    mock_responses.get(
+        host, status=503, headers={"X-Elastic-Product": "Elasticsearch"}, repeat=True
+    )
     # if we can't reach the server, we need to catch it cleanly
     config = {
         "username": "elastic",

--- a/connectors/tests/test_es_client.py
+++ b/connectors/tests/test_es_client.py
@@ -79,12 +79,16 @@ async def test_es_client_auth_error(mock_responses, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_es_client_no_server(patch_logger):
+async def test_es_client_no_server(mock_responses, patch_logger):
+    host = "http://nowhere.com:9200"
+    mock_responses.get(host, status=503, headers={"X-Elastic-Product": "Elasticsearch"}, repeat=True)
     # if we can't reach the server, we need to catch it cleanly
     config = {
         "username": "elastic",
         "password": "changeme",
-        "host": "http://nowhere.com:9200",
+        "host": host,
+        "max_wait_duration": 0.1,
+        "initial_backoff_duration": 0.1,
     }
     es_client = ESClient(config)
     assert not await es_client.ping()

--- a/connectors/tests/test_es_client.py
+++ b/connectors/tests/test_es_client.py
@@ -9,6 +9,7 @@ import pytest
 
 from connectors.es.client import ESClient
 from elasticsearch import ConnectionError
+from unittest import mock
 
 
 def test_esclient():
@@ -91,7 +92,7 @@ async def test_es_client_no_server(patch_logger):
     }
     es_client = ESClient(config)
 
-    with mock.patch.object(es_client.client, "info", side_effect=ConnectionError()):
+    with mock.patch.object(es_client.client, "info", side_effect=ConnectionError("Cannot connect - no route to host.")):
         # Execute
         assert not await es_client.ping()
         await es_client.close()

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -110,7 +110,7 @@ async def test_mem_queue_race(patch_logger):
 @pytest.mark.asyncio
 async def test_mem_queue(patch_logger):
 
-    queue = MemQueue(maxmemsize=1024, refresh_interval=0, refresh_timeout=2)
+    queue = MemQueue(maxmemsize=1024, refresh_interval=0, refresh_timeout=0.1)
     await queue.put("small stuff")
 
     assert not queue.full()


### PR DESCRIPTION
Similar to https://github.com/elastic/connectors-python/pull/343 speeding up two slowest tests:

1. test_es_client.py

```
> bin/pytest -sv --durations=0 connectors/tests/test_es_client.py
```

Before:

```
================================================================================================ slowest durations ================================================================================================
4.17s call     connectors/tests/test_es_client.py::test_es_client_no_server
```

After:

```
================================================================================================ slowest durations ================================================================================================
0.02s call     connectors/tests/test_es_client.py::test_es_client_no_server
0.01s setup    connectors/tests/test_es_client.py::test_es_client_no_server
```

2. connectors/tests/test_utils.py

Before:

```
================================================================================================ slowest durations ================================================================================================
2.10s call     connectors/tests/test_utils.py::test_mem_queue
```

After:

```
================================================================================================ slowest durations ================================================================================================
0.20s call     connectors/tests/test_utils.py::test_mem_queue
```
