### PR TITLE
[Refactoring] Remove duplicate AsyncIter class

### DIFF
--- a/connectors/sources/tests/test_abs.py
+++ b/connectors/sources/tests/test_abs.py
@@ -15,19 +15,7 @@ from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClien
 from connectors.source import DataSourceConfiguration
 from connectors.sources.abs import AzureBlobStorageDataSource
 from connectors.sources.tests.support import create_source
-
-
-class AsyncIter:
-    """This Class is use to return async generator"""
-
-    def __init__(self, items):
-        """Setup list of dictionary"""
-        self.items = items
-
-    async def __aiter__(self):
-        """This Method is used to return async generator"""
-        for item in self.items:
-            yield item
+from connectors.tests.commons import AsyncIterator
 
 
 def test_get_configuration():
@@ -132,7 +120,7 @@ async def test_get_container():
     # Setup
     source = create_source(AzureBlobStorageDataSource)
     source.connection_string = source._configure_connection_string()
-    mock_repsonse = AsyncIter(
+    mock_repsonse = AsyncIterator(
         [
             {
                 "name": "container1",
@@ -163,7 +151,7 @@ async def test_get_blob():
     # Setup
     source = create_source(AzureBlobStorageDataSource)
     source.connection_string = source._configure_connection_string()
-    mock_response = AsyncIter(
+    mock_response = AsyncIterator(
         [
             {
                 "container": "container1",
@@ -212,7 +200,7 @@ async def test_get_doc():
     # Setup
     source = create_source(AzureBlobStorageDataSource)
     source.get_container = Mock(
-        return_value=AsyncIter(
+        return_value=AsyncIterator(
             [
                 {
                     "type": "container",
@@ -227,7 +215,7 @@ async def test_get_doc():
         )
     )
     source.get_blob = Mock(
-        return_value=AsyncIter(
+        return_value=AsyncIterator(
             [
                 {
                     "type": "blob",

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -17,7 +17,7 @@ from connectors.filtering.validation import SyncRuleValidationResult
 from connectors.source import DataSourceConfiguration
 from connectors.sources.mysql import MySQLAdvancedRulesValidator, MySqlDataSource
 from connectors.sources.tests.support import create_source
-from connectors.tests.commons import AsyncGeneratorFake
+from connectors.tests.commons import AsyncIterator
 
 
 def immutable_doc(**kwargs):
@@ -342,7 +342,7 @@ async def test_get_docs_with_list(patch_validate_databases):
         aiomysql, "create_pool", return_value=(await mock_mysql_response())
     ):
         source.fetch_rows_from_all_tables = mock.MagicMock(
-            return_value=AsyncGeneratorFake([{"a": 1, "b": 2}])
+            return_value=AsyncIterator([{"a": 1, "b": 2}])
         )
 
         async for doc, _ in source.get_docs():
@@ -357,7 +357,7 @@ async def test_get_docs_with_str():
         aiomysql, "create_pool", return_value=(await mock_mysql_response())
     ):
         source.fetch_rows_from_all_tables = mock.MagicMock(
-            return_value=AsyncGeneratorFake([{"a": 1, "b": 2}])
+            return_value=AsyncIterator([{"a": 1, "b": 2}])
         )
 
     with mock.patch.object(MySqlDataSource, "validate_databases", return_value=([])):
@@ -382,7 +382,7 @@ async def test_get_docs():
         aiomysql, "create_pool", return_value=(await mock_mysql_response())
     ):
         source.fetch_rows_from_all_tables = mock.MagicMock(
-            return_value=AsyncGeneratorFake([{"a": 1, "b": 2}])
+            return_value=AsyncIterator([{"a": 1, "b": 2}])
         )
 
     with mock.patch.object(MySqlDataSource, "validate_databases", return_value=([])):
@@ -491,7 +491,7 @@ async def test_get_docs_with_advanced_rules(
 ):
     source = await setup_mysql_source([DB_ONE, DB_TWO])
     docs_in_db = setup_available_docs(filtering["advanced_snippet"])
-    patch_fetch_rows_for_table.return_value = AsyncGeneratorFake(docs_in_db)
+    patch_fetch_rows_for_table.return_value = AsyncIterator(docs_in_db)
 
     yielded_docs = set()
     async for doc, _ in source.get_docs(filtering):

--- a/connectors/sources/tests/test_oracle.py
+++ b/connectors/sources/tests/test_oracle.py
@@ -10,23 +10,7 @@ import pytest
 
 from connectors.sources.oracle import OracleDataSource
 from connectors.sources.tests.support import create_source
-
-
-class AsyncIter:
-    """This Class is use to return async generator"""
-
-    def __init__(self, items):
-        """Setup list of dictionary"""
-        self.items = items
-
-    async def __aiter__(self):
-        """This Method is used to return async generator"""
-        for item in self.items:
-            yield item
-
-    async def __anext__(self):
-        """This Method is used to return one document"""
-        return self.items[0]
+from connectors.tests.commons import AsyncIterator
 
 
 @pytest.mark.asyncio
@@ -34,7 +18,7 @@ async def test_ping(patch_logger):
     """Test ping method of OracleDataSource class"""
     # Setup
     source = create_source(OracleDataSource)
-    source.execute_query = Mock(return_value=AsyncIter(["table1", "table2"]))
+    source.execute_query = Mock(return_value=AsyncIterator(["table1", "table2"]))
 
     # Execute
     await source.ping()

--- a/connectors/sources/tests/test_postgresql.py
+++ b/connectors/sources/tests/test_postgresql.py
@@ -11,26 +11,10 @@ import pytest
 
 from connectors.sources.postgresql import PostgreSQLDataSource
 from connectors.sources.tests.support import create_source
+from connectors.tests.commons import AsyncIterator
 
 
-class AsyncIter:
-    """This Class is use to return async generator"""
-
-    def __init__(self, items):
-        """Setup list of dictionary"""
-        self.items = items
-
-    async def __aiter__(self):
-        """This Method is used to return async generator"""
-        for item in self.items:
-            yield item
-
-    async def __anext__(self):
-        """This Method is used to return one document"""
-        return self.items[0]
-
-
-class mock_ssl:
+class MockSsl:
     """This class contains methods which returns dummy ssl context"""
 
     def load_verify_locations(self, cadata):
@@ -43,7 +27,7 @@ async def test_ping(patch_logger):
     """Test ping method of PostgreSQLDataSource class"""
     # Setup
     source = create_source(PostgreSQLDataSource)
-    source.execute_query = Mock(return_value=AsyncIter(["table1", "table2"]))
+    source.execute_query = Mock(return_value=AsyncIterator(["table1", "table2"]))
 
     # Execute
     await source.ping()
@@ -72,5 +56,5 @@ def test_get_connect_argss(patch_logger):
     source.ssl_ca = "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"
 
     # Execute
-    with patch.object(ssl, "create_default_context", return_value=mock_ssl()):
+    with patch.object(ssl, "create_default_context", return_value=MockSsl()):
         source.get_connect_args()

--- a/connectors/tests/commons.py
+++ b/connectors/tests/commons.py
@@ -1,24 +1,24 @@
-class AsyncGeneratorFake:
+class AsyncIterator:
     """
     Async documents generator fake class, which records the args and kwargs it was called with.
     """
 
     def __init__(self, items):
-        self.docs = items
+        self.items = items
         self.call_args = []
         self.call_kwargs = []
+        self.i = 0
 
     def __aiter__(self):
-        self.i = 0
         return self
 
     async def __anext__(self):
-        if self.i >= len(self.docs):
+        if self.i >= len(self.items):
             raise StopAsyncIteration
 
-        doc = self.docs[self.i]
+        item = self.items[self.i]
         self.i += 1
-        return doc
+        return item
 
     def __call__(self, *args, **kwargs):
         if args:

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -34,7 +34,7 @@ from connectors.config import load_config
 from connectors.filtering.validation import ValidationTarget
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.tests.commons import AsyncGeneratorFake
+from connectors.tests.commons import AsyncIterator
 
 CONFIG = os.path.join(os.path.dirname(__file__), "config.yml")
 
@@ -963,7 +963,7 @@ JOB_SOURCE = {"_id": "1", "_source": {"status": "pending", "connector": {"id": "
 @patch("connectors.byoc.SyncJobIndex.get_all_docs")
 async def test_pending_jobs(get_all_docs, set_env):
     job = Mock()
-    get_all_docs.return_value = AsyncGeneratorFake([job])
+    get_all_docs.return_value = AsyncIterator([job])
     config = load_config(CONFIG)
     connector_ids = [1, 2]
     expected_query = {
@@ -996,7 +996,7 @@ async def test_pending_jobs(get_all_docs, set_env):
 @patch("connectors.byoc.SyncJobIndex.get_all_docs")
 async def test_orphaned_jobs(get_all_docs, set_env):
     job = Mock()
-    get_all_docs.return_value = AsyncGeneratorFake([job])
+    get_all_docs.return_value = AsyncIterator([job])
     config = load_config(CONFIG)
     connector_ids = [1, 2]
     expected_query = {"bool": {"must_not": {"terms": {"connector.id": connector_ids}}}}
@@ -1015,7 +1015,7 @@ async def test_orphaned_jobs(get_all_docs, set_env):
 @patch("connectors.byoc.SyncJobIndex.get_all_docs")
 async def test_stuck_jobs(get_all_docs, set_env):
     job = Mock()
-    get_all_docs.return_value = AsyncGeneratorFake([job])
+    get_all_docs.return_value = AsyncIterator([job])
     config = load_config(CONFIG)
     connector_ids = [1, 2]
     expected_query = {
@@ -1090,7 +1090,7 @@ async def test_prepare_docs(filtering, expected_filtering_calls):
     doc_source_copy = deepcopy(DOC_SOURCE)
     connector = Connector(StubIndex(), "1", doc_source_copy, {})
 
-    docs_generator_fake = AsyncGeneratorFake([(doc_source_copy, None)])
+    docs_generator_fake = AsyncIterator([(doc_source_copy, None)])
     connector.data_provider = AsyncMock()
     connector.data_provider.get_docs = docs_generator_fake
 

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -18,7 +18,7 @@ from connectors.byoei import (
     Fetcher,
     IndexMissing,
 )
-from connectors.tests.commons import AsyncGeneratorFake
+from connectors.tests.commons import AsyncIterator
 
 INDEX = "some-index"
 TIMESTAMP = datetime.datetime(year=2023, month=1, day=1)
@@ -566,7 +566,7 @@ async def test_get_docs(
 
         # deep copying docs is needed as get_docs mutates the document ids which has side effects on other test
         # instances
-        doc_generator = AsyncGeneratorFake([deepcopy(doc) for doc in docs_from_source])
+        doc_generator = AsyncIterator([deepcopy(doc) for doc in docs_from_source])
 
         fetcher = await setup_fetcher(
             basic_rule_engine, existing_docs, queue, sync_rules_enabled

--- a/connectors/tests/test_job_cleanup.py
+++ b/connectors/tests/test_job_cleanup.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, Mock, call, patch
 import pytest
 
 from connectors.services.job_cleanup import STUCK_JOB_ERROR, JobCleanUpService
-from connectors.tests.commons import AsyncGeneratorFake
+from connectors.tests.commons import AsyncIterator
 
 CONFIG = {
     "elasticsearch": {
@@ -66,11 +66,11 @@ async def test_cleanup_jobs(
     connector = mock_connector()
     sync_job = mock_sync_job()
 
-    all_connectors.return_value = AsyncGeneratorFake([connector])
-    supported_connectors.return_value = AsyncGeneratorFake([connector])
+    all_connectors.return_value = AsyncIterator([connector])
+    supported_connectors.return_value = AsyncIterator([connector])
     fetch_by_id.return_value = connector
-    orphaned_jobs.return_value = AsyncGeneratorFake([sync_job])
-    stuck_jobs.return_value = AsyncGeneratorFake([sync_job])
+    orphaned_jobs.return_value = AsyncIterator([sync_job])
+    stuck_jobs.return_value = AsyncIterator([sync_job])
     delete_jobs.return_value = {"deleted": 1, "failures": [], "total": 1}
 
     service = create_service()


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/###

This PR removes multiple duplicates of `AsyncIter` and uses the common implementation under `commons.py`.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~