### PR TITLE
[GCS]-Parse configurations from Kibana UI

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -20,6 +20,16 @@ from connectors.filtering.validation import (
 """
 
 
+class DataSourceConfigurationError(Exception):
+    """Raise when configurations are invalid.
+
+    Args:
+        Exception (DataSourceConfigurationError): Invalid configurations exception.
+    """
+
+    pass
+
+
 class Field:
     def __init__(self, name, label=None, value="", type="str"):
         if label is None:

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -20,16 +20,6 @@ from connectors.filtering.validation import (
 )
 
 
-class DataSourceConfigurationError(Exception):
-    """Raise when configurations are invalid.
-
-    Args:
-        Exception (DataSourceConfigurationError): Invalid configurations exception.
-    """
-
-    pass
-
-
 class Field:
     def __init__(self, name, label=None, value="", type="str"):
         if label is None:

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -273,8 +273,8 @@ class GoogleCloudStorageDataSource(BaseDataSource):
             resource="buckets",
             method="list",
             full_response=True,
-            project=self.google_storage_client.user_project_id,
-            userProject=self.google_storage_client.user_project_id,
+            project=self.get_storage_client().user_project_id,
+            userProject=self.get_storage_client().user_project_id,
         ):
             yield bucket
 
@@ -293,7 +293,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
                 method="list",
                 full_response=True,
                 bucket=bucket["id"],
-                userProject=self.google_storage_client.user_project_id,
+                userProject=self.get_storage_client().user_project_id,
             ):
                 yield blob
 
@@ -366,7 +366,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
                     bucket=blob["bucket_name"],
                     object=blob_name,
                     alt="media",
-                    userProject=self.google_storage_client.user_project_id,
+                    userProject=self.get_storage_client().user_project_id,
                     pipe_to=async_buffer,
                 )
             )

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -255,7 +255,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
                     resource="projects",
                     method="serviceAccount",
                     sub_method="get",
-                    projectId=self.google_storage_client.user_project_id,
+                    projectId=self.get_storage_client().user_project_id,
                 )
             )
             logger.info("Successfully connected to the Google Cloud Storage.")
@@ -288,7 +288,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
             Dictionary: Contains the list of fetched blobs from Google Cloud Storage.
         """
         for bucket in buckets.get("items", []):
-            async for blob in self.google_storage_client._api_call(
+            async for blob in self.get_storage_client()._api_call(
                 resource="objects",
                 method="list",
                 full_response=True,
@@ -312,7 +312,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
         blob_name = urllib.parse.quote(blob_document["name"], safe="'")
         blob_document[
             "url"
-        ] = f"{CLOUD_STORAGE_BASE_URL}{blob_document['bucket_name']}/{blob_name};tab=live_object?project={self.google_storage_client.user_project_id}"
+        ] = f"{CLOUD_STORAGE_BASE_URL}{blob_document['bucket_name']}/{blob_name};tab=live_object?project={self.get_storage_client().user_project_id}"
         return blob_document
 
     def get_blob_document(self, blobs):
@@ -360,7 +360,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
         source_file_name = ""
         async with NamedTemporaryFile(mode="wb", delete=False) as async_buffer:
             await anext(
-                self.google_storage_client._api_call(
+                self.get_storage_client()._api_call(
                     resource="objects",
                     method="get",
                     bucket=blob["bucket_name"],

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -126,7 +126,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
         ):
             raise Exception("Google Cloud service account json can't be empty.")
         try:
-            _ = json.loads(self.configuration["service_account_credentials"])
+            json.loads(self.configuration["service_account_credentials"])
         except ValueError:
             raise Exception("Google Cloud service account is not a valid JSON.")
 

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -76,7 +76,7 @@ class GoogleCloudStorageClient:
         )
         self.user_project_id = self.service_account_credentials.project_id
 
-    async def _api_call(
+    async def api_call(
         self,
         resource,
         method,
@@ -251,7 +251,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
 
         try:
             await anext(
-                self.get_storage_client()._api_call(
+                self.get_storage_client().api_call(
                     resource="projects",
                     method="serviceAccount",
                     sub_method="get",
@@ -269,7 +269,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
         Yields:
             Dictionary: Contains the list of fetched buckets from Google Cloud Storage.
         """
-        async for bucket in self.get_storage_client()._api_call(
+        async for bucket in self.get_storage_client().api_call(
             resource="buckets",
             method="list",
             full_response=True,
@@ -288,7 +288,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
             Dictionary: Contains the list of fetched blobs from Google Cloud Storage.
         """
         for bucket in buckets.get("items", []):
-            async for blob in self.get_storage_client()._api_call(
+            async for blob in self.get_storage_client().api_call(
                 resource="objects",
                 method="list",
                 full_response=True,
@@ -360,7 +360,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
         source_file_name = ""
         async with NamedTemporaryFile(mode="wb", delete=False) as async_buffer:
             await anext(
-                self.get_storage_client()._api_call(
+                self.get_storage_client().api_call(
                     resource="objects",
                     method="get",
                     bucket=blob["bucket_name"],

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -32,7 +32,7 @@ def get_mocked_source_object():
         {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS, "retry_count": 0}
     )
     mocked_gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
-    mocked_gcs_object.get_service_account_credentials()
+    mocked_gcs_object.get_storage_client()
     return mocked_gcs_object
 
 
@@ -399,7 +399,7 @@ async def test_get_content():
         Aiogoogle, "as_service_account", return_value=blob_content_response
     ):
         google_client = Aiogoogle(
-            service_account_creds=mocked_gcs_object.service_account_credentials
+            service_account_creds=mocked_gcs_object.google_storage_client.service_account_credentials
         )
         storage_client = await google_client.discover(
             api_name=API_NAME, api_version=API_VERSION
@@ -438,7 +438,7 @@ async def test_get_content_when_type_not_supported():
 
     # Execute and Assert
     google_client = Aiogoogle(
-        service_account_creds=mocked_gcs_object.service_account_credentials
+        service_account_creds=mocked_gcs_object.google_storage_client.service_account_credentials
     )
     storage_client = await google_client.discover(
         api_name=API_NAME, api_version=API_VERSION
@@ -482,7 +482,7 @@ async def test_get_content_when_file_size_is_large(catch_stdout, patch_logger):
 
     # Execute and Assert
     google_client = Aiogoogle(
-        service_account_creds=mocked_gcs_object.service_account_credentials
+        service_account_creds=mocked_gcs_object.google_storage_client.service_account_credentials
     )
     storage_client = await google_client.discover(
         api_name=API_NAME, api_version=API_VERSION

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -32,6 +32,7 @@ def get_mocked_source_object():
         {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS, "retry_count": 0}
     )
     mocked_gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
+    mocked_gcs_object._initialize_configurations()
     return mocked_gcs_object
 
 
@@ -62,10 +63,11 @@ async def test_empty_configuration():
 
     # Setup
     configuration = DataSourceConfiguration({"service_account_credentials": ""})
+    gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
 
     # Execute
     with pytest.raises(Exception, match="service_account_credentials can't be empty."):
-        _ = GoogleCloudStorageDataSource(configuration=configuration)
+        gcs_object._validate_configurations()
 
 
 @pytest.mark.asyncio
@@ -499,3 +501,28 @@ async def test_api_call_for_attribute_error(catch_stdout, patch_logger):
             userProject=mocked_gcs_object.user_project_id,
         ):
             print("Method called successfully....")
+
+
+def test_get_pem_format():
+    """This function tests prepare private key with dummy values"""
+    # Setup
+    expected_formated_pem_key = """-----BEGIN PRIVATE KEY-----
+PrivateKey
+-----END PRIVATE KEY-----"""
+    source = get_mocked_source_object()
+    private_key = "-----BEGIN PRIVATE KEY----- PrivateKey -----END PRIVATE KEY-----"
+
+    # Execute
+    formated_privat_key = source.get_pem_format(private_key, max_split=2)
+    assert formated_privat_key == expected_formated_pem_key
+
+    # Setup
+    expected_formated_certificate = """-----BEGIN CERTIFICATE-----
+Certificate1
+Certificate2
+-----END CERTIFICATE-----"""
+    private_key = "-----BEGIN CERTIFICATE----- Certificate1 Certificate2 -----END CERTIFICATE-----"
+
+    # Execute
+    formated_privat_key = source.get_pem_format(private_key, max_split=1)
+    assert formated_privat_key == expected_formated_certificate

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -525,4 +525,4 @@ def test_get_storage_client():
     first_instance = mocked_gcs_object.get_storage_client()
     second_instance = mocked_gcs_object.get_storage_client()
 
-    assert first_instance == second_instance
+    assert first_instance is second_instance

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -32,7 +32,6 @@ def get_mocked_source_object():
         {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS, "retry_count": 0}
     )
     mocked_gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
-    mocked_gcs_object._validate_configurations()
     mocked_gcs_object._initialize_configurations()
     return mocked_gcs_object
 
@@ -67,11 +66,14 @@ async def test_empty_configuration():
     gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
 
     # Execute
-    with pytest.raises(Exception, match="Service account json can't be empty."):
-        gcs_object._validate_configurations()
+    with pytest.raises(
+        Exception, match="Google Cloud service account json can't be empty."
+    ):
+        await gcs_object.validate_config()
 
 
-def test_invalid_configuration():
+@pytest.mark.asyncio
+async def test_invalid_configuration():
     """Tests that the service account credential is in invalid json format"""
 
     # Setup
@@ -81,8 +83,10 @@ def test_invalid_configuration():
     gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
 
     # Execute
-    with pytest.raises(Exception, match="Service account json is not in valid format."):
-        gcs_object._validate_configurations()
+    with pytest.raises(
+        Exception, match="Google Cloud service account is not a valid JSON"
+    ):
+        await gcs_object.validate_config()
 
 
 @pytest.mark.asyncio

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -32,7 +32,7 @@ def get_mocked_source_object():
         {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS, "retry_count": 0}
     )
     mocked_gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
-    mocked_gcs_object._initialize_configurations()
+    mocked_gcs_object.get_service_account_credentials()
     return mocked_gcs_object
 
 
@@ -73,9 +73,7 @@ async def test_empty_configuration():
 
 
 @pytest.mark.asyncio
-async def test_invalid_configuration():
-    """Tests that the service account credential is in invalid json format"""
-
+async def test_raise_on_invalid_configuration():
     # Setup
     configuration = DataSourceConfiguration(
         {"service_account_credentials": "{'abc':'bcd','cd'}"}
@@ -520,28 +518,3 @@ async def test_api_call_for_attribute_error(catch_stdout, patch_logger):
             userProject=mocked_gcs_object.user_project_id,
         ):
             print("Method called successfully....")
-
-
-def test_get_pem_format():
-    """This function tests prepare private key with dummy values"""
-    # Setup
-    expected_formated_pem_key = """-----BEGIN PRIVATE KEY-----
-PrivateKey
------END PRIVATE KEY-----"""
-    source = get_mocked_source_object()
-    private_key = "-----BEGIN PRIVATE KEY----- PrivateKey -----END PRIVATE KEY-----"
-
-    # Execute
-    formated_privat_key = source.get_pem_format(private_key, max_split=2)
-    assert formated_privat_key == expected_formated_pem_key
-
-    # Setup
-    expected_formated_certificate = """-----BEGIN CERTIFICATE-----
-Certificate1
-Certificate2
------END CERTIFICATE-----"""
-    private_key = "-----BEGIN CERTIFICATE----- Certificate1 Certificate2 -----END CERTIFICATE-----"
-
-    # Execute
-    formated_privat_key = source.get_pem_format(private_key, max_split=1)
-    assert formated_privat_key == expected_formated_certificate

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -22,7 +22,7 @@ API_NAME = "storage"
 API_VERSION = "v1"
 
 
-def get_mocked_source_object():
+def get_gcs_source_object():
     """Creates the mocked Google cloud storage object.
 
     Returns:
@@ -96,7 +96,7 @@ async def test_ping_for_successful_connection(catch_stdout, patch_logger):
         "kind": "storage#serviceAccount",
         "email_address": "serviceaccount@email.com",
     }
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
     as_service_account_response = asyncio.Future()
     as_service_account_response.set_result(expected_response)
 
@@ -114,7 +114,7 @@ async def test_ping_for_failed_connection(catch_stdout, patch_logger):
 
     # Setup
 
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
 
     # Execute
     with mock.patch.object(
@@ -173,7 +173,7 @@ def test_get_blob_document(previous_documents_list, updated_documents_list):
     """
 
     # Setup
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
 
     # Execute and Assert
     assert updated_documents_list == list(
@@ -186,7 +186,7 @@ async def test_fetch_buckets():
     """Tests the method which lists the storage buckets available in Google Cloud Storage."""
 
     # Setup
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
     expected_response = {
         "kind": "storage#objects",
         "items": [
@@ -238,7 +238,7 @@ async def test_fetch_blobs():
     """Tests the method responsible to yield blobs from Google Cloud Storage bucket."""
 
     # Setup
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
     expected_bucket_response = {
         "kind": "storage#objects",
         "items": [
@@ -287,7 +287,7 @@ async def test_get_docs():
     """Tests the module responsible to fetch and yield blobs documents from Google Cloud Storage."""
 
     # Setup
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
     expected_response = {
         "kind": "storage#objects",
         "items": [
@@ -341,7 +341,7 @@ async def test_get_docs_when_no_buckets_present():
     """
 
     # Setup
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
     expected_response = {
         "kind": "storage#objects",
     }
@@ -368,7 +368,7 @@ async def test_get_content():
     """Test the module responsible for fetching the content of the file if it is extractable."""
 
     # Setup
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
     blob_document = {
         "id": "bucket_1/blob_1/123123123",
         "component_count": None,
@@ -416,7 +416,7 @@ async def test_get_content_when_type_not_supported():
     """Test the module responsible for fetching the content of the file if it is not extractable or doit is not true."""
 
     # Setup
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
     blob_document = {
         "_id": "bucket_1/blob_1/123123123",
         "component_count": None,
@@ -460,7 +460,7 @@ async def test_get_content_when_file_size_is_large(catch_stdout, patch_logger):
     """Test the module responsible for fetching the content of the file if it is not extractable or doit is not true."""
 
     # Setup
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
     blob_document = {
         "_id": "bucket_1/blob_1/123123123",
         "component_count": None,
@@ -501,15 +501,15 @@ async def test_get_content_when_file_size_is_large(catch_stdout, patch_logger):
 
 @pytest.mark.asyncio
 async def test_api_call_for_attribute_error(catch_stdout, patch_logger):
-    """Tests the _api_call method when resource attribute is not present in the getattr."""
+    """Tests the api_call method when resource attribute is not present in the getattr."""
 
     # Setup
 
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
 
     # Execute
     with pytest.raises(AttributeError):
-        async for _ in mocked_gcs_object.get_storage_client()._api_call(
+        async for _ in mocked_gcs_object.get_storage_client().api_call(
             resource="buckets_dummy",
             method="list",
             full_response=True,
@@ -521,7 +521,7 @@ async def test_api_call_for_attribute_error(catch_stdout, patch_logger):
 
 def test_get_storage_client():
     """Test that the instance returned is always the same for the same datasource class."""
-    mocked_gcs_object = get_mocked_source_object()
+    mocked_gcs_object = get_gcs_source_object()
     first_instance = mocked_gcs_object.get_storage_client()
     second_instance = mocked_gcs_object.get_storage_client()
 

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -32,6 +32,7 @@ def get_mocked_source_object():
         {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS, "retry_count": 0}
     )
     mocked_gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
+    mocked_gcs_object._validate_configurations()
     mocked_gcs_object._initialize_configurations()
     return mocked_gcs_object
 
@@ -66,7 +67,21 @@ async def test_empty_configuration():
     gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
 
     # Execute
-    with pytest.raises(Exception, match="service_account_credentials can't be empty."):
+    with pytest.raises(Exception, match="Service account json can't be empty."):
+        gcs_object._validate_configurations()
+
+
+def test_invalid_configuration():
+    """Tests that the service account credential is in invalid json format"""
+
+    # Setup
+    configuration = DataSourceConfiguration(
+        {"service_account_credentials": "{'abc':'bcd','cd'}"}
+    )
+    gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
+
+    # Execute
+    with pytest.raises(Exception, match="Service account json is not in valid format."):
         gcs_object._validate_configurations()
 
 

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -398,7 +398,7 @@ async def test_get_content():
         Aiogoogle, "as_service_account", return_value=blob_content_response
     ):
         google_client = Aiogoogle(
-            service_account_creds=mocked_gcs_object.get_storage_client().service_account_credentials
+            service_account_creds=mocked_gcs_object._google_storage_client.service_account_credentials
         )
         storage_client = await google_client.discover(
             api_name=API_NAME, api_version=API_VERSION
@@ -437,7 +437,7 @@ async def test_get_content_when_type_not_supported():
 
     # Execute and Assert
     google_client = Aiogoogle(
-        service_account_creds=mocked_gcs_object.get_storage_client().service_account_credentials
+        service_account_creds=mocked_gcs_object._google_storage_client.service_account_credentials
     )
     storage_client = await google_client.discover(
         api_name=API_NAME, api_version=API_VERSION
@@ -481,7 +481,7 @@ async def test_get_content_when_file_size_is_large(catch_stdout, patch_logger):
 
     # Execute and Assert
     google_client = Aiogoogle(
-        service_account_creds=mocked_gcs_object.get_storage_client().service_account_credentials
+        service_account_creds=mocked_gcs_object._google_storage_client.service_account_credentials
     )
     storage_client = await google_client.discover(
         api_name=API_NAME, api_version=API_VERSION
@@ -509,20 +509,11 @@ async def test_api_call_for_attribute_error(catch_stdout, patch_logger):
 
     # Execute
     with pytest.raises(AttributeError):
-        async for _ in mocked_gcs_object.get_storage_client().api_call(
+        async for _ in mocked_gcs_object._google_storage_client.api_call(
             resource="buckets_dummy",
             method="list",
             full_response=True,
-            project=mocked_gcs_object.get_storage_client().user_project_id,
-            userProject=mocked_gcs_object.get_storage_client().user_project_id,
+            project=mocked_gcs_object._google_storage_client.user_project_id,
+            userProject=mocked_gcs_object._google_storage_client.user_project_id,
         ):
             print("Method called successfully....")
-
-
-def test_get_storage_client():
-    """Test that the instance returned is always the same for the same datasource class."""
-    mocked_gcs_object = get_gcs_source_object()
-    first_instance = mocked_gcs_object.get_storage_client()
-    second_instance = mocked_gcs_object.get_storage_client()
-
-    assert first_instance is second_instance

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -27,6 +27,7 @@ from connectors.utils import (
     RetryStrategy,
     convert_to_b64,
     get_base64_value,
+    get_pem_format,
     get_size,
     next_run,
     retryable,
@@ -336,3 +337,27 @@ async def test_exponential_backoff_retry():
 
     # would fail, if retried once (retry_interval = 5 seconds). Explicit time boundary for this test: 1 second
     await does_not_raise()
+
+
+def test_get_pem_format():
+    """This function tests prepare private key and certificate with dummy values"""
+    # Setup
+    expected_formated_pem_key = """-----BEGIN PRIVATE KEY-----
+PrivateKey
+-----END PRIVATE KEY-----"""
+    private_key = "-----BEGIN PRIVATE KEY----- PrivateKey -----END PRIVATE KEY-----"
+
+    # Execute
+    formated_privat_key = get_pem_format(key=private_key, max_split=2)
+    assert formated_privat_key == expected_formated_pem_key
+
+    # Setup
+    expected_formated_certificate = """-----BEGIN CERTIFICATE-----
+Certificate1
+Certificate2
+-----END CERTIFICATE-----"""
+    certificate = "-----BEGIN CERTIFICATE----- Certificate1 Certificate2 -----END CERTIFICATE-----"
+
+    # Execute
+    formated_certificate = get_pem_format(key=certificate, max_split=1)
+    assert formated_certificate == expected_formated_certificate

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -399,3 +399,19 @@ def retryable(retries=3, interval=1.0, strategy=RetryStrategy.LINEAR_BACKOFF):
         return func_to_execute
 
     return wrapper
+
+
+def get_pem_format(key, max_split=-1):
+    """Convert key into PEM format.
+
+    Args:
+        key (str): Key in raw format.
+        max_split (int): Specifies how many splits to do. Defaults to -1.
+
+    Returns:
+        string: PEM format
+    """
+    key = key.replace(" ", "\n")
+    key = " ".join(key.split("\n", max_split))
+    key = " ".join(key.rsplit("\n", max_split))
+    return key


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/466

This PR addresses the following changes:
- Parse the private-key present in the configurations passed from UI.
- Moves the configuration validation to a separate method.

## Checklists

<!--You can remove unrelated items from the checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally by running `make test` and `make ftest NAME=google_cloud_storage`
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] ~~Considered corresponding documentation changes~~
- [ ] ~~Contributed any configuration settings changes to the configuration reference~~
