### PR TITLE
Mark jobs that were running during service termination as Suspended

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -256,6 +256,12 @@ class SyncJob:
 
         return await self.client.update(index=JOBS_INDEX, id=self.job_id, doc=job_def)
 
+    async def suspend(self):
+        self.status = JobStatus.SUSPENDED
+        job_def = {"status": e2str(self.status)}
+
+        return await self.client.update(index=JOBS_INDEX, id=self.job_id, doc=job_def)
+
     @classmethod
     def transform_filtering(cls, filtering):
         # deepcopy to not change the reference resulting in changing .elastic-connectors filtering
@@ -423,6 +429,7 @@ class Connector:
         self.bulk_options = bulk_options
         self.source_klass = None
         self.data_provider = None
+        self._sync_task = None
 
     def _update_config(self, doc_source):
         self.status = doc_source["status"]
@@ -448,6 +455,14 @@ class Connector:
     @property
     def status(self):
         return self._status
+
+    @property
+    def last_sync_status(self):
+        status = self.doc_source["last_sync_status"]
+        if status is None:
+            return None
+        value = JobStatus[status.upper()]
+        return value
 
     @status.setter
     def status(self, value):
@@ -489,6 +504,13 @@ class Connector:
         )
         self.doc_source["status"] = e2str(status)
         self._update_config(self.doc_source)
+
+    async def suspend(self):
+        if self._sync_task is not None:
+            task = self._sync_task
+            cancelled = task.cancel()
+            await task
+        await self.close()
 
     async def close(self):
         self._closed = True
@@ -552,6 +574,11 @@ class Connector:
 
     async def error(self, error):
         self.doc_source["error"] = str(error)
+        await self.sync_doc()
+
+    async def _sync_suspended(self, job):
+        await job.suspend()
+        self.doc_source["last_sync_status"] = e2str(job.status)
         await self.sync_doc()
 
     async def _sync_done(self, job, result, exception=None):
@@ -655,29 +682,25 @@ class Connector:
 
         try:
             service_type = self.service_type
-            # if we don't sync, we still want to make sure we tell kibana we are connected
-            # if the status is different from comnected
-            if self.status != Status.CONNECTED:
-                self.status = Status.CONNECTED
-                await self.sync_doc()
-
             if sync_now:
                 self.sync_now = True
                 logger.info("Sync forced")
+            elif self.last_sync_status == JobStatus.SUSPENDED:
+                logger.info("Restarting sync after suspension")
             else:
                 next_sync = self.next_sync()
-                # First we check if sync is disabled, and it terminates all other conditions
-                if next_sync == SYNC_DISABLED:
-                    logger.debug(f"Scheduling is disabled for {service_type}")
-                    return
-                # Then we check if we need to restart SUSPENDED job
-                elif self.last_sync_status == JobStatus.SUSPENDED:
-                    logger.info("Restarting sync after suspension")
-                # And only then we check if we need to run sync right now or not
-                elif next_sync - idling > 0:
-                    logger.debug(
-                        f"Next sync for {service_type} due in {int(next_sync)} seconds"
-                    )
+                if next_sync == SYNC_DISABLED or next_sync - idling > 0:
+                    if next_sync == SYNC_DISABLED:
+                        logger.debug(f"Scheduling is disabled for {service_type}")
+                    else:
+                        logger.debug(
+                            f"Next sync for {service_type} due in {int(next_sync)} seconds"
+                        )
+                    # if we don't sync, we still want to make sure we tell kibana we are connected
+                    # if the status is different from comnected
+                    if self.status != Status.CONNECTED:
+                        self.status = Status.CONNECTED
+                        await self.sync_doc()
                     return
 
             try:
@@ -699,6 +722,7 @@ class Connector:
 
         logger.debug(f"Syncing '{service_type}'")
         self._syncing = True
+        self._sync_task = asyncio.current_task()
         job = await self._sync_starts()
         try:
             logger.debug(f"Pinging the {self.data_provider} backend")
@@ -733,13 +757,15 @@ class Connector:
                 options=bulk_options,
             )
             await self._sync_done(job, result)
-
+        except asyncio.CancelledError:
+            await self._sync_suspended(job)
         except Exception as e:
             await self._sync_done(job, {}, exception=e)
             raise
         finally:
             self._syncing = False
             self._start_time = None
+            self._sync_task = None
 
 
 STUCK_JOBS_THRESHOLD = 60  # 60 seconds

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -571,6 +571,9 @@ class Connector:
     async def _sync_suspended(self, job):
         await job.suspend()
         self.doc_source["last_sync_status"] = e2str(job.status)
+        self.doc_source["last_sync_error"] = None
+        self.doc_source["error"] = None
+        self.doc_source["last_synced"] = iso_utc()
         await self.sync_doc()
         logger.info(f"Sync suspended, Job id: {job.job_id}")
 

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -572,6 +572,7 @@ class Connector:
         await job.suspend()
         self.doc_source["last_sync_status"] = e2str(job.status)
         await self.sync_doc()
+        logger.info(f"Sync suspended, Job id: {job.job_id}")
 
     async def _sync_done(self, job, result, exception=None):
         doc_updated = result.get("doc_updated", 0)

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -678,24 +678,29 @@ class Connector:
 
         try:
             service_type = self.service_type
-            if not sync_now:
-                next_sync = self.next_sync()
-                if next_sync == SYNC_DISABLED or next_sync - idling > 0:
-                    if next_sync == SYNC_DISABLED:
-                        logger.debug(f"Scheduling is disabled for {service_type}")
-                    else:
-                        logger.debug(
-                            f"Next sync for {service_type} due in {int(next_sync)} seconds"
-                        )
-                    # if we don't sync, we still want to make sure we tell kibana we are connected
-                    # if the status is different from comnected
-                    if self.status != Status.CONNECTED:
-                        self.status = Status.CONNECTED
-                        await self.sync_doc()
-                    return
-            else:
+            # if the status is different from comnected
+            if self.status != Status.CONNECTED:
+                self.status = Status.CONNECTED
+                await self.sync_doc()
+
+            if sync_now:
                 self.sync_now = True
                 logger.info("Sync forced")
+            else:
+                next_sync = self.next_sync()
+                # First we check if sync is disabled, and it terminates all other conditions
+                if next_sync == SYNC_DISABLED:
+                    logger.debug(f"Scheduling is disabled for {service_type}")
+                    return
+                # Then we check if we need to restart SUSPENDED job
+                elif self.last_sync_status == JobStatus.SUSPENDED:
+                    logger.info("Restarting sync after suspension")
+                # And only then we check if we need to run sync right now or not
+                elif next_sync - idling > 0:
+                    logger.debug(
+                        f"Next sync for {service_type} due in {int(next_sync)} seconds"
+                    )
+                    return
 
             try:
                 self.data_provider = self.source_klass(self.configuration)

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -22,7 +22,7 @@ class BaseService:
         self._sleeps = CancellableSleeps()
         self.errors = [0, time.time()]
 
-    def stop(self):
+    async def stop(self):
         self.running = False
         self._sleeps.cancel()
 
@@ -42,7 +42,7 @@ class BaseService:
             logger.critical(e, exc_info=True)
             self.raise_if_spurious(e)
         finally:
-            self.stop()
+            await self.stop()
 
     def raise_if_spurious(self, exception):
         errors, first = self.errors

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -49,7 +49,8 @@ class SyncService(BaseService):
 
     async def stop(self):
         await super().stop()
-        self.syncs.cancel()
+        if self.syncs is not None:
+            self.syncs.cancel()
 
     async def _one_sync(self, connector, es, sync_now):
         if self.running is False:

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -147,6 +147,10 @@ class SyncService(BaseService):
                     await self.syncs.join()
                     if one_sync:
                         break
+
+                # Immediately break instead of sleeping
+                if not self.running:
+                    break
                 await self._sleeps.sleep(self.idling)
         finally:
             if self.connectors is not None:

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -45,8 +45,19 @@ class SyncService(BaseService):
             "max_concurrent_syncs", DEFAULT_MAX_CONCURRENT_SYNCS
         )
         self.connectors = None
+        self.syncs = ConcurrentTasks(max_concurrency=self.concurrent_syncs)
+
+    async def stop(self):
+        await super().stop()
+        self.syncs.cancel()
 
     async def _one_sync(self, connector, es, sync_now):
+        if self.running is False:
+            logger.debug(
+                f"Skipping run for {connector.id} because service is terminating"
+            )
+            return
+
         if connector.native:
             logger.debug(f"Connector {connector.id} natively supported")
 
@@ -118,14 +129,13 @@ class SyncService(BaseService):
         es = ElasticServer(self.es_config)
         try:
             while self.running:
-                syncs = ConcurrentTasks(max_concurrency=self.concurrent_syncs)
                 try:
                     logger.debug(f"Polling every {self.idling} seconds")
                     query = self.connectors.build_docs_query(
                         native_service_types, connectors_ids
                     )
                     async for connector in self.connectors.get_all_docs(query=query):
-                        await syncs.put(
+                        await self.syncs.put(
                             functools.partial(self._one_sync, connector, es, sync_now)
                         )
                     if one_sync:
@@ -134,10 +144,9 @@ class SyncService(BaseService):
                     logger.critical(e, exc_info=True)
                     self.raise_if_spurious(e)
                 finally:
-                    await syncs.join()
+                    await self.syncs.join()
                     if one_sync:
                         break
-
                 await self._sleeps.sleep(self.idling)
         finally:
             if self.connectors is not None:

--- a/connectors/tests/test_job_cleanup.py
+++ b/connectors/tests/test_job_cleanup.py
@@ -46,6 +46,7 @@ def mock_sync_job(id="1", connector_id="1", index_name="index_name"):
     job.index_name = index_name
     return job
 
+
 async def run_service_with_stop_after(service, stop_after):
     async def _terminate():
         await asyncio.sleep(stop_after)

--- a/connectors/tests/test_job_cleanup.py
+++ b/connectors/tests/test_job_cleanup.py
@@ -46,6 +46,13 @@ def mock_sync_job(id="1", connector_id="1", index_name="index_name"):
     job.index_name = index_name
     return job
 
+async def run_service_with_stop_after(service, stop_after):
+    async def _terminate():
+        await asyncio.sleep(stop_after)
+        await service.stop()
+
+    await asyncio.gather(service.run(), _terminate())
+
 
 @pytest.mark.asyncio
 @patch("connectors.byoc.SyncJobIndex.delete_jobs")
@@ -78,8 +85,7 @@ async def test_cleanup_jobs(
     delete_jobs.return_value = {"deleted": 1, "failures": [], "total": 1}
 
     service = create_service()
-    asyncio.get_event_loop().call_later(0.5, service.stop)
-    await service.run()
+    await run_service_with_stop_after(service, 0.1)
 
     assert delete_indices.call_args_list == [call(indices=[to_be_deleted_index_name])]
     assert delete_jobs.call_args_list == [

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -450,10 +450,7 @@ async def test_connector_service_poll_cron_broken(
     )
     await create_and_run_service(CONFIG_FILE, 0, sync_now=False)
     patch_logger.assert_not_present("Sync done")
-    assert (
-        calls[0]["status"] == "connected"
-    )  # first it's marked as connected as we picked it up
-    assert calls[1]["status"] == "error"  # and only then it's marked as error
+    assert calls[0]["status"] == "error"
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -206,6 +206,7 @@ class Args:
         self.one_sync = options.get("one_sync", False)
         self.sync_now = options.get("sync_now", False)
 
+
 async def stop_service(service, pre_delay=0):
     # TODO: It's a bit of a hack, :sad:
     # How can we actually test it better?
@@ -214,6 +215,7 @@ async def stop_service(service, pre_delay=0):
     # test things separately
     await asyncio.sleep(pre_delay)
     return await service.stop()
+
 
 def create_service(config_file, **options):
     config = load_config(config_file)
@@ -398,8 +400,12 @@ async def test_connector_service_poll_unconfigured(
     # we should not sync a connector that is not configured
     # but still send out a heartbeat
 
+<<<<<<< HEAD
 
     await set_server_responses(mock_responses, [FAKE_CONFIG_NEEDS_CONFIG])
+=======
+    await set_server_responses(mock_responses, FAKE_CONFIG_NEEDS_CONFIG)
+>>>>>>> 3bd7a96 (Make autoformat)
     service = create_service(CONFIG_FILE)
     asyncio.ensure_future(stop_service(service))
     await service.run()

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -450,7 +450,10 @@ async def test_connector_service_poll_cron_broken(
     )
     await create_and_run_service(CONFIG_FILE, 0, sync_now=False)
     patch_logger.assert_not_present("Sync done")
-    assert calls[0]["status"] == "error"
+    assert (
+        calls[0]["status"] == "connected"
+    )  # first it's marked as connected as we picked it up
+    assert calls[1]["status"] == "error"  # and only then it's marked as error
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -513,7 +513,7 @@ async def test_connector_service_poll_https(mock_responses, patch_logger, set_en
 async def test_connector_service_poll_large(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [LARGE_FAKE_CONFIG])
     service = create_service(MEM_CONFIG_FILE)
-    asyncio.ensure_future(stop_service(service, 0.5))
+    asyncio.ensure_future(stop_service(service, 0.7))
     await service.run()
 
     # let's make sure we are seeing bulk batches of various sizes

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -522,6 +522,7 @@ async def test_connector_service_poll_suspended(mock_responses, patch_logger, se
     # that the running job was suspended
     assert_re(".*suspended.*Job id: 1", patch_logger.logs)
 
+
 @pytest.mark.asyncio
 async def test_connector_service_poll_sync_now(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [FAKE_CONFIG_NO_SYNC])

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -454,11 +454,11 @@ async def test_connector_service_poll_cron_broken(
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_suspended_restarts_sync(mock_responses, patch_logger, set_env):
+async def test_connector_service_poll_suspended_restarts_sync(
+    mock_responses, patch_logger, set_env
+):
     await set_server_responses(mock_responses, [FAKE_CONFIG_LAST_JOB_SUSPENDED])
-    service = create_service(CONFIG_FILE, one_sync=True)
-    # one_sync means it won't loop forever
-    await service.run()
+    await create_and_run_service(CONFIG_FILE, 0.1, sync_now=False)
     patch_logger.assert_present("Restarting sync after suspension")
 
 
@@ -509,7 +509,9 @@ async def test_connector_service_poll_large(mock_responses, patch_logger, set_en
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_suspended_suspends_job(mock_responses, patch_logger, set_env):
+async def test_connector_service_poll_suspended_suspends_job(
+    mock_responses, patch_logger, set_env
+):
     # Service is having a large payload, but we terminate it ASAP
     # This way it should suspend existing running jobs
     await set_server_responses(mock_responses, [LARGE_FAKE_CONFIG])

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -454,7 +454,7 @@ async def test_connector_service_poll_cron_broken(
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_suspended(mock_responses, patch_logger, set_env):
+async def test_connector_service_poll_suspended_restarts_sync(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [FAKE_CONFIG_LAST_JOB_SUSPENDED])
     service = create_service(CONFIG_FILE, one_sync=True)
     # one_sync means it won't loop forever
@@ -463,7 +463,7 @@ async def test_connector_service_poll_suspended(mock_responses, patch_logger, se
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_suspended_when_scheduling_disabled(
+async def test_connector_service_poll_suspended_does_not_restart_when_scheduling_disabled(
     mock_responses, patch_logger, set_env
 ):
     await set_server_responses(
@@ -509,7 +509,7 @@ async def test_connector_service_poll_large(mock_responses, patch_logger, set_en
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_suspended(mock_responses, patch_logger, set_env):
+async def test_connector_service_poll_suspended_suspends_job(mock_responses, patch_logger, set_env):
     # Service is having a large payload, but we terminate it ASAP
     # This way it should suspend existing running jobs
     await set_server_responses(mock_responses, [LARGE_FAKE_CONFIG])

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -206,23 +206,23 @@ class Args:
         self.one_sync = options.get("one_sync", False)
         self.sync_now = options.get("sync_now", False)
 
-
-async def stop_service(service, pre_delay=0):
-    # TODO: It's a bit of a hack, :sad:
-    # How can we actually test it better?
-    # I think, in future we should separate the "Loop" logic
-    # and what is happening inside the loop, this way we can
-    # test things separately
-    await asyncio.sleep(pre_delay)
-    return await service.stop()
-
-
 def create_service(config_file, **options):
     config = load_config(config_file)
     service = SyncService(config, Args(**options))
-    service.idling = 1
+    service.idling = 0
 
     return service
+
+async def run_service_with_stop_after(service, stop_after):
+    async def _terminate():
+        await asyncio.sleep(stop_after)
+        await service.stop()
+
+    await asyncio.gather(service.run(), _terminate())
+
+async def create_and_run_service(config_file, stop_after, **options):
+    service = create_service(config_file, **options)
+    await run_service_with_stop_after(service, stop_after)
 
 
 async def set_server_responses(
@@ -385,9 +385,7 @@ async def set_server_responses(
 @pytest.mark.asyncio
 async def test_connector_service_poll(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses)
-    service = create_service(CONFIG_FILE)
-    asyncio.ensure_future(stop_service(service, 0.1))
-    await service.run()
+    await create_and_run_service(CONFIG_FILE, 0.1)
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
     # we want to make sure we DON'T get memory usage report
     patch_logger.assert_not_present("===> Largest memory usage:")
@@ -400,11 +398,8 @@ async def test_connector_service_poll_unconfigured(
     # we should not sync a connector that is not configured
     # but still send out a heartbeat
 
-
     await set_server_responses(mock_responses, [FAKE_CONFIG_NEEDS_CONFIG])
-    service = create_service(CONFIG_FILE)
-    asyncio.ensure_future(stop_service(service))
-    await service.run()
+    await create_and_run_service(CONFIG_FILE, 0)
 
     patch_logger.assert_present("*** Connector 1 HEARTBEAT")
     patch_logger.assert_present("Can't sync with status `needs_configuration`")
@@ -426,9 +421,7 @@ async def test_connector_service_poll_no_sync_but_status_updated(
     await set_server_responses(
         mock_responses, [FAKE_CONFIG_NO_SYNC], connectors_update=upd
     )
-    service = create_service(CONFIG_FILE, sync_now=False)
-    asyncio.ensure_future(stop_service(service))
-    await service.run()
+    await create_and_run_service(CONFIG_FILE, 0, sync_now=False)
 
     patch_logger.assert_present("*** Connector 1 HEARTBEAT")
     patch_logger.assert_present("Scheduling is disabled")
@@ -452,9 +445,7 @@ async def test_connector_service_poll_cron_broken(
     await set_server_responses(
         mock_responses, [FAKE_CONFIG_CRON_BROKEN], connectors_update=upd
     )
-    service = create_service(CONFIG_FILE, sync_now=False)
-    asyncio.ensure_future(stop_service(service))
-    await service.run()
+    await create_and_run_service(CONFIG_FILE, 0, sync_now=False)
     patch_logger.assert_not_present("Sync done")
     assert (
         calls[0]["status"] == "connected"
@@ -491,9 +482,7 @@ async def test_connector_service_poll_just_created(
     # we should not sync a connector that is not configured
     # but still send out an heartbeat
     await set_server_responses(mock_responses, [FAKE_CONFIG_CREATED])
-    service = create_service(CONFIG_FILE)
-    asyncio.ensure_future(stop_service(service))
-    await service.run()
+    await create_and_run_service(CONFIG_FILE, 0)
 
     patch_logger.assert_present("*** Connector 1 HEARTBEAT")
     patch_logger.assert_present("Can't sync with status `created`")
@@ -503,18 +492,14 @@ async def test_connector_service_poll_just_created(
 @pytest.mark.asyncio
 async def test_connector_service_poll_https(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, host="https://safenowhere.com:443")
-    service = create_service(CONFIG_HTTPS_FILE)
-    asyncio.ensure_future(stop_service(service, 0.2))
-    await service.run()
+    await create_and_run_service(CONFIG_HTTPS_FILE, 0.2)
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
 
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_large(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [LARGE_FAKE_CONFIG])
-    service = create_service(MEM_CONFIG_FILE)
-    asyncio.ensure_future(stop_service(service, 0.7))
-    await service.run()
+    await create_and_run_service(MEM_CONFIG_FILE, 0.7)
 
     # let's make sure we are seeing bulk batches of various sizes
     assert_re(".*Sending a batch.*", patch_logger.logs)
@@ -526,9 +511,7 @@ async def test_connector_service_poll_large(mock_responses, patch_logger, set_en
 @pytest.mark.asyncio
 async def test_connector_service_poll_sync_now(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [FAKE_CONFIG_NO_SYNC])
-    service = create_service(CONFIG_FILE, sync_now=True, one_sync=True)
-    # one_sync means it won't loop forever
-    await service.run()
+    await create_and_run_service(CONFIG_FILE, 0.1, sync_now=True, one_sync=True)
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
 
 
@@ -542,8 +525,7 @@ async def test_connector_service_poll_sync_ts(mock_responses, patch_logger, set_
         return CallbackResult(status=200, payload={"items": []})
 
     await set_server_responses(mock_responses, [FAKE_CONFIG_TS], bulk_call=bulk_call)
-    service = create_service(CONFIG_FILE, sync_now=True, one_sync=True)
-    await service.run()
+    await create_and_run_service(CONFIG_FILE, 0.1, sync_now=True, one_sync=True)
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
 
     # make sure we kept the original ts
@@ -553,9 +535,7 @@ async def test_connector_service_poll_sync_ts(mock_responses, patch_logger, set_
 @pytest.mark.asyncio
 async def test_connector_service_poll_sync_fails(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [FAKE_CONFIG_FAIL_SERVICE])
-    service = create_service(CONFIG_FILE)
-    asyncio.ensure_future(stop_service(service, 0.2))
-    await service.run()
+    await create_and_run_service(CONFIG_FILE, 0.2)
     patch_logger.assert_present("The document fetcher failed")
 
 
@@ -564,18 +544,7 @@ async def test_connector_service_poll_unknown_service(
     mock_responses, patch_logger, set_env
 ):
     await set_server_responses(mock_responses, [FAKE_CONFIG_UNKNOWN_SERVICE])
-    service = create_service(CONFIG_FILE)
-    asyncio.ensure_future(stop_service(service))
-    await service.run()
-
-
-async def service_with_max_errors(mock_responses, config, max_errors):
-    await set_server_responses(mock_responses, [config])
-    service = create_service(CONFIG_FILE)
-    service.service_config["max_errors"] = max_errors
-    asyncio.ensure_future(stop_service(service))
-
-    return service
+    await create_and_run_service(CONFIG_FILE, 0)
 
 
 @pytest.mark.parametrize(
@@ -607,17 +576,18 @@ async def test_connector_service_filtering(
     set_env,
     patch_validate_filtering_in_sync,
 ):
-    service = await service_with_max_errors(mock_responses, config, 0)
+    await set_server_responses(mock_responses, config)
+
     patch_validate_filtering_in_sync.side_effect = (
         [InvalidFilteringError] if should_raise_filtering_error else None
     )
 
     if should_raise_filtering_error:
-        await service.run()
+        await create_and_run_service(CONFIG_FILE, 0, service={"max_errors": 0})
         patch_logger.assert_check(lambda log: isinstance(log, InvalidFilteringError))
     else:
         try:
-            await service.run()
+            await create_and_run_service(CONFIG_FILE, 0, service={"max_errors": 0})
         except Exception as e:
             # mark test as failed
             assert False, f"Unexpected exception of type {type(e)} raised."
@@ -639,9 +609,8 @@ async def test_connector_service_poll_buggy_service(
     await set_server_responses(
         mock_responses, [FAKE_CONFIG_BUGGY_SERVICE], connectors_update=connectors_update
     )
-    service = create_service(CONFIG_FILE)
-    asyncio.ensure_future(stop_service(service))
-    await service.run()
+
+    await create_and_run_service(CONFIG_FILE, 0)
 
     for log in patch_logger.logs:
         if isinstance(log, DataSourceError):
@@ -663,10 +632,7 @@ async def test_spurious(mock_responses, patch_logger, set_env):
     Connector.sync = _sync
 
     try:
-        service = create_service(CONFIG_FILE)
-        service.idling = 0
-        service.service_config["max_errors"] = 0
-        await service.run()
+        await create_and_run_service(CONFIG_FILE, 0, service={"max_errors": 0})
     except Exception:
         await asyncio.sleep(0.1)
     finally:
@@ -704,9 +670,7 @@ async def test_spurious_continue(mock_responses, patch_logger, set_env):
     )
 
     try:
-        service = create_service(CONFIG_FILE)
-        asyncio.ensure_future(stop_service(service))
-        await service.run()
+        await create_and_run_service(CONFIG_FILE, 0.1)
     except Exception:
         await asyncio.sleep(0.1)
     finally:

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -206,6 +206,7 @@ class Args:
         self.one_sync = options.get("one_sync", False)
         self.sync_now = options.get("sync_now", False)
 
+
 def create_service(config_file, **options):
     config = load_config(config_file)
     service = SyncService(config, Args(**options))
@@ -213,12 +214,14 @@ def create_service(config_file, **options):
 
     return service
 
+
 async def run_service_with_stop_after(service, stop_after):
     async def _terminate():
         await asyncio.sleep(stop_after)
         await service.stop()
 
     await asyncio.gather(service.run(), _terminate())
+
 
 async def create_and_run_service(config_file, stop_after, **options):
     service = create_service(config_file, **options)

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -512,6 +512,17 @@ async def test_connector_service_poll_large(mock_responses, patch_logger, set_en
 
 
 @pytest.mark.asyncio
+async def test_connector_service_poll_suspended(mock_responses, patch_logger, set_env):
+    # Service is having a large payload, but we terminate it ASAP
+    # This way it should suspend existing running jobs
+    await set_server_responses(mock_responses, LARGE_FAKE_CONFIG)
+    await create_and_run_service(MEM_CONFIG_FILE, 0)
+
+    # For now just let's make sure that message is displayed
+    # that the running job was suspended
+    assert_re(".*suspended.*Job id: 1", patch_logger.logs)
+
+@pytest.mark.asyncio
 async def test_connector_service_poll_sync_now(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [FAKE_CONFIG_NO_SYNC])
     await create_and_run_service(CONFIG_FILE, 0.1, sync_now=True, one_sync=True)

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -400,12 +400,8 @@ async def test_connector_service_poll_unconfigured(
     # we should not sync a connector that is not configured
     # but still send out a heartbeat
 
-<<<<<<< HEAD
 
     await set_server_responses(mock_responses, [FAKE_CONFIG_NEEDS_CONFIG])
-=======
-    await set_server_responses(mock_responses, FAKE_CONFIG_NEEDS_CONFIG)
->>>>>>> 3bd7a96 (Make autoformat)
     service = create_service(CONFIG_FILE)
     asyncio.ensure_future(stop_service(service))
     await service.run()


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3567

This PR makes sure that several things happen when service is being terminated/restarted:

1. Jobs are interrupted immediately instead of waiting of it to finish
2. When jobs are interrupted, they are marked as "Suspended" so that other logic that restarts the job can kick-in

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes

## Related Pull Requests

- [ ] https://github.com/elastic/connectors-python/pull/382

## Release Note

When service is interrupted, it suspends the jobs immediately so that it can be restarted later when the service is back up.
