### PR TITLE
Refactor SyncJob class

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -265,11 +265,7 @@ class SyncJob(ESDocument):
 
         if validation_result.state != FilteringValidationState.VALID:
             raise InvalidFilteringError(
-                f"Filtering in state {validation_result.state}. Expected: {FilteringValidationState.VALID}."
-            )
-        if len(validation_result.errors):
-            raise InvalidFilteringError(
-                f"Filtering validation errors present: {validation_result.errors}."
+                f"Filtering in state {validation_result.state}, errors: {validation_result.errors}."
             )
 
     async def claim(self):

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -255,29 +255,33 @@ class SyncJob(ESDocument):
         }
         await self.index.update(doc_id=self.id, doc=doc)
 
-    async def done(self, ingestion_stats={}, connector_metadata={}):
+    async def done(self, ingestion_stats=None, connector_metadata=None):
         await self._terminate(
             JobStatus.COMPLETED, None, ingestion_stats, connector_metadata
         )
 
-    async def fail(self, message, ingestion_stats={}, connector_metadata={}):
+    async def fail(self, message, ingestion_stats=None, connector_metadata=None):
         await self._terminate(
             JobStatus.ERROR, str(message), ingestion_stats, connector_metadata
         )
 
-    async def cancel(self, ingestion_stats={}, connector_metadata={}):
+    async def cancel(self, ingestion_stats=None, connector_metadata=None):
         await self._terminate(
             JobStatus.CANCELED, None, ingestion_stats, connector_metadata
         )
 
-    async def suspend(self, ingestion_stats={}, connector_metadata={}):
+    async def suspend(self, ingestion_stats=None, connector_metadata=None):
         await self._terminate(
             JobStatus.SUSPENDED, None, ingestion_stats, connector_metadata
         )
 
     async def _terminate(
-        self, status, error=None, ingestion_stats={}, connector_metadata={}
+        self, status, error=None, ingestion_stats=None, connector_metadata=None
     ):
+        if ingestion_stats is None:
+            ingestion_stats = {}
+        if connector_metadata is None:
+            connector_metadata = {}
         doc = {
             "last_seen": iso_utc(),
             "status": status.value,

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -306,17 +306,6 @@ class SyncJob(ESDocument):
             doc["metadata"] = connector_metadata
         await self.index.update(doc_id=self.id, doc=doc)
 
-    @classmethod
-    def transform_filtering(cls, filtering):
-        # deepcopy to not change the reference resulting in changing .elastic-connectors filtering
-        filtering = (
-            {"advanced_snippet": {}, "rules": []}
-            if (filtering is None or len(filtering) == 0)
-            else deepcopy(filtering)
-        )
-
-        return filtering
-
 
 class Filtering:
     DEFAULT_DOMAIN = "DEFAULT"
@@ -377,8 +366,6 @@ class Filter(dict):
             {"advanced_snippet": {}, "rules": []} if len(self) == 0 else deepcopy(self)
         )
 
-        # extract value for sync job
-        filtering["advanced_snippet"] = self.advanced_rules
         return filtering
 
 

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -13,7 +13,7 @@ from collections import UserDict
 from copy import deepcopy
 from enum import Enum
 
-from connectors.es import ESIndex, Mappings
+from connectors.es import ESDocument, ESIndex, Mappings
 from connectors.filtering.validation import (
     FilteringValidationState,
     InvalidFilteringError,
@@ -179,28 +179,6 @@ class ConnectorIndex(ESIndex):
     async def all_connectors(self):
         async for connector in self.get_all_docs():
             yield connector
-
-
-class ESDocument:
-    def __init__(self, elastic_index, doc_source=None):
-        self.index = elastic_index
-        if doc_source is None:
-            doc_source = dict()
-        self.id = doc_source.get("_id")
-        self._source = doc_source.get("_source", {})
-
-    def get(self, *keys, default=None):
-        value = self._source
-        for key in keys:
-            if not isinstance(value, dict):
-                return default
-            value = value.get(key)
-        if value is None:
-            return default
-        return value
-
-    async def reload(self):
-        return await self.index.fetch_by_id(self.id)
 
 
 class SyncJob(ESDocument):

--- a/connectors/es/__init__.py
+++ b/connectors/es/__init__.py
@@ -4,5 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 from connectors.es.client import ESClient  # NOQA
+from connectors.es.document import ESDocument, InvalidDocumentSourceError  # NOQA
 from connectors.es.index import ESIndex  # NOQA
 from connectors.es.settings import DEFAULT_LANGUAGE, Mappings  # NOQA

--- a/connectors/es/document.py
+++ b/connectors/es/document.py
@@ -12,13 +12,21 @@ class InvalidDocumentSourceError(Exception):
 
 
 class ESDocument:
-    def __init__(self, elastic_index, doc_source=None):
+    def __init__(self, elastic_index, doc_source):
         self.index = elastic_index
         try:
             self.id = doc_source.get("_id")
-            assert isinstance(self.id, str)
+            if not isinstance(self.id, str):
+                raise InvalidDocumentSourceError(
+                    f"Invalid format found for id: {self.id}"
+                )
             self._source = doc_source.get("_source", {})
-            assert isinstance(self._source, dict)
+            if not isinstance(self._source, dict):
+                raise InvalidDocumentSourceError(
+                    f"Invalid format found for source: {self._source}"
+                )
+        except InvalidDocumentSourceError:
+            raise
         except Exception as e:
             logger.critical(e, exc_info=True)
             raise InvalidDocumentSourceError(f"Invalid doc source found: {doc_source}")

--- a/connectors/es/document.py
+++ b/connectors/es/document.py
@@ -1,0 +1,37 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+from connectors.logger import logger
+
+
+class InvalidDocumentSourceError(Exception):
+    pass
+
+
+class ESDocument:
+    def __init__(self, elastic_index, doc_source=None):
+        self.index = elastic_index
+        try:
+            self.id = doc_source.get("_id")
+            assert isinstance(self.id, str)
+            self._source = doc_source.get("_source", {})
+            assert isinstance(self._source, dict)
+        except Exception as e:
+            logger.critical(e, exc_info=True)
+            raise InvalidDocumentSourceError(f"Invalid doc source found: {doc_source}")
+
+    def get(self, *keys, default=None):
+        value = self._source
+        for key in keys:
+            if not isinstance(value, dict):
+                return default
+            value = value.get(key)
+        if value is None:
+            return default
+        return value
+
+    async def reload(self):
+        return await self.index.fetch_by_id(self.id)

--- a/connectors/es/document.py
+++ b/connectors/es/document.py
@@ -3,33 +3,31 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-
-from connectors.logger import logger
-
-
 class InvalidDocumentSourceError(Exception):
     pass
 
 
 class ESDocument:
+    """
+    Represents a document in an Elasticsearch index.
+    """
+
     def __init__(self, elastic_index, doc_source):
         self.index = elastic_index
-        try:
-            self.id = doc_source.get("_id")
-            if not isinstance(self.id, str):
-                raise InvalidDocumentSourceError(
-                    f"Invalid format found for id: {self.id}"
-                )
-            self._source = doc_source.get("_source", {})
-            if not isinstance(self._source, dict):
-                raise InvalidDocumentSourceError(
-                    f"Invalid format found for source: {self._source}"
-                )
-        except InvalidDocumentSourceError:
-            raise
-        except Exception as e:
-            logger.critical(e, exc_info=True)
-            raise InvalidDocumentSourceError(f"Invalid doc source found: {doc_source}")
+        if not isinstance(doc_source, dict):
+            raise InvalidDocumentSourceError(
+                f"Invalid type found for doc_source: {type(doc_source).__name__}, expected: {dict.__name__}"
+            )
+        self.id = doc_source.get("_id")
+        if not isinstance(self.id, str):
+            raise InvalidDocumentSourceError(
+                f"Invalid type found for id: {type(self.id).__name__}, expected: {str.__name__}"
+            )
+        self._source = doc_source.get("_source", {})
+        if not isinstance(self._source, dict):
+            raise InvalidDocumentSourceError(
+                f"Invalid type found for source: {type(self._source).__name__}, expected: {dict.__name__}"
+            )
 
     def get(self, *keys, default=None):
         value = self._source

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -52,7 +52,7 @@ class ESIndex(ESClient):
                 return None
             raise
 
-        return self._create_object(resp)
+        return self._create_object(resp.body)
 
     async def index(self, doc):
         resp = await self.client.index(index=self.index_name, document=doc)

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -863,6 +863,10 @@ def test_get_draft_filter(domain, expected_filter):
             {"advanced_snippet": {"value": {}}, "rules": []},
             {"advanced_snippet": {"value": {}}, "rules": []},
         ),
+        (
+            {"advanced_snippet": {"query": {}}, "rules": []},
+            {"advanced_snippet": {"query": {}}, "rules": []},
+        ),
         ({"advanced_snippet": {}, "rules": []}, {"advanced_snippet": {}, "rules": []}),
         ({}, {"advanced_snippet": {}, "rules": []}),
         (None, {"advanced_snippet": {}, "rules": []}),

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -18,6 +18,7 @@ from connectors.byoc import (
     IDLE_JOBS_THRESHOLD,
     Connector,
     ConnectorIndex,
+    ESDocument,
     Features,
     Filter,
     Filtering,
@@ -208,48 +209,6 @@ def test_utc():
     now = datetime.utcnow()
     then = json.loads(json.dumps({"date": iso_utc(when=now)}))["date"]
     assert now.isoformat() == then
-
-
-@pytest.mark.asyncio
-async def test_sync_job():
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
-    job_filtering = {
-        "advanced_snippet": ACTIVE_ADVANCED_SNIPPET,
-        "rules": [{"id": ACTIVE_RULE_ONE_ID}, {"id": ACTIVE_RULE_TWO_ID}],
-        "validation": FILTERING_VALIDATION_VALID,
-    }
-
-    jobs_index = SyncJobIndex(elastic_config=config)
-
-    index_mock = AsyncMock()
-    update_mock = AsyncMock()
-
-    jobs_index.client.index = index_mock
-    jobs_index.client.update = update_mock
-
-    job = SyncJob(connector_id="connector-id", elastic_index=jobs_index)
-
-    await job.start(filtering=job_filtering)
-
-    assert job.duration == -1
-    assert job.status == JobStatus.IN_PROGRESS
-    assert job.job_id is not None
-
-    job_def = index_mock.call_args.kwargs["document"]
-
-    assert job_def["status"] == "in_progress"
-    assert job_def["connector"]["filtering"] == job_filtering
-
-    await job.done(12, 34)
-
-    assert job.status == JobStatus.COMPLETED
-    assert job.duration > 0
-
-    updated_job_def = update_mock.call_args.kwargs["doc"]
-
-    assert updated_job_def["status"] == "completed"
-    assert updated_job_def["indexed_document_count"] == 12
-    assert updated_job_def["deleted_document_count"] == 34
 
 
 mongo = {
@@ -475,6 +434,11 @@ async def test_sync_mongo(
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
     )
+    mock_responses.post(
+        "http://nowhere.com:9200/.elastic-connectors-sync-jobs/_refresh",
+        headers=headers,
+        repeat=True,
+    )
 
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_search?expand_wildcards=hidden",
@@ -512,6 +476,12 @@ async def test_sync_mongo(
         "http://nowhere.com:9200/.elastic-connectors-sync-jobs/_doc/1",
         payload={"_id": "1"},
         headers=headers,
+    )
+    mock_responses.get(
+        "http://nowhere.com:9200/.elastic-connectors-sync-jobs/_doc/1",
+        payload={"_id": "1", "_source": {"status": "completed"}},
+        headers=headers,
+        repeat=True,
     )
     mock_responses.head(
         "http://nowhere.com:9200/search-airbnb?expand_wildcards=open",
@@ -580,6 +550,32 @@ async def test_sync_mongo(
     patch_logger.assert_present("max_concurrency 3")
 
 
+def test_es_document_get():
+    source = {
+        "_id": "test",
+        "_source": {
+            "string": "string_value",
+            "none_value": None,
+            "empty_dict": {},
+            "nested_dict": {"string": "string_value"},
+        },
+    }
+    default_value = "default"
+    es_doc = ESDocument(elastic_index=None, doc_source=source)
+    assert es_doc.id == "test"
+    assert es_doc.get("string", default=default_value) == "string_value"
+    assert es_doc.get("non_existing") is None
+    assert es_doc.get("non_existing", default=default_value) == default_value
+    assert es_doc.get("empty_dict", default=default_value) == {}
+    assert es_doc.get("empty_dict", "string") is None
+    assert es_doc.get("empty_dict", "string", default=default_value) == default_value
+    assert es_doc.get("nested_dict", "non_existing") is None
+    assert (
+        es_doc.get("nested_dict", "non_existing", default=default_value)
+        == default_value
+    )
+
+
 @pytest.mark.asyncio
 async def test_properties(mock_responses):
     connector_src = {
@@ -614,6 +610,139 @@ async def test_properties(mock_responses):
 
     with pytest.raises(TypeError):
         connector.status = 1234
+
+
+@pytest.mark.asyncio
+async def test_sync_job_properties():
+    sync_job_src = {
+        "_id": "test",
+        "_source": {
+            "status": "error",
+            "error": "something wrong",
+            "indexed_document_count": 10,
+            "indexed_document_volume": 20,
+            "deleted_document_count": 30,
+            "total_document_count": 100,
+            "connector": {
+                "id": "connector_id",
+                "service_type": "test",
+                "index_name": "search-some-index",
+                "configuration": {},
+                "language": "en",
+                "filtering": {},
+                "pipeline": {},
+            },
+        },
+    }
+
+    index = Mock()
+    sync_job = SyncJob(elastic_index=index, doc_source=sync_job_src)
+
+    assert sync_job.id == "test"
+    assert sync_job.status == JobStatus.ERROR
+    assert sync_job.error == "something wrong"
+    assert sync_job.connector_id == "connector_id"
+    assert sync_job.service_type == "test"
+    assert sync_job.configuration.is_empty()
+    assert sync_job.index_name == "search-some-index"
+    assert sync_job.language == "en"
+    assert sync_job.indexed_document_count == 10
+    assert sync_job.indexed_document_volume == 20
+    assert sync_job.deleted_document_count == 30
+    assert sync_job.total_document_count == 100
+    assert isinstance(sync_job.filtering, Filter)
+    assert isinstance(sync_job.pipeline, Pipeline)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_claim(patch_logger):
+    source = {"_id": "1"}
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "status": e2str(JobStatus.IN_PROGRESS),
+        "started_at": ANY,
+        "last_seen": ANY,
+        "worker_hostname": ANY,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.claim()
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_done(patch_logger):
+    source = {"_id": "1"}
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "last_seen": ANY,
+        "completed_at": ANY,
+        "status": e2str(JobStatus.COMPLETED),
+        "error": None,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.done()
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_fail(patch_logger):
+    source = {"_id": "1"}
+    message = "something wrong"
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "last_seen": ANY,
+        "completed_at": ANY,
+        "status": e2str(JobStatus.ERROR),
+        "error": message,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.fail(message)
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_cancel(patch_logger):
+    source = {"_id": "1"}
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "last_seen": ANY,
+        "completed_at": ANY,
+        "status": e2str(JobStatus.CANCELED),
+        "error": None,
+        "canceled_at": ANY,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.cancel()
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_suspend(patch_logger):
+    source = {"_id": "1"}
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "last_seen": ANY,
+        "status": e2str(JobStatus.SUSPENDED),
+        "error": None,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.suspend()
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
 
 
 class Banana(BaseDataSource):
@@ -740,7 +869,10 @@ def test_get_draft_filter(domain, expected_filter):
     ],
 )
 def test_transform_filtering(filtering, expected_transformed_filtering):
-    assert SyncJob.transform_filtering(filtering) == expected_transformed_filtering
+    assert (
+        Filter(filter_=filtering).transform_filtering()
+        == expected_transformed_filtering
+    )
 
 
 @pytest.mark.parametrize(
@@ -1024,7 +1156,7 @@ async def test_create_job(
     connector.language = "en"
     config = load_config(CONFIG)
     connector.sync_now = sync_now
-    connector.filtering.get_active_filter.return_value = Filter()
+    connector.filtering.get_active_filter.transform_filtering.return_value = Filter()
     connector.pipeline = Pipeline({})
 
     expected_index_doc = {

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -673,11 +673,6 @@ async def test_sync_job_properties():
             ["something wrong"],
             True,
         ),
-        (
-            FilteringValidationState.VALID,
-            ["something wrong"],
-            True,
-        ),
     ],
 )
 async def test_sync_job_validate_filtering(
@@ -907,10 +902,6 @@ def test_get_draft_filter(domain, expected_filter):
         (
             {"advanced_snippet": {"value": {}}, "rules": []},
             {"advanced_snippet": {"value": {}}, "rules": []},
-        ),
-        (
-            {"advanced_snippet": {"query": {}}, "rules": []},
-            {"advanced_snippet": {"query": {}}, "rules": []},
         ),
         ({"advanced_snippet": {}, "rules": []}, {"advanced_snippet": {}, "rules": []}),
         ({}, {"advanced_snippet": {}, "rules": []}),

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -18,7 +18,6 @@ from connectors.byoc import (
     IDLE_JOBS_THRESHOLD,
     Connector,
     ConnectorIndex,
-    ESDocument,
     Features,
     Filter,
     Filtering,
@@ -553,32 +552,6 @@ async def test_sync_mongo(
     # verify that the Data source was able to override the option
     patch_logger.assert_not_present("max_concurrency 10")
     patch_logger.assert_present("max_concurrency 3")
-
-
-def test_es_document_get():
-    source = {
-        "_id": "test",
-        "_source": {
-            "string": "string_value",
-            "none_value": None,
-            "empty_dict": {},
-            "nested_dict": {"string": "string_value"},
-        },
-    }
-    default_value = "default"
-    es_doc = ESDocument(elastic_index=None, doc_source=source)
-    assert es_doc.id == "test"
-    assert es_doc.get("string", default=default_value) == "string_value"
-    assert es_doc.get("non_existing") is None
-    assert es_doc.get("non_existing", default=default_value) == default_value
-    assert es_doc.get("empty_dict", default=default_value) == {}
-    assert es_doc.get("empty_dict", "string") is None
-    assert es_doc.get("empty_dict", "string", default=default_value) == default_value
-    assert es_doc.get("nested_dict", "non_existing") is None
-    assert (
-        es_doc.get("nested_dict", "non_existing", default=default_value)
-        == default_value
-    )
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -29,7 +29,6 @@ from connectors.byoc import (
     SyncJobIndex,
     iso_utc,
 )
-from connectors.byoei import ElasticServer
 from connectors.config import load_config
 from connectors.filtering.validation import (
     FilteringValidationResult,
@@ -37,7 +36,6 @@ from connectors.filtering.validation import (
     InvalidFilteringError,
     ValidationTarget,
 )
-from connectors.logger import logger
 from connectors.source import BaseDataSource
 from connectors.tests.commons import AsyncIterator
 

--- a/connectors/tests/test_es_document.py
+++ b/connectors/tests/test_es_document.py
@@ -9,23 +9,24 @@ from connectors.es import ESDocument, InvalidDocumentSourceError
 
 
 @pytest.mark.parametrize(
-    "doc_source, exception",
+    "doc_source",
     [
-        (None, InvalidDocumentSourceError),
-        ("hahaha", InvalidDocumentSourceError),
-        ({}, InvalidDocumentSourceError),
-        ({"_id": {}}, InvalidDocumentSourceError),
-        ({"_id": "1", "_source": "hahaha"}, InvalidDocumentSourceError),
-        ({"_id": "1", "_source": {}}, None),
+        None,
+        "hahaha",
+        {},
+        {"_id": {}},
+        {"_id": "1", "_source": "hahaha"},
     ],
 )
-def test_es_document(doc_source, exception, patch_logger):
-    try:
+def test_es_document_raise(doc_source, patch_logger):
+    with pytest.raises(InvalidDocumentSourceError):
         ESDocument(elastic_index=None, doc_source=doc_source)
-    except Exception as e:
-        assert e.__class__ == exception
-    else:
-        assert exception is None
+
+
+def test_es_document_ok(patch_logger):
+    doc_source = {"_id": "1", "_source": {}}
+    es_document = ESDocument(elastic_index=None, doc_source=doc_source)
+    assert isinstance(es_document, ESDocument)
 
 
 def test_es_document_get():

--- a/connectors/tests/test_es_document.py
+++ b/connectors/tests/test_es_document.py
@@ -1,0 +1,54 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+import pytest
+
+from connectors.es import ESDocument, InvalidDocumentSourceError
+
+
+@pytest.mark.parametrize(
+    "doc_source, exception",
+    [
+        (None, InvalidDocumentSourceError),
+        ("hahaha", InvalidDocumentSourceError),
+        ({}, InvalidDocumentSourceError),
+        ({"_id": {}}, InvalidDocumentSourceError),
+        ({"_id": "1", "_source": "hahaha"}, InvalidDocumentSourceError),
+        ({"_id": "1", "_source": {}}, None),
+    ],
+)
+def test_es_document(doc_source, exception, patch_logger):
+    try:
+        ESDocument(elastic_index=None, doc_source=doc_source)
+    except Exception as e:
+        assert e.__class__ == exception
+    else:
+        assert exception is None
+
+
+def test_es_document_get():
+    source = {
+        "_id": "test",
+        "_source": {
+            "string": "string_value",
+            "none_value": None,
+            "empty_dict": {},
+            "nested_dict": {"string": "string_value"},
+        },
+    }
+    default_value = "default"
+    es_doc = ESDocument(elastic_index=None, doc_source=source)
+    assert es_doc.id == "test"
+    assert es_doc.get("string", default=default_value) == "string_value"
+    assert es_doc.get("non_existing") is None
+    assert es_doc.get("non_existing", default=default_value) == default_value
+    assert es_doc.get("empty_dict", default=default_value) == {}
+    assert es_doc.get("empty_dict", "string") is None
+    assert es_doc.get("empty_dict", "string", default=default_value) == default_value
+    assert es_doc.get("nested_dict", "non_existing") is None
+    assert (
+        es_doc.get("nested_dict", "non_existing", default=default_value)
+        == default_value
+    )

--- a/connectors/tests/test_job_cleanup.py
+++ b/connectors/tests/test_job_cleanup.py
@@ -5,7 +5,7 @@
 #
 
 import asyncio
-from unittest.mock import AsyncMock, Mock, call, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -35,7 +35,7 @@ def mock_connector(id="1", index_name="index_name"):
     connector = Mock()
     connector.id = id
     connector.index_name = index_name
-    connector._sync_done = AsyncMock()
+    connector.sync_done = AsyncMock()
     return connector
 
 
@@ -44,6 +44,7 @@ def mock_sync_job(id="1", connector_id="1", index_name="index_name"):
     job.job_id = id
     job.connector_id = connector_id
     job.index_name = index_name
+    job.fail = AsyncMock()
     return job
 
 
@@ -56,6 +57,7 @@ async def run_service_with_stop_after(service, stop_after):
 
 
 @pytest.mark.asyncio
+@patch("connectors.byoc.SyncJobIndex.fetch_by_id")
 @patch("connectors.byoc.SyncJobIndex.delete_jobs")
 @patch("connectors.byoc.SyncJobIndex.delete_indices")
 @patch("connectors.byoc.SyncJobIndex.idle_jobs")
@@ -66,11 +68,13 @@ async def run_service_with_stop_after(service, stop_after):
 async def test_cleanup_jobs(
     all_connectors,
     supported_connectors,
-    fetch_by_id,
+    connector_fetch_by_id,
     orphaned_jobs,
     idle_jobs,
     delete_indices,
     delete_jobs,
+    sync_job_fetch_by_id,
+    patch_logger,
 ):
     existing_index_name = "foo"
     to_be_deleted_index_name = "bar"
@@ -80,18 +84,16 @@ async def test_cleanup_jobs(
 
     all_connectors.return_value = AsyncIterator([connector])
     supported_connectors.return_value = AsyncIterator([connector])
-    fetch_by_id.return_value = connector
+    connector_fetch_by_id.return_value = connector
     orphaned_jobs.return_value = AsyncIterator([sync_job, another_sync_job])
     idle_jobs.return_value = AsyncIterator([sync_job])
     delete_jobs.return_value = {"deleted": 1, "failures": [], "total": 1}
+    sync_job_fetch_by_id.return_value = sync_job
 
     service = create_service()
     await run_service_with_stop_after(service, 0.1)
 
-    assert delete_indices.call_args_list == [call(indices=[to_be_deleted_index_name])]
-    assert delete_jobs.call_args_list == [
-        call(job_ids=[sync_job.job_id, another_sync_job.job_id])
-    ]
-    assert connector._sync_done.call_args_list == [
-        call(job=sync_job, result={}, exception=IDLE_JOB_ERROR)
-    ]
+    delete_indices.assert_called_with(indices=[to_be_deleted_index_name])
+    delete_jobs.assert_called_with(job_ids=[sync_job.id, another_sync_job.id])
+    sync_job.fail.assert_called_with(message=IDLE_JOB_ERROR)
+    connector.sync_done.assert_called_with(job=sync_job)

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -305,33 +305,30 @@ async def set_server_responses(
         callback=connectors_read,
         repeat=True,
     )
-    mock_responses.post(
-        f"{host}/.elastic-connectors-sync-jobs/_doc",
-        payload={"_id": "1"},
-        headers=headers,
-        repeat=True,
-    )
-
     for id_ in range(len(configs)):
+        mock_responses.post(
+            f"{host}/.elastic-connectors-sync-jobs/_doc",
+            payload={"_id": f"{id_+1}"},
+            headers=headers,
+        )
         mock_responses.post(
             f"{host}/.elastic-connectors-sync-jobs/_update/{id_+1}",
             headers=headers,
             callback=jobs_update,
             repeat=True,
         )
-    mock_responses.put(
-        f"{host}/.elastic-connectors-sync-jobs/_doc/1",
-        payload={"_id": "1"},
-        callback=jobs_update,
-        headers=headers,
-    )
-
-    mock_responses.get(
-        f"{host}/.elastic-connectors-sync-jobs/_doc/1",
-        payload=JOB_DOC_SOURCE,
-        headers=headers,
-        repeat=True,
-    )
+        mock_responses.put(
+            f"{host}/.elastic-connectors-sync-jobs/_doc/{id_+1}",
+            payload={"_id": f"{id_+1}"},
+            callback=jobs_update,
+            headers=headers,
+        )
+        mock_responses.get(
+            f"{host}/.elastic-connectors-sync-jobs/_doc/{id_+1}",
+            payload=JOB_DOC_SOURCE | {"_id": f"{id_+1}"},
+            headers=headers,
+            repeat=True,
+        )
 
     mock_responses.put(
         f"{host}/.elastic-connectors/_doc/1",
@@ -730,3 +727,5 @@ async def test_concurrent_syncs(mock_responses, patch_logger, set_env):
 
     # make sure we synced the three connectors
     patch_logger.assert_present("[1] Sync done: 1 indexed, 0  deleted. (0 seconds)")
+    patch_logger.assert_present("[2] Sync done: 1 indexed, 0  deleted. (0 seconds)")
+    patch_logger.assert_present("[3] Sync done: 1 indexed, 0  deleted. (0 seconds)")

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -195,12 +195,6 @@ def patch_validate_filtering_in_sync():
         yield validate_filtering_mock
 
 
-@pytest.fixture(autouse=True)
-def patch_validate_filtering_in_byoc():
-    with mock.patch("connectors.byoc.validate_filtering", return_value=AsyncMock()):
-        yield
-
-
 def create_service(config_file):
     config = load_config(config_file)
     service = SyncService(config)

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -186,6 +186,32 @@ FAKE_CONFIG_UNKNOWN_SERVICE = {
     "sync_now": True,
 }
 
+JOB_DOC_SOURCE = {
+    "_id": "1",
+    "_source": {
+        "status": "completed",
+        "connector": {
+            "configuration": {
+                "host": {"value": "mongodb://127.0.0.1:27021", "label": "MongoDB Host"},
+                "database": {"value": "sample_airbnb", "label": "MongoDB Database"},
+                "collection": {
+                    "value": "listingsAndReviews",
+                    "label": "MongoDB Collection",
+                },
+            },
+            "pipeline": {
+                "extract_binary_content": True,
+                "reduce_whitespace": True,
+                "run_ml_inference": True,
+            },
+            "index_name": "search-airbnb",
+            "service_type": "fake",
+            "status": "configured",
+            "language": "en",
+        },
+    },
+}
+
 
 @pytest.fixture(autouse=True)
 def patch_validate_filtering_in_sync():
@@ -302,7 +328,7 @@ async def set_server_responses(
 
     mock_responses.get(
         f"{host}/.elastic-connectors-sync-jobs/_doc/1",
-        payload={"_id": "1", "_source": {"status": "completed"}},
+        payload=JOB_DOC_SOURCE,
         headers=headers,
         repeat=True,
     )
@@ -704,5 +730,3 @@ async def test_concurrent_syncs(mock_responses, patch_logger, set_env):
 
     # make sure we synced the three connectors
     patch_logger.assert_present("[1] Sync done: 1 indexed, 0  deleted. (0 seconds)")
-    patch_logger.assert_present("[2] Sync done: 1 indexed, 0  deleted. (0 seconds)")
-    patch_logger.assert_present("[3] Sync done: 1 indexed, 0  deleted. (0 seconds)")


### PR DESCRIPTION
This PR refactors `SyncJob` class. The changes are:

1. Add a new class `ESDocument`, to be a parent class of `SyncJob` and `Connector` class.
2. Make `SyncJob` data representation of a document in `.elastic-connectors-sync-jobs`, and include self-mutating methods.
3. Move `transform_filtering` method from `SyncJob` to `Filter`.
4. Add `validate_filtering` method to `SyncJob`.
5. Make the system work with the refactored `SyncJob`.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference