### PR TITLE
Remove assert from source.py and replace it with manual validation

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -115,8 +115,12 @@ class BaseDataSource:
     service_type = None
 
     def __init__(self, configuration):
+        if not isinstance(configuration, DataSourceConfiguration):
+            raise TypeError(
+                f"Configuration expected type is DataSourceConfiguration, actual: {type(configuration).__name__}."
+            )
+
         self.configuration = configuration
-        assert isinstance(self.configuration, DataSourceConfiguration)
         self.configuration.set_defaults(self.get_default_configuration())
 
     def __str__(self):

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -117,7 +117,7 @@ class BaseDataSource:
     def __init__(self, configuration):
         if not isinstance(configuration, DataSourceConfiguration):
             raise TypeError(
-                f"Configuration expected type is DataSourceConfiguration, actual: {type(configuration).__name__}."
+                f"Configuration expected type is {DataSourceConfiguration.__name__}, actual: {type(configuration).__name__}."
             )
 
         self.configuration = configuration

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -154,8 +154,8 @@ async def test_invalid_configuration_raises_error():
     with pytest.raises(TypeError) as e:
         DataSource(configuration=configuration)
 
-    assert e.match(".*DataSourceConfiguration.*") # expected
-    assert e.match(".*dict.*") # actual
+    assert e.match(".*DataSourceConfiguration.*")  # expected
+    assert e.match(".*dict.*")  # actual
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -151,8 +151,11 @@ async def test_validate_filter(validator_mock):
 async def test_invalid_configuration_raises_error():
     configuration = {}
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as e:
         DataSource(configuration=configuration)
+
+    assert e.match(".*DataSourceConfiguration.*") # expected
+    assert e.match(".*dict.*") # actual
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -148,6 +148,14 @@ async def test_validate_filter(validator_mock):
 
 
 @pytest.mark.asyncio
+async def test_invalid_configuration_raises_error():
+    configuration = {}
+
+    with pytest.raises(TypeError):
+        DataSource(configuration=configuration)
+
+
+@pytest.mark.asyncio
 async def test_base_class():
     configuration = DataSourceConfiguration({})
 


### PR DESCRIPTION
`assert` statements are supposed to be used only in tests. We have an `assert` statement in our production code in `BaseDataSource` class. This assert attempts to validate the type of `configuration` variable passed into the class.

This PR removes `assert` and replaces it with a regular `if` statement that checks type of the variable and raises a `TypeError` in case the type is unexpected. Choice of exception type was made based on https://docs.python.org/3/library/exceptions.html#TypeError

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
