### PR TITLE
Create an event loop instead of getting for verify.py

### DIFF
--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -77,9 +77,8 @@ def main(args=None):
     with open(config_file) as f:
         config = yaml.safe_load(f)
 
-    loop = asyncio.new_event_loop()
     try:
-        loop.run_until_complete(
+        asyncio.run(
             verify(args.service_type, args.index_name, args.size, config)
         )
         print("Bye")

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -78,9 +78,7 @@ def main(args=None):
         config = yaml.safe_load(f)
 
     try:
-        asyncio.run(
-            verify(args.service_type, args.index_name, args.size, config)
-        )
+        asyncio.run(verify(args.service_type, args.index_name, args.size, config))
         print("Bye")
     except (asyncio.CancelledError, KeyboardInterrupt):
         print("Bye")

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -77,7 +77,7 @@ def main(args=None):
     with open(config_file) as f:
         config = yaml.safe_load(f)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     try:
         loop.run_until_complete(
             verify(args.service_type, args.index_name, args.size, config)


### PR DESCRIPTION
Small fix for a warning when running functional tests:

> /Users/artemshelkovnikov/git_tree/connectors-py/connectors/tests/../../scripts/verify.py:80: DeprecationWarning: There is no current event loop
>  loop = asyncio.get_event_loop()