### PR TITLE
[Fix] Add empty filtering to functional tests and update the default filtering

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -179,7 +179,7 @@ class SyncJob:
         self.completed_at = None
         self.job_id = None
         self.status = None
-        self.filtering = {}
+        self.filtering = Filter()
         self.client = elastic_index.client
         if doc_source is None:
             doc_source = dict()
@@ -195,15 +195,15 @@ class SyncJob:
 
     async def start(self, trigger_method=JobTriggerMethod.SCHEDULED, filtering=None):
         if filtering is None:
-            filtering = {}
+            filtering = Filter()
 
         self.status = JobStatus.IN_PROGRESS
-        self.filtering = SyncJob.transform_filtering(filtering)
+        self.filtering = filtering
 
         job_def = {
             "connector": {
                 "id": self.connector_id,
-                "filtering": self.filtering,
+                "filtering": SyncJob.transform_filtering(filtering),
             },
             "trigger_method": e2str(trigger_method),
             "status": e2str(self.status),
@@ -275,7 +275,7 @@ class Filtering:
                 for filter_ in self.filtering
                 if filter_["domain"] == domain
             ),
-            {},
+            Filter(),
         )
 
 
@@ -557,7 +557,7 @@ class Connector:
 
     async def prepare_docs(self, data_provider, filtering=None):
         if filtering is None:
-            filtering = {}
+            filtering = Filter()
 
         logger.debug(f"Using pipeline {self.pipeline}")
 

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -108,6 +108,8 @@ async def prepare(service_type, index_name, config):
             "created_at": "",
             # Date the connector was updated
             "updated_at": "",
+            # filtering: for now empty
+            "filtering": [],
             # Scheduling intervals
             "scheduling": {"enabled": True, "interval": "1 * * * * *"},  # quartz syntax
             "pipeline": {

--- a/connectors/tests/commons.py
+++ b/connectors/tests/commons.py
@@ -1,0 +1,30 @@
+class AsyncDocsGeneratorFake:
+    """
+    Async documents generator fake class, which records the args and kwargs it was called with.
+    """
+
+    def __init__(self, docs):
+        self.docs = docs
+        self.call_args = []
+        self.call_kwargs = []
+
+    def __aiter__(self):
+        self.i = 0
+        return self
+
+    async def __anext__(self):
+        if self.i >= len(self.docs):
+            raise StopAsyncIteration
+
+        doc = self.docs[self.i]
+        self.i += 1
+        return doc
+
+    def __call__(self, *args, **kwargs):
+        if args:
+            self.call_args.append(*args)
+
+        if kwargs:
+            self.call_kwargs.append(*kwargs.items())
+
+        return self

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -18,6 +18,7 @@ from connectors.byoei import (
     Fetcher,
     IndexMissing,
 )
+from connectors.tests.commons import AsyncDocsGeneratorFake
 
 INDEX = "some-index"
 TIMESTAMP = datetime.datetime(year=2023, month=1, day=1)
@@ -320,23 +321,6 @@ def lazy_download_fake(doc):
         return deepcopy(doc)
 
     return lazy_download
-
-
-class AsyncDocsGeneratorFake:
-    def __init__(self, docs):
-        self.docs = docs
-
-    def __aiter__(self):
-        self.i = 0
-        return self
-
-    async def __anext__(self):
-        if self.i >= len(self.docs):
-            raise StopAsyncIteration
-
-        doc = self.docs[self.i]
-        self.i += 1
-        return doc
 
 
 def queue_called_with_operations(queue, operations):


### PR DESCRIPTION
This PR adds empty filtering to the functional tests and also updates the default filters to be actual `Filter` objects and not plain dicts.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally