### PR TITLE
Fix service stop code

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -106,7 +106,7 @@ async def _start_service(config, loop):
                     service.stop()
                 except Exception as e:
                     logger.warning(
-                        f"Failed to shutdown {service.__class__.__name__} due to an error: {e}"
+                        f"Failed to correctly shutdown {service.__class__.__name__} due to an error: {e}"
                     )
 
             return

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -104,8 +104,10 @@ async def _start_service(config, loop):
                 try:
                     logger.info(f"Shutdown {service.__class__.__name__}...")
                     service.stop()
-                except Exception e:
-                    logger.warning(f"Failed to shutdown {service.__class__.__name__} due to an error: {e}")
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to shutdown {service.__class__.__name__} due to an error: {e}"
+                    )
 
             return
 

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -101,8 +101,12 @@ async def _start_service(config, loop):
         def _shutdown(sig_name):
             logger.info(f"Caught {sig_name}. Graceful shutdown.")
             for service in services:
-                logger.info(f"Shutdown {service.__class__.__name__}...")
-                service.stop()
+                try:
+                    logger.info(f"Shutdown {service.__class__.__name__}...")
+                    service.stop()
+                except Exception e:
+                    logger.warning(f"Failed to shutdown {service.__class__.__name__} due to an error: {e}")
+
             return
 
         loop.add_signal_handler(sig, functools.partial(_shutdown, sig.name))

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -98,14 +98,14 @@ async def _start_service(config, loop):
     services = [SyncService(config), JobCleanUpService(config)]
     for sig in (signal.SIGINT, signal.SIGTERM):
 
-        async def _shutdown(sig_name):
+        def _shutdown(sig_name):
             logger.info(f"Caught {sig_name}. Graceful shutdown.")
             for service in services:
                 logger.info(f"Shutdown {service.__class__.__name__}...")
-                await service.stop()
+                service.stop()
             return
 
-        loop.add_signal_handler(sig, lambda: asyncio.ensure_future(_shutdown(sig.name)))
+        loop.add_signal_handler(sig, functools.partial(_shutdown, sig.name))
 
     async def _run_service(service):
         if "PERF8" in os.environ:

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -22,7 +22,7 @@ class BaseService:
         self._sleeps = CancellableSleeps()
         self.errors = [0, time.time()]
 
-    async def stop(self):
+    def stop(self):
         self.running = False
         self._sleeps.cancel()
 
@@ -42,7 +42,7 @@ class BaseService:
             logger.critical(e, exc_info=True)
             self.raise_if_spurious(e)
         finally:
-            await self.stop()
+            self.stop()
 
     def raise_if_spurious(self, exception):
         errors, first = self.errors

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -45,8 +45,8 @@ class SyncService(BaseService):
         self.connectors = None
         self.syncs = None
 
-    async def stop(self):
-        await super().stop()
+    def stop(self):
+        super().stop()
         if self.syncs is not None:
             self.syncs.cancel()
 

--- a/connectors/tests/test_job_cleanup.py
+++ b/connectors/tests/test_job_cleanup.py
@@ -50,7 +50,7 @@ def mock_sync_job(id="1", connector_id="1", index_name="index_name"):
 async def run_service_with_stop_after(service, stop_after):
     async def _terminate():
         await asyncio.sleep(stop_after)
-        await service.stop()
+        service.stop()
 
     await asyncio.gather(service.run(), _terminate())
 

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -223,7 +223,7 @@ async def run_service_with_stop_after(service, stop_after=0):
             # but if stop_after is provided we want to
             # interrupt the service after the timeout
             await asyncio.sleep(stop_after)
-            await service.stop()
+            service.stop()
 
         await asyncio.sleep(0)
 


### PR DESCRIPTION
As discussed with @tarekziade before, `loop.add_signal_handler(sig, lambda: asyncio.ensure_future(_shutdown(sig.name)))` is not the right way to handle the cancellation - ensure_future expects a synchronous function.

This patch does the following:

- Makes BaseService.stop a non-async function like it was before
- Modifies loop.add_signal_handler to properly call shutdown without a `lambda` statement.