### PR TITLE
Fix one flaky test relying on time

### DIFF
--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -15,6 +15,7 @@ import time
 
 import pytest
 from pympler import asizeof
+from freezegun import freeze_time
 
 from connectors import utils
 from connectors.utils import (
@@ -29,6 +30,7 @@ from connectors.utils import (
 )
 
 
+@freeze_time("2023-01-18 17:18:56.814003", tick=True)
 def test_next_run():
     # can run within two minutes
     assert next_run("1 * * * * *") < 120

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -14,8 +14,8 @@ import tempfile
 import time
 
 import pytest
-from pympler import asizeof
 from freezegun import freeze_time
+from pympler import asizeof
 
 from connectors import utils
 from connectors.utils import (

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,3 +8,4 @@ pytest-cov>=3.0.0
 pytest-asyncio>=0.19.0
 pytest-randomly>=3.12.0
 git+https://github.com/elastic/perf8#egg=perf8
+freezegun>=0.3.4


### PR DESCRIPTION
See for example pipeline https://buildkite.com/elastic/connectors-python/builds/1611#0185c5c1-f3fb-47bd-a9c3-91f50b4270fa: 

```
=================================== FAILURES ===================================
________________________________ test_next_run _________________________________

    def test_next_run():
        # can run within two minutes
        assert next_run("1 * * * * *") < 120
>       assert next_run("* * * * * *") == 0
E       AssertionError: assert 1.999814 == 0
E        +  where 1.999814 = next_run('* * * * * *')

connectors/tests/test_utils.py:35: AssertionError
```


The problem happens because test that checks when next cron trigger happens uses current time for the fixture - in some cases it seems to produce unexpected results.

This fix adds `freezegun` package and uses it to rewind the time for this specific test: https://github.com/spulec/freezegun 