### PR TITLE
[Refactoring] Make error more explicit when basic auth and api key are used at the same time

### DIFF
--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -37,7 +37,7 @@ class ESClient:
 
         if "username" in config:
             if "api_key" in config:
-                raise KeyError("You can't use basic auth and Api Key at the same time")
+                raise KeyError("You can't use basic auth ('username' and 'password') and 'api_key' at the same time in config.yml")
             auth = config["username"], config["password"]
             options["basic_auth"] = auth
             logger.debug(f"Connecting using Basic Auth (user: {config['username']})")

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -37,7 +37,9 @@ class ESClient:
 
         if "username" in config:
             if "api_key" in config:
-                raise KeyError("You can't use basic auth ('username' and 'password') and 'api_key' at the same time in config.yml")
+                raise KeyError(
+                    "You can't use basic auth ('username' and 'password') and 'api_key' at the same time in config.yml"
+                )
             auth = config["username"], config["password"]
             options["basic_auth"] = auth
             logger.debug(f"Connecting using Basic Auth (user: {config['username']})")


### PR DESCRIPTION
I think this error message should be more explicit, what the conditions are detecting that basic auth and the api key are used at the same time.