### PR TITLE
Update validate_filtering function

### DIFF
--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -19,7 +19,7 @@ class ValidationTarget(Enum):
 
 
 async def validate_filtering(
-    connector, index, validation_target=ValidationTarget.ACTIVE
+    connector, source_klass, validation_target=ValidationTarget.ACTIVE
 ):
     filter_to_validate = (
         connector.filtering.get_active_filter()
@@ -27,11 +27,11 @@ async def validate_filtering(
         else connector.filtering.get_draft_filter()
     )
 
-    validation_result = await connector.source_klass(
-        connector.configuration
-    ).validate_filtering(filter_to_validate)
+    validation_result = await source_klass(connector.configuration).validate_filtering(
+        filter_to_validate
+    )
 
-    await index.update_filtering_validation(
+    await connector.index.update_filtering_validation(
         connector, validation_result, validation_target
     )
 


### PR DESCRIPTION
This PR extracts some changes from #474 , which updates `validate_filtering` function. 

`source_klass` is passed in as a param as `source_klass` won't be availbe in `Connector` class anymore.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference