### PR TITLE
[Fix] delete_indices used a default mutable argument

### DIFF
--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -125,5 +125,7 @@ class ESClient:
             except NotFoundError:
                 raise PreflightCheckError(f"Could not find pipeline {pipeline}")
 
-    async def delete_indices(self, indices=[]):
+    async def delete_indices(self, indices=None):
+        if indices is None:
+            indices = []
         await self.client.indices.delete(index=indices, ignore_unavailable=True)


### PR DESCRIPTION
`delete_indices` used a default mutable argument, which could've lead to weird bugs in the future.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference