### PR TITLE
Update source.py

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -21,7 +21,7 @@ from connectors.logger import logger, set_logger
 from connectors.preflight_check import PreflightCheck
 from connectors.services.job_cleanup import JobCleanUpService
 from connectors.services.sync import SyncService
-from connectors.source import get_data_sources
+from connectors.source import get_source_klasses
 from connectors.utils import get_event_loop
 
 
@@ -119,7 +119,7 @@ def run(args):
     # just display the list of connectors
     if args.action == "list":
         logger.info("Registered connectors:")
-        for source in get_data_sources(config):
+        for source in get_source_klasses(config):
             logger.info(f"- {source.name}")
         logger.info("Bye")
         return 0

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -58,10 +58,11 @@ class DataSourceConfiguration:
     """Holds the configuration needed by the source class"""
 
     def __init__(self, config):
+        self._raw_config = config
         self._config = {}
         self._defaults = {}
-        if config is not None:
-            for key, value in config.items():
+        if self._raw_config is not None:
+            for key, value in self._raw_config.items():
                 if isinstance(value, dict):
                     self.set_field(
                         key,
@@ -102,6 +103,9 @@ class DataSourceConfiguration:
 
     def is_empty(self):
         return len(self._config) == 0
+
+    def to_dict(self):
+        return dict(self._raw_config)
 
 
 class BaseDataSource:
@@ -275,7 +279,15 @@ def get_source_klass(fqn):
     return getattr(module, klass_name)
 
 
-def get_data_sources(config):
+def get_source_klasses(config):
     """Returns an iterator of all registered sources."""
     for name, fqn in config["sources"].items():
         yield get_source_klass(fqn)
+
+
+def get_source_klass_dict(config):
+    """Returns a service type - source klass dictionary"""
+    result = {}
+    for name, fqn in config["sources"].items():
+        result[name] = get_source_klass(fqn)
+    return result

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -19,8 +19,9 @@ from connectors.source import (
     BaseDataSource,
     DataSourceConfiguration,
     Field,
-    get_data_sources,
     get_source_klass,
+    get_source_klass_dict,
+    get_source_klasses,
 )
 
 CONFIG = {
@@ -86,13 +87,23 @@ def test_get_source_klass():
     assert get_source_klass("test_source:MyConnector") is MyConnector
 
 
-def test_get_data_sources():
+def test_get_source_klasses():
     settings = {
         "sources": {"yea": "test_source:MyConnector", "yea2": "test_source:MyConnector"}
     }
 
-    sources = list(get_data_sources(settings))
+    sources = list(get_source_klasses(settings))
     assert sources == [MyConnector, MyConnector]
+
+
+def test_get_source_klass_dict():
+    settings = {
+        "sources": {"yea": "test_source:MyConnector", "yea2": "test_source:MyConnector"}
+    }
+
+    source_klass_dict = get_source_klass_dict(settings)
+    assert source_klass_dict["yea"] == MyConnector
+    assert source_klass_dict["yea2"] == MyConnector
 
 
 # ABCs


### PR DESCRIPTION
This PR updates `source.py`:
1. It adds `to_dict` method to class `DataSourceConfiguration`, which returns the config in dictionary format. This will be used when creating a job, where `configuration` of a connector will be passed to the job.
2. It renames the function `get_data_sources` to `get_source_klasses`
3. It adds a new function `get_source_klass_dict`, which returns a dictionary (`service_type` -> `source class`).

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
