### PR TITLE
Clean up config field names for all sources

### DIFF
--- a/connectors/sources/abs.py
+++ b/connectors/sources/abs.py
@@ -85,24 +85,19 @@ class AzureBlobStorageDataSource(BaseDataSource):
                 "label": "Azure Blob Storage blob endpoint",
                 "type": "str",
             },
-            "connector_name": {
-                "value": "Azure Blob Storage Connector",
-                "label": "Friendly name for the connector",
-                "type": "str",
-            },
             "enable_content_extraction": {
                 "value": DEFAULT_CONTENT_EXTRACTION,
-                "label": "Flag to check if content extraction is enabled or not",
+                "label": "Enable content extraction",
                 "type": "bool",
             },
             "retry_count": {
                 "value": DEFAULT_RETRY_COUNT,
-                "label": "How many retry count for fetching rows on each call",
+                "label": "Retries per request",
                 "type": "int",
             },
             "concurrent_downloads": {
                 "value": MAX_CONCURRENT_DOWNLOADS,
-                "label": "How many concurrent downloads for fetching blob content",
+                "label": "Maximum concurrent downloads",
                 "type": "int",
             },
         }

--- a/connectors/sources/abs.py
+++ b/connectors/sources/abs.py
@@ -87,7 +87,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
             },
             "enable_content_extraction": {
                 "value": DEFAULT_CONTENT_EXTRACTION,
-                "label": "Enable content extraction",
+                "label": "Enable content extraction (true/false)",
                 "type": "bool",
             },
             "retry_count": {

--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -46,7 +46,7 @@ class DirectoryDataSource(BaseDataSource):
             },
             "enable_content_extraction": {
                 "value": DEFAULT_CONTENT_EXTRACTION,
-                "label": "Flag to check if content extraction is enabled or not",
+                "label": "Enable content extraction",
                 "type": "bool",
             },
         }

--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -46,7 +46,7 @@ class DirectoryDataSource(BaseDataSource):
             },
             "enable_content_extraction": {
                 "value": DEFAULT_CONTENT_EXTRACTION,
-                "label": "Enable content extraction",
+                "label": "Enable content extraction (true/false)",
                 "type": "bool",
             },
         }

--- a/connectors/sources/gcs.py
+++ b/connectors/sources/gcs.py
@@ -113,22 +113,17 @@ class GoogleCloudStorageDataSource(BaseDataSource):
         return {
             "service_account_credentials": {
                 "value": json.dumps(default_credentials),
-                "label": "JSON string for Google cloud service account",
-                "type": "str",
-            },
-            "connector_name": {
-                "value": "Google Cloud Storage Connector",
-                "label": "Friendly name for the connector",
+                "label": "JSON string for Google Cloud service account",
                 "type": "str",
             },
             "retry_count": {
                 "value": DEFAULT_RETRY_COUNT,
-                "label": "Retry count for failed requests",
+                "label": "Maximum retries for failed requests",
                 "type": "int",
             },
             "enable_content_extraction": {
                 "value": DEFAULT_CONTENT_EXTRACTION,
-                "label": "Flag to check if content extraction is enabled or not",
+                "label": "Enable content extraction (true/false)",
                 "type": "bool",
             },
         }

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -78,24 +78,19 @@ class GenericBaseDataSource(BaseDataSource):
                 "label": "Databases",
                 "type": "str",
             },
-            "connector_name": {
-                "value": "Generic Database",
-                "label": "Friendly name for the connector",
-                "type": "str",
-            },
             "fetch_size": {
                 "value": DEFAULT_FETCH_SIZE,
-                "label": "How many rows to fetch on each call",
+                "label": "Rows fetched per request",
                 "type": "int",
             },
             "retry_count": {
                 "value": DEFAULT_RETRY_COUNT,
-                "label": "How many retry count for fetching rows on each call",
+                "label": "Retries per request",
                 "type": "int",
             },
             "ssl_disabled": {
                 "value": DEFAULT_SSL_DISABLED,
-                "label": "SSL verification will be enabled or not",
+                "label": "Disable SSL (true/false)",
                 "type": "bool",
             },
             "ssl_ca": {

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -171,7 +171,7 @@ class MySqlDataSource(BaseDataSource):
             },
             "retry_count": {
                 "value": RETRIES,
-                "label": "Retries per request",
+                "label": "Maximum retries per request",
                 "type": "int",
             },
             "ssl_disabled": {

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -164,19 +164,14 @@ class MySqlDataSource(BaseDataSource):
                 "label": "Databases",
                 "type": "list",
             },
-            "connector_name": {
-                "value": "MySQL Connector",
-                "label": "Friendly name for the connector",
-                "type": "str",
-            },
             "fetch_size": {
                 "value": DEFAULT_FETCH_SIZE,
-                "label": "How many rows to fetch on each call",
+                "label": "Number of rows fetched per request",
                 "type": "int",
             },
             "retry_count": {
                 "value": RETRIES,
-                "label": "How many retry count for fetching rows on each call",
+                "label": "Retries per request",
                 "type": "int",
             },
             "ssl_disabled": {

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -75,14 +75,9 @@ class NASDataSource(BaseDataSource):
                 "label": "SMB shared folder/directory",
                 "type": "str",
             },
-            "connector_name": {
-                "value": "Network Drive Connector",
-                "label": "Friendly name for the connector",
-                "type": "str",
-            },
             "enable_content_extraction": {
                 "value": DEFAULT_CONTENT_EXTRACTION,
-                "label": "Flag to check if content extraction is enabled or not",
+                "label": "Enable content extraction (true/false)",
                 "type": "bool",
             },
         }

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -252,14 +252,9 @@ class S3DataSource(BaseDataSource):
                 "label": "Maximum size of page",
                 "type": "int",
             },
-            "connector_name": {
-                "value": "AWS Connector",
-                "label": "Friendly name for the connector",
-                "type": "str",
-            },
             "enable_content_extraction": {
                 "value": DEFAULT_CONTENT_EXTRACTION,
-                "label": "Content extraction will be enabled or not",
+                "label": "Enable content extraction (true/false)",
                 "type": "bool",
             },
         }


### PR DESCRIPTION
This cleans up the labels of configuration fields in various sources, making them more easily understandable and consistent.