### PR TITLE
[Docs] Move connector protocol to python

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ If you are looking for the implementation in Ruby, See [connectors-ruby](https:/
 - [Developer guide](docs/DEVELOPING.md)
 - [Security Policy](docs/SECURITY.md)
 - [Elastic-internal guide](docs/INTERNAL.md)
-- [Connector Protocol](https://github.com/elastic/connectors-python/docs/CONNECTOR_PROTOCOL.md)
+- [Connector Protocol](https://github.com/elastic/connectors-python/blob/main/docs/CONNECTOR_PROTOCOL.md)
 - [Configuration](docs/CONFIG.md)
 - [Contribution guide](docs/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ If you are looking for the implementation in Ruby, See [connectors-ruby](https:/
 - [Developer guide](docs/DEVELOPING.md)
 - [Security Policy](docs/SECURITY.md)
 - [Elastic-internal guide](docs/INTERNAL.md)
-- [Connector Protocol](https://github.com/elastic/connectors-ruby/blob/main/docs/CONNECTOR_PROTOCOL.md)
+- [Connector Protocol](https://github.com/elastic/connectors-python/docs/CONNECTOR_PROTOCOL.md)
 - [Configuration](docs/CONFIG.md)
 - [Contribution guide](docs/CONTRIBUTING.md)

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -1,0 +1,470 @@
+# Connector Protocol
+
+To enable Elasticsearch users to ingest any kind of data and build a search experience on top of that data, we are providing a lightweight protocol that will allow users to easily ingest data, use Enterprise Search features to manipulate that data and create a search experience, while providing them with a seamless user experience in Kibana. To be compatible with Enterprise Search and take full advantage of the connector features available in Kibana, a connector should adhere to the protocol defined here.
+
+## Main tenets
+
+### Architecture
+- All communication between connectors and other parts of the system happen asynchronously through an Elasticsearch index
+- We want to minimize the number of indices we use to manage the system. Elasticsearch is not a relational database but a document store, and we want to optimize for that architecture.
+- Users must be able to easily manage their search-related indices and connectors in Kibana
+- The system must be robust and able to deal with unexpected downtime and crashes.
+
+### Connectors
+
+Connectors can:
+- Ship large amounts of data to an Elasticsearch index independently.
+- communicate their status to Elasticsearch and Kibana so that users can provide it with configuration and diagnose any issues.
+- Handle early termination and crashes well .
+
+At this stage, our assumption is that one connector will manage one index, and one index will have only one connector associated with it. This may change in the future.
+
+## Communication protocol
+
+All communication will need to go through Elasticsearch. We've created a connector index called `.elastic-connectors`, where a document represents a connector. In addition, there's a connector job index called `.elastic-connectors-sync-jobs`, which holds the job history. You can find the definitions for these indices in the next section.
+
+### Index definition
+
+#### Connector index `.elastic-connectors`
+
+This is our main communication index, used to communicate the connector's configuration, status and other related data. All dates in UTC.
+```
+{
+  api_key_id: string;   -> ID of the current API key in use
+  configuration: {
+    [key]: {
+      label: string     -> The label to be displayed for the field in Kibana
+      value: string,    -> The value of the field configured in Kibana
+    }
+  };                    -> Definition and values of configurable
+                           fields
+  custom_scheduling: {
+    [key]: {
+      configuration_overrides: {
+        [key]: {
+          label: string     -> The label to be displayed for the field in Kibana
+          value: string,    -> The value of the field configured in Kibana
+        }
+      };                    -> Configurable fields to be overridden when custom schedule runs
+      enabled: boolean;     -> Whether job schedule is enabled
+      interval: string;     -> Quartz Cron syntax
+      last_synced: string;  -> Date/time of last job (UTC)
+      name: string;         -> The name of the custom schedule
+    }
+  };                        -> Schedules with custom configurations
+  description: string;  -> The description of the connector
+  error: string;        -> Optional error message
+  features: {
+    [feature_name]: {
+        [subfeature_name]: {
+            enabled: boolean; -> Whether this feature is enabled
+        }
+    };                                  -> Features to enable/disable for this connector
+  };
+  filtering: [          -> Array of filtering rules, connectors use the first entry by default
+    {          
+      domain: string,     -> what data domain these rules apply to
+      active: {           -> "active" rules are run in jobs. 
+        rules: {
+          id: string,         -> rule identifier
+          policy: string,     -> one of ["include", "exclude"]
+          field: string,      -> the field on the document this rule applies to
+          rule: string,       -> one of ["regex", "starts_with", "ends_with", "contains", "equals", "<", ">"]
+          value: string,      -> paired with the `rule`, this `value` either matches the contents of the document's `field` or does not
+          order: number,      -> the order in which to match rules. The first rule to match has its `policy` applied
+          created_at: string, -> when the rule was added
+          updated_at: string  -> when the rule was last edited
+        },
+        advanced_snippet: {   -> used for filtering data from the 3rd party at query time
+          value: object,      -> this JSON object is passed directly to the connector
+          created_at: string, -> when this JSON object was created
+          updated_at: string  -> when this JSON object was last edited
+        },
+        validation: {
+          state: string,      -> one of ["edited", "valid", "invalid"]
+          errors: {
+            ids: string,      -> the id(s) of any rules that are deemed invalid
+            messages: string  -> the message(s) to display in Kibana, explaining what is invalid
+          }
+        }
+      },
+      draft: object;      -> Identical to the above "active" object, but used when drafting edits to filtering rules
+    }
+  ];
+  index_name: string;   -> The name of the content index where data will be written to
+  is_native: boolean;   -> Whether this is a native connector
+  language: string;     -> the language used for the analyzer
+  last_deleted_document_count: number;    -> How many documents were deleted in the last job
+  last_indexed_document_count: number;    -> How many documents were indexed in the last job  
+  last_seen: date;      -> Connector writes check-in date-time regularly (UTC)
+  last_sync_error: string;   -> Optional last job error message
+  last_sync_status: string;  -> Status of the last job, or null if no job has been executed
+  last_synced: date;    -> Date/time of last job (UTC)
+  name: string; -> the name to use for the connector
+  pipeline: {
+    extract_binary_content: boolean; -> Whether the `request_pipeline` should handle binary data
+    name: string; ->  Ingest pipeline to utilize on indexing data to Elasticsearch
+    reduce_whitespace: boolean; -> Whether the `request_pipeline` should squish redundant whitespace
+    run_ml_inference: boolean; -> Whether the `request_pipeline` should run the ML Inference pipeline
+  }
+  scheduling: {
+    enabled: boolean; -> Whether job schedule is enabled
+    interval: string; -> Quartz Cron syntax
+  };
+  service_type: string; -> Service type of the connector
+  status: string;       -> Connector status Enum, see below
+  sync_now: boolean;    -> Flag to signal user wants to initiate a job
+}
+```
+**Possible values for 'status'**
+- `created` -> A document for a connector has been created in connector index but the connector has not connected to elasticsearch (written by index creator).
+- `needs_configuration` -> Configurable fields have been written into the connector, either by Kibana (for native connector) or connector (for custom connector).
+- `configured` -> A connector has been fully configured (written by Kibana on updating configuration, or directly by connector if no further configuration is necessary).
+- `connected` -> A connector has successfully connected to the data source (written by connector on successfully connecting to data source).
+- `error` -> A connector has encountered an error, either because the data source is not healthy or the last job failed.
+
+#### Elasticsearch mappings for `.elastic-connectors`:
+```
+"mappings" : {
+  "_meta" : {
+    "pipeline" : {
+      "default_extract_binary_content" : true,
+      "default_name" : "ent-search-generic-ingestion",
+      "default_reduce_whitespace" : true,
+      "default_run_ml_inference" : true
+    },
+    "version" : "1"
+  },
+  "dynamic": false,
+  "properties" : {
+    "api_key_id" : { "type" : "keyword" },
+    "configuration" : { "type" : "object" },
+    "custom_scheduling" : { "type" : "object" },
+    "description" : { "type" : "text" },
+    "error" : { "type" : "keyword" },
+    "features": {
+      "properties": {
+        "filtering_advanced_config": { "type": "boolean" },
+        "filtering_rules": { "type": "boolean" }
+      }
+    },
+    "filtering" : {
+      "properties" : {
+        "domain" : { "type" : "keyword" },
+        "active" : {
+          "properties" : {
+            "rules" : {
+              "properties" : {
+                "id" : { "type" : "keyword" },
+                "policy" : { "type" : "keyword" },
+                "field" : { "type" : "keyword" },
+                "rule" : { "type" : "keyword" },
+                "value" : { "type" : "keyword" },
+                "order" : { "type" : "short" },
+                "created_at" : { "type" : "date" },
+                "updated_at" : { "type" : "date" }
+              }
+            },
+            "advanced_snippet" : {
+              "properties" : {
+                "value" : { "type" : "object" },
+                "created_at" : { "type" : "date" },
+                "updated_at" : { "type" : "date" }
+              }
+            },
+            "validation" : {
+              "properties" : {
+                "state" : { "type" : "keyword" },
+                "errors" : {
+                  "properties" : {
+                    "ids" : { "type" : "keyword" },
+                    "messages" : { "type" : "text" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "draft" : {
+          "properties" : {
+            "rules" : {
+              "properties" : {
+                "id" : { "type" : "keyword" },
+                "policy" : { "type" : "keyword" },
+                "field" : { "type" : "keyword" },
+                "rule" : { "type" : "keyword" },
+                "value" : { "type" : "keyword" },
+                "order" : { "type" : "short" },
+                "created_at" : { "type" : "date" },
+                "updated_at" : { "type" : "date" }
+              }
+            },
+            "advanced_snippet" : {
+              "properties" : {
+                "value" : { "type" : "object" },
+                "created_at" : { "type" : "date" },
+                "updated_at" : { "type" : "date" }
+              }
+            },
+            "validation" : {
+              "properties" : {
+                "state" : { "type" : "keyword" },
+                "errors" : {
+                  "properties" : {
+                    "ids" : { "type" : "keyword" },
+                    "messages" : { "type" : "text" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "index_name" : { "type" : "keyword" },
+    "is_native" : { "type" : "boolean" },
+    "language" : { "type" : "keyword" },
+    "last_deleted_document_count" : { "type" : "long" },
+    "last_indexed_document_count" : { "type" : "long" },
+    "last_seen" : { "type" : "date" },
+    "last_sync_error" : { "type" : "keyword" },
+    "last_sync_status" : { "type" : "keyword" },
+    "last_synced" : { "type" : "date" },
+    "name" : { "type" : "keyword" },
+    "pipeline" : {
+      "properties" : {
+        "extract_binary_content" : { "type" : "boolean" },
+        "name" : { "type" : "keyword" },
+        "reduce_whitespace" : { "type" : "boolean" },
+        "run_ml_inference" : { "type" : "boolean" }
+      }
+    },
+    "scheduling" : {
+      "properties" : {
+        "enabled" : { "type" : "boolean" },
+        "interval" : { "type" : "text" }
+      }
+    },
+    "service_type" : { "type" : "keyword" },
+    "status" : { "type" : "keyword" },
+    "sync_now" : { "type" : "boolean" }
+  }
+}
+```
+
+#### Connector job index `.elastic-connectors-sync-jobs`
+In addition to the connector index `.elastic-connectors`, we have an additional index to log all jobs run by connectors. This is the `.elastic-connectors-sync-jobs` index. Each JSON document will have the following structure:
+```
+{
+  cancelation_requested_at: date; -> The date/time when the cancelation of the job is requested
+  canceled_at: date; -> The date/time when the job is canceled
+  completed_at: date; -> The data/time when the job is completed
+  connector: {              -> Connector snapshot
+    id: string;   -> ID of the connector
+    configuration: object;  -> Connector configuration
+    filtering: [             -> Array of filtering rules, connectors use the first entry by default
+      {
+        domain: string,       -> what data domain these rules apply to
+        rules: {
+          id: string,         -> rule identifier
+          policy: string,     -> one of ["include", "exclude"]
+          field: string,      -> the field on the document this rule applies to
+          rule: string,       -> one of ["regex", "starts_with", "ends_with", "contains", "equals", "<", ">"]
+          value: string,      -> paired with the `rule`, this `value` either matches the contents of the document's `field` or does not
+          order: number,      -> the order in which to match rules. The first rule to match has its `policy` applied
+          created_at: string, -> when the rule was added
+          updated_at: string  -> when the rule was last edited
+        },
+        advanced_snippet: {   -> used for filtering data from the 3rd party at query time
+          value: object,      -> this JSON object is passed directly to the connector
+          created_at: string, -> when this JSON object was created
+          updated_at: string  -> when this JSON object was last edited
+        },
+        warnings: {
+          ids: string,        -> the id(s) of any rules that cannot be used for query-time filtering
+          messages: string    -> the reason(s) those rules cannot be used for query-time filtering
+        }
+      };
+      index_name: string;     -> The name of the content index
+      language: string        -> The language used for the analyzer
+      pipeline: {             -> Connector pipeline
+        extract_binary_content: boolean;
+        name: string;
+        reduce_whitespace: boolean;
+        run_ml_inference: boolean;
+      };
+      service_type: string;   -> Service type of the connector
+    }
+  ];
+  created_at: date; -> The date/time when the job is created
+  deleted_document_count: number; -> Number of documents deleted in the job
+  error: string; -> Optional error message
+  indexed_document_count: number; -> Number of documents indexed in the job
+  indexed_document_volume: number; -> The volume (in bytes) of documents indexed in the job
+  last_seen: date; -> Connector writes check-in date-time regularly (UTC)
+  metadata: object; -> Connector-specific metadata
+  started_at: date; -> The date/time when the job is started
+  status: string; -> Job status Enum, see below
+  total_document_count: number; -> Number of documents in the index after the job completes
+  trigger_method: string; -> How the job is triggered. Possible values are on_demand, scheduled.
+  worker_hostname: string; -> The hostname of the worker to run the job
+}
+```
+
+**Possible values for `status`**
+- `pending` -> A job is just enqueued.
+- `in_progress` -> A job is successfully started.
+- `canceling` -> The cancelation of the job is initiated.
+- `canceled` -> A job is canceled.
+- `suspended` -> A job is successfully started.
+- `completed` -> A job is successfully completed.
+- `error` -> A job failed.
+
+#### Elasticsearch mappings for `.elastic-connectors-sync-jobs`:
+```
+"mappings" " {
+  "_meta" : {
+    "version" : 1
+  },
+  "dynamic": false,
+  "properties" : {
+    "cancelation_requested_at" : { "type" : "date" },
+    "canceled_at" : { "type" : "date" },
+    "completed_at" : { "type" : "date" },
+    "connector" : {
+      "properties" : {
+        "configuration" : { "type" : "object" },
+        "filtering" : {
+          "properties" : {
+            "domain" : { "type" : "keyword" },
+            "rules" : {
+              "properties" : {
+                "id" : { "type" : "keyword" },
+                "policy" : { "type" : "keyword" },
+                "field" : { "type" : "keyword" },
+                "rule" : { "type" : "keyword" },
+                "value" : { "type" : "keyword" },
+                "order" : { "type" : "short" },
+                "created_at" : { "type" : "date" },
+                "updated_at" : { "type" : "date" }
+              }
+            },
+            "advanced_snippet" : {
+              "properties" : {
+                "value" : { "type" : "object" },
+                "created_at" : { "type" : "date" },
+                "updated_at" : { "type" : "date" }
+              }
+            },
+            "warnings" : {
+              "properties" : {
+                "ids" : { "type" : "keyword" },
+                "messages" : { "type" : "text" }
+              }
+            }
+          }
+        },
+        "id" : { "type" : "keyword" },
+        "index_name" : { "type" : "keyword" },
+        "language" : { "type" : "keyword" },
+        "pipeline" : {
+          "properties" : {
+            "extract_binary_content" : { "type" : "boolean" },
+            "name" : { "type" : "keyword" },
+            "reduce_whitespace" : { "type" : "boolean" },
+            "run_ml_inference" : { "type" : "boolean" }
+          }
+        },
+        "service_type" : { "type" : "keyword" }
+      }
+    },
+    "created_at" : { "type" : "date" },
+    "deleted_document_count" : { "type" : "integer" },
+    "error" : { "type" : "keyword" },
+    "indexed_document_count" : { "type" : "integer" },
+    "indexed_document_volume" : { "type" : "integer" },
+    "last_seen" : { "type" : "date" },
+    "metadata" : { "type" : "object" },
+    "started_at" : { "type" : "date" },
+    "status" : { "type" : "keyword" },
+    "total_document_count" : { "type" : "integer" },
+    "trigger_method" : { "type" : "keyword" },
+    "worker_hostname" : { "type" : "keyword" }
+  }
+}
+```
+
+### Protocol flow and responsibilities
+
+To connect a custom connector to Elasticsearch, it requires an Elasticsearch API key that grants read and write access to `.elastic-connectors` and `.elastic-connectors-sync-jobs` as well as `manage`, `read` and `write` to the index it will write documents to. In addition, the connector will need the document ID for their entry in the `.elastic-connectors` index. Users will need to manually configure that API key and the document ID in their deployment.
+
+Once configured, the connector will be able to connect and read the specified configuration in the `.elastic-connectors` index, and write its own configuration schema and status to that document. The user will then be able to use Kibana to update that configuration with the appropriate values, as well as enable and change a job schedule or request an immediate job.
+
+**Connector responsibilities**
+
+For every half hour, and every time a job is executed, the connector should update the following fields so we can signal to the user when a connector is likely to be offline:
+- the `last_seen` field with their current datetime in UTC format (timezone-agnostic).
+- the `status` field to either `connected` or `error`, indicating the health status of the remote data source.
+- the `error` field, when the remote data source is not healthy.
+
+For custom connectors, the connector should also update `configuration` field if its status is `created`.
+
+The connector should also sync data for connectors:
+- Read connector definitions from `.elastic-connectors` regularly, and determine whether to sync data based on `sync_now` flag, as well as `scheduling` and `custom_scheduling` values. 
+- Set the index mappings of the to-be-written-to index if not already present.
+- Sync with the data source and index resulting documents into the correct index.
+- Log jobs to `.elastic-connectors-sync-jobs`.
+
+**Sequence diagram**:
+```mermaid
+sequenceDiagram
+    actor User
+    participant Kibana
+    participant Elasticsearch
+    participant Connector
+    participant Data source
+    alt Custom connector
+        User->>Kibana: Creates a connector via Build a connector
+        Kibana->>Elasticsearch: Saves connector definition
+        User->>Kibana: Generates new API key & id
+        Kibana->>Elasticsearch: Saves API key & id
+        User->>Connector: Deploys with API key, id & Elasticsearch host (for custom connector)
+    else Native connector
+        User->>Kibana: Creates a connector via Use a connector
+        Kibana->>Elasticsearch: Saves connector definition
+    end
+    User->>Kibana: Enters necessary configuration and synchronization schedule
+    Kibana->>Elasticsearch: Writes configuration and synchronization schedule
+    loop Every 3 seconds (by default)
+        par Heartbeat
+            Connector->>Elasticsearch: Updates last_seen and status regularly
+        and Configuration
+            Connector->>Elasticsearch: Updates configurable fields for custom connector
+        and Rule Validation
+            Connector->>Elasticsearch: Updates validation state of filtering rules
+        and Job
+            Connector->>Elasticsearch: Reads sync_now flag and job schedule and filtering rules
+            opt Sync_now is true or sync_schedule requires synchronization
+                Connector->>Elasticsearch: Sets sync_now to false and last_sync_status to in_progress
+                Connector->>Data source: Queries data
+                Connector->>Elasticsearch: Indexes filtered data
+                alt Job is successfully completed
+                    Connector->>Elasticsearch: Sets last_sync_status to completed
+                else Job error
+                    Connector->>Elasticsearch: Sets status and last_sync_status to error
+                    Connector->>Elasticsearch: Writes error message to error field
+                end
+            end
+        end
+    end
+```
+
+
+### Migration concerns
+If the mapping of `.elastic-connectors` or `.elastic-connectors-sync-jobs` is updated in a future version in a way that necessitates a complete re-indexing, Enterprise Search will migrate that data on startup.
+
+To facilitate migrations we'll use aliases for the `.elastic-connectors` and `.elastic-connectors-sync-jobs` indices, and update the underlying index the alias points to when we need to migrate data to a new mapping. The name of those indices will be the same as the alias, with a version appended. So right now, those indices are:
+- `.elastic-connectors-v1`
+- `.elastic-connectors-sync-jobs-v1`
+
+In addition to the name of the index, we'll store a version number in each index's metadata to check against and make sure we're operating on the correct version of each index, and migrate the data otherwise.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -349,7 +349,7 @@ The details of Elastic instance and other relevant fields such as `service` and 
 
 ## Installation
 
-Provides a CLI to ingest documents into Elasticsearch, following the [connector protocol](https://github.com/elastic/connectors-python/docs/CONNECTOR_PROTOCOL.md).
+Provides a CLI to ingest documents into Elasticsearch, following the [connector protocol](https://github.com/elastic/connectors-python/blob/main/docs/CONNECTOR_PROTOCOL.md).
 
 To install the CLI, run:
 ```shell
@@ -381,7 +381,7 @@ Users can execute `make run` command to run the elastic-ingest process in `debug
 
 The CLI runs the [ConnectorService](../connectors/runner.py) which is an asynchronous event loop. It calls Elasticsearch on a regular basis to see if some syncs need to happen.
 
-That information is provided by Kibana and follows the [connector protocol](https://github.com/elastic/connectors-python/docs/CONNECTOR_PROTOCOL.md). That protocol defines a few structures in a couple of dedicated Elasticsearch indices, that are used by Kibana to drive sync jobs, and by the connectors to report on that work.
+That information is provided by Kibana and follows the [connector protocol](https://github.com/elastic/connectors-python/blob/main/docs/CONNECTOR_PROTOCOL.md). That protocol defines a few structures in a couple of dedicated Elasticsearch indices, that are used by Kibana to drive sync jobs, and by the connectors to report on that work.
 
 When a user asks for a sync of a specific source, the service instantiates a class that it uses to reach out the source and collect data.
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -349,7 +349,7 @@ The details of Elastic instance and other relevant fields such as `service` and 
 
 ## Installation
 
-Provides a CLI to ingest documents into Elasticsearch, following the [connector protocol](https://github.com/elastic/connectors-ruby/blob/8.6/docs/CONNECTOR_PROTOCOL.md).
+Provides a CLI to ingest documents into Elasticsearch, following the [connector protocol](https://github.com/elastic/connectors-python/docs/CONNECTOR_PROTOCOL.md).
 
 To install the CLI, run:
 ```shell
@@ -381,7 +381,7 @@ Users can execute `make run` command to run the elastic-ingest process in `debug
 
 The CLI runs the [ConnectorService](../connectors/runner.py) which is an asynchronous event loop. It calls Elasticsearch on a regular basis to see if some syncs need to happen.
 
-That information is provided by Kibana and follows the [connector protocol](https://github.com/elastic/connectors-ruby/blob/8.6/docs/CONNECTOR_PROTOCOL.md). That protocol defines a few structures in a couple of dedicated Elasticsearch indices, that are used by Kibana to drive sync jobs, and by the connectors to report on that work.
+That information is provided by Kibana and follows the [connector protocol](https://github.com/elastic/connectors-python/docs/CONNECTOR_PROTOCOL.md). That protocol defines a few structures in a couple of dedicated Elasticsearch indices, that are used by Kibana to drive sync jobs, and by the connectors to report on that work.
 
 When a user asks for a sync of a specific source, the service instantiates a class that it uses to reach out the source and collect data.
 


### PR DESCRIPTION
I think it makes more sense to have the connector protocol in the python repository as we're moving onwards with python.

TODOs:
- [ ] Change links in ent-search docs
- [ ] Change links in connectors-ruby
- [ ] Change links in connectors-python
- [ ] (Create a redirect in connectors-ruby?)