### PR TITLE
[Docs] Fix commands in docker docs

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -2,10 +2,10 @@
 
 Make sure you have the latest `docker` command, then build the image:
 
-    make docker
+    make docker-build
 
 
 To use it, tweak your [configuration file](./CONFIG.md) and run:
 
-    make run-docker
+    make docker-run
 


### PR DESCRIPTION
The correct commands are `docker-build` and `docker-run`.