### PR TITLE
Allow concurrent syncs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -22,7 +22,7 @@ service:
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600
-  max_concurrent_syncs: 2
+  max_concurrent_syncs: 1
 
 native_service_types:
   - mongodb

--- a/config.yml
+++ b/config.yml
@@ -22,6 +22,7 @@ service:
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600
+  max_concurrent_syncs: 2
 
 native_service_types:
   - mongodb

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -551,7 +551,7 @@ class Connector:
         self.doc_source["last_synced"] = iso_utc()
         await self.sync_doc()
         logger.info(
-            f"Sync done: {indexed_count} indexed, {doc_deleted} "
+            f"[{self.id}] Sync done: {indexed_count} indexed, {doc_deleted} "
             f" deleted. ({int(time.time() - self._start_time)} seconds)"
         )
 

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -32,7 +32,7 @@ from connectors.logger import logger
 from connectors.services.base import BaseService
 from connectors.utils import ConcurrentTasks
 
-DEFAULT_MAX_CONCURRENT_SYNCS = 5
+DEFAULT_MAX_CONCURRENT_SYNCS = 1
 
 
 class SyncService(BaseService):

--- a/connectors/tests/config.yml
+++ b/connectors/tests/config.yml
@@ -14,6 +14,7 @@ service:
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600
+  max_concurrent_syncs: 10
 
 connector_id: '1'
 

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -477,7 +477,7 @@ async def test_connector_service_poll_large(mock_responses, patch_logger, set_en
     assert_re(".*Sending a batch.*", patch_logger.logs)
     assert_re(".*0.48MiB", patch_logger.logs)
     assert_re(".*0.17MiB", patch_logger.logs)
-    assert_re("Sync done: 1001 indexed, 0  deleted", patch_logger.logs)
+    assert_re(".*Sync done: 1001 indexed, 0  deleted", patch_logger.logs)
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -210,13 +210,15 @@ def create_service(config_file, **options):
 
 async def set_server_responses(
     mock_responses,
-    config=FAKE_CONFIG,
+    configs=None,
     connectors_read=None,
     connectors_update=None,
     host="http://nowhere.com:9200",
     jobs_update=None,
     bulk_call=None,
 ):
+    if configs is None:
+        configs = [FAKE_CONFIG]
     headers = {"X-Elastic-Product": "Elasticsearch"}
 
     mock_responses.get(
@@ -228,13 +230,19 @@ async def set_server_responses(
         f"{host}/.elastic-connectors/_refresh", headers=headers, repeat=True
     )
 
+    hits = []
+    for index, config in enumerate(configs):
+        hits.append({"_id": str(index + 1), "_source": config})
+
     def _connectors_read(url, **kw):
+        nonlocal hits
+
         return CallbackResult(
             status=200,
             payload={
                 "hits": {
-                    "hits": [{"_id": "1", "_source": config}],
-                    "total": {"value": 1},
+                    "hits": hits,
+                    "total": {"value": len(hits)},
                 }
             },
         )
@@ -317,13 +325,13 @@ async def set_server_responses(
     )
     mock_responses.get(
         f"{host}/search-airbnb",
-        payload={"hits": {"hits": [{"_id": "1", "_source": config}]}},
+        payload={"hits": {"hits": hits}},
         headers=headers,
         repeat=True,
     )
     mock_responses.get(
         f"{host}/search-airbnb/_search?scroll=5m",
-        payload={"hits": {"hits": [{"_id": "1", "_source": config}]}},
+        payload={"hits": {"hits": hits}},
         headers=headers,
         repeat=True,
     )
@@ -372,7 +380,7 @@ async def test_connector_service_poll_unconfigured(
     # we should not sync a connector that is not configured
     # but still send out a heartbeat
 
-    await set_server_responses(mock_responses, FAKE_CONFIG_NEEDS_CONFIG)
+    await set_server_responses(mock_responses, [FAKE_CONFIG_NEEDS_CONFIG])
     service = create_service(CONFIG_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
     await service.run()
@@ -395,7 +403,7 @@ async def test_connector_service_poll_no_sync_but_status_updated(
     # if a connector is correctly configured but we don't sync (not scheduled)
     # we still want to tell kibana we are connected
     await set_server_responses(
-        mock_responses, FAKE_CONFIG_NO_SYNC, connectors_update=upd
+        mock_responses, [FAKE_CONFIG_NO_SYNC], connectors_update=upd
     )
     service = create_service(CONFIG_FILE, sync_now=False)
     asyncio.get_event_loop().call_soon(service.stop)
@@ -421,7 +429,7 @@ async def test_connector_service_poll_cron_broken(
     # is broken
     # we still want to tell kibana we are connected
     await set_server_responses(
-        mock_responses, FAKE_CONFIG_CRON_BROKEN, connectors_update=upd
+        mock_responses, [FAKE_CONFIG_CRON_BROKEN], connectors_update=upd
     )
     service = create_service(CONFIG_FILE, sync_now=False)
     asyncio.get_event_loop().call_soon(service.stop)
@@ -436,7 +444,7 @@ async def test_connector_service_poll_just_created(
 ):
     # we should not sync a connector that is not configured
     # but still send out an heartbeat
-    await set_server_responses(mock_responses, FAKE_CONFIG_CREATED)
+    await set_server_responses(mock_responses, [FAKE_CONFIG_CREATED])
     service = create_service(CONFIG_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
     await service.run()
@@ -457,7 +465,7 @@ async def test_connector_service_poll_https(mock_responses, patch_logger, set_en
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_large(mock_responses, patch_logger, set_env):
-    await set_server_responses(mock_responses, LARGE_FAKE_CONFIG)
+    await set_server_responses(mock_responses, [LARGE_FAKE_CONFIG])
     service = create_service(MEM_CONFIG_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
     await service.run()
@@ -471,7 +479,7 @@ async def test_connector_service_poll_large(mock_responses, patch_logger, set_en
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_sync_now(mock_responses, patch_logger, set_env):
-    await set_server_responses(mock_responses, FAKE_CONFIG_NO_SYNC)
+    await set_server_responses(mock_responses, [FAKE_CONFIG_NO_SYNC])
     service = create_service(CONFIG_FILE, sync_now=True, one_sync=True)
     # one_sync means it won't loop forever
     await service.run()
@@ -487,7 +495,7 @@ async def test_connector_service_poll_sync_ts(mock_responses, patch_logger, set_
         indexed.append(queries[1])
         return CallbackResult(status=200, payload={"items": []})
 
-    await set_server_responses(mock_responses, FAKE_CONFIG_TS, bulk_call=bulk_call)
+    await set_server_responses(mock_responses, [FAKE_CONFIG_TS], bulk_call=bulk_call)
     service = create_service(CONFIG_FILE, sync_now=True, one_sync=True)
     await service.run()
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
@@ -498,7 +506,7 @@ async def test_connector_service_poll_sync_ts(mock_responses, patch_logger, set_
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_sync_fails(mock_responses, patch_logger, set_env):
-    await set_server_responses(mock_responses, FAKE_CONFIG_FAIL_SERVICE)
+    await set_server_responses(mock_responses, [FAKE_CONFIG_FAIL_SERVICE])
     service = create_service(CONFIG_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
     await service.run()
@@ -509,14 +517,14 @@ async def test_connector_service_poll_sync_fails(mock_responses, patch_logger, s
 async def test_connector_service_poll_unknown_service(
     mock_responses, patch_logger, set_env
 ):
-    await set_server_responses(mock_responses, FAKE_CONFIG_UNKNOWN_SERVICE)
+    await set_server_responses(mock_responses, [FAKE_CONFIG_UNKNOWN_SERVICE])
     service = create_service(CONFIG_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
     await service.run()
 
 
 async def service_with_max_errors(mock_responses, config, max_errors):
-    await set_server_responses(mock_responses, config)
+    await set_server_responses(mock_responses, [config])
     service = create_service(CONFIG_FILE)
     service.service_config["max_errors"] = max_errors
     asyncio.get_event_loop().call_soon(service.stop)
@@ -582,7 +590,7 @@ async def test_connector_service_poll_buggy_service(
         return CallbackResult(status=200)
 
     await set_server_responses(
-        mock_responses, FAKE_CONFIG_BUGGY_SERVICE, connectors_update=connectors_update
+        mock_responses, [FAKE_CONFIG_BUGGY_SERVICE], connectors_update=connectors_update
     )
     service = create_service(CONFIG_FILE)
     asyncio.get_event_loop().call_soon(service.stop)
@@ -658,3 +666,12 @@ async def test_spurious_continue(mock_responses, patch_logger, set_env):
         Connector.sync = old_sync
 
     patch_logger.assert_instance(Exception)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_syncs(mock_responses, patch_logger, set_env):
+    await set_server_responses(mock_responses)
+    service = create_service(CONFIG_FILE)
+    asyncio.get_event_loop().call_soon(service.stop)
+    await service.run()
+    patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -61,28 +61,18 @@ def test_invalid_names():
 @pytest.mark.asyncio
 async def test_mem_queue_speed(patch_logger):
     # with memqueue
-    mem_queue_duration = 10000
-
-    for i in range(3):
-        queue = MemQueue(maxmemsize=1024 * 1024, refresh_interval=0.1, refresh_timeout=2)
-        start = time.time()
-        for i in range(1000):
-            await queue.put("x" * 100)
-        current = time.time() - start
-        if current < mem_queue_duration:
-            mem_queue_duration = current
+    queue = MemQueue(maxmemsize=1024 * 1024, refresh_interval=0.1, refresh_timeout=2)
+    start = time.time()
+    for i in range(1000):
+        await queue.put("x" * 100)
+    mem_queue_duration = time.time() - start
 
     # vanilla queue
-    queue_duration = 10000
-
-    for i in range(3):
-        queue = asyncio.Queue()
-        start = time.time()
-        for i in range(1000):
-            await queue.put("x" * 100)
-        current = time.time() - start
-        if current < queue_duration:
-            queue_duration = current
+    queue = asyncio.Queue()
+    start = time.time()
+    for i in range(1000):
+        await queue.put("x" * 100)
+    queue_duration = time.time() - start
 
     # mem queue should be 30 times slower at the most
     quotient, _ = divmod(mem_queue_duration, queue_duration)

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -61,18 +61,28 @@ def test_invalid_names():
 @pytest.mark.asyncio
 async def test_mem_queue_speed(patch_logger):
     # with memqueue
-    queue = MemQueue(maxmemsize=1024 * 1024, refresh_interval=0.1, refresh_timeout=2)
-    start = time.time()
-    for i in range(1000):
-        await queue.put("x" * 100)
-    mem_queue_duration = time.time() - start
+    mem_queue_duration = 10000
+
+    for i in range(3):
+        queue = MemQueue(maxmemsize=1024 * 1024, refresh_interval=0.1, refresh_timeout=2)
+        start = time.time()
+        for i in range(1000):
+            await queue.put("x" * 100)
+        current = time.time() - start
+        if current < mem_queue_duration:
+            mem_queue_duration = current
 
     # vanilla queue
-    queue = asyncio.Queue()
-    start = time.time()
-    for i in range(1000):
-        await queue.put("x" * 100)
-    queue_duration = time.time() - start
+    queue_duration = 10000
+
+    for i in range(3):
+        queue = asyncio.Queue()
+        start = time.time()
+        for i in range(1000):
+            await queue.put("x" * 100)
+        current = time.time() - start
+        if current < queue_duration:
+            queue_duration = current
 
     # mem queue should be 30 times slower at the most
     quotient, _ = divmod(mem_queue_duration, queue_duration)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -335,6 +335,11 @@ class ConcurrentTasks:
         """Wait for all tasks to finish."""
         await asyncio.gather(*self.tasks)
 
+    def cancel(self):
+        """Cancels all tasks"""
+        for task in self.tasks:
+            task.cancel()
+
 
 def get_event_loop(uvloop=False):
     if uvloop:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -33,9 +33,10 @@ Configuration lives in [config.yml](../config.yml).
   - `preflight_idle`: The number of seconds to wait between each pre-flight check. Defaults to 30.
   - `max_errors`: The maximum number of errors allowed in one event loop.
   - `max_errors_span`: The number of seconds to reset `max_errors` count.
+  - `max_concurrent_syncs`: The maximum number of concurrent syncs. Defaults to 1.
 - `native_service_types`: An array of supported native connectors (in service type).
 - `connector_id`: The ID of the custom connector.
-- `servcie_type` The service type of the custom connector.
+- `service_type` The service type of the custom connector.
 - `sources`: A mapping/dictionary between service type and [Fully Qualified Name
 (FQN)](https://en.wikipedia.org/wiki/Fully_qualified_name). E.g. `mongodb: connectors.sources.mongo:MongoDataSource`.
 


### PR DESCRIPTION
Allows concurrent syncs to happen.

The `SyncService` class runs syncs sequentially. This patch will allow it to run several syncs at the same time (with a max concurrency value)

We can keep that value to `1` on cloud for now, because this will make the service grow in memory.

