### PR TITLE
[8.7] Terminate all services if one exits (#437)

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -19,6 +19,7 @@ from connectors import __version__
 from connectors.config import load_config
 from connectors.logger import logger, set_logger
 from connectors.preflight_check import PreflightCheck
+from connectors.services.base import MultiService
 from connectors.services.job_cleanup import JobCleanUpService
 from connectors.services.sync import SyncService
 from connectors.source import get_source_klasses
@@ -95,34 +96,17 @@ async def _start_service(config, loop):
         for sig in (signal.SIGINT, signal.SIGTERM):
             loop.remove_signal_handler(sig)
 
-    services = [SyncService(config), JobCleanUpService(config)]
+    multiservice = MultiService(SyncService(config), JobCleanUpService(config))
     for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, functools.partial(multiservice.shutdown, sig.name))
 
-        def _shutdown(sig_name):
-            logger.info(f"Caught {sig_name}. Graceful shutdown.")
-            for service in services:
-                try:
-                    logger.info(f"Shutdown {service.__class__.__name__}...")
-                    service.stop()
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to correctly shutdown {service.__class__.__name__} due to an error: {e}"
-                    )
+    if "PERF8" in os.environ:
+        import perf8
 
-            return
-
-        loop.add_signal_handler(sig, functools.partial(_shutdown, sig.name))
-
-    async def _run_service(service):
-        if "PERF8" in os.environ:
-            import perf8
-
-            async with perf8.measure():
-                return await service.run()
-        else:
-            return await service.run()
-
-    await asyncio.gather(*[_run_service(service) for service in services])
+        async with perf8.measure():
+            return await multiservice.run()
+    else:
+        return await multiservice.run()
 
 
 def run(args):

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import asyncio
 import time
 
 from connectors.logger import logger
@@ -59,3 +60,28 @@ class BaseService:
 
         self.errors[0] = errors
         self.errors[1] = first
+
+
+class MultiService:
+    def __init__(self, *services):
+        self._services = services
+
+    async def run(self):
+        tasks = [asyncio.create_task(service.run()) for service in self._services]
+
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+        for task in pending:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                logger.error("Service did not handle cancellation gracefully.")
+
+    def shutdown(self, sig):
+        logger.info(f"Caught {sig}. Graceful shutdown.")
+
+        for service in self._services:
+            logger.debug(f"Shutting down {service.__class__.__name__}...")
+            service.stop()
+            logger.debug(f"Done shutting down {service.__class__.__name__}...")

--- a/connectors/tests/test_base_service.py
+++ b/connectors/tests/test_base_service.py
@@ -1,0 +1,117 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+import asyncio
+import functools
+
+import pytest
+
+from connectors.services.base import MultiService
+
+
+class StubService:
+    def __init__(self):
+        self.running = False
+        self.cancelled = False
+        self.exploding = False
+        self.stopped = False
+        self.handle_cancellation = True
+
+    async def run(self):
+        if self.handle_cancellation:
+            try:
+                await self._run()
+            except asyncio.CancelledError:
+                self.running = False
+                self.cancelled = True
+        else:
+            await self._run()
+
+    async def _run(self):
+        self.running = True
+        while self.running:
+            if self.exploding:
+                raise Exception("Something went wrong")
+            await asyncio.sleep(0)
+
+    def stop(self):
+        self.running = False
+        self.stopped = True
+
+    def explode(self):
+        self.exploding = True
+
+
+@pytest.mark.asyncio
+async def test_multiservice_run_stops_all_services_when_one_stops():
+    service_1 = StubService()
+    service_2 = StubService()
+    service_3 = StubService()
+
+    multiservice = MultiService(service_1, service_2, service_3)
+
+    asyncio.get_event_loop().call_later(0.1, service_1.stop)
+
+    await multiservice.run()
+
+    assert not service_1.cancelled
+    assert service_2.cancelled
+    assert service_3.cancelled
+
+
+@pytest.mark.asyncio
+async def test_multiservice_run_stops_all_services_when_one_raises_exception():
+    service_1 = StubService()
+    service_2 = StubService()
+    service_3 = StubService()
+
+    multiservice = MultiService(service_1, service_2, service_3)
+
+    asyncio.get_event_loop().call_later(0.1, service_1.explode)
+
+    await multiservice.run()
+
+    assert not service_1.cancelled
+    assert service_2.cancelled
+    assert service_3.cancelled
+
+
+@pytest.mark.asyncio
+async def test_multiservice_run_stops_all_services_when_shutdown_happens():
+    service_1 = StubService()
+    service_2 = StubService()
+    service_3 = StubService()
+
+    multiservice = MultiService(service_1, service_2, service_3)
+
+    asyncio.get_event_loop().call_later(
+        0.1, functools.partial(multiservice.shutdown, "SIGTERM")
+    )
+
+    await multiservice.run()
+
+    assert service_1.stopped
+    assert service_2.stopped
+    assert service_3.stopped
+
+
+@pytest.mark.asyncio
+async def test_multiservice_run_stops_all_services_when_shutdown_happens_and_some_dont_handle_cancellation():
+    service_1 = StubService()
+    service_2 = StubService()
+    service_3 = StubService()
+
+    service_3.handle_cancellation = False
+
+    multiservice = MultiService(service_1, service_2, service_3)
+
+    asyncio.get_event_loop().call_later(0.1, service_1.stop)
+
+    await multiservice.run()
+
+    assert service_1.stopped
+    assert service_2.cancelled
+    # We assert False for service_3 - it does not handle cancellation gracefully
+    assert not service_3.cancelled


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Terminate all services if one exits (#437)](https://github.com/elastic/connectors-python/pull/437)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)