### PR TITLE
move log from method _sync_done to finally block

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -598,10 +598,6 @@ class Connector:
 
         self.doc_source["last_synced"] = iso_utc()
         await self.sync_doc()
-        logger.info(
-            f"[{self.id}] Sync done: {indexed_count} indexed, {doc_deleted} "
-            f" deleted. ({int(time.time() - self._start_time)} seconds)"
-        )
 
     async def prepare_docs(self, data_provider, filtering=None):
         if filtering is None:
@@ -758,6 +754,15 @@ class Connector:
             await self._sync_done(job, {}, exception=e)
             raise
         finally:
+            if result is None:
+                result = {}
+            doc_updated = result.get("doc_updated", 0)
+            doc_created = result.get("doc_created", 0)
+            doc_deleted = result.get("doc_deleted", 0)
+            logger.info(
+                f"[{self.id}] Sync done: {doc_updated + doc_created} indexed, {doc_deleted} "
+                f" deleted. ({int(time.time() - self._start_time)} seconds)"
+            )
             self._syncing = False
             self._start_time = None
             self._sync_task = None


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3200

The method `_sync_done` is also called in `JobCleanUpService` to mark a job as `error`, and it will report error because at the end of method `_sync_done`, there is a log:

https://github.com/elastic/connectors-python/blob/66af09843512b88f28f89746a45d45ade351095b/connectors/byoc.py#L601-L604

When called from `JobCleanUpService`, `self._start_time` is not defined.

This is a [known issue](https://github.com/elastic/connectors-python/pull/219#discussion_r1090960415), and should be fixed by the refactor PR https://github.com/elastic/connectors-python/pull/375. But now we feel it's too risky to merge the refactor PR and I need time to break it down into multiple small PRs, we may not have it in 8.7. So I want to have this change to make the https://github.com/elastic/enterprise-search-team/issues/3200 completed

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)