### PR TITLE
Fix problem with index_name being unavailable for a job

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -207,10 +207,14 @@ class SyncJob:
     def index_name(self):
         return self.doc_source["_source"]["connector"]["index_name"]
 
-    async def start(self, connector, trigger_method=JobTriggerMethod.SCHEDULED, filtering=None):
-        # Okay that's temporary here. When we separate scheduling from execution , this code will go away
+    async def start(
+        self, connector, trigger_method=JobTriggerMethod.SCHEDULED, filtering=None
+    ):
+        # TODO: that's temporary here. When we separate scheduling from execution, this code will go away
         if connector.id != self.connector_id:
-            raise Exception("Job.connector_id is not equal to connector.id that is passed into the method")
+            raise Exception(
+                "Job.connector_id is not equal to connector.id that is passed into the method"
+            )
 
         if filtering is None:
             filtering = Filter()
@@ -222,7 +226,7 @@ class SyncJob:
             "connector": {
                 "id": self.connector_id,
                 "index_name": connector.index_name,
-                "filtering": SyncJob.transform_filtering(filtering)
+                "filtering": SyncJob.transform_filtering(filtering),
             },
             "trigger_method": trigger_method.value,
             "status": self.status.value,
@@ -554,7 +558,9 @@ class Connector:
         trigger_method = (
             JobTriggerMethod.ON_DEMAND if self.sync_now else JobTriggerMethod.SCHEDULED
         )
-        job_id = await job.start(self, trigger_method, self.filtering.get_active_filter())
+        job_id = await job.start(
+            self, trigger_method, self.filtering.get_active_filter()
+        )
 
         self.sync_now = self.doc_source["sync_now"] = False
         self.doc_source["last_sync_status"] = job.status.value

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -219,7 +219,14 @@ async def test_sync_job():
         "validation": FILTERING_VALIDATION_VALID,
     }
 
+    connector_id = "connector-id"
+    index_name = "search-target"
+
     jobs_index = SyncJobIndex(elastic_config=config)
+
+    connector_mock = Mock()
+    connector_mock.id = connector_id
+    connector_mock.index_name = index_name
 
     index_mock = AsyncMock()
     update_mock = AsyncMock()
@@ -227,9 +234,9 @@ async def test_sync_job():
     jobs_index.client.index = index_mock
     jobs_index.client.update = update_mock
 
-    job = SyncJob(connector_id="connector-id", elastic_index=jobs_index)
+    job = SyncJob(connector_id=connector_id, elastic_index=jobs_index)
 
-    await job.start(filtering=job_filtering)
+    await job.start(connector_mock, filtering=job_filtering)
 
     assert job.duration == -1
     assert job.status == JobStatus.IN_PROGRESS
@@ -239,6 +246,7 @@ async def test_sync_job():
 
     assert job_def["status"] == "in_progress"
     assert job_def["connector"]["filtering"] == job_filtering
+    assert job_def["connector"]["index_name"] == index_name
 
     await job.done(12, 34)
 


### PR DESCRIPTION
Fixes a problem reported in Slack:

```
[FMWK][15:05:17][CRITICAL] 'index_name'
Traceback (most recent call last):
  File "/Users/artemshelkovnikov/git_tree/connectors-py/connectors/services/job_cleanup.py", line 64, in _process_orphaned_jobs
    job.index_name is not None
  File "/Users/artemshelkovnikov/git_tree/connectors-py/connectors/byoc.py", line 208, in index_name
    return self.doc_source["_source"]["connector"]["index_name"]
KeyError: 'index_name'
```

Problem happens because when job is created the property "source.index_name" is never populated, while logic that cleans up jobs uses this key.

This fix is suboptimal - better refactor the whole structure of classes, but I know @wangch079 is addressing some of it in his PRs, thus I'm proposing this temporary fix for the problem until refactoring lands.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
