### PR TITLE
Rename stuck jobs to idle jobs

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -764,7 +764,7 @@ class Connector:
             self._sync_task = None
 
 
-STUCK_JOBS_THRESHOLD = 60  # 60 seconds
+IDLE_JOBS_THRESHOLD = 60  # 60 seconds
 
 
 class SyncJobIndex(ESIndex):
@@ -839,7 +839,7 @@ class SyncJobIndex(ESIndex):
         async for job in self.get_all_docs(query=query):
             yield job
 
-    async def stuck_jobs(self, connector_ids):
+    async def idle_jobs(self, connector_ids):
         query = {
             "bool": {
                 "filter": [
@@ -852,7 +852,7 @@ class SyncJobIndex(ESIndex):
                             ]
                         }
                     },
-                    {"range": {"last_seen": {"lte": f"now-{STUCK_JOBS_THRESHOLD}s"}}},
+                    {"range": {"last_seen": {"lte": f"now-{IDLE_JOBS_THRESHOLD}s"}}},
                 ]
             }
         }

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -15,7 +15,7 @@ import pytest
 
 from connectors.byoc import (
     CONNECTORS_INDEX,
-    STUCK_JOBS_THRESHOLD,
+    IDLE_JOBS_THRESHOLD,
     Connector,
     ConnectorIndex,
     Features,
@@ -1095,7 +1095,7 @@ async def test_orphaned_jobs(get_all_docs, patch_logger, set_env):
 
 @pytest.mark.asyncio
 @patch("connectors.byoc.SyncJobIndex.get_all_docs")
-async def test_stuck_jobs(get_all_docs, patch_logger, set_env):
+async def test_idle_jobs(get_all_docs, patch_logger, set_env):
     job = Mock()
     get_all_docs.return_value = AsyncIterator([job])
     config = load_config(CONFIG)
@@ -1112,13 +1112,13 @@ async def test_stuck_jobs(get_all_docs, patch_logger, set_env):
                         ]
                     }
                 },
-                {"range": {"last_seen": {"lte": f"now-{STUCK_JOBS_THRESHOLD}s"}}},
+                {"range": {"last_seen": {"lte": f"now-{IDLE_JOBS_THRESHOLD}s"}}},
             ]
         }
     }
 
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
-    jobs = [job async for job in sync_job_index.stuck_jobs(connector_ids=connector_ids)]
+    jobs = [job async for job in sync_job_index.idle_jobs(connector_ids=connector_ids)]
 
     get_all_docs.assert_called_with(query=expected_query)
     assert len(jobs) == 1


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3727

This PR renames `stuck` jobs to `idle` jobs, including comments, variable names and method names.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference