### PR TITLE
Make param indices of delete_indices method mandatory

### DIFF
--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -125,7 +125,8 @@ class ESClient:
             except NotFoundError:
                 raise PreflightCheckError(f"Could not find pipeline {pipeline}")
 
-    async def delete_indices(self, indices=None):
-        if indices is None:
-            indices = []
+    async def delete_indices(self, indices):
+        if indices is None or len(indices) == 0:
+            logger.debug("indices are not provided, skipping...")
+            return
         await self.client.indices.delete(index=indices, ignore_unavailable=True)

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -126,7 +126,4 @@ class ESClient:
                 raise PreflightCheckError(f"Could not find pipeline {pipeline}")
 
     async def delete_indices(self, indices):
-        if indices is None or len(indices) == 0:
-            logger.debug("indices are not provided, skipping...")
-            return
         await self.client.indices.delete(index=indices, ignore_unavailable=True)

--- a/connectors/tests/test_es_client.py
+++ b/connectors/tests/test_es_client.py
@@ -5,6 +5,7 @@
 #
 import base64
 from unittest import mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from elasticsearch import ConnectionError
@@ -100,3 +101,26 @@ async def test_es_client_no_server(patch_logger):
         # Execute
         assert not await es_client.ping()
         await es_client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "indices, expect_es_call", [(None, False), ([], False), (["search-mongo"], True)]
+)
+async def test_delete_indices(indices, expect_es_call):
+    config = {
+        "username": "elastic",
+        "password": "changeme",
+        "host": "http://nowhere.com:9200",
+    }
+    es_client = ESClient(config)
+    es_client.client = Mock()
+    es_client.client.indices.delete = AsyncMock()
+
+    await es_client.delete_indices(indices=indices)
+    if expect_es_call:
+        es_client.client.indices.delete.assert_awaited_with(
+            index=indices, ignore_unavailable=True
+        )
+    else:
+        es_client.client.indices.delete.assert_not_awaited()

--- a/connectors/tests/test_es_client.py
+++ b/connectors/tests/test_es_client.py
@@ -104,23 +104,18 @@ async def test_es_client_no_server(patch_logger):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "indices, expect_es_call", [(None, False), ([], False), (["search-mongo"], True)]
-)
-async def test_delete_indices(indices, expect_es_call):
+async def test_delete_indices():
     config = {
         "username": "elastic",
         "password": "changeme",
         "host": "http://nowhere.com:9200",
     }
+    indices = ["search-mongo"]
     es_client = ESClient(config)
     es_client.client = Mock()
     es_client.client.indices.delete = AsyncMock()
 
     await es_client.delete_indices(indices=indices)
-    if expect_es_call:
-        es_client.client.indices.delete.assert_awaited_with(
-            index=indices, ignore_unavailable=True
-        )
-    else:
-        es_client.client.indices.delete.assert_not_awaited()
+    es_client.client.indices.delete.assert_awaited_with(
+        index=indices, ignore_unavailable=True
+    )


### PR DESCRIPTION
## Follow-up on PR https://github.com/elastic/connectors-python/pull/462

This PR
1. makes the param `indices` of method `ESClient.delete_indices` mandatory, 
2. returns early without making ES request if `indices` is empty.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=mysql`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference