### PR TITLE
Use None instead of empty string for datetime field

### DIFF
--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -148,15 +148,15 @@ async def prepare(service_type, index_name, config, filtering=None):
             "language": "en",
             # Last sync
             "last_sync_status": None,
-            "last_sync_error": "",
-            "last_synced": "",
+            "last_sync_error": None,
+            "last_synced": None,
             # Written by connector on each operation,
             # used by Kibana to hint to user about status of connector
-            "last_seen": "",
+            "last_seen": None,
             # Date the connector was created
-            "created_at": "",
+            "created_at": None,
             # Date the connector was updated
-            "updated_at": "",
+            "updated_at": None,
             "filtering": filtering,
             # Scheduling intervals
             "scheduling": {
@@ -267,7 +267,7 @@ def _load_filtering(filtering_file_path):
     if not os.path.exists(filtering_file_path) and not os.path.isfile(
         filtering_file_path
     ):
-        logger.warn(
+        logger.warning(
             f"filtering file at '{filtering_file_path}' does not exist. Fallback to default filtering."
         )
         filtering = DEFAULT_FILTERING


### PR DESCRIPTION
This PR updates the ftest connector data, to use `None` instead of `""` for datetime fields 

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
