### PR TITLE
Fix flaky tests

### DIFF
--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -217,7 +217,7 @@ async def run_service_with_stop_after(service, stop_after):
     await asyncio.gather(service.run(), _terminate())
 
 
-async def create_and_run_service(config_file, stop_after):
+async def create_and_run_service(config_file=CONFIG_FILE, stop_after=0.2):
     service = create_service(config_file)
     await run_service_with_stop_after(service, stop_after)
 
@@ -382,7 +382,7 @@ async def set_server_responses(
 @pytest.mark.asyncio
 async def test_connector_service_poll(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses)
-    await create_and_run_service(CONFIG_FILE, 0.1)
+    await create_and_run_service()
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
     # we want to make sure we DON'T get memory usage report
     patch_logger.assert_not_present("===> Largest memory usage:")
@@ -396,7 +396,7 @@ async def test_connector_service_poll_unconfigured(
     # but still send out a heartbeat
 
     await set_server_responses(mock_responses, [FAKE_CONFIG_NEEDS_CONFIG])
-    await create_and_run_service(CONFIG_FILE, 0.2)
+    await create_and_run_service()
 
     patch_logger.assert_present("*** Connector 1 HEARTBEAT")
     patch_logger.assert_present("Can't sync with status `needs_configuration`")
@@ -418,7 +418,7 @@ async def test_connector_service_poll_no_sync_but_status_updated(
     await set_server_responses(
         mock_responses, [FAKE_CONFIG_NO_SYNC], connectors_update=upd
     )
-    await create_and_run_service(CONFIG_FILE, 0.2)
+    await create_and_run_service()
 
     patch_logger.assert_present("*** Connector 1 HEARTBEAT")
     patch_logger.assert_present("Scheduling is disabled")
@@ -442,7 +442,7 @@ async def test_connector_service_poll_cron_broken(
     await set_server_responses(
         mock_responses, [FAKE_CONFIG_CRON_BROKEN], connectors_update=upd
     )
-    await create_and_run_service(CONFIG_FILE, 0)
+    await create_and_run_service(stop_after=0)
     patch_logger.assert_not_present("Sync done")
     assert (
         calls[0]["status"] == "connected"
@@ -455,7 +455,7 @@ async def test_connector_service_poll_suspended_restarts_sync(
     mock_responses, patch_logger, set_env
 ):
     await set_server_responses(mock_responses, [FAKE_CONFIG_LAST_JOB_SUSPENDED])
-    await create_and_run_service(CONFIG_FILE, 0.1)
+    await create_and_run_service()
     patch_logger.assert_present("Restarting sync after suspension")
 
 
@@ -466,7 +466,7 @@ async def test_connector_service_poll_suspended_does_not_restart_when_scheduling
     await set_server_responses(
         mock_responses, [FAKE_CONFIG_LAST_JOB_SUSPENDED_SCHEDULING_DISABLED]
     )
-    await create_and_run_service(CONFIG_FILE, 0.2)
+    await create_and_run_service()
     patch_logger.assert_present("Scheduling is disabled")
 
 
@@ -477,7 +477,7 @@ async def test_connector_service_poll_just_created(
     # we should not sync a connector that is not configured
     # but still send out a heartbeat
     await set_server_responses(mock_responses, [FAKE_CONFIG_CREATED])
-    await create_and_run_service(CONFIG_FILE, 0.2)
+    await create_and_run_service()
 
     patch_logger.assert_present("*** Connector 1 HEARTBEAT")
     patch_logger.assert_present("Can't sync with status `created`")
@@ -487,14 +487,14 @@ async def test_connector_service_poll_just_created(
 @pytest.mark.asyncio
 async def test_connector_service_poll_https(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, host="https://safenowhere.com:443")
-    await create_and_run_service(CONFIG_HTTPS_FILE, 0.3)
+    await create_and_run_service(config_file=CONFIG_HTTPS_FILE, stop_after=0.3)
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
 
 
 @pytest.mark.asyncio
 async def test_connector_service_poll_large(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [LARGE_FAKE_CONFIG])
-    await create_and_run_service(MEM_CONFIG_FILE, 0.7)
+    await create_and_run_service(config_file=MEM_CONFIG_FILE, stop_after=0.7)
 
     # let's make sure we are seeing bulk batches of various sizes
     assert_re(".*Sending a batch.*", patch_logger.logs)
@@ -510,7 +510,7 @@ async def test_connector_service_poll_suspended_suspends_job(
     # Service is having a large payload, but we terminate it ASAP
     # This way it should suspend existing running jobs
     await set_server_responses(mock_responses, [LARGE_FAKE_CONFIG])
-    await create_and_run_service(MEM_CONFIG_FILE, 0.1)
+    await create_and_run_service(config_file=MEM_CONFIG_FILE, stop_after=0.1)
 
     # For now just let's make sure that message is displayed
     # that the running job was suspended
@@ -527,7 +527,7 @@ async def test_connector_service_poll_sync_ts(mock_responses, patch_logger, set_
         return CallbackResult(status=200, payload={"items": []})
 
     await set_server_responses(mock_responses, [FAKE_CONFIG_TS], bulk_call=bulk_call)
-    await create_and_run_service(CONFIG_FILE, 0.1)
+    await create_and_run_service()
     patch_logger.assert_present("Sync done: 1 indexed, 0  deleted. (0 seconds)")
 
     # make sure we kept the original ts
@@ -537,7 +537,7 @@ async def test_connector_service_poll_sync_ts(mock_responses, patch_logger, set_
 @pytest.mark.asyncio
 async def test_connector_service_poll_sync_fails(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [FAKE_CONFIG_FAIL_SERVICE])
-    await create_and_run_service(CONFIG_FILE, 0.2)
+    await create_and_run_service()
     patch_logger.assert_present("The document fetcher failed")
 
 
@@ -546,7 +546,7 @@ async def test_connector_service_poll_unknown_service(
     mock_responses, patch_logger, set_env
 ):
     await set_server_responses(mock_responses, [FAKE_CONFIG_UNKNOWN_SERVICE])
-    await create_and_run_service(CONFIG_FILE, 0)
+    await create_and_run_service(stop_after=0)
 
 
 @pytest.mark.parametrize(
@@ -585,11 +585,11 @@ async def test_connector_service_filtering(
     )
 
     if should_raise_filtering_error:
-        await create_and_run_service(CONFIG_FILE, 0)
+        await create_and_run_service(stop_after=0)
         patch_logger.assert_check(lambda log: isinstance(log, InvalidFilteringError))
     else:
         try:
-            await create_and_run_service(CONFIG_FILE, 0)
+            await create_and_run_service(stop_after=0)
         except Exception as e:
             # mark test as failed
             assert False, f"Unexpected exception of type {type(e)} raised."
@@ -612,7 +612,7 @@ async def test_connector_service_poll_buggy_service(
         mock_responses, [FAKE_CONFIG_BUGGY_SERVICE], connectors_update=connectors_update
     )
 
-    await create_and_run_service(CONFIG_FILE, 0)
+    await create_and_run_service(stop_after=0)
 
     for log in patch_logger.logs:
         if isinstance(log, DataSourceError):
@@ -634,7 +634,7 @@ async def test_spurious(mock_responses, patch_logger, set_env):
     Connector.sync = _sync
 
     try:
-        await create_and_run_service(CONFIG_FILE, 0)
+        await create_and_run_service(stop_after=0)
     except Exception:
         await asyncio.sleep(0.1)
     finally:
@@ -672,7 +672,7 @@ async def test_spurious_continue(mock_responses, patch_logger, set_env):
     )
 
     try:
-        await create_and_run_service(CONFIG_FILE, 0.1)
+        await create_and_run_service()
     except Exception:
         await asyncio.sleep(0.1)
     finally:
@@ -684,7 +684,7 @@ async def test_spurious_continue(mock_responses, patch_logger, set_env):
 @pytest.mark.asyncio
 async def test_concurrent_syncs(mock_responses, patch_logger, set_env):
     await set_server_responses(mock_responses, [FAKE_CONFIG, FAKE_CONFIG, FAKE_CONFIG])
-    await create_and_run_service(CONFIG_FILE, 0.1)
+    await create_and_run_service()
 
     # make sure we synced the three connectors
     patch_logger.assert_present("[1] Sync done: 1 indexed, 0  deleted. (0 seconds)")


### PR DESCRIPTION
I noticed some flaky tests in [test_sync.py](https://github.com/elastic/connectors-python/blob/main/connectors/tests/test_sync.py), due to short `stop_after` specified:

https://github.com/elastic/connectors-python/blob/66af09843512b88f28f89746a45d45ade351095b/connectors/tests/test_sync.py#L220

This PR adds default `config_file` and `stop_after`, to make sure the service doesn't stop before the job completes.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference