### PR TITLE
[Refactoring] Remove duplicate setup code/AsyncIter in test_mysql

### DIFF
--- a/connectors/tests/commons.py
+++ b/connectors/tests/commons.py
@@ -3,8 +3,8 @@ class AsyncGeneratorFake:
     Async documents generator fake class, which records the args and kwargs it was called with.
     """
 
-    def __init__(self, docs):
-        self.docs = docs
+    def __init__(self, items):
+        self.docs = items
         self.call_args = []
         self.call_kwargs = []
 


### PR DESCRIPTION
This PR removes some duplicate setup code, the `AsyncIter` class and some unnecessary comments.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~