### PR TITLE
Use active filter in async_bulk

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -739,7 +739,7 @@ class Connector:
                 self.index_name,
                 self.prepare_docs(self.data_provider, job.filtering),
                 self.pipeline,
-                filtering=self.filtering.get_active_filter(),
+                filter=self.filtering.get_active_filter(),
                 sync_rules_enabled=sync_rules_enabled,
                 options=bulk_options,
             )

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -739,7 +739,7 @@ class Connector:
                 self.index_name,
                 self.prepare_docs(self.data_provider, job.filtering),
                 self.pipeline,
-                filtering=self.filtering,
+                filtering=self.filtering.get_active_filter(),
                 sync_rules_enabled=sync_rules_enabled,
                 options=bulk_options,
             )

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -177,7 +177,7 @@ class Fetcher:
         queue,
         index,
         existing_ids,
-        filtering=Filter(),
+        filter=Filter(),
         sync_rules_enabled=False,
         queue_size=DEFAULT_QUEUE_SIZE,
         display_every=DEFAULT_DISPLAY_EVERY,
@@ -196,9 +196,9 @@ class Fetcher:
         self.total_docs_created = 0
         self.total_docs_deleted = 0
         self.fetch_error = None
-        self.filtering = filtering
+        self.filter = filter
         self.basic_rule_engine = (
-            BasicRuleEngine(parse(filtering.get("rules", [])))
+            BasicRuleEngine(parse(filter.get("rules", [])))
             if sync_rules_enabled
             else None
         )
@@ -414,7 +414,7 @@ class ElasticServer(ESClient):
         index,
         generator,
         pipeline,
-        filtering=Filter(),
+        filter=Filter(),
         sync_rules_enabled=False,
         options=None,
     ):
@@ -445,7 +445,7 @@ class ElasticServer(ESClient):
             stream,
             index,
             existing_ids,
-            filtering=filtering,
+            filter=filter,
             sync_rules_enabled=sync_rules_enabled,
             queue_size=queue_size,
             display_every=display_every,

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -198,9 +198,7 @@ class Fetcher:
         self.fetch_error = None
         self.filter = filter
         self.basic_rule_engine = (
-            BasicRuleEngine(parse(filter.get("rules", [])))
-            if sync_rules_enabled
-            else None
+            BasicRuleEngine(parse(filter.basic_rules)) if sync_rules_enabled else None
         )
         self.display_every = display_every
         self.concurrent_downloads = concurrent_downloads

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from elasticsearch import NotFoundError as ElasticNotFoundError
 from elasticsearch.helpers import async_scan
 
-from connectors.byoc import Filtering
+from connectors.byoc import Filter
 from connectors.es import ESClient
 from connectors.filtering.basic_rule import BasicRuleEngine, parse
 from connectors.logger import logger
@@ -177,7 +177,7 @@ class Fetcher:
         queue,
         index,
         existing_ids,
-        filtering=Filtering(),
+        filtering=Filter(),
         sync_rules_enabled=False,
         queue_size=DEFAULT_QUEUE_SIZE,
         display_every=DEFAULT_DISPLAY_EVERY,
@@ -198,7 +198,7 @@ class Fetcher:
         self.fetch_error = None
         self.filtering = filtering
         self.basic_rule_engine = (
-            BasicRuleEngine(parse(filtering.get_active_filter().get("rules", [])))
+            BasicRuleEngine(parse(filtering.get("rules", [])))
             if sync_rules_enabled
             else None
         )
@@ -414,7 +414,7 @@ class ElasticServer(ESClient):
         index,
         generator,
         pipeline,
-        filtering=Filtering(),
+        filtering=Filter(),
         sync_rules_enabled=False,
         options=None,
     ):

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -355,9 +355,9 @@ async def setup_fetcher(basic_rule_engine, existing_docs, queue, sync_rules_enab
     existing_ids = {doc["_id"]: doc["_timestamp"] for doc in existing_docs}
 
     # filtering content doesn't matter as the BasicRuleEngine behavior is mocked
-    filtering_mock = Mock()
-    filtering_mock.get_active_filter = Mock(return_value={})
-    fetcher = Fetcher(client, queue, INDEX, existing_ids, filtering=filtering_mock)
+    filter_mock = Mock()
+    filter_mock.get_active_filter = Mock(return_value={})
+    fetcher = Fetcher(client, queue, INDEX, existing_ids, filter=filter_mock)
     fetcher.basic_rule_engine = basic_rule_engine if sync_rules_enabled else None
     return fetcher
 


### PR DESCRIPTION
### Changes made:

Pass the active filtering (an instance of `Filter`) instead of filtering (a list of filtering including `active` and `draft` filtering, an instance of `Filtering`).

### Why the change:

Moving forward, we will use `filtering` data in `syncJob`, where only active filtering data is available.


## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference