### PR TITLE
Update data source __doc__

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -101,7 +101,7 @@ class DataSourceConfiguration:
 
 
 class BaseDataSource:
-    """Base class, defines a lose contract."""
+    """Base class, defines a loose contract."""
 
     def __init__(self, configuration):
         self.configuration = configuration

--- a/connectors/sources/abs.py
+++ b/connectors/sources/abs.py
@@ -30,10 +30,10 @@ MAX_CONCURRENT_DOWNLOADS = 100  # Max concurrent download supported by abs
 
 
 class AzureBlobStorageDataSource(BaseDataSource):
-    """Class to fetch documents from Azure Blob Storage"""
+    """Azure Blob Storage"""
 
     def __init__(self, configuration):
-        """Setup the connection to the azure base client
+        """Set up the connection to the azure base client
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.

--- a/connectors/sources/gcs.py
+++ b/connectors/sources/gcs.py
@@ -60,13 +60,13 @@ DEFAULT_PEM_FILE = os.path.join(
 
 
 class GoogleCloudStorageDataSource(BaseDataSource):
-    """Class to fetch documents from Google Cloud Storage."""
+    """Google Cloud Storage"""
 
     def __init__(self, configuration):
-        """Setup connection to the Google Cloud Storage Client.
+        """Set up the connection to the Google Cloud Storage Client.
 
         Args:
-            connector (Connector): Object of the Connector class.
+            configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
         super().__init__(configuration=configuration)
         if not self.configuration["service_account_credentials"]:

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -31,13 +31,13 @@ DEFAULT_SSL_CA = None
 
 
 class MySqlDataSource(BaseDataSource):
-    """Class to fetch and modify documents from MySQL server"""
+    """MySQL"""
 
     def __init__(self, configuration):
-        """Setup connection to the MySQL server.
+        """Set up the connection to the MySQL server.
 
         Args:
-            connector (Connector): Object of the Connector class
+            configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
         super().__init__(configuration=configuration)
         self.retry_count = self.configuration["retry_count"]

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -23,13 +23,13 @@ DEFAULT_FILE_SIZE_LIMIT = 10485760
 
 
 class NASDataSource(BaseDataSource):
-    """Class to fetch documents from Network Drive"""
+    """Network Drive"""
 
     def __init__(self, configuration):
-        """Setup the connection to the Network Drive
+        """Set up the connection to the Network Drive
 
         Args:
-            connector (Connector): Object of the Connector class
+            configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
         super().__init__(configuration=configuration)
         self.username = self.configuration["username"]

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -37,10 +37,10 @@ class S3DataSource(BaseDataSource):
     """Amazon S3"""
 
     def __init__(self, configuration):
-        """Setup connection to the Amazon S3.
+        """Set up the connection to the Amazon S3.
 
         Args:
-            connector (Connector): Object of the Connector class.
+            configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
         super().__init__(configuration=configuration)
         self.session = aioboto3.Session()


### PR DESCRIPTION
When running `bin/elastic-ingest --action list`, it prints:

```
[FMWK][11:14:02][INFO] Registered connectors:
[FMWK][11:14:02][INFO] - MongoDB
[FMWK][11:14:02][INFO] - Amazon S3
[FMWK][11:14:02][INFO] - Directory
[FMWK][11:14:02][INFO] - Class to fetch and modify documents from MySQL server
[FMWK][11:14:02][INFO] - Class to fetch documents from Network Drive
[FMWK][11:14:02][INFO] - Class to fetch documents from Google Cloud Storage.
[FMWK][11:14:03][INFO] - Class to fetch documents from Azure Blob Storage
[FMWK][11:14:03][INFO] Bye
```

The `__doc__` of each data source is expected to be the name of each data source:

https://github.com/elastic/connectors-python/blob/002901eeadb5faa9e66fdaaa8fab06f477ff648f/connectors/cli.py#L118

This PR updates the `__doc__` of some data sources.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
