### PR TITLE
Add pytest plugin to fail tests that are too slow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PYTHON=python3.10
 ARCH=$(shell uname -m)
 PERF8?=no
+SLOW_TEST_THRESHOLD=1 # seconds
 
 bin/python:
 	$(PYTHON) -m venv .
@@ -45,7 +46,7 @@ autoformat: bin/python bin/black bin/elastic-ingest
 	bin/black scripts
 
 test:	bin/pytest bin/elastic-ingest
-	bin/pytest --cov-report term-missing --cov-fail-under 92 --cov-report html --cov=connectors -sv connectors/tests connectors/sources/tests
+	bin/pytest --cov-report term-missing --cov-fail-under 92 --cov-report html --cov=connectors --fail-slow=$(SLOW_TEST_THRESHOLD) -sv connectors/tests connectors/sources/tests
 
 release: install
 	bin/python setup.py sdist

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -80,7 +80,7 @@ async def test_mem_queue_speed(patch_logger):
 async def test_mem_queue_race(patch_logger):
     item = "small stuff"
     queue = MemQueue(
-        maxmemsize=get_size(item) * 2 + 1, refresh_interval=0.1, refresh_timeout=30
+        maxmemsize=get_size(item) * 2 + 1, refresh_interval=0.01, refresh_timeout=1
     )
     max_size = 0
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -9,3 +9,4 @@ pytest-asyncio>=0.19.0
 pytest-randomly>=3.12.0
 git+https://github.com/elastic/perf8#egg=perf8
 freezegun>=0.3.4
+pytest-fail-slow>=0.3.0


### PR DESCRIPTION
A couple small changes bundled:

1. Add `pytest-fail-slow` pytest plugin that fails tests that are too slow. Too slow = 1 second for now (there are a couple tests that take ~500ms). This can be changed later to something smaller, ideally ~100ms. Package page: https://pypi.org/project/pytest-fail-slow/ Package license is MIT.
2. Speed up `connectors/tests/test_utils.py::test_mem_queue_race` by decreasing intervals + set test timeout to 1 second