### PR TITLE
[8.7] Add --log-level setting for ingest service instead of --debug flag (#446)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,13 @@ ftest: bin/pytest bin/elastic-ingest
 	connectors/tests/ftest.sh $(NAME) $(PERF8)
 
 run: install
-	bin/elastic-ingest --debug
+	bin/elastic-ingest
 
 docker-build:
 	docker build -t docker.elastic.co/enterprise-search/elastic-connectors:$(VERSION)-SNAPSHOT .
 
 docker-run:
-	docker run -v $(PWD):/config docker.elastic.co/enterprise-search/elastic-connectors:$(VERSION)-SNAPSHOT /app/bin/elastic-ingest -c /config/config.yml --debug
+	docker run -v $(PWD):/config docker.elastic.co/enterprise-search/elastic-connectors:$(VERSION)-SNAPSHOT /app/bin/elastic-ingest -c /config/config.yml --log-level=DEBUG
 
 docker-push:
 	docker push docker.elastic.co/enterprise-search/elastic-connectors:$(VERSION)-SNAPSHOT

--- a/config.yml
+++ b/config.yml
@@ -24,6 +24,7 @@ service:
   max_errors_span: 600
   max_concurrent_syncs: 1
   job_cleanup_interval: 300
+  log_level: INFO
 
 native_service_types:
   - mongodb

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -44,11 +44,20 @@ def _parser():
         default=os.path.join(os.path.dirname(__file__), "..", "config.yml"),
     )
 
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--log-level",
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default=None,
+        help="Set log level for the service.",
+    )
+    group.add_argument(
         "--debug",
-        action="store_true",
-        default=False,
-        help="Run the event loop in debug mode.",
+        dest="log_level",
+        action="store_const",
+        const="DEBUG",
+        help="Run the event loop in debug mode (alias for --log-level DEBUG)",
     )
 
     parser.add_argument(
@@ -115,6 +124,11 @@ def run(args):
 
     # load config
     config = load_config(args.config_file)
+    # Precedence: CLI args >> Config Setting >> INFO
+    set_logger(
+        args.log_level or config["service"]["log_level"] or logging.INFO,
+        filebeat=args.filebeat,
+    )
 
     # just display the list of connectors
     if args.action == "list":
@@ -143,5 +157,4 @@ def main(args=None):
     if args.version:
         print(__version__)
         return 0
-    set_logger(args.debug and logging.DEBUG or logging.INFO, filebeat=args.filebeat)
     return run(args)

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -46,6 +46,7 @@ def test_run(mock_responses, patch_logger, set_env):
     args = mock.MagicMock()
     args.config_file = CONFIG
     args.action = "list"
+    args.log_level = "DEBUG"
     assert run(args) == 0
     patch_logger.assert_present(
         ["Registered connectors:", "- Fakey", "- Phatey", "Bye"]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -35,6 +35,7 @@ Configuration lives in [config.yml](../config.yml).
   - `max_errors_span`: The number of seconds to reset `max_errors` count.
   - `max_concurrent_syncs`: The maximum number of concurrent syncs. Defaults to 1.
   - `job_cleanup_interval`: The interval (in seconds) to run job cleanup task.
+  - `log_level`: Connector service log level. Defaults to `INFO`.
 - `native_service_types`: An array of supported native connectors (in service type).
 - `connector_id`: The ID of the custom connector.
 - `service_type` The service type of the custom connector.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -348,14 +348,19 @@ The `elastic-ingest` CLI will be installed on your system:
 
 ```shell
 $ bin/elastic-ingest --help
-usage: elastic-ingest [-h] [--action {poll,list}] [-c CONFIG_FILE] [--debug]
+usage: elastic-ingest [-h] [--action {poll,list}] [-c CONFIG_FILE] [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL} | --debug] [--filebeat] [--version] [--uvloop]
 
-optional arguments:
--h, --help            show this help message and exit
---action {poll,list}  What elastic-ingest should do
--c CONFIG_FILE, --config-file CONFIG_FILE
+options:
+  -h, --help            show this help message and exit
+  --action {poll,list}  What elastic-ingest should do
+  -c CONFIG_FILE, --config-file CONFIG_FILE
                         Configuration file
---debug               Run the event loop in debug mode
+  --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+                        Set log level for the service.
+  --debug               Run the event loop in debug mode (alias for --log-level DEBUG)
+  --filebeat            Output in filebeat format.
+  --version             Display the version and exit.
+  --uvloop              Use uvloop if possible
 ```
 
 # Architecture


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Add --log-level setting for ingest service instead of --debug flag (#446)](https://github.com/elastic/connectors-python/pull/446)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)