### PR TITLE
Pin azure-storage-blob version

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -12,7 +12,7 @@ aiogoogle==4.5.0
 uvloop==0.17.0; sys_platform != 'win32'
 fastjsonschema==2.16.2
 base64io==1.0.3
-azure-storage-blob>=12.13.0
+azure-storage-blob==12.13.0
 SQLAlchemy==1.4.44
 cx-Oracle==7.3.0
 asyncpg==0.27.0


### PR DESCRIPTION
Seems to be connected to the CI failure from [this post](https://elastic.slack.com/archives/CA65B8NUR/p1675084007614339?thread_ts=1675073394.259549&cid=CA65B8NUR):

```
[2023-01-30T10:09:51.161Z]   × python setup.py egg_info did not run successfully.
[2023-01-30T10:09:51.161Z]   │ exit code: 1
[2023-01-30T10:09:51.161Z]   ╰─> [3 lines of output]
[2023-01-30T10:09:51.161Z]       error in elasticsearch-connectors setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after name and no valid version specifier)
[2023-01-30T10:09:51.161Z]           azure-storage-blob>
[2023-01-30T10:09:51.161Z]                             ^
[2023-01-30T10:09:51.161Z]       [end of output]
[2023-01-30T10:09:51.161Z]   
[2023-01-30T10:09:51.161Z]   note: This error originates from a subprocess, and is likely not a problem with pip.
[2023-01-30T10:09:51.161Z] error: metadata-generation-failed
```

Most likely it happens because the dependency in `framework.txt` is not pinned and `setup.py` actually is unable to parse it - it uses `=` as a delimiter to get the name of the package here: https://github.com/elastic/connectors-python/blob/main/setup.py#L36