### PR TITLE
[Performance] Speed up sync tests

### DIFF
--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -191,7 +191,10 @@ class Args:
 
 def create_service(config_file, **options):
     config = load_config(config_file)
-    return SyncService(config, Args(**options))
+    service = SyncService(config, Args(**options))
+    service.idling = 0
+
+    return service
 
 
 async def set_server_responses(


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/###

Reduce the idling time from the sync service to 0 when it's created in the tests within `test_sync.py`.

Speed up: ~ 4.5 seconds to ~ 400 ms (This would've add up for every new test in `test_sync.py`; +0.5s with every test)

Before:
<img width="500" alt="Screenshot 2023-01-23 at 11 06 01" src="https://user-images.githubusercontent.com/26525778/214013788-5ca44a92-3d79-4111-b7c2-e454c9f60f1a.png">

After:
<img width="499" alt="Screenshot 2023-01-23 at 11 06 19" src="https://user-images.githubusercontent.com/26525778/214013809-2256c633-b126-4e13-bdad-cb1337e9f12f.png">


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
~~- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)~~
~~- [ ] Considered corresponding documentation changes~~
~~- [ ] Contributed any configuration settings changes to the configuration reference~~