### PR TITLE
[Fix] Fix test_serialize tests to test the actual logic

### DIFF
--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -4,15 +4,10 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """Tests the Generic Database source class methods"""
-import datetime
-import decimal
-import random
-from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
 from asyncpg.exceptions._base import InternalClientError
-from bson import Decimal128
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -203,37 +198,6 @@ def test_validate_configuration_ssl(patch_logger):
 
         # Execute
         source._validate_configuration()
-
-
-@pytest.mark.asyncio
-async def test_serialize(patch_logger):
-    """This function test serialize method of GDC"""
-    # Setup
-    source = create_source(GenericBaseDataSource)
-
-    # Execute
-    response = source.serialize(
-        {
-            "key1": "value",
-            "key2": [],
-            "key3": {"Key": "value"},
-            "key4": datetime.datetime.now(),
-            "key5": decimal.Decimal(str(random.random())),
-            "key6": Decimal128(Decimal("0.0005")),
-            "key7": bytes("value", "utf-8"),
-        }
-    )
-
-    # Assert
-    assert list(response.keys()) == [
-        "key1",
-        "key2",
-        "key3",
-        "key4",
-        "key5",
-        "key6",
-        "key7",
-    ]
 
 
 @pytest.mark.asyncio

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -5,16 +5,11 @@
 #
 """Tests the MySQL source class methods"""
 import asyncio
-import datetime
-import decimal
-import random
 import ssl
-from decimal import Decimal
 from unittest import mock
 
 import aiomysql
 import pytest
-from bson import Decimal128
 
 from connectors.source import DataSourceConfiguration
 from connectors.sources.mysql import MySqlDataSource
@@ -216,37 +211,6 @@ async def test_connect_with_retry(patch_logger, patch_default_wait_multiplier):
         with pytest.raises(Exception):
             async for response in streamer:
                 response
-
-
-@pytest.mark.asyncio
-async def test_serialize():
-    """This function test serialize method of MySQL"""
-    # Setup
-    source = create_source(MySqlDataSource)
-
-    # Execute
-    response = source.serialize(
-        {
-            "key1": "value",
-            "key2": [],
-            "key3": {"Key": "value"},
-            "key4": datetime.datetime.now(),
-            "key5": decimal.Decimal(str(random.random())),
-            "key6": Decimal128(Decimal("0.0005")),
-            "key7": bytes("value", "utf-8"),
-        }
-    )
-
-    # Assert
-    assert list(response.keys()) == [
-        "key1",
-        "key2",
-        "key3",
-        "key4",
-        "key5",
-        "key6",
-        "key7",
-    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes the `test_serialize` tests as they were not testing the actual logic and were still green, when you've changed the logic in `serialize` to return wrong values/types. Also move it to the appropriate place.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally