### PR TITLE
Make SyncJobIndex methods param compulsory

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -820,7 +820,7 @@ class SyncJobIndex(ESIndex):
         }
         return await self.index(job_def)
 
-    async def pending_jobs(self, connector_ids=[]):
+    async def pending_jobs(self, connector_ids):
         query = {
             "bool": {
                 "must": [
@@ -839,12 +839,12 @@ class SyncJobIndex(ESIndex):
         async for job in self.get_all_docs(query=query):
             yield job
 
-    async def orphaned_jobs(self, connector_ids=[]):
+    async def orphaned_jobs(self, connector_ids):
         query = {"bool": {"must_not": {"terms": {"connector.id": connector_ids}}}}
         async for job in self.get_all_docs(query=query):
             yield job
 
-    async def stuck_jobs(self, connector_ids=[]):
+    async def stuck_jobs(self, connector_ids):
         query = {
             "bool": {
                 "filter": [
@@ -865,6 +865,6 @@ class SyncJobIndex(ESIndex):
         async for job in self.get_all_docs(query=query):
             yield job
 
-    async def delete_jobs(self, job_ids=[]):
+    async def delete_jobs(self, job_ids):
         query = {"terms": {"_id": job_ids}}
         return await self.client.delete_by_query(index=self.index_name, query=query)


### PR DESCRIPTION
Pointed out by @tarekziade here https://github.com/elastic/connectors-python/pull/460#discussion_r1106300817, we should not use mutable default. This PR made changes to some methods of `SyncJobIndex` class, to make some params compulsory. 

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference