### PR TITLE
[8.7] Make --action list command output to stdout (#454)

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -132,10 +132,10 @@ def run(args):
 
     # just display the list of connectors
     if args.action == "list":
-        logger.info("Registered connectors:")
+        print("Registered connectors:")
         for source in get_source_klasses(config):
-            logger.info(f"- {source.name}")
-        logger.info("Bye")
+            print(f"- {source.name}")
+        print("Bye")
         return 0
 
     loop = get_event_loop(args.uvloop)

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -6,7 +6,9 @@
 import asyncio
 import os
 import signal
+from io import StringIO
 from unittest import mock
+from unittest.mock import patch
 
 from connectors import __version__
 from connectors.cli import main, run
@@ -44,10 +46,15 @@ def test_main_and_kill(patch_logger, mock_responses):
 
 def test_run(mock_responses, patch_logger, set_env):
     args = mock.MagicMock()
+    args.log_level = "DEBUG"
     args.config_file = CONFIG
     args.action = "list"
-    args.log_level = "DEBUG"
-    assert run(args) == 0
-    patch_logger.assert_present(
-        ["Registered connectors:", "- Fakey", "- Phatey", "Bye"]
-    )
+    with patch("sys.stdout", new=StringIO()) as patched_stdout:
+        assert run(args) == 0
+
+        output = patched_stdout.getvalue().strip()
+
+        assert "Registered connectors:" in output
+        assert "- Fakey" in output
+        assert "- Phatey" in output
+        assert "Bye" in output


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Make --action list command output to stdout (#454)](https://github.com/elastic/connectors-python/pull/454)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)