### PR TITLE
Fix linters on 8.6 branch

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -347,7 +347,9 @@ class BYOConnector:
 
     async def _sync_starts(self):
         job = SyncJob(self.id, self.client)
-        trigger_method = JobTriggerMethod.ON_DEMAND if self.sync_now else JobTriggerMethod.SCHEDULED
+        trigger_method = (
+            JobTriggerMethod.ON_DEMAND if self.sync_now else JobTriggerMethod.SCHEDULED
+        )
         job_id = await job.start(trigger_method)
 
         self.sync_now = self.doc_source["sync_now"] = False

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -61,7 +61,7 @@ class DataSourceConfiguration:
                     self.set_field(key, label=key.capitalize(), value=str(value))
 
     def set_defaults(self, default_config):
-        for (name, item) in default_config.items():
+        for name, item in default_config.items():
             self._defaults[name] = item["value"]
             if name in self._config:
                 self._config[name].type = item["type"]

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -26,6 +26,7 @@ DEFAULT_FETCH_SIZE = 50
 DEFAULT_RETRY_COUNT = 3
 DEFAULT_WAIT_MULTIPLIER = 2
 
+
 class MySqlDataSource(BaseDataSource):
     """Class to fetch and modify documents from MySQL server"""
 
@@ -320,7 +321,6 @@ class MySqlDataSource(BaseDataSource):
 
         keys = []
         if columns:
-
             # Query to get the table's last update time
             last_update_time_query = QUERIES["TABLE_LAST_UPDATE_TIME"].format(
                 database=database, table=table

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -48,7 +48,6 @@ def build_resp():
     "pymongo.mongo_client.MongoClient._run_operation", lambda *xi, **kw: build_resp()
 )
 async def test_get_docs(patch_logger, *args):
-
     source = create_source(MongoDataSource)
     num = 0
     async for (doc, dl) in source.get_docs():

--- a/connectors/sources/tests/test_network_drive.py
+++ b/connectors/sources/tests/test_network_drive.py
@@ -338,7 +338,6 @@ async def test_get_doc(mock_get_files, mock_walk):
 
     # Execute
     async for _, _ in source.get_docs():
-
         # Assert
         mock_get_files.assert_awaited()
 

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -275,7 +275,6 @@ async def test_get_docs(patch_logger, mock_aws):
         "aiobotocore.utils.AioInstanceMetadataFetcher.retrieve_iam_role_credentials",
         get_roles,
     ):
-
         num = 0
         # Execute
         async for (doc, dl) in source.get_docs():

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -311,7 +311,6 @@ async def test_sync_mongo(mock_responses, patch_logger):
 
 @pytest.mark.asyncio
 async def test_properties(mock_responses):
-
     connector_src = {
         "service_type": "test",
         "index_name": "search-some-index",

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -210,7 +210,6 @@ async def test_async_bulk(mock_responses, patch_logger):
 
 @pytest.mark.asyncio
 async def test_async_bulk_same_ts(mock_responses, patch_logger):
-
     ts = datetime.datetime.now().isoformat()
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     set_responses(mock_responses, ts)

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -419,7 +419,6 @@ async def test_connector_service_poll_unconfigured(
 async def test_connector_service_poll_no_sync_but_status_updated(
     mock_responses, patch_logger, patch_ping, set_env
 ):
-
     calls = []
 
     def upd(url, **kw):
@@ -446,7 +445,6 @@ async def test_connector_service_poll_no_sync_but_status_updated(
 async def test_connector_service_poll_cron_broken(
     mock_responses, patch_logger, patch_ping, set_env
 ):
-
     calls = []
 
     def upd(url, **kw):
@@ -568,6 +566,7 @@ async def test_connector_service_poll_with_entsearch(
     mock_responses, patch_logger, patch_ping, set_env, catch_stdout
 ):
     with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG}):
+
         def connectors_read(url, **kw):
             assert kw["headers"]["x-elastic-auth"] == "SomeYeahValue"
 
@@ -617,7 +616,6 @@ async def test_connector_service_poll_sync_ts(
 async def test_connector_service_poll_sync_fails(
     mock_responses, patch_logger, patch_ping, set_env
 ):
-
     await set_server_responses(mock_responses, FAKE_CONFIG_FAIL_SERVICE)
     service = ConnectorService(CONFIG)
     asyncio.get_event_loop().call_soon(service.stop)
@@ -629,7 +627,6 @@ async def test_connector_service_poll_sync_fails(
 async def test_connector_service_poll_unknown_service(
     mock_responses, patch_logger, patch_ping, set_env
 ):
-
     await set_server_responses(mock_responses, FAKE_CONFIG_UNKNOWN_SERVICE)
     service = ConnectorService(CONFIG)
     asyncio.get_event_loop().call_soon(service.stop)

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -49,7 +49,6 @@ def test_field_convert():
 
 
 def test_data_source_configuration():
-
     c = DataSourceConfiguration(CONFIG)
     assert c["database"] == "sample_airbnb"
     assert c.get_field("database").label == "MongoDB Database"

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -125,7 +125,6 @@ async def test_es_client_no_server(patch_logger):
 
 @pytest.mark.asyncio
 async def test_mem_queue(patch_logger):
-
     queue = MemQueue(maxmemsize=1024, refresh_interval=0, refresh_timeout=2)
     await queue.put("small stuff")
 


### PR DESCRIPTION
Mirror of https://github.com/elastic/connectors-python/pull/409 to 8.6 branch.

Black updated to a new version, so now need to reformat the code base here if we want to backport changes to this branch.