### PR TITLE
Fix linters on 8.5 branch

### DIFF
--- a/connectors/sources/aws.py
+++ b/connectors/sources/aws.py
@@ -67,7 +67,6 @@ class S3DataSource(BaseDataSource):
             await asyncio.sleep(0)
 
             async for obj_summary in bucket.objects.all():
-
                 doc_id = md5(obj_summary.key.encode("utf8")).hexdigest()
                 last_modified = await obj_summary.last_modified
                 await asyncio.sleep(0)

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -26,6 +26,7 @@ DEFAULT_FETCH_SIZE = 50
 DEFAULT_RETRY_COUNT = 3
 DEFAULT_WAIT_MULTIPLIER = 2
 
+
 class MySqlDataSource(BaseDataSource):
     """Class to fetch and modify documents from MySQL server"""
 
@@ -297,7 +298,6 @@ class MySqlDataSource(BaseDataSource):
 
         keys = []
         if columns:
-
             # Query to get the table's last update time
             last_update_time_query = QUERIES["TABLE_LAST_UPDATE_TIME"].format(
                 database=database, table=table

--- a/connectors/sources/tests/test_aws.py
+++ b/connectors/sources/tests/test_aws.py
@@ -81,7 +81,6 @@ async def test_get_docs(patch_logger, mock_aws):
             get_roles,
         ),
     ):
-
         num = 0
         async for (doc, dl) in source.get_docs():
             assert doc["_id"] in (

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -27,7 +27,6 @@ async def test_basics():
 
 @pytest.mark.asyncio
 async def test_get_docs(patch_logger):
-
     doc1 = {"id": "one", "tuple": (1, 2, 3), "date": datetime.now()}
     doc2 = {"id": "two", "dict": {"a": "b"}, "decimal": Decimal128("0.0005")}
 

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -303,7 +303,6 @@ async def test_sync_mongo(mock_responses, patch_logger):
 
 @pytest.mark.asyncio
 async def test_properties(mock_responses):
-
     connector_src = {
         "service_type": "test",
         "index_name": "search-some-index",

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -210,7 +210,6 @@ async def test_async_bulk(mock_responses, patch_logger):
 
 @pytest.mark.asyncio
 async def test_async_bulk_same_ts(mock_responses, patch_logger):
-
     ts = datetime.datetime.now().isoformat()
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     set_responses(mock_responses, ts)

--- a/connectors/tests/test_runner.py
+++ b/connectors/tests/test_runner.py
@@ -419,7 +419,6 @@ async def test_connector_service_poll_unconfigured(
 async def test_connector_service_poll_no_sync_but_status_updated(
     mock_responses, patch_logger, patch_ping, set_env
 ):
-
     calls = []
 
     def upd(url, **kw):
@@ -446,7 +445,6 @@ async def test_connector_service_poll_no_sync_but_status_updated(
 async def test_connector_service_poll_cron_broken(
     mock_responses, patch_logger, patch_ping, set_env
 ):
-
     calls = []
 
     def upd(url, **kw):
@@ -568,6 +566,7 @@ async def test_connector_service_poll_with_entsearch(
     mock_responses, patch_logger, patch_ping, set_env, catch_stdout
 ):
     with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG}):
+
         def connectors_read(url, **kw):
             assert kw["headers"]["x-elastic-auth"] == "SomeYeahValue"
 
@@ -617,7 +616,6 @@ async def test_connector_service_poll_sync_ts(
 async def test_connector_service_poll_sync_fails(
     mock_responses, patch_logger, patch_ping, set_env
 ):
-
     await set_server_responses(mock_responses, FAKE_CONFIG_FAIL_SERVICE)
     service = ConnectorService(CONFIG)
     asyncio.get_event_loop().call_soon(service.stop)
@@ -629,7 +627,6 @@ async def test_connector_service_poll_sync_fails(
 async def test_connector_service_poll_unknown_service(
     mock_responses, patch_logger, patch_ping, set_env
 ):
-
     await set_server_responses(mock_responses, FAKE_CONFIG_UNKNOWN_SERVICE)
     service = ConnectorService(CONFIG)
     asyncio.get_event_loop().call_soon(service.stop)

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -42,7 +42,6 @@ def test_field():
 
 
 def test_data_source_configuration():
-
     c = DataSourceConfiguration(CONFIG)
     assert c["database"] == "sample_airbnb"
     assert c.get_field("database").label == "MongoDB Database"

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -18,7 +18,6 @@ from connectors.utils import (
 
 
 def test_next_run():
-
     assert next_run("1 * * * * *") < 120.0
     assert next_run("* * * * * *") == 0
 
@@ -124,7 +123,6 @@ async def test_es_client_no_server(patch_logger):
 
 @pytest.mark.asyncio
 async def test_mem_queue(patch_logger):
-
     queue = MemQueue(maxmemsize=1024, refresh_interval=0, refresh_timeout=2)
     await queue.put("small stuff")
 


### PR DESCRIPTION
Mirror of https://github.com/elastic/connectors-python/pull/409 to 8.5 branch.

Black updated to a new version, so now need to reformat the code base here if we want to backport changes to this branch.