### PR TITLE
Add validation and errors for invalid mongodb database/collection

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -82,6 +82,7 @@ class MongoAdvancedRulesValidator(AdvancedRulesValidator):
                 validation_message=e.message,
             )
 
+
 class MongoDataSource(BaseDataSource):
     """MongoDB"""
 
@@ -137,7 +138,7 @@ class MongoDataSource(BaseDataSource):
         return [MongoAdvancedRulesValidator()]
 
     async def ping(self):
-        await self.client.admin.command('ping')
+        await self.client.admin.command("ping")
 
     # TODO: That's a lot of work. Find a better way
     def serialize(self, doc):
@@ -171,7 +172,6 @@ class MongoDataSource(BaseDataSource):
 
         self._dirty = False
 
-
     async def validate_config(self):
         client = self.client
         configured_database_name = self.configuration["database"]
@@ -182,12 +182,18 @@ class MongoDataSource(BaseDataSource):
         logger.debug(f"Existing databases: {existing_database_names}")
 
         if configured_database_name not in existing_database_names:
-            raise Exception(f"Database ({configured_database_name}) does not exist. Existing databases: {', '.join(existing_database_names)}")
+            raise Exception(
+                f"Database ({configured_database_name}) does not exist. Existing databases: {', '.join(existing_database_names)}"
+            )
 
         database = client[configured_database_name]
 
         existing_collection_names = await database.list_collection_names()
-        logger.debug(f"Existing collections in {configured_database_name}: {existing_collection_names}")
+        logger.debug(
+            f"Existing collections in {configured_database_name}: {existing_collection_names}"
+        )
 
         if configured_collection_name not in existing_collection_names:
-            raise Exception(f"Collection ({configured_collection_name}) does not exist within database {configured_database_name}. Existing collections: {', '.join(existing_collection_names)}")
+            raise Exception(
+                f"Collection ({configured_collection_name}) does not exist within database {configured_database_name}. Existing collections: {', '.join(existing_collection_names)}"
+            )

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -186,10 +186,10 @@ async def test_validate_config_when_collection_name_invalid_then_raises_exceptio
     with mock.patch(
         "motor.motor_asyncio.AsyncIOMotorClient.list_database_names",
         return_value=future_with_result(server_database_names),
-    ) as _list_database_names_patch, mock.patch(
+    ), mock.patch(
         "motor.motor_asyncio.AsyncIOMotorDatabase.list_collection_names",
         return_value=future_with_result(server_collection_names),
-    ) as _list_collection_names_patch:
+    ):
         source = create_source(
             MongoDataSource,
             database=configured_database_name,
@@ -214,10 +214,10 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise():
     with mock.patch(
         "motor.motor_asyncio.AsyncIOMotorClient.list_database_names",
         return_value=future_with_result(server_database_names),
-    ) as _list_database_names_patch, mock.patch(
+    ), mock.patch(
         "motor.motor_asyncio.AsyncIOMotorDatabase.list_collection_names",
         return_value=future_with_result(server_collection_names),
-    ) as _list_collection_names_patch:
+    ):
         source = create_source(
             MongoDataSource,
             database=configured_database_name,

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import asyncio
 from datetime import datetime
 from unittest import mock
 
@@ -147,3 +148,80 @@ async def test_get_docs(patch_logger, *args):
         num += 1
 
     assert num == 2
+
+
+def future_with_result(result):
+    future = asyncio.Future()
+    future.set_result(result)
+
+    return future
+
+
+@pytest.mark.asyncio
+async def test_validate_config_when_database_name_invalid_then_raises_exception():
+    server_database_names = ["hello", "world"]
+    configured_database_name = "something"
+
+    with mock.patch(
+        "motor.motor_asyncio.AsyncIOMotorClient.list_database_names",
+        return_value=future_with_result(server_database_names),
+    ):
+        source = create_source(MongoDataSource, database=configured_database_name)
+        with pytest.raises(Exception) as e:
+            await source.validate_config()
+        # assert that message contains database name from config
+        assert e.match(configured_database_name)
+        # assert that message contains database names from the server too
+        for database_name in server_database_names:
+            assert e.match(database_name)
+
+
+@pytest.mark.asyncio
+async def test_validate_config_when_collection_name_invalid_then_raises_exception():
+    server_database_names = ["hello"]
+    server_collection_names = ["first", "second"]
+    configured_database_name = "hello"
+    configured_collection_name = "third"
+
+    with mock.patch(
+        "motor.motor_asyncio.AsyncIOMotorClient.list_database_names",
+        return_value=future_with_result(server_database_names),
+    ) as _list_database_names_patch, mock.patch(
+        "motor.motor_asyncio.AsyncIOMotorDatabase.list_collection_names",
+        return_value=future_with_result(server_collection_names),
+    ) as _list_collection_names_patch:
+        source = create_source(
+            MongoDataSource,
+            database=configured_database_name,
+            collection=configured_collection_name,
+        )
+        with pytest.raises(Exception) as e:
+            await source.validate_config()
+        # assert that message contains database name from config
+        assert e.match(configured_collection_name)
+        # assert that message contains database names from the server too
+        for collection_name in server_collection_names:
+            assert e.match(collection_name)
+
+
+@pytest.mark.asyncio
+async def test_validate_config_when_configuration_valid_then_does_not_raise():
+    server_database_names = ["hello"]
+    server_collection_names = ["first", "second"]
+    configured_database_name = "hello"
+    configured_collection_name = "second"
+
+    with mock.patch(
+        "motor.motor_asyncio.AsyncIOMotorClient.list_database_names",
+        return_value=future_with_result(server_database_names),
+    ) as _list_database_names_patch, mock.patch(
+        "motor.motor_asyncio.AsyncIOMotorDatabase.list_collection_names",
+        return_value=future_with_result(server_collection_names),
+    ) as _list_collection_names_patch:
+        source = create_source(
+            MongoDataSource,
+            database=configured_database_name,
+            collection=configured_collection_name,
+        )
+
+        await source.validate_config()


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4023


This PR adds validation logic to MongoDB connector in the same way it works in Ruby. Particularly, these two cases:

-  Entering invalid database name displays a helpful error message in Kibana UI
-  Entering invalid collection name displays a helpful error message in Kibana UI

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
