### PR TITLE
Fix linters for new version of black

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -390,7 +390,6 @@ class Connector:
         doc_source,
         bulk_options,
     ):
-
         self.doc_source = doc_source
         self.id = connector_id
         self.index = elastic_index

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -73,7 +73,7 @@ class DataSourceConfiguration:
                     self.set_field(key, label=key.capitalize(), value=str(value))
 
     def set_defaults(self, default_config):
-        for (name, item) in default_config.items():
+        for name, item in default_config.items():
             self._defaults[name] = item["value"]
             if name in self._config:
                 self._config[name].type = item["type"]

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,7 +329,6 @@ class MySqlDataSource(BaseDataSource):
             keys.append(f"{database}_{table}_{column_name[0]}")
 
         if keys:
-
             # Query to get the table's last update time
             response = await anext(
                 self._connect(

--- a/connectors/sources/tests/test_abs.py
+++ b/connectors/sources/tests/test_abs.py
@@ -152,7 +152,6 @@ async def test_get_container():
 
         # Execute
         async for actual_document in source.get_container():
-
             # Assert
             assert actual_document == expected_output
 
@@ -202,7 +201,6 @@ async def test_get_blob():
         async for actual_document in source.get_blob(
             {"name": "container1", "metadata": {"key1": "value1"}}
         ):
-
             # Assert
             assert actual_document == expected_output
 

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -195,7 +195,6 @@ def test_validate_configuration_ssl(patch_logger):
     source.configuration.set_field(name="ssl_disabled", value=False)
 
     with pytest.raises(Exception):
-
         # Execute
         source._validate_configuration()
 

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -47,7 +47,6 @@ def build_resp():
     "pymongo.mongo_client.MongoClient._run_operation", lambda *xi, **kw: build_resp()
 )
 async def test_get_docs(patch_logger, *args):
-
     source = create_source(MongoDataSource)
     num = 0
     async for (doc, dl) in source.get_docs():

--- a/connectors/sources/tests/test_network_drive.py
+++ b/connectors/sources/tests/test_network_drive.py
@@ -339,7 +339,6 @@ async def test_get_doc(mock_get_files, mock_walk):
 
     # Execute
     async for _, _ in source.get_docs():
-
         # Assert
         mock_get_files.assert_awaited()
 

--- a/connectors/sources/tests/test_oracle.py
+++ b/connectors/sources/tests/test_oracle.py
@@ -49,7 +49,6 @@ async def test_ping_negative(patch_logger):
     with patch.object(
         OracleDataSource, "execute_query", side_effect=Exception("Something went wrong")
     ):
-
         # Execute
         with pytest.raises(Exception):
             await source.ping()

--- a/connectors/sources/tests/test_postgresql.py
+++ b/connectors/sources/tests/test_postgresql.py
@@ -60,7 +60,6 @@ async def test_ping_negative(patch_logger):
         "execute_query",
         side_effect=Exception("Something went wrong"),
     ):
-
         # Execute
         with pytest.raises(Exception):
             await source.ping()

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -285,7 +285,6 @@ async def test_get_docs(patch_logger, mock_aws):
         "aiobotocore.utils.AioInstanceMetadataFetcher.retrieve_iam_role_credentials",
         get_roles,
     ):
-
         num = 0
         # Execute
         async for (doc, dl) in source.get_docs():

--- a/connectors/tests/test_validation.py
+++ b/connectors/tests/test_validation.py
@@ -928,7 +928,6 @@ def test_basic_rules_set_no_conflicting_policies_validation(
     if should_be_valid:
         assert all(result.is_valid for result in validation_results)
     else:
-
         assert not any(result.is_valid for result in validation_results)
 
     validation_results_rule_ids = set(

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ def read_reqs(req_file):
                 subreq_file = req.split("-r")[-1].strip()
                 subreq_file = os.path.join(reqs_dir, subreq_file)
                 for subreq in read_reqs(subreq_file):
-
                     dep = extract_req(subreq)
                     if dep is not None and dep not in deps:
                         deps.append(dep)


### PR DESCRIPTION
See thread: https://elastic.slack.com/archives/C01795T48LQ/p1675244947774679?thread_ts=1675177627.706859&cid=C01795T48LQ

Linter stage broke because of Black update. Rules that were triggered make sense, so I propose we fix them with `make autoformat`.