### PR TITLE
Update ConnectorIndex

### DIFF
--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -20,9 +20,9 @@ class JobCleanUpService(BaseService):
         self.idling = int(self.service_config.get("job_cleanup_interval", 60 * 5))
         self.native_service_types = self.config.get("native_service_types", [])
         if "connector_id" in self.config:
-            self.connectors_ids = [self.config.get("connector_id")]
+            self.connector_ids = [self.config.get("connector_id")]
         else:
-            self.connectors_ids = []
+            self.connector_ids = []
         self.connector_index = None
         self.sync_job_index = None
 
@@ -91,7 +91,7 @@ class JobCleanUpService(BaseService):
                 connector.id
                 async for connector in self.connector_index.supported_connectors(
                     native_service_types=self.native_service_types,
-                    connectors_ids=self.connectors_ids,
+                    connector_ids=self.connector_ids,
                 )
             ]
 

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -113,11 +113,11 @@ class SyncService(BaseService):
 
         # XXX we can support multiple connectors but Ruby can't so let's use a
         # single id
-        # connectors_ids = self.config.get("connectors_ids", [])
+        # connector_ids = self.config.get("connector_ids", [])
         if "connector_id" in self.config:
-            connectors_ids = [self.config.get("connector_id")]
+            connector_ids = [self.config.get("connector_id")]
         else:
-            connectors_ids = []
+            connector_ids = []
 
         logger.info(
             f"Service started, listening to events from {self.es_config['host']}"
@@ -131,10 +131,10 @@ class SyncService(BaseService):
 
                 try:
                     logger.debug(f"Polling every {self.idling} seconds")
-                    query = self.connectors.build_docs_query(
-                        native_service_types, connectors_ids
-                    )
-                    async for connector in self.connectors.get_all_docs(query=query):
+                    async for connector in self.connectors.supported_connectors(
+                        native_service_types=native_service_types,
+                        connector_ids=connector_ids,
+                    ):
                         await self.syncs.put(
                             functools.partial(self._one_sync, connector, es)
                         )

--- a/connectors/tests/config_2.yml
+++ b/connectors/tests/config_2.yml
@@ -14,7 +14,7 @@ service:
   max_errors: 20
   max_errors_span: 600
 
-connectors_id: 'blah'
+connector_id: 'blah'
 
 sources:
   fake: fake_sources:FakeSource

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -135,13 +135,6 @@ EXPECTED_FILTERING_AFTER_UPDATE_ACTIVE = {
     "filtering": [FILTERING_DEFAULT_DOMAIN_ACTIVE_AFTER_UPDATE, FILTERING_OTHER_DOMAIN]
 }
 
-EXPECTED_UPDATED_DOC_SOURCE_DRAFT_FILTERING = (
-    DOC_SOURCE | EXPECTED_FILTERING_AFTER_UPDATE_DRAFT
-)
-EXPECTED_UPDATED_DOC_SOURCE_ACTIVE_FILTERING = (
-    DOC_SOURCE | EXPECTED_FILTERING_AFTER_UPDATE_ACTIVE
-)
-
 OTHER_DOMAIN_ONE = "other-domain-1"
 OTHER_DOMAIN_TWO = "other-domain-2"
 NON_EXISTING_DOMAIN = "non-existing-domain"
@@ -322,8 +315,9 @@ async def test_heartbeat(mock_responses, patch_logger):
     connectors = ConnectorIndex(config)
     conns = []
 
-    query = connectors.build_docs_query([["mongodb"]])
-    async for connector in connectors.get_all_docs(query=query):
+    async for connector in connectors.supported_connectors(
+        native_service_types=["mongodb"]
+    ):
         connector.start_heartbeat(0.2)
         connector.start_heartbeat(1.0)  # NO-OP
         conns.append(connector)
@@ -334,7 +328,86 @@ async def test_heartbeat(mock_responses, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_connectors_get_list(mock_responses):
+async def test_connectors_get_list_no_connector(mock_responses):
+    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
+    connectors = ConnectorIndex(config)
+    conns = []
+    async for connector in connectors.supported_connectors():
+        conns.append(connector)
+
+    assert len(conns) == 0
+    await connectors.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "native_service_types, connector_ids, expected_connector_count",
+    [
+        ([], [], 0),
+        (["mongodb"], [], 1),
+        ([], ["1"], 1),
+        (["mongodb"], ["1"], 1),
+    ],
+)
+async def test_supported_connectors(
+    native_service_types, connector_ids, expected_connector_count, mock_responses
+):
+    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
+    native_connectors_query = {
+        "bool": {
+            "filter": [
+                {"term": {"is_native": True}},
+                {"terms": {"service_type": native_service_types}},
+            ]
+        }
+    }
+
+    custom_connectors_query = {
+        "bool": {
+            "filter": [
+                {"term": {"is_native": False}},
+                {"terms": {"_id": connector_ids}},
+            ]
+        }
+    }
+
+    if len(native_service_types) > 0 and len(connector_ids) > 0:
+        query = {"bool": {"should": [native_connectors_query, custom_connectors_query]}}
+    elif len(native_service_types) > 0:
+        query = native_connectors_query
+    elif len(connector_ids) > 0:
+        query = custom_connectors_query
+    else:
+        query = {}
+
+    headers = {"X-Elastic-Product": "Elasticsearch"}
+    mock_responses.post(
+        "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
+    )
+    mock_responses.post(
+        "http://nowhere.com:9200/.elastic-connectors/_search?expand_wildcards=hidden",
+        body={"query": query},
+        payload={
+            "hits": {"hits": [{"_id": "1", "_source": mongo}], "total": {"value": 1}}
+        },
+        headers=headers,
+    )
+
+    connector_index = ConnectorIndex(config)
+    connectors = [
+        connector
+        async for connector in connector_index.supported_connectors(
+            native_service_types=native_service_types, connector_ids=connector_ids
+        )
+    ]
+    assert len(connectors) == expected_connector_count
+    if expected_connector_count > 0:
+        assert connectors[0].service_type == mongo["service_type"]
+    await connector_index.close()
+
+
+@pytest.mark.asyncio
+async def test_all_connectors(mock_responses):
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.post(
@@ -351,8 +424,7 @@ async def test_connectors_get_list(mock_responses):
 
     connectors = ConnectorIndex(config)
     conns = []
-    query = connectors.build_docs_query([["mongodb"]])
-    async for connector in connectors.get_all_docs(query=query):
+    async for connector in connectors.all_connectors():
         conns.append(connector)
 
     assert len(conns) == 1
@@ -509,8 +581,9 @@ async def test_sync_mongo(
     service_config = {"sources": {"mongodb": "connectors.tests.test_byoc:Data"}}
 
     try:
-        query = connectors.build_docs_query([["mongodb"]])
-        async for connector in connectors.get_all_docs(query=query):
+        async for connector in connectors.supported_connectors(
+            native_service_types=["mongodb"]
+        ):
             connector.features.sync_rules_enabled = Mock(return_value=with_filtering)
 
             await connector.prepare(service_config)
@@ -699,12 +772,12 @@ def test_transform_filtering(filtering, expected_transformed_filtering):
         (
             FILTERING_VALIDATION_DEFAULT_DOMAIN_WITH_ERRORS,
             ValidationTarget.DRAFT,
-            EXPECTED_UPDATED_DOC_SOURCE_DRAFT_FILTERING,
+            EXPECTED_FILTERING_AFTER_UPDATE_DRAFT,
         ),
         (
             FILTERING_VALIDATION_DEFAULT_DOMAIN_WITH_ERRORS,
             ValidationTarget.ACTIVE,
-            EXPECTED_UPDATED_DOC_SOURCE_ACTIVE_FILTERING,
+            EXPECTED_FILTERING_AFTER_UPDATE_ACTIVE,
         ),
     ],
 )
@@ -715,7 +788,7 @@ async def test_update_filtering_validation(
     config = {"host": "https://nowhere.com:9200", "user": "tarek", "password": "blah"}
 
     connector = Mock()
-    connector.doc_source = DOC_SOURCE
+    connector.filtering.to_list.return_value = DOC_SOURCE_FILTERING
     connector.id = CONNECTOR_ID
 
     validation_result_mock = Mock()

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -328,18 +328,6 @@ async def test_heartbeat(mock_responses, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_connectors_get_list_no_connector(mock_responses):
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
-    connectors = ConnectorIndex(config)
-    conns = []
-    async for connector in connectors.supported_connectors():
-        conns.append(connector)
-
-    assert len(conns) == 0
-    await connectors.close()
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "native_service_types, connector_ids, expected_connector_count",
     [
@@ -400,10 +388,11 @@ async def test_supported_connectors(
             native_service_types=native_service_types, connector_ids=connector_ids
         )
     ]
+    await connector_index.close()
+
     assert len(connectors) == expected_connector_count
     if expected_connector_count > 0:
         assert connectors[0].service_type == mongo["service_type"]
-    await connector_index.close()
 
 
 @pytest.mark.asyncio
@@ -426,9 +415,9 @@ async def test_all_connectors(mock_responses):
     conns = []
     async for connector in connectors.all_connectors():
         conns.append(connector)
+    await connectors.close()
 
     assert len(conns) == 1
-    await connectors.close()
 
 
 class StubIndex:


### PR DESCRIPTION
This PR made those changes:
1. move the query-building logic to `supported_connectors` method, as it's only used here.
2. Use method `supported_connectors` directly, instead of calling `build_docs_query` and then `get_all_docs`
3. change `update_filtering_validation` to only update `filtering` instead of the whole document.
4. add some wrapping methods to `ESIndex`
5. rename all `connectors_ids` to `connector_ids`


## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference