### PR TITLE
[Refactoring] Move e2str to utils to avoid cyclic imports

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -16,17 +16,13 @@ from connectors.es import DEFAULT_LANGUAGE, ESIndex, Mappings
 from connectors.filtering.validation import ValidationTarget, validate_filtering
 from connectors.logger import logger
 from connectors.source import DataSourceConfiguration, get_source_klass
-from connectors.utils import iso_utc, next_run
+from connectors.utils import e2str, iso_utc, next_run
 
 CONNECTORS_INDEX = ".elastic-connectors"
 JOBS_INDEX = ".elastic-connectors-sync-jobs"
 PIPELINE = "ent-search-generic-ingestion"
 RETRY_ON_CONFLICT = 3
 SYNC_DISABLED = -1
-
-
-def e2str(entry):
-    return entry.name.lower()
 
 
 class Status(Enum):

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -20,7 +20,6 @@ from connectors.byoc import (
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
     Status,
-    e2str,
 )
 from connectors.byoei import ElasticServer
 from connectors.filtering.validation import (
@@ -30,7 +29,7 @@ from connectors.filtering.validation import (
 )
 from connectors.logger import logger
 from connectors.services.base import BaseService
-from connectors.utils import ConcurrentTasks
+from connectors.utils import ConcurrentTasks, e2str
 
 DEFAULT_MAX_CONCURRENT_SYNCS = 1
 

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -26,7 +26,6 @@ from connectors.byoc import (
     Status,
     SyncJob,
     SyncJobIndex,
-    e2str,
     iso_utc,
 )
 from connectors.byoei import ElasticServer
@@ -35,6 +34,7 @@ from connectors.filtering.validation import ValidationTarget
 from connectors.logger import logger
 from connectors.source import BaseDataSource
 from connectors.tests.commons import AsyncIterator
+from connectors.utils import e2str
 
 CONFIG = os.path.join(os.path.dirname(__file__), "config.yml")
 
@@ -193,11 +193,6 @@ def patch_validate_filtering_in_byoc():
         "connectors.byoc.validate_filtering", return_value=AsyncMock()
     ) as validate_filtering_mock:
         yield validate_filtering_mock
-
-
-def test_e2str():
-    # The BYOC protocol uses lower case
-    assert e2str(Status.NEEDS_CONFIGURATION) == "needs_configuration"
 
 
 def test_utc():

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -13,12 +13,13 @@ from unittest.mock import AsyncMock
 import pytest
 from aioresponses import CallbackResult
 
-from connectors.byoc import DataSourceError, JobStatus, e2str
+from connectors.byoc import DataSourceError, JobStatus
 from connectors.config import load_config
 from connectors.conftest import assert_re
 from connectors.filtering.validation import InvalidFilteringError
 from connectors.services.sync import SyncService
 from connectors.tests.fake_sources import FakeSourceTS
+from connectors.utils import e2str
 
 CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.yml")
 CONFIG_FILE_2 = os.path.join(os.path.dirname(__file__), "config_2.yml")

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -13,6 +13,7 @@ import random
 import tempfile
 import time
 import timeit
+from enum import Enum
 from unittest.mock import Mock
 
 import pytest
@@ -26,6 +27,7 @@ from connectors.utils import (
     MemQueue,
     RetryStrategy,
     convert_to_b64,
+    e2str,
     get_base64_value,
     get_size,
     next_run,
@@ -336,3 +338,10 @@ async def test_exponential_backoff_retry():
 
     # would fail, if retried once (retry_interval = 5 seconds). Explicit time boundary for this test: 1 second
     await does_not_raise()
+
+
+def test_e2str():
+    class SomeEnum(Enum):
+        A_FIELD = 0
+
+    assert e2str(SomeEnum.A_FIELD) == "a_field"

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -397,3 +397,7 @@ def retryable(retries=3, interval=1.0, strategy=RetryStrategy.LINEAR_BACKOFF):
         return func_to_execute
 
     return wrapper
+
+
+def e2str(entry):
+    return entry.name.lower()


### PR DESCRIPTION
`e2str` is a pretty generic method and should probably live in `utils.py`, so we don't run into possible cyclic imports, when we import it.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
