### PR TITLE
[Performance] Fix and speed up test in MySQL tests

### DIFF
--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -21,6 +21,12 @@ from connectors.sources.mysql import MySqlDataSource
 from connectors.sources.tests.support import create_source
 
 
+@pytest.fixture
+def patch_default_wait_multiplier():
+    with mock.patch("connectors.sources.mysql.DEFAULT_WAIT_MULTIPLIER", 0):
+        yield
+
+
 def test_get_configuration():
     """Test get_configuration method of MySQL"""
     # Setup
@@ -189,7 +195,7 @@ async def test_ping_negative(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_connect_with_retry(patch_logger):
+async def test_connect_with_retry(patch_logger, patch_default_wait_multiplier):
     """Test _connect method of MySQL with retry"""
     # Setup
     source = create_source(MySqlDataSource)
@@ -204,7 +210,7 @@ async def test_connect_with_retry(patch_logger):
     ):
         # Execute
         streamer = source._connect(
-            query_name="select * from database.table", fetch_many=True
+            query_name="TABLE_DATA", fetch_many=True, database="db", table="table"
         )
 
         with pytest.raises(Exception):


### PR DESCRIPTION
The test actually worked for the wrong reason: A query was passed instead of a query name, which lead to an exception thrown not for the reason of exceeding retries, but for formatting a string in a wrong way. As this [PR](https://github.com/elastic/connectors-python/pull/378) changed this behavior the test started to work in the intended way and got slow as the `DEFAULT_WAIT_MULTIPLIER` was not mocked and had a high value. This PR mocks now `DEFAULT_WAIT_MULTIPLIER` and speeds up the test.

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally