### PR TITLE
Implement Pipeline as a derived class of UserDict

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -322,16 +322,34 @@ class Filter(dict):
 
 class PipelineSettings:
     def __init__(self, pipeline):
-        self.name = pipeline.get("name", "ent-search-generic-ingestion")
-        self.extract_binary_content = pipeline.get("extract_binary_content", True)
-        self.reduce_whitespace = pipeline.get("reduce_whitespace", True)
-        self.run_ml_inference = pipeline.get("run_ml_inference", True)
+        self._pipeline = pipeline
+        if self._pipeline is None:
+            self._pipeline = {}
+
+    @property
+    def name(self):
+        return self._pipeline.get("name", "ent-search-generic-ingestion")
+
+    @property
+    def extract_binary_content(self):
+        return self._pipeline.get("extract_binary_content", True)
+
+    @property
+    def reduce_whitespace(self):
+        return self._pipeline.get("reduce_whitespace", True)
+
+    @property
+    def run_ml_inference(self):
+        return self._pipeline.get("run_ml_inference", True)
 
     def __repr__(self):
         return (
             f"Pipeline {self.name} <binary: {self.extract_binary_content}, "
             f"whitespace {self.reduce_whitespace}, ml inference {self.run_ml_inference}>"
         )
+
+    def to_dict(self):
+        return dict(self._pipeline)
 
 
 class Features:

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -69,7 +69,7 @@ class Bulker:
     - `max_concurrency` -- a maximum number of concurrent bulk requests
 
     Extra options:
-    - `pipeline_settings` -- ingest pipeline settings to pass to the bulk API
+    - `pipeline` -- ingest pipeline settings to pass to the bulk API
     """
 
     def __init__(
@@ -77,7 +77,7 @@ class Bulker:
         client,
         queue,
         chunk_size,
-        pipeline_settings,
+        pipeline,
         chunk_mem_size,
         max_concurrency,
     ):
@@ -87,7 +87,7 @@ class Bulker:
         self.bulking = False
         self.ops = defaultdict(int)
         self.chunk_size = chunk_size
-        self.pipeline_settings = pipeline_settings
+        self.pipeline = pipeline
         self.chunk_mem_size = chunk_mem_size * 1024 * 1024
         self.max_concurrent_bulks = max_concurrency
         self.bulk_tasks = ConcurrentTasks(max_concurrency=max_concurrency)
@@ -118,7 +118,7 @@ class Bulker:
         start = time.time()
         try:
             res = await self.client.bulk(
-                operations=operations, pipeline=self.pipeline_settings.name
+                operations=operations, pipeline=self.pipeline["name"]
             )
 
             if res.get("errors"):

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -23,7 +23,7 @@ from connectors.byoc import (
     Filter,
     Filtering,
     JobStatus,
-    PipelineSettings,
+    Pipeline,
     Status,
     SyncJob,
     SyncJobIndex,
@@ -1108,25 +1108,14 @@ async def test_prepare_docs(filtering, expected_filtering_calls):
 
 
 @pytest.mark.parametrize(
-    "key, value, expected_value",
+    "key, value, default_value",
     [
-        ("name", None, "ent-search-generic-ingestion"),
-        ("name", "foobar", "foobar"),
-        ("extract_binary_content", None, True),
-        ("extract_binary_content", False, False),
-        ("reduce_whitespace", None, True),
-        ("reduce_whitespace", False, False),
-        ("run_ml_inference", None, True),
-        ("run_ml_inference", False, False),
+        ("name", "foobar", "ent-search-generic-ingestion"),
+        ("extract_binary_content", False, True),
+        ("reduce_whitespace", False, True),
+        ("run_ml_inference", False, True),
     ],
 )
-def test_pipeline_properties(key, value, expected_value):
-    pipeline = {} if value is None else {key: value}
-    pipeline_settings = PipelineSettings(pipeline)
-    assert getattr(pipeline_settings, key) == expected_value
-
-
-def test_pipeline_to_dict():
-    pipeline = {"name": "foobar", "run_ml_inference": False}
-    pipeline_settings = PipelineSettings(pipeline)
-    assert pipeline == pipeline_settings.to_dict()
+def test_pipeline_properties(key, value, default_value):
+    assert Pipeline({})[key] == default_value
+    assert Pipeline({key: value})[key] == value

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -23,6 +23,7 @@ from connectors.byoc import (
     Filter,
     Filtering,
     JobStatus,
+    PipelineSettings,
     Status,
     SyncJob,
     SyncJobIndex,
@@ -1104,3 +1105,28 @@ async def test_prepare_docs(filtering, expected_filtering_calls):
     assert all(
         type(filter_) == Filter for _, filter_ in docs_generator_fake.call_kwargs
     )
+
+
+@pytest.mark.parametrize(
+    "key, value, expected_value",
+    [
+        ("name", None, "ent-search-generic-ingestion"),
+        ("name", "foobar", "foobar"),
+        ("extract_binary_content", None, True),
+        ("extract_binary_content", False, False),
+        ("reduce_whitespace", None, True),
+        ("reduce_whitespace", False, False),
+        ("run_ml_inference", None, True),
+        ("run_ml_inference", False, False),
+    ],
+)
+def test_pipeline_properties(key, value, expected_value):
+    pipeline = {} if value is None else {key: value}
+    pipeline_settings = PipelineSettings(pipeline)
+    assert getattr(pipeline_settings, key) == expected_value
+
+
+def test_pipeline_to_dict():
+    pipeline = {"name": "foobar", "run_ml_inference": False}
+    pipeline_settings = PipelineSettings(pipeline)
+    assert pipeline == pipeline_settings.to_dict()

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -11,7 +11,7 @@ from unittest.mock import Mock, call
 
 import pytest
 
-from connectors.byoc import PipelineSettings
+from connectors.byoc import Pipeline
 from connectors.byoei import (
     ContentIndexNameInvalid,
     ElasticServer,
@@ -187,7 +187,7 @@ async def test_async_bulk(mock_responses, patch_logger):
     set_responses(mock_responses)
 
     es = ElasticServer(config)
-    pipeline = PipelineSettings({})
+    pipeline = Pipeline({})
 
     async def get_docs():
         async def _dl_none(doit=True, timestamp=None):
@@ -234,7 +234,7 @@ async def test_async_bulk_same_ts(mock_responses, patch_logger):
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     set_responses(mock_responses, ts)
     es = ElasticServer(config)
-    pipeline = PipelineSettings({})
+    pipeline = Pipeline({})
 
     async def get_docs():
         async def _dl(doit=True, timestamp=None):


### PR DESCRIPTION
This PR implements the class `Pipeline` as a derived class of `UserDict`, which provides default values for:
1. name
2. extract_binary_content
3. reduce_whitespace
4. run_ml_inference

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference