### PR TITLE
Make mongodb configuration parity with ruby

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -17,12 +17,28 @@ class MongoDataSource(BaseDataSource):
 
     def __init__(self, configuration):
         super().__init__(configuration=configuration)
+
+        client_params = {
+        }
+
+        host = self.configuration["host"]
+        user = self.configuration["user"]
+        password = self.configuration["password"]
+
+        if self.configuration["direct_connection"]:
+            client_params["directConnection"] = True
+
+        if len(user) > 0 or len(password) > 0:
+            client_params["username"] = user
+            client_params["password"] = password
+
+
+        print(f"host: {host}, params: {client_params}")
         self.client = AsyncIOMotorClient(
-            self.configuration["host"],
-            directConnection=True,
-            connectTimeoutMS=120,
-            socketTimeoutMS=120,
+            host,
+            **client_params
         )
+
         self.db = self.client[self.configuration["database"]]
 
     @classmethod
@@ -30,19 +46,34 @@ class MongoDataSource(BaseDataSource):
         return {
             "host": {
                 "value": "mongodb://127.0.0.1:27021",
-                "label": "MongoDB Host",
+                "label": "Server Hostname",
                 "type": "str",
             },
             "database": {
                 "value": "sample_database",
-                "label": "MongoDB Database",
+                "label": "Database",
                 "type": "str",
             },
             "collection": {
                 "value": "sample_collection",
-                "label": "MongoDB Collection",
+                "label": "Collection",
                 "type": "str",
             },
+            "user": {
+                "label": "Username",
+                "type": "str",
+                "value": ""
+            },
+            "password": {
+                "label": "Password",
+                "type": "str",
+                "value": ""
+            },
+            "direct_connection": {
+                "label": "Direct connection? (true/false)",
+                "type": "bool",
+                "value": False
+            }
         }
 
     async def ping(self):

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -18,8 +18,7 @@ class MongoDataSource(BaseDataSource):
     def __init__(self, configuration):
         super().__init__(configuration=configuration)
 
-        client_params = {
-        }
+        client_params = {}
 
         host = self.configuration["host"]
         user = self.configuration["user"]
@@ -32,12 +31,8 @@ class MongoDataSource(BaseDataSource):
             client_params["username"] = user
             client_params["password"] = password
 
-
         print(f"host: {host}, params: {client_params}")
-        self.client = AsyncIOMotorClient(
-            host,
-            **client_params
-        )
+        self.client = AsyncIOMotorClient(host, **client_params)
 
         self.db = self.client[self.configuration["database"]]
 
@@ -59,21 +54,13 @@ class MongoDataSource(BaseDataSource):
                 "label": "Collection",
                 "type": "str",
             },
-            "user": {
-                "label": "Username",
-                "type": "str",
-                "value": ""
-            },
-            "password": {
-                "label": "Password",
-                "type": "str",
-                "value": ""
-            },
+            "user": {"label": "Username", "type": "str", "value": ""},
+            "password": {"label": "Password", "type": "str", "value": ""},
             "direct_connection": {
                 "label": "Direct connection? (true/false)",
                 "type": "bool",
-                "value": False
-            }
+                "value": False,
+            },
         }
 
     async def ping(self):


### PR DESCRIPTION
This change introduces same options for MongoDB connector as in ruby.

Now configuration also has `user`, `password` and `direct_connection` parameters that work exactly like in Ruby.
Copy for all configurable fields was updated.