### PR TITLE
[Testing] Read in filtering.json for functional tests

### DIFF
--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -4,6 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
+import json
 import logging
 import os
 import sys
@@ -21,6 +22,51 @@ from connectors.utils import validate_index_name
 CONNECTORS_INDEX = ".elastic-connectors"
 JOBS_INDEX = ".elastic-connectors-sync-jobs"
 DEFAULT_CONFIG = os.path.join(os.path.dirname(__file__), "..", "config.yml")
+DEFAULT_FILTERING = [
+    {
+        "domain": "DEFAULT",
+        "draft": {
+            "advanced_snippet": {
+                "updated_at": "2023-01-31T16:41:27.341Z",
+                "created_at": "2023-01-31T16:38:49.244Z",
+                "value": {},
+            },
+            "rules": [
+                {
+                    "field": "_",
+                    "updated_at": "2023-01-31T16:41:27.341Z",
+                    "created_at": "2023-01-31T16:38:49.244Z",
+                    "rule": "regex",
+                    "id": "DEFAULT",
+                    "value": ".*",
+                    "order": 1,
+                    "policy": "include",
+                }
+            ],
+            "validation": {"state": "valid", "errors": []},
+        },
+        "active": {
+            "advanced_snippet": {
+                "updated_at": "2023-01-31T16:41:27.341Z",
+                "created_at": "2023-01-31T16:38:49.244Z",
+                "value": {},
+            },
+            "rules": [
+                {
+                    "field": "_",
+                    "updated_at": "2023-01-31T16:41:27.341Z",
+                    "created_at": "2023-01-31T16:38:49.244Z",
+                    "rule": "regex",
+                    "id": "DEFAULT",
+                    "value": ".*",
+                    "order": 1,
+                    "policy": "include",
+                }
+            ],
+            "validation": {"state": "valid", "errors": []},
+        },
+    }
+]
 DEFAULT_PIPELINE = {
     "version": 1,
     "description": "For testing",
@@ -45,7 +91,10 @@ DEFAULT_PIPELINE = {
 
 
 # XXX simulating Kibana click-arounds
-async def prepare(service_type, index_name, config):
+async def prepare(service_type, index_name, config, filtering=None):
+    if filtering is None:
+        filtering = []
+
     klass = get_source_klass(config["sources"][service_type])
     es = ElasticServer(config["elasticsearch"])
 
@@ -108,8 +157,7 @@ async def prepare(service_type, index_name, config):
             "created_at": "",
             # Date the connector was updated
             "updated_at": "",
-            # filtering: for now empty
-            "filtering": [],
+            "filtering": filtering,
             # Scheduling intervals
             "scheduling": {"enabled": True, "interval": "1 * * * * *"},  # quartz syntax
             "pipeline": {
@@ -204,22 +252,52 @@ def _parser():
         default=False,
         help="Run the event loop in debug mode.",
     )
+    parser.add_argument(
+        "--filtering",
+        type=str,
+        help="Path to a json file containing an array of filters",
+    )
 
     return parser
+
+
+def _load_filtering(filtering_file_path):
+    if not os.path.exists(filtering_file_path):
+        logger.warn(
+            f"filtering file at '{filtering_file_path}' does not exist. Fallback to default filtering."
+        )
+        filtering = DEFAULT_FILTERING
+    else:
+        filtering_file = open(
+            os.path.join(
+                os.path.dirname(__file__),
+                "sources",
+                "tests",
+                "fixtures",
+                filtering_file_path,
+            )
+        )
+        filtering = json.load(filtering_file)
+        logger.info(f"Successfully loaded filtering file from '{filtering_file_path}'.")
+
+    return filtering
 
 
 def main(args=None):
     parser = _parser()
     args = parser.parse_args(args=args)
     config_file = args.config_file
+    filtering_file = args.filtering
 
     if not os.path.exists(config_file):
-        raise IOError(f"{config_file} does not exist")
+        raise IOError(f"config file at '{config_file}' does not exist")
+
+    filtering = _load_filtering(filtering_file)
 
     set_logger(args.debug and logging.DEBUG or logging.INFO)
     config = EnvYAML(config_file)
     try:
-        asyncio.run(prepare(args.service_type, args.index_name, config))
+        asyncio.run(prepare(args.service_type, args.index_name, config, filtering))
     except (asyncio.CancelledError, KeyboardInterrupt):
         logger.info("Bye")
 

--- a/connectors/sources/tests/fixtures/mysql/filtering.json
+++ b/connectors/sources/tests/fixtures/mysql/filtering.json
@@ -1,0 +1,51 @@
+[
+    {
+        "domain": "DEFAULT",
+        "draft": {
+            "advanced_snippet": {
+                "updated_at": "2023-01-31T16:41:27.341Z",
+                "created_at": "2023-01-31T16:38:49.244Z",
+                "value": {}
+            },
+            "rules": [
+                {
+                    "field": "_",
+                    "updated_at": "2023-01-31T16:41:27.341Z",
+                    "created_at": "2023-01-31T16:38:49.244Z",
+                    "rule": "regex",
+                    "id": "DEFAULT",
+                    "value": ".*",
+                    "order": 1,
+                    "policy": "include"
+                }
+            ],
+            "validation": {
+                "state": "valid",
+                "errors": []
+            }
+        },
+        "active": {
+            "advanced_snippet": {
+                "updated_at": "2023-01-31T16:41:27.341Z",
+                "created_at": "2023-01-31T16:38:49.244Z",
+                "value": {}
+            },
+            "rules": [
+                {
+                    "field": "_",
+                    "updated_at": "2023-01-31T16:41:27.341Z",
+                    "created_at": "2023-01-31T16:38:49.244Z",
+                    "rule": "regex",
+                    "id": "DEFAULT",
+                    "value": ".*",
+                    "order": 1,
+                    "policy": "include"
+                }
+            ],
+            "validation": {
+                "state": "valid",
+                "errors": []
+            }
+        }
+    }
+]

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -37,7 +37,7 @@ fi
 $PYTHON -m pip install -r $NAME/requirements.txt
 $PYTHON fixture.py --name $NAME --action setup
 $PYTHON fixture.py --name $NAME --action start_stack
-$ROOT_DIR/bin/fake-kibana --index-name search-$NAME --service-type $NAME --debug
+$ROOT_DIR/bin/fake-kibana --index-name search-$NAME --service-type $NAME --debug --filtering $NAME/filtering.json
 $PYTHON fixture.py --name $NAME --action load
 
 if [[ $PERF8 == "yes" ]]

--- a/connectors/tests/test_kibana.py
+++ b/connectors/tests/test_kibana.py
@@ -61,6 +61,8 @@ def test_main(patch_logger, mock_responses):
                 "fake",
                 "--index-name",
                 "data",
+                "--filtering",
+                "data"
             ]
         )
         == 0

--- a/connectors/tests/test_kibana.py
+++ b/connectors/tests/test_kibana.py
@@ -62,7 +62,7 @@ def test_main(patch_logger, mock_responses):
                 "--index-name",
                 "data",
                 "--filtering",
-                "data"
+                "data",
             ]
         )
         == 0


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/3736 ##

This PR adds a mechanism to read a `filtering.json` file located in the fixtures for each data source. If no `filtering.json` file is present we fall back to the default filtering. 

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
~- [ ] Covered the changes with automated tests~
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~