### PR TITLE
[Fix] Multiplier shouldn't be powered but multiplied

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -253,7 +253,7 @@ class MySqlDataSource(BaseDataSource):
                 if retry == self.retry_count:
                     raise exception
                 cursor_position = rows_fetched
-                await asyncio.sleep(DEFAULT_WAIT_MULTIPLIER**retry)
+                await asyncio.sleep(DEFAULT_WAIT_MULTIPLIER*retry)
                 retry += 1
 
     async def fetch_rows(self, database):


### PR DESCRIPTION
I think it's not the right intention to power a multiplier with retries, but to multiply the multiplier with the retry count.