### PR TITLE
Add logic to allow running a new job if connector was suspended before

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -443,8 +443,7 @@ class Connector:
         status = self.doc_source.get("last_sync_status")
         if status is None:
             return None
-        value = JobStatus[status.upper()]
-        return value
+        return JobStatus[status.upper()]
 
     @property
     def status(self):

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -655,25 +655,29 @@ class Connector:
 
         try:
             service_type = self.service_type
+            # if we don't sync, we still want to make sure we tell kibana we are connected
+            # if the status is different from comnected
+            if self.status != Status.CONNECTED:
+                self.status = Status.CONNECTED
+                await self.sync_doc()
+
             if sync_now:
                 self.sync_now = True
                 logger.info("Sync forced")
             else:
                 next_sync = self.next_sync()
-                if next_sync == SYNC_DISABLED or next_sync - idling > 0:
-                    if next_sync == SYNC_DISABLED:
-                        logger.debug(f"Scheduling is disabled for {service_type}")
-                    elif self.last_sync_status == JobStatus.SUSPENDED:
-                        logger.info("Restarting sync after suspension")
-                    else:
-                        logger.debug(
-                            f"Next sync for {service_type} due in {int(next_sync)} seconds"
-                        )
-                    # if we don't sync, we still want to make sure we tell kibana we are connected
-                    # if the status is different from comnected
-                    if self.status != Status.CONNECTED:
-                        self.status = Status.CONNECTED
-                        await self.sync_doc()
+                # First we check if sync is disabled, and it terminates all other conditions
+                if next_sync == SYNC_DISABLED:
+                    logger.debug(f"Scheduling is disabled for {service_type}")
+                    return
+                # Then we check if we need to restart SUSPENDED job
+                elif self.last_sync_status == JobStatus.SUSPENDED:
+                    logger.info("Restarting sync after suspension")
+                # And only then we check if we need to run sync right now or not
+                elif next_sync - idling > 0:
+                    logger.debug(
+                        f"Next sync for {service_type} due in {int(next_sync)} seconds"
+                    )
                     return
 
             try:

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -288,7 +288,7 @@ mongo = {
     "service_type": "mongodb",
     "status": "configured",
     "language": "en",
-    "last_sync_status": "null",
+    "last_sync_status": None,
     "last_sync_error": "",
     "last_synced": "",
     "last_seen": "",

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock
 import pytest
 from aioresponses import CallbackResult
 
-from connectors.byoc import DataSourceError
+from connectors.byoc import DataSourceError, JobStatus, e2str
 from connectors.config import load_config
 from connectors.conftest import assert_re
 from connectors.filtering.validation import InvalidFilteringError
@@ -48,7 +48,7 @@ FAKE_CONFIG = {
     "service_type": "fake",
     "status": "configured",
     "language": "en",
-    "last_sync_status": "null",
+    "last_sync_status": None,
     "last_sync_error": "",
     "last_synced": "",
     "last_seen": "",
@@ -74,6 +74,13 @@ FAKE_CONFIG_PIPELINE_CHANGED["pipeline"] = {
     "reduce_whitespace": False,
     "run_ml_inference": False,
 }
+FAKE_CONFIG_LAST_JOB_SUSPENDED = copy.deepcopy(FAKE_CONFIG)
+FAKE_CONFIG_LAST_JOB_SUSPENDED["sync_now"] = False
+FAKE_CONFIG_LAST_JOB_SUSPENDED["last_sync_status"] = e2str(JobStatus.SUSPENDED)
+FAKE_CONFIG_LAST_JOB_SUSPENDED_SCHEDULING_DISABLED = copy.deepcopy(
+    FAKE_CONFIG_LAST_JOB_SUSPENDED
+)
+FAKE_CONFIG_LAST_JOB_SUSPENDED_SCHEDULING_DISABLED["scheduling"]["enabled"] = False
 FAKE_CONFIG_TS = copy.deepcopy(FAKE_CONFIG)
 FAKE_CONFIG_TS["service_type"] = "fake_ts"
 
@@ -91,7 +98,7 @@ FAKE_CONFIG_NOT_NATIVE = {
     "service_type": "fake",
     "status": "configured",
     "language": "en",
-    "last_sync_status": "null",
+    "last_sync_status": None,
     "last_sync_error": "",
     "last_synced": "",
     "last_seen": "",
@@ -135,7 +142,7 @@ FAKE_CONFIG_FAIL_SERVICE = {
     "service_type": "fake",
     "status": "configured",
     "language": "en",
-    "last_sync_status": "null",
+    "last_sync_status": None,
     "last_sync_error": "",
     "last_synced": "",
     "last_seen": "",
@@ -152,7 +159,7 @@ FAKE_CONFIG_BUGGY_SERVICE = {
     "service_type": "fake",
     "status": "configured",
     "language": "en",
-    "last_sync_status": "null",
+    "last_sync_status": None,
     "last_sync_error": "",
     "last_synced": "",
     "last_seen": "",
@@ -169,7 +176,7 @@ FAKE_CONFIG_UNKNOWN_SERVICE = {
     "service_type": "UNKNOWN",
     "status": "configured",
     "language": "en",
-    "last_sync_status": "null",
+    "last_sync_status": None,
     "last_sync_error": "",
     "last_synced": "",
     "last_seen": "",
@@ -439,6 +446,28 @@ async def test_connector_service_poll_cron_broken(
     await service.run()
     patch_logger.assert_not_present("Sync done")
     assert calls[0]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_connector_service_poll_suspended(mock_responses, patch_logger, set_env):
+    await set_server_responses(mock_responses, FAKE_CONFIG_LAST_JOB_SUSPENDED)
+    service = create_service(CONFIG_FILE, one_sync=True)
+    # one_sync means it won't loop forever
+    await service.run()
+    patch_logger.assert_present("Restarting sync after suspension")
+
+
+@pytest.mark.asyncio
+async def test_connector_service_poll_suspended_when_scheduling_disabled(
+    mock_responses, patch_logger, set_env
+):
+    await set_server_responses(
+        mock_responses, FAKE_CONFIG_LAST_JOB_SUSPENDED_SCHEDULING_DISABLED
+    )
+    service = create_service(CONFIG_FILE, one_sync=True)
+    # one_sync means it won't loop forever
+    await service.run()
+    patch_logger.assert_present("Scheduling is disabled")
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -453,7 +453,7 @@ async def test_connector_service_poll_cron_broken(
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_suspended(mock_responses, patch_logger, set_env):
-    await set_server_responses(mock_responses, FAKE_CONFIG_LAST_JOB_SUSPENDED)
+    await set_server_responses(mock_responses, [FAKE_CONFIG_LAST_JOB_SUSPENDED])
     service = create_service(CONFIG_FILE, one_sync=True)
     # one_sync means it won't loop forever
     await service.run()
@@ -465,7 +465,7 @@ async def test_connector_service_poll_suspended_when_scheduling_disabled(
     mock_responses, patch_logger, set_env
 ):
     await set_server_responses(
-        mock_responses, FAKE_CONFIG_LAST_JOB_SUSPENDED_SCHEDULING_DISABLED
+        mock_responses, [FAKE_CONFIG_LAST_JOB_SUSPENDED_SCHEDULING_DISABLED]
     )
     service = create_service(CONFIG_FILE, one_sync=True)
     # one_sync means it won't loop forever


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3564

This change allows to continue with Suspended jobs.

When connector service checks connector and sees that "last_sync_status" was "Suspended", then service schedules an absolutely new job for this connector.

What it means in practice, also, is that if configuration/filtering of connector changed between the moment service was suspended and restarted, then new job will have new configuration/filtering as well.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes

## Related Pull Requests

- [ ] https://github.com/elastic/connectors-python/pull/376

## Release Note

If connector service was restarted/terminated when connector was working on a sync, the connector will try to sync again when the service is started again.
