### PR TITLE
[Filtering] Pass valid filtering to a sync

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from connectors.es import DEFAULT_LANGUAGE, ESIndex, Mappings
+from connectors.filtering.validation import validate_filtering
 from connectors.logger import logger
 from connectors.source import DataSourceConfiguration, get_source_klass
 from connectors.utils import iso_utc, next_run
@@ -572,6 +573,8 @@ class Connector:
             # allows the data provider to change the bulk options
             bulk_options = self.bulk_options.copy()
             self.data_provider.tweak_bulk_options(bulk_options)
+
+            await validate_filtering(self)
 
             result = await elastic_server.async_bulk(
                 self.index_name,

--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -12,6 +12,20 @@ from connectors.filtering.basic_rule import BasicRule, Policy, Rule
 from connectors.logger import logger
 
 
+async def validate_filtering(connector):
+    validation_result = await connector.source_klass.validate_filtering(
+        connector.filtering.get_active_filter()
+    )
+    if validation_result.state != FilteringValidationState.VALID:
+        raise InvalidFilteringError(
+            f"Filtering in state {validation_result.state}. Expected: {FilteringValidationState.VALID}."
+        )
+    if len(validation_result.errors):
+        raise InvalidFilteringError(
+            f"Filtering validation errors present: {validation_result.errors}."
+        )
+
+
 class InvalidFilteringError(Exception):
     pass
 

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -109,7 +109,6 @@ class SyncService(BaseService):
             await asyncio.sleep(0)
         except InvalidFilteringError as e:
             logger.error(e)
-            self.raise_if_spurious(e)
             return
         finally:
             await connector.close()

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -24,27 +24,10 @@ from connectors.byoc import (
     e2str,
 )
 from connectors.byoei import ElasticServer
-from connectors.filtering.validation import (
-    FilteringValidationState,
-    InvalidFilteringError,
-)
+from connectors.filtering.validation import InvalidFilteringError, validate_filtering
 from connectors.logger import logger
 from connectors.services.base import BaseService
 from connectors.utils import CancellableSleeps
-
-
-async def _validate_filtering(connector):
-    validation_result = await connector.source_klass.validate_filtering(
-        connector.filtering.get_active_filter()
-    )
-    if validation_result.state != FilteringValidationState.VALID:
-        raise InvalidFilteringError(
-            f"Filtering in state {validation_result.state}. Expected: {FilteringValidationState.VALID}."
-        )
-    if len(validation_result.errors):
-        raise InvalidFilteringError(
-            f"Filtering validation errors present: {validation_result.errors}."
-        )
 
 
 class SyncService(BaseService):
@@ -120,7 +103,7 @@ class SyncService(BaseService):
                 # we can't sync in that state
                 logger.info(f"Can't sync with status `{e2str(connector.status)}`")
             else:
-                await _validate_filtering(connector)
+                await validate_filtering(connector)
                 await connector.sync(es, self.idling, sync_now)
 
             await asyncio.sleep(0)

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -547,8 +547,10 @@ async def test_connector_service_filtering(
     service = await service_with_max_errors(mock_responses, config, 0)
 
     if should_raise_filtering_error:
-        with pytest.raises(InvalidFilteringError):
-            await service.run()
+        await service.run()
+        patch_logger.assert_check(
+            lambda log: isinstance(log, InvalidFilteringError)
+        )
     else:
         try:
             await service.run()


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3571 ##

This PR makes sure that a sync is only executed if filtering is valid. Also we should not quit when filtering is invalid, but update the status in the .elastic-connectors index (will follow with another PR).

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference