### PR TITLE
Add support for fetching data all buckets

### DIFF
--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -47,6 +47,7 @@ class S3DataSource(BaseDataSource):
         set_extra_logger(aws_logger, log_level=logging.DEBUG, prefix="S3")
         set_extra_logger("aioboto3.resources", log_level=logging.INFO, prefix="S3")
         self.bucket_list = []
+        self.buckets = self.configuration["buckets"]
         self.config = AioConfig(
             read_timeout=self.configuration["read_timeout"],
             connect_timeout=self.configuration["connect_timeout"],
@@ -65,8 +66,19 @@ class S3DataSource(BaseDataSource):
         ) as s3:
             yield s3
 
+    def _validate_configuration(self):
+        """Validates whether user input is empty or not for configuration fields
+
+        Raises:
+            Exception: Configured keys can't be empty
+        """
+        if self.configuration["buckets"] == [""]:
+            raise Exception("Configured keys: buckets can't be empty.")
+
     async def ping(self):
         """Verify the connection with AWS"""
+        logger.info("Validating Amazon S3 Configuration...")
+        self._validate_configuration()
         try:
             async with self.client() as s3:
                 self.bucket_list = await s3.list_buckets()
@@ -167,7 +179,7 @@ class S3DataSource(BaseDataSource):
         Yields:
             dictionary: Document from Amazon S3.
         """
-        bucket_list = self.configuration["buckets"] or self.get_bucket_list()
+        bucket_list = self.buckets if self.buckets != ["*"] else self.get_bucket_list()
         page_size = int(self.configuration.get("page_size", DEFAULT_PAGE_SIZE))
         for bucket in bucket_list:
             region_name = await self.get_bucket_region(bucket)
@@ -185,13 +197,13 @@ class S3DataSource(BaseDataSource):
                         doc_id = md5(
                             f"{bucket}/{obj_summary.key}".encode("utf8")
                         ).hexdigest()
-
+                        owner = await obj_summary.owner
                         doc = {
                             "_id": doc_id,
                             "filename": obj_summary.key,
                             "size": await obj_summary.size,
                             "bucket": bucket,
-                            "owner": (await obj_summary.owner).get("DisplayName"),
+                            "owner": owner.get("DisplayName") if owner else "",
                             "storage_class": await obj_summary.storage_class,
                             "_timestamp": (await obj_summary.last_modified).isoformat(),
                         }

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -225,8 +225,8 @@ class S3DataSource(BaseDataSource):
         """
         return {
             "buckets": {
-                "value": ["ent-search-ingest-dev"],
-                "label": "List of AWS Buckets",
+                "value": "ent-search-ingest-dev",
+                "label": "AWS Buckets",
                 "type": "list",
             },
             "read_timeout": {

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -316,3 +316,13 @@ def test_get_bucket_list():
 
     # Assert
     assert expected_response == actual_response
+
+
+def test_validate_configuration_for_empty_bucket_string():
+    """This function test _validate_configuration  when buckets string is empty"""
+    # Setup
+    source = create_source(S3DataSource)
+    source.configuration.set_field(name="buckets", value=[""])
+    # Execute
+    with pytest.raises(Exception):
+        source._validate_configuration()

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -2,7 +2,7 @@
 
 ## Network Drive Connector
 
-The [Elastic Network Drive connector](https://github.com/elastic/connectors-python/blob/main/connectors/sources/network_drive.py) is provided in the Elastic connectors python framework and can be used via [build a connector](https://www.elastic.co/guide/en/enterprise-search/current/build-connector.html).
+The [Elastic Network Drive connector](https://github.com/elastic/connectors-python/blob/8.6/connectors/sources/network_drive.py) is provided in the Elastic connectors python framework and can be used via [build a connector](https://www.elastic.co/guide/en/enterprise-search/current/build-connector.html).
 
 ### Availability and prerequisites
 
@@ -72,7 +72,7 @@ Whether the connector should extract file content from network drive. Default va
 
 #### Content extraction
 
-The connector uses the Elastic ingest attachment processor plugin for extracting file contents. The ingest attachment processor extracts files by using the Apache text extraction library Tika. Supported file types eligible for extraction can be found [here](https://github.com/elastic/connectors-python/blob/9cf07a96288dcd542b641c51533ee2d427ef56ae/connectors/utils.py#L27).
+The connector uses the Elastic ingest attachment processor plugin for extracting file contents. The ingest attachment processor extracts files by using the Apache text extraction library Tika. Supported file types eligible for extraction can be found [here](https://github.com/elastic/connectors-python/blob/8.6/connectors/sources/network_drive.py#L19).
 
 ### Connector Limitations
 
@@ -92,7 +92,7 @@ $ make ftest NAME=network_drive
 
 ## Amazon S3 Connector
 
-The [Elastic Amazon S3 connector](https://github.com/elastic/connectors-python/blob/main/connectors/sources/s3.py) is used to sync files and file content for supported file types from [Amazon S3](https://s3.console.aws.amazon.com/s3/home) data sources. It is provided in the Elastic connectors python framework and can be used via [build a connector](https://www.elastic.co/guide/en/enterprise-search/current/build-connector.html).
+The [Elastic Amazon S3 connector](https://github.com/elastic/connectors-python/blob/8.6/connectors/sources/s3.py) is used to sync files and file content for supported file types from [Amazon S3](https://s3.console.aws.amazon.com/s3/home) data sources. It is provided in the Elastic connectors python framework and can be used via [build a connector](https://www.elastic.co/guide/en/enterprise-search/current/build-connector.html).
 
 ### Availability and prerequisites
 
@@ -167,7 +167,7 @@ Whether the connector should extract file content from Amazon S3. Default value 
 
 #### Content extraction
 
-The connector uses the Elastic ingest attachment processor plugin for extracting file contents. The ingest attachment processor extracts files by using the Apache text extraction library Tika. Supported file types eligible for extraction can be found [here](https://github.com/elastic/connectors-python/blob/9cf07a96288dcd542b641c51533ee2d427ef56ae/connectors/utils.py#L27).
+The connector uses the Elastic ingest attachment processor plugin for extracting file contents. The ingest attachment processor extracts files by using the Apache text extraction library Tika. Supported file types eligible for extraction can be found [here](https://github.com/elastic/connectors-python/blob/8.6/connectors/sources/s3.py#L25).
 
 ### Connector Limitations
 
@@ -188,7 +188,7 @@ $ make ftest NAME=s3
 
 ## Installation
 
-Provides a CLI to ingest documents into Elasticsearch, following the [connector protocol](https://github.com/elastic/connectors-ruby/blob/main/docs/CONNECTOR_PROTOCOL.md).
+Provides a CLI to ingest documents into Elasticsearch, following the [connector protocol](https://github.com/elastic/connectors-ruby/blob/8.6/docs/CONNECTOR_PROTOCOL.md).
 
 To install the CLI, run:
 ```shell
@@ -213,7 +213,7 @@ optional arguments:
 
 The CLI runs the [ConnectorService](../connectors/runner.py) which is an asynchronous event loop. It calls Elasticsearch on a regular basis to see if some syncs need to happen.
 
-That information is provided by Kibana and follows the [connector protocol](https://github.com/elastic/connectors-ruby/blob/main/docs/CONNECTOR_PROTOCOL.md). That protocol defines a few structures in a couple of dedicated Elasticsearch indices, that are used by Kibana to drive sync jobs, and by the connectors to report on that work.
+That information is provided by Kibana and follows the [connector protocol](https://github.com/elastic/connectors-ruby/blob/8.6/docs/CONNECTOR_PROTOCOL.md). That protocol defines a few structures in a couple of dedicated Elasticsearch indices, that are used by Kibana to drive sync jobs, and by the connectors to report on that work.
 
 When a user asks for a sync of a specific source, the service instantiates a class that it uses to reach out the source and collect data.
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -128,10 +128,11 @@ The following configuration fields need to be provided for setting up the connec
 
 ##### `buckets`
 
-List buckets for Amazon S3. For empty list connector will fetch data for all the buckets. Examples:
+List buckets for Amazon S3. For * in string connector will fetch data for all the buckets. Examples:
 
-  - `[testbucket, prodbucket]`
-  - `[]`
+  - `testbucket, prodbucket`
+  - `testbucket`
+  - `*`
 
 ##### `read_timeout`
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/362###
This PR includes following changes 
- Updated comma separated string to pass buckets
- Added * to index all buckets example : "buckets": {"value": "*", "label": "AWS Buckets", "type": "list"}
- Added exception when user passes an empty string ("")
## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference



