### PR TITLE
Add str2e function

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -16,7 +16,7 @@ from connectors.es import DEFAULT_LANGUAGE, ESIndex, Mappings
 from connectors.filtering.validation import ValidationTarget, validate_filtering
 from connectors.logger import logger
 from connectors.source import DataSourceConfiguration, get_source_klass
-from connectors.utils import e2str, iso_utc, next_run
+from connectors.utils import e2str, iso_utc, next_run, str2e
 
 CONNECTORS_INDEX = ".elastic-connectors"
 JOBS_INDEX = ".elastic-connectors-sync-jobs"
@@ -194,8 +194,7 @@ class SyncJob:
 
         self.doc_source = doc_source
         self.job_id = self.doc_source.get("_id")
-        _status = self.doc_source.get("_source", {}).get("status")
-        self.status = None if _status is None else JobStatus[_status.upper()]
+        self.status = str2e(self.doc_source.get("_source", {}).get("status"), JobStatus)
 
     @property
     def duration(self):
@@ -443,10 +442,7 @@ class Connector:
 
     @property
     def last_sync_status(self):
-        status = self.doc_source.get("last_sync_status")
-        if status is None:
-            return None
-        return JobStatus[status.upper()]
+        return str2e(self.doc_source.get("last_sync_status"), JobStatus)
 
     @property
     def status(self):
@@ -455,7 +451,7 @@ class Connector:
     @status.setter
     def status(self, value):
         if isinstance(value, str):
-            value = Status[value.upper()]
+            value = str2e(value, Status)
         if not isinstance(value, Status):
             raise TypeError(value)
 

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -32,6 +32,7 @@ from connectors.utils import (
     get_size,
     next_run,
     retryable,
+    str2e,
     validate_index_name,
 )
 
@@ -340,8 +341,15 @@ async def test_exponential_backoff_retry():
     await does_not_raise()
 
 
-def test_e2str():
-    class SomeEnum(Enum):
-        A_FIELD = 0
+class SomeEnum(Enum):
+    A_FIELD = 0
 
+
+def test_e2str():
     assert e2str(SomeEnum.A_FIELD) == "a_field"
+
+
+def test_str2e():
+    assert str2e(None, SomeEnum) is None
+    assert str2e("another_field", SomeEnum) is None
+    assert str2e("a_field", SomeEnum) == SomeEnum.A_FIELD

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -401,3 +401,14 @@ def retryable(retries=3, interval=1.0, strategy=RetryStrategy.LINEAR_BACKOFF):
 
 def e2str(entry):
     return entry.name.lower()
+
+
+def str2e(name, enum_class):
+    if name is None:
+        return None
+
+    name = str(name).upper()
+    if name not in enum_class.__members__:
+        return None
+
+    return enum_class[name]


### PR DESCRIPTION
This PR adds a `str2e` function in module `connectors.utils`, to convert a string to an Enum value

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference