### PR TITLE
Make --action list command output to stdout

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -138,10 +138,10 @@ def run(args):
 
     # just display the list of connectors
     if args.action == "list":
-        logger.info("Registered connectors:")
+        print("Registered connectors:")
         for source in get_source_klasses(config):
-            logger.info(f"- {source.name}")
-        logger.info("Bye")
+            print(f"- {source.name}")
+        print("Bye")
         return 0
 
     loop = get_event_loop(args.uvloop)

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -46,6 +46,7 @@ def test_main_and_kill(patch_logger, mock_responses):
 
 def test_run(mock_responses, patch_logger, set_env):
     args = mock.MagicMock()
+    args.log_level = "DEBUG"
     args.config_file = CONFIG
     args.action = "list"
     with patch("sys.stdout", new=StringIO()) as patched_stdout:

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -45,8 +45,6 @@ def test_main_and_kill(patch_logger, mock_responses):
 
 
 def test_run(mock_responses, patch_logger, set_env):
-    import sys
-
     args = mock.MagicMock()
     args.config_file = CONFIG
     args.action = "list"

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -6,7 +6,9 @@
 import asyncio
 import os
 import signal
+from io import StringIO
 from unittest import mock
+from unittest.mock import patch
 
 from connectors import __version__
 from connectors.cli import main, run
@@ -43,11 +45,17 @@ def test_main_and_kill(patch_logger, mock_responses):
 
 
 def test_run(mock_responses, patch_logger, set_env):
+    import sys
+
     args = mock.MagicMock()
     args.config_file = CONFIG
     args.action = "list"
-    args.log_level = "DEBUG"
-    assert run(args) == 0
-    patch_logger.assert_present(
-        ["Registered connectors:", "- Fakey", "- Phatey", "Bye"]
-    )
+    with patch("sys.stdout", new=StringIO()) as patched_stdout:
+        assert run(args) == 0
+
+        output = patched_stdout.getvalue().strip()
+
+        assert "Registered connectors:" in output
+        assert "- Fakey" in output
+        assert "- Phatey" in output
+        assert "Bye" in output


### PR DESCRIPTION
Small change connected to discussion in https://github.com/elastic/connectors-python/pull/446#discussion_r1101566293.

`elastic-ingest --action list` outputs to the logger, while it naturally feels like it should instead output to STDOUT.

Before:

```
artemshelkovnikov@Artems-MBP connectors-py % bin/elastic-ingest --action list
[FMWK][14:12:54][INFO] Loading config from /Users/artemshelkovnikov/git_tree/connectors-py/connectors/../config.yml
[FMWK][14:12:54][INFO] Registered connectors:
[FMWK][14:12:54][INFO] - MongoDB
[FMWK][14:12:54][INFO] - Amazon S3
[FMWK][14:12:54][INFO] - System Directory
[FMWK][14:12:54][INFO] - MySQL
[FMWK][14:12:55][INFO] - Network Drive
[FMWK][14:12:55][INFO] - Google Cloud Storage
[FMWK][14:12:55][INFO] - Azure Blob Storage
[FMWK][14:12:55][INFO] - PostgreSQL
[FMWK][14:12:55][INFO] - Oracle Database
[FMWK][14:12:55][INFO] Bye
```

After:
```
artemshelkovnikov@Artems-MBP connectors-py % bin/elastic-ingest --action list
[FMWK][14:12:42][INFO] Loading config from /Users/artemshelkovnikov/git_tree/connectors-py/connectors/../config.yml
Registered connectors:
- MongoDB
- Amazon S3
- System Directory
- MySQL
- Network Drive
- Google Cloud Storage
- Azure Blob Storage
- PostgreSQL
- Oracle Database
Bye
```

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference


## Related Pull Requests

https://github.com/elastic/connectors-python/pull/446

## Release Note

Now running `elastic-ingest --action list` outputs directly to STDOUT instead of using logger.