### PR TITLE
[8.7] Refactor SyncJob class (#460)

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -340,10 +340,11 @@ class Filter(dict):
         )
 
     def get_advanced_rules(self):
-        return self.advanced_rules
+        return self.advanced_rules.get("value", {})
 
     def has_advanced_rules(self):
-        return len(self.advanced_rules) > 0
+        advanced_rules = self.get_advanced_rules()
+        return advanced_rules is not None and len(advanced_rules) > 0
 
     def has_validation_state(self, validation_state):
         return FilteringValidationState(self.validation["state"]) == validation_state

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -7,17 +7,17 @@
 Implementation of BYOC protocol.
 """
 import asyncio
+import socket
 import time
 from collections import UserDict
 from copy import deepcopy
-from datetime import datetime, timezone
 from enum import Enum
 
-from connectors.es import ESIndex, Mappings
+from connectors.es import ESDocument, ESIndex, Mappings
 from connectors.filtering.validation import (
     FilteringValidationState,
+    InvalidFilteringError,
     ValidationTarget,
-    validate_filtering,
 )
 from connectors.logger import logger
 from connectors.source import DataSourceConfiguration, get_source_klass
@@ -181,96 +181,120 @@ class ConnectorIndex(ESIndex):
             yield connector
 
 
-class SyncJob:
-    def __init__(self, elastic_index, connector_id, doc_source=None):
-        self.connector_id = connector_id
-        self.elastic_index = elastic_index
-        self.created_at = datetime.now(timezone.utc)
-        self.completed_at = None
-        self.filtering = Filter()
-        self.client = elastic_index.client
-        if doc_source is None:
-            doc_source = dict()
-
-        self.doc_source = doc_source
-        self.job_id = self.doc_source.get("_id")
-        self.status = JobStatus(self.doc_source.get("_source", {}).get("status"))
+class SyncJob(ESDocument):
+    @property
+    def status(self):
+        return JobStatus(self.get("status"))
 
     @property
-    def duration(self):
-        if self.completed_at is None:
-            return -1
-        msec = (self.completed_at - self.created_at).microseconds
-        return round(msec / 9, 2)
+    def error(self):
+        return self.get("error")
+
+    @property
+    def connector_id(self):
+        return self.get("connector", "id")
 
     @property
     def index_name(self):
-        return self.doc_source["_source"]["connector"]["index_name"]
+        return self.get("connector", "index_name")
 
-    async def start(self, trigger_method=JobTriggerMethod.SCHEDULED, filtering=None):
-        if filtering is None:
-            filtering = Filter()
+    @property
+    def language(self):
+        return self.get("connector", "language")
 
-        self.status = JobStatus.IN_PROGRESS
-        self.filtering = filtering
+    @property
+    def service_type(self):
+        return self.get("connector", "service_type")
 
-        job_def = {
-            "connector": {
-                "id": self.connector_id,
-                "filtering": SyncJob.transform_filtering(filtering),
-            },
-            "trigger_method": trigger_method.value,
-            "status": self.status.value,
-            "error": None,
-            "deleted_document_count": 0,
-            "indexed_document_count": 0,
-            "created_at": iso_utc(self.created_at),
-            "completed_at": None,
+    @property
+    def configuration(self):
+        return DataSourceConfiguration(self.get("connector", "configuration"))
+
+    @property
+    def filtering(self):
+        return Filter(self.get("connector", "filtering", default={}))
+
+    @property
+    def pipeline(self):
+        return Pipeline(self.get("connector", "pipeline"))
+
+    @property
+    def terminated(self):
+        return self.status in (JobStatus.ERROR, JobStatus.COMPLETED, JobStatus.CANCELED)
+
+    @property
+    def indexed_document_count(self):
+        return self.get("indexed_document_count", default=0)
+
+    @property
+    def indexed_document_volume(self):
+        return self.get("indexed_document_volume", default=0)
+
+    @property
+    def deleted_document_count(self):
+        return self.get("deleted_document_count", default=0)
+
+    @property
+    def total_document_count(self):
+        return self.get("total_document_count", default=0)
+
+    async def validate_filtering(self, validator):
+        validation_result = await validator.validate_filtering(self.filtering)
+
+        if validation_result.state != FilteringValidationState.VALID:
+            raise InvalidFilteringError(
+                f"Filtering in state {validation_result.state}, errors: {validation_result.errors}."
+            )
+
+    async def claim(self):
+        doc = {
+            "status": JobStatus.IN_PROGRESS.value,
+            "started_at": iso_utc(),
+            "last_seen": iso_utc(),
+            "worker_hostname": socket.gethostname(),
         }
-        resp = await self.client.index(index=JOBS_INDEX, document=job_def)
-        self.job_id = resp["_id"]
-        return self.job_id
+        await self.index.update(doc_id=self.id, doc=doc)
 
-    async def done(self, indexed_count=0, deleted_count=0, exception=None):
-        self.completed_at = datetime.now(timezone.utc)
-
-        job_def = {
-            "deleted_document_count": deleted_count,
-            "indexed_document_count": indexed_count,
-            "completed_at": iso_utc(self.completed_at),
-        }
-
-        if exception is None:
-            self.status = JobStatus.COMPLETED
-            job_def["error"] = None
-        else:
-            self.status = JobStatus.ERROR
-            job_def["error"] = str(exception)
-
-        job_def["status"] = self.status.value
-
-        return await self.client.update(index=JOBS_INDEX, id=self.job_id, doc=job_def)
-
-    async def suspend(self):
-        self.status = JobStatus.SUSPENDED
-        job_def = {"status": self.status.value}
-
-        await self.client.update(index=JOBS_INDEX, id=self.job_id, doc=job_def)
-
-    @classmethod
-    def transform_filtering(cls, filtering):
-        # deepcopy to not change the reference resulting in changing .elastic-connectors filtering
-        filtering = (
-            {"advanced_snippet": {}, "rules": []}
-            if (filtering is None or len(filtering) == 0)
-            else deepcopy(filtering)
+    async def done(self, ingestion_stats=None, connector_metadata=None):
+        await self._terminate(
+            JobStatus.COMPLETED, None, ingestion_stats, connector_metadata
         )
 
-        # extract value for sync job
-        filtering["advanced_snippet"] = filtering.get("advanced_snippet", {}).get(
-            "value", {}
+    async def fail(self, message, ingestion_stats=None, connector_metadata=None):
+        await self._terminate(
+            JobStatus.ERROR, str(message), ingestion_stats, connector_metadata
         )
-        return filtering
+
+    async def cancel(self, ingestion_stats=None, connector_metadata=None):
+        await self._terminate(
+            JobStatus.CANCELED, None, ingestion_stats, connector_metadata
+        )
+
+    async def suspend(self, ingestion_stats=None, connector_metadata=None):
+        await self._terminate(
+            JobStatus.SUSPENDED, None, ingestion_stats, connector_metadata
+        )
+
+    async def _terminate(
+        self, status, error=None, ingestion_stats=None, connector_metadata=None
+    ):
+        if ingestion_stats is None:
+            ingestion_stats = {}
+        if connector_metadata is None:
+            connector_metadata = {}
+        doc = {
+            "last_seen": iso_utc(),
+            "status": status.value,
+            "error": error,
+        }
+        if status in (JobStatus.ERROR, JobStatus.COMPLETED, JobStatus.CANCELED):
+            doc["completed_at"] = iso_utc()
+        if status == JobStatus.CANCELED:
+            doc["canceled_at"] = iso_utc()
+        doc.update(ingestion_stats)
+        if len(connector_metadata) > 0:
+            doc["metadata"] = connector_metadata
+        await self.index.update(doc_id=self.id, doc=doc)
 
 
 class Filtering:
@@ -309,9 +333,7 @@ class Filter(dict):
 
         super().__init__(filter_)
 
-        advanced_rules = filter_.get("advanced_snippet", {})
-
-        self.advanced_rules = advanced_rules.get("value", advanced_rules)
+        self.advanced_rules = filter_.get("advanced_snippet", {})
         self.basic_rules = filter_.get("rules", [])
         self.validation = filter_.get(
             "validation", {"state": FilteringValidationState.VALID.value, "errors": []}
@@ -325,6 +347,17 @@ class Filter(dict):
 
     def has_validation_state(self, validation_state):
         return FilteringValidationState(self.validation["state"]) == validation_state
+
+    def transform_filtering(self):
+        """
+        Transform the filtering in .elastic-connectors to filtering ready-to-use in .elastic-connectors-sync-jobs
+        """
+        # deepcopy to not change the reference resulting in changing .elastic-connectors filtering
+        filtering = (
+            {"advanced_snippet": {}, "rules": []} if len(self) == 0 else deepcopy(self)
+        )
+
+        return filtering
 
 
 PIPELINE_DEFAULT = {
@@ -551,21 +584,19 @@ class Connector:
             return SYNC_DISABLED
         return next_run(self.scheduling["interval"])
 
-    async def _sync_starts(self):
-        job = SyncJob(connector_id=self.id, elastic_index=self.index)
-        trigger_method = (
-            JobTriggerMethod.ON_DEMAND if self.sync_now else JobTriggerMethod.SCHEDULED
-        )
-        job_id = await job.start(trigger_method, self.filtering.get_active_filter())
+    async def _sync_starts(self, sync_job_index):
+        job_id = await sync_job_index.create(self)
+        sync_job = await sync_job_index.fetch_by_id(job_id)
+        await sync_job.claim()
 
         self.sync_now = self.doc_source["sync_now"] = False
-        self.doc_source["last_sync_status"] = job.status.value
+        self.doc_source["last_sync_status"] = JobStatus.IN_PROGRESS.value
         self.status = Status.CONNECTED
         await self.sync_doc()
 
         self._start_time = time.time()
         logger.info(f"Sync starts, Job id: {job_id}")
-        return job
+        return await sync_job_index.fetch_by_id(job_id)
 
     async def error(self, error):
         self.doc_source["error"] = str(error)
@@ -580,39 +611,60 @@ class Connector:
         await self.sync_doc()
         logger.info(f"Sync suspended, Job id: {job.job_id}")
 
-    async def _sync_done(self, job, result, exception=None):
+    async def _sync_done(self, job, status, result, exception=None):
         doc_updated = result.get("doc_updated", 0)
         doc_created = result.get("doc_created", 0)
         doc_deleted = result.get("doc_deleted", 0)
         exception = result.get("fetch_error", exception)
+        if exception is not None:
+            status = JobStatus.ERROR
 
         indexed_count = doc_updated + doc_created
+        ingestion_stats = {
+            "indexed_document_count": indexed_count,
+            "indexed_document_volume": 0,
+            "deleted_document_count": doc_deleted,
+        }
 
-        await job.done(indexed_count, doc_deleted, exception)
-
-        self.doc_source["last_sync_status"] = job.status.value
-        if exception is None:
-            self.doc_source["last_sync_error"] = None
-            self.doc_source["error"] = None
+        job_id = job.id
+        if status == JobStatus.ERROR:
+            await job.fail(exception, ingestion_stats=ingestion_stats)
+        elif status == JobStatus.SUSPENDED:
+            await job.suspend(ingestion_stats=ingestion_stats)
+            logger.info(f"Sync suspended, Job id: {job.id}")
         else:
-            self.doc_source["last_sync_error"] = str(exception)
-            self.doc_source["error"] = str(exception)
-            self.status = Status.ERROR
+            await job.done(ingestion_stats=ingestion_stats)
 
+        job = await job.reload()
+        await self.sync_done(job)
+        logger.info(
+            f"[{job_id}] Sync done: {doc_updated + doc_created} indexed, {doc_deleted} "
+            f" deleted. ({int(time.time() - self._start_time)} seconds)"
+        )
+
+    async def sync_done(self, job):
+        self.doc_source["last_sync_status"] = job.status.value
+        self.doc_source["last_sync_error"] = job.error
+        self.doc_source["error"] = job.error
+        self.status = (
+            Status.ERROR if job.status == JobStatus.ERROR else Status.CONNECTED
+        )
         self.doc_source["last_synced"] = iso_utc()
         await self.sync_doc()
 
-    async def prepare_docs(self, data_provider, filtering=None):
+    async def prepare_docs(self, data_provider, pipeline=None, filtering=None):
+        if pipeline is None:
+            pipeline = Pipeline({})
         if filtering is None:
             filtering = Filter()
 
-        logger.debug(f"Using pipeline {self.pipeline}")
+        logger.debug(f"Using pipeline {pipeline}")
 
         async for doc, lazy_download in data_provider.get_docs(filtering=filtering):
             # adapt doc for pipeline settings
-            doc["_extract_binary_content"] = self.pipeline["extract_binary_content"]
-            doc["_reduce_whitespace"] = self.pipeline["reduce_whitespace"]
-            doc["_run_ml_inference"] = self.pipeline["run_ml_inference"]
+            doc["_extract_binary_content"] = pipeline["extract_binary_content"]
+            doc["_reduce_whitespace"] = pipeline["reduce_whitespace"]
+            doc["_run_ml_inference"] = pipeline["run_ml_inference"]
             yield doc, lazy_download
 
     async def prepare(self, config):
@@ -666,7 +718,7 @@ class Connector:
 
         self.source_klass = source_klass
 
-    async def sync(self, elastic_server, idling):
+    async def sync(self, sync_job_index, elastic_server, idling):
         # If anything bad happens before we create a sync job
         # (like bad scheduling config, etc.)
         #
@@ -717,7 +769,7 @@ class Connector:
         logger.debug(f"Syncing '{service_type}'")
         self._syncing = True
         self._sync_task = asyncio.current_task()
-        job = await self._sync_starts()
+        job = await self._sync_starts(sync_job_index)
         try:
             logger.debug(f"Pinging the {self.data_provider} backend")
             await self.data_provider.ping()
@@ -740,32 +792,24 @@ class Connector:
             sync_rules_enabled = self.features.sync_rules_enabled()
 
             if sync_rules_enabled:
-                await validate_filtering(self, self.index, ValidationTarget.ACTIVE)
+                await job.validate_filtering(validator=self.data_provider)
 
             result = await elastic_server.async_bulk(
-                self.index_name,
-                self.prepare_docs(self.data_provider, job.filtering),
-                self.pipeline,
-                filter=self.filtering.get_active_filter(),
+                job.index_name,
+                self.prepare_docs(self.data_provider, job.pipeline, job.filtering),
+                job.pipeline,
+                filter=job.filtering,
                 sync_rules_enabled=sync_rules_enabled,
                 options=bulk_options,
             )
-            await self._sync_done(job, result)
+            await self._sync_done(job, JobStatus.COMPLETED, result)
         except asyncio.CancelledError:
-            await self._sync_suspended(job)
+            await self._sync_done(job, JobStatus.SUSPENDED, {})
+            logger.info(f"Sync suspended, Job id: {job.id}")
         except Exception as e:
-            await self._sync_done(job, {}, exception=e)
+            await self._sync_done(job, JobStatus.ERROR, {}, exception=e)
             raise
         finally:
-            if result is None:
-                result = {}
-            doc_updated = result.get("doc_updated", 0)
-            doc_created = result.get("doc_created", 0)
-            doc_deleted = result.get("doc_deleted", 0)
-            logger.info(
-                f"[{self.id}] Sync done: {doc_updated + doc_created} indexed, {doc_deleted} "
-                f" deleted. ({int(time.time() - self._start_time)} seconds)"
-            )
             self._syncing = False
             self._start_time = None
             self._sync_task = None
@@ -794,7 +838,6 @@ class SyncJobIndex(ESIndex):
         """
         return SyncJob(
             self,
-            connector_id=doc_source["_source"]["connector"]["id"],
             doc_source=doc_source,
         )
 
@@ -804,11 +847,11 @@ class SyncJobIndex(ESIndex):
             if connector.sync_now
             else JobTriggerMethod.SCHEDULED
         )
-        filtering = connector.filtering.get_active_filter()
+        filtering = connector.filtering.get_active_filter().transform_filtering()
         job_def = {
             "connector": {
                 "id": connector.id,
-                "filtering": SyncJob.transform_filtering(filtering),
+                "filtering": filtering,
                 "index_name": connector.index_name,
                 "language": connector.language,
                 "pipeline": connector.pipeline.data,

--- a/connectors/es/__init__.py
+++ b/connectors/es/__init__.py
@@ -4,5 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 from connectors.es.client import ESClient  # NOQA
+from connectors.es.document import ESDocument, InvalidDocumentSourceError  # NOQA
 from connectors.es.index import ESIndex  # NOQA
 from connectors.es.settings import DEFAULT_LANGUAGE, Mappings  # NOQA

--- a/connectors/es/document.py
+++ b/connectors/es/document.py
@@ -1,0 +1,43 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+class InvalidDocumentSourceError(Exception):
+    pass
+
+
+class ESDocument:
+    """
+    Represents a document in an Elasticsearch index.
+    """
+
+    def __init__(self, elastic_index, doc_source):
+        self.index = elastic_index
+        if not isinstance(doc_source, dict):
+            raise InvalidDocumentSourceError(
+                f"Invalid type found for doc_source: {type(doc_source).__name__}, expected: {dict.__name__}"
+            )
+        self.id = doc_source.get("_id")
+        if not isinstance(self.id, str):
+            raise InvalidDocumentSourceError(
+                f"Invalid type found for id: {type(self.id).__name__}, expected: {str.__name__}"
+            )
+        self._source = doc_source.get("_source", {})
+        if not isinstance(self._source, dict):
+            raise InvalidDocumentSourceError(
+                f"Invalid type found for source: {type(self._source).__name__}, expected: {dict.__name__}"
+            )
+
+    def get(self, *keys, default=None):
+        value = self._source
+        for key in keys:
+            if not isinstance(value, dict):
+                return default
+            value = value.get(key)
+        if value is None:
+            return default
+        return value
+
+    async def reload(self):
+        return await self.index.fetch_by_id(self.id)

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -52,7 +52,7 @@ class ESIndex(ESClient):
                 return None
             raise
 
-        return self._create_object(resp)
+        return self._create_object(resp.body)
 
     async def index(self, doc):
         resp = await self.client.index(index=self.index_name, document=doc)

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -693,11 +693,11 @@ def test_get_draft_filter(domain, expected_filter):
     [
         (
             {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
-            {"advanced_snippet": {"query": {}}, "rules": []},
+            {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
         ),
         (
             {"advanced_snippet": {"value": {}}, "rules": []},
-            {"advanced_snippet": {}, "rules": []},
+            {"advanced_snippet": {"value": {}}, "rules": []},
         ),
         ({"advanced_snippet": {}, "rules": []}, {"advanced_snippet": {}, "rules": []}),
         ({}, {"advanced_snippet": {}, "rules": []}),

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -29,10 +29,13 @@ from connectors.byoc import (
     SyncJobIndex,
     iso_utc,
 )
-from connectors.byoei import ElasticServer
 from connectors.config import load_config
-from connectors.filtering.validation import FilteringValidationState, ValidationTarget
-from connectors.logger import logger
+from connectors.filtering.validation import (
+    FilteringValidationResult,
+    FilteringValidationState,
+    InvalidFilteringError,
+    ValidationTarget,
+)
 from connectors.source import BaseDataSource
 from connectors.tests.commons import AsyncIterator
 
@@ -198,7 +201,7 @@ ADVANCED_AND_BASIC_RULES_NON_EMPTY = {
 @pytest.fixture(autouse=True)
 def patch_validate_filtering_in_byoc():
     with mock.patch(
-        "connectors.byoc.validate_filtering", return_value=AsyncMock()
+        "connectors.byoc.SyncJob.validate_filtering", return_value=AsyncMock()
     ) as validate_filtering_mock:
         yield validate_filtering_mock
 
@@ -208,57 +211,6 @@ def test_utc():
     now = datetime.utcnow()
     then = json.loads(json.dumps({"date": iso_utc(when=now)}))["date"]
     assert now.isoformat() == then
-
-
-@pytest.mark.asyncio
-async def test_sync_job():
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
-    job_filtering = {
-        "advanced_snippet": ACTIVE_ADVANCED_SNIPPET,
-        "rules": [{"id": ACTIVE_RULE_ONE_ID}, {"id": ACTIVE_RULE_TWO_ID}],
-        "validation": FILTERING_VALIDATION_VALID,
-    }
-
-    jobs_index = SyncJobIndex(elastic_config=config)
-
-    index_mock = AsyncMock()
-    update_mock = AsyncMock()
-
-    jobs_index.client.index = index_mock
-    jobs_index.client.update = update_mock
-
-    job = SyncJob(connector_id="connector-id", elastic_index=jobs_index)
-
-    await job.start(filtering=job_filtering)
-
-    assert job.duration == -1
-    assert job.status == JobStatus.IN_PROGRESS
-    assert job.job_id is not None
-
-    job_def = index_mock.call_args.kwargs["document"]
-
-    expected_filtering = {
-        "advanced_snippet": {
-            # "value" should be omitted by extracting content inside "value" and moving it one level up
-            "find": {"settings": {}}
-        },
-        "rules": [{"id": ACTIVE_RULE_ONE_ID}, {"id": ACTIVE_RULE_TWO_ID}],
-        "validation": {"state": "valid", "errors": []},
-    }
-
-    assert job_def["status"] == "in_progress"
-    assert job_def["connector"]["filtering"] == expected_filtering
-
-    await job.done(12, 34)
-
-    assert job.status == JobStatus.COMPLETED
-    assert job.duration > 0
-
-    updated_job_def = update_mock.call_args.kwargs["doc"]
-
-    assert updated_job_def["status"] == "completed"
-    assert updated_job_def["indexed_document_count"] == 12
-    assert updated_job_def["deleted_document_count"] == 34
 
 
 mongo = {
@@ -425,170 +377,6 @@ class StubIndex:
         pass
 
 
-doc = {"_id": 1}
-max_concurrency = 0
-
-
-class Data(BaseDataSource):
-    name = "MongoDB"
-    service_type = "mongodb"
-
-    def __init__(self, connector):
-        super().__init__(connector)
-        self.concurrency = 0
-
-    @classmethod
-    def get_default_configuration(cls):
-        return {}
-
-    async def ping(self):
-        pass
-
-    async def changed(self):
-        return True
-
-    async def lazy(self, doit=True, timestamp=None):
-        if not doit:
-            return
-        self.concurrency += 1
-        global max_concurrency
-        max_concurrency = 0
-
-        if self.concurrency > max_concurrency:
-            max_concurrency = self.concurrency
-            logger.info(f"max_concurrency {max_concurrency}")
-        try:
-            await asyncio.sleep(0.01)
-            return {"extra_data": 100}
-        finally:
-            self.concurrency -= 1
-
-    async def get_docs(self, *args, **kw):
-        for _ in [doc] * 100:
-            yield {"_id": 1}, self.lazy
-
-    async def close(self):
-        pass
-
-    def tweak_bulk_options(self, options):
-        options["concurrent_downloads"] = 3
-
-
-@pytest.mark.parametrize("with_filtering", [True, False])
-@pytest.mark.asyncio
-async def test_sync_mongo(
-    with_filtering, mock_responses, patch_logger, patch_validate_filtering_in_byoc
-):
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
-    headers = {"X-Elastic-Product": "Elasticsearch"}
-    mock_responses.post(
-        "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
-    )
-
-    mock_responses.post(
-        "http://nowhere.com:9200/.elastic-connectors/_search?expand_wildcards=hidden",
-        payload={
-            "hits": {"hits": [{"_id": "1", "_source": mongo}], "total": {"value": 1}}
-        },
-        headers=headers,
-    )
-    mock_responses.put(
-        "http://nowhere.com:9200/.elastic-connectors/_doc/1",
-        payload={"_id": "1"},
-        headers=headers,
-    )
-    mock_responses.post(
-        "http://nowhere.com:9200/.elastic-connectors/_update/1",
-        headers=headers,
-        repeat=True,
-    )
-    mock_responses.put(
-        "http://nowhere.com:9200/.elastic-connectors/_doc/1",
-        payload={"_id": "1"},
-        headers=headers,
-    )
-    mock_responses.post(
-        "http://nowhere.com:9200/.elastic-connectors-sync-jobs/_doc",
-        payload={"_id": "1"},
-        headers=headers,
-    )
-    mock_responses.post(
-        "http://nowhere.com:9200/.elastic-connectors-sync-jobs/_update/1",
-        headers=headers,
-        repeat=True,
-    )
-    mock_responses.put(
-        "http://nowhere.com:9200/.elastic-connectors-sync-jobs/_doc/1",
-        payload={"_id": "1"},
-        headers=headers,
-    )
-    mock_responses.head(
-        "http://nowhere.com:9200/search-airbnb?expand_wildcards=open",
-        headers=headers,
-        repeat=True,
-    )
-    mock_responses.get(
-        "http://nowhere.com:9200/search-airbnb/_mapping?expand_wildcards=open",
-        payload={"search-airbnb": {"mappings": {}}},
-        headers=headers,
-    )
-    mock_responses.put(
-        "http://nowhere.com:9200/search-airbnb/_mapping?expand_wildcards=open",
-        headers=headers,
-    )
-    mock_responses.get(
-        "http://nowhere.com:9200/search-airbnb",
-        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}]}},
-        headers=headers,
-    )
-    mock_responses.get(
-        "http://nowhere.com:9200/search-airbnb/_search?scroll=5m",
-        payload={"hits": {"hits": [{"_id": "1", "_source": mongo}]}},
-        headers=headers,
-    )
-    mock_responses.post(
-        "http://nowhere.com:9200/search-airbnb/_search?scroll=5m",
-        payload={"_id": "1"},
-        headers=headers,
-    )
-    mock_responses.put(
-        "http://nowhere.com:9200/search-airbnb/_search?scroll=5m",
-        payload={"_id": "1"},
-        headers=headers,
-    )
-    mock_responses.put(
-        "http://nowhere.com:9200/_bulk?pipeline=ent-search-generic-ingestion",
-        payload={"items": []},
-        headers=headers,
-    )
-
-    es = ElasticServer(config)
-    connectors = ConnectorIndex(config)
-    service_config = {"sources": {"mongodb": "connectors.tests.test_byoc:Data"}}
-
-    try:
-        async for connector in connectors.supported_connectors(
-            native_service_types=["mongodb"]
-        ):
-            connector.features.sync_rules_enabled = Mock(return_value=with_filtering)
-
-            await connector.prepare(service_config)
-            await connector.sync(es, 0)
-            await connector.close()
-    finally:
-        await connectors.close()
-        await es.close()
-
-    if with_filtering:
-        assert patch_validate_filtering_in_byoc.call_count
-    else:
-        assert not patch_validate_filtering_in_byoc.call_count
-
-    # verify that the Data source was able to override the option
-    patch_logger.assert_not_present("max_concurrency 10")
-    patch_logger.assert_present("max_concurrency 3")
-
-
 @pytest.mark.asyncio
 async def test_properties(mock_responses):
     connector_src = {
@@ -623,6 +411,174 @@ async def test_properties(mock_responses):
 
     with pytest.raises(TypeError):
         connector.status = 1234
+
+
+@pytest.mark.asyncio
+async def test_sync_job_properties():
+    sync_job_src = {
+        "_id": "test",
+        "_source": {
+            "status": "error",
+            "error": "something wrong",
+            "indexed_document_count": 10,
+            "indexed_document_volume": 20,
+            "deleted_document_count": 30,
+            "total_document_count": 100,
+            "connector": {
+                "id": "connector_id",
+                "service_type": "test",
+                "index_name": "search-some-index",
+                "configuration": {},
+                "language": "en",
+                "filtering": {},
+                "pipeline": {},
+            },
+        },
+    }
+
+    index = Mock()
+    sync_job = SyncJob(elastic_index=index, doc_source=sync_job_src)
+
+    assert sync_job.id == "test"
+    assert sync_job.status == JobStatus.ERROR
+    assert sync_job.error == "something wrong"
+    assert sync_job.connector_id == "connector_id"
+    assert sync_job.service_type == "test"
+    assert sync_job.configuration.is_empty()
+    assert sync_job.index_name == "search-some-index"
+    assert sync_job.language == "en"
+    assert sync_job.indexed_document_count == 10
+    assert sync_job.indexed_document_volume == 20
+    assert sync_job.deleted_document_count == 30
+    assert sync_job.total_document_count == 100
+    assert isinstance(sync_job.filtering, Filter)
+    assert isinstance(sync_job.pipeline, Pipeline)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "validation_result_state, validation_result_errors, should_raise_exception",
+    [
+        (
+            FilteringValidationState.VALID,
+            [],
+            False,
+        ),
+        (
+            FilteringValidationState.INVALID,
+            ["something wrong"],
+            True,
+        ),
+    ],
+)
+async def test_sync_job_validate_filtering(
+    validation_result_state, validation_result_errors, should_raise_exception
+):
+    source = {"_id": "1"}
+    index = Mock()
+    validator = Mock()
+    validation_result = FilteringValidationResult(
+        state=validation_result_state, errors=validation_result_errors
+    )
+    validator.validate_filtering = AsyncMock(return_value=validation_result)
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+
+    try:
+        await sync_job.validate_filtering(validator=validator)
+    except InvalidFilteringError:
+        assert should_raise_exception
+
+
+@pytest.mark.asyncio
+async def test_sync_job_claim(patch_logger):
+    source = {"_id": "1"}
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "status": JobStatus.IN_PROGRESS.value,
+        "started_at": ANY,
+        "last_seen": ANY,
+        "worker_hostname": ANY,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.claim()
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_done(patch_logger):
+    source = {"_id": "1"}
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "last_seen": ANY,
+        "completed_at": ANY,
+        "status": JobStatus.COMPLETED.value,
+        "error": None,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.done()
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_fail(patch_logger):
+    source = {"_id": "1"}
+    message = "something wrong"
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "last_seen": ANY,
+        "completed_at": ANY,
+        "status": JobStatus.ERROR.value,
+        "error": message,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.fail(message)
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_cancel(patch_logger):
+    source = {"_id": "1"}
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "last_seen": ANY,
+        "completed_at": ANY,
+        "status": JobStatus.CANCELED.value,
+        "error": None,
+        "canceled_at": ANY,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.cancel()
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_suspend(patch_logger):
+    source = {"_id": "1"}
+    index = Mock()
+    index.update = AsyncMock(return_value=1)
+    expected_doc_source_update = {
+        "last_seen": ANY,
+        "status": JobStatus.SUSPENDED.value,
+        "error": None,
+    }
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    await sync_job.suspend()
+
+    index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
 
 
 class Banana(BaseDataSource):
@@ -749,7 +705,10 @@ def test_get_draft_filter(domain, expected_filter):
     ],
 )
 def test_transform_filtering(filtering, expected_transformed_filtering):
-    assert SyncJob.transform_filtering(filtering) == expected_transformed_filtering
+    assert (
+        Filter(filter_=filtering).transform_filtering()
+        == expected_transformed_filtering
+    )
 
 
 @pytest.mark.parametrize(
@@ -1033,7 +992,7 @@ async def test_create_job(
     connector.language = "en"
     config = load_config(CONFIG)
     connector.sync_now = sync_now
-    connector.filtering.get_active_filter.return_value = Filter()
+    connector.filtering.get_active_filter.transform_filtering.return_value = Filter()
     connector.pipeline = Pipeline({})
 
     expected_index_doc = {
@@ -1137,11 +1096,11 @@ async def test_idle_jobs(get_all_docs, patch_logger, set_env):
 @pytest.mark.parametrize(
     "filtering, should_advanced_rules_be_present",
     [
-        (ADVANCED_RULES_NON_EMPTY, True),
-        (ADVANCED_AND_BASIC_RULES_NON_EMPTY, True),
-        (ADVANCED_RULES_EMPTY, False),
-        (BASIC_RULES_NON_EMPTY, False),
-        (EMPTY_FILTERING, False),
+        ({"advanced_snippet": {"value": ADVANCED_RULES_NON_EMPTY}}, True),
+        ({"advanced_snippet": {"value": ADVANCED_AND_BASIC_RULES_NON_EMPTY}}, True),
+        ({"advanced_snippet": {"value": {}}}, False),
+        ({"advanced_snippet": {"value": None}}, False),
+        ({"advanced_snippet": {"value": {}}, "rules": BASIC_RULES_NON_EMPTY}, False),
         (None, False),
     ],
 )
@@ -1165,23 +1124,6 @@ def test_has_validation_state(
         Filter(filtering).has_validation_state(validation_state)
         == has_expected_validation_state
     )
-
-
-@pytest.mark.parametrize(
-    "filtering, expected_advanced_rules",
-    (
-        [
-            (ADVANCED_RULES_NON_EMPTY, ADVANCED_RULES),
-            (ADVANCED_AND_BASIC_RULES_NON_EMPTY, ADVANCED_RULES),
-            (ADVANCED_RULES_EMPTY, {}),
-            (BASIC_RULES_NON_EMPTY, {}),
-            (EMPTY_FILTERING, {}),
-            (None, {}),
-        ]
-    ),
-)
-def test_extract_advanced_rules(filtering, expected_advanced_rules):
-    assert Filter(filtering).get_advanced_rules() == expected_advanced_rules
 
 
 @pytest.mark.parametrize(
@@ -1229,3 +1171,17 @@ async def test_prepare_docs(filtering, expected_filtering_calls):
 def test_pipeline_properties(key, value, default_value):
     assert Pipeline({})[key] == default_value
     assert Pipeline({key: value})[key] == value
+
+
+@pytest.mark.parametrize(
+    "filtering, expected_advanced_rules",
+    [
+        ({"advanced_snippet": {"value": {"query": {}}}, "rules": []}, {"query": {}}),
+        ({"advanced_snippet": {"value": {}}, "rules": []}, {}),
+        ({"advanced_snippet": {}, "rules": []}, {}),
+        ({}, {}),
+        (None, {}),
+    ],
+)
+def test_get_advanced_rules(filtering, expected_advanced_rules):
+    assert Filter(filtering).get_advanced_rules() == expected_advanced_rules

--- a/connectors/tests/test_es_document.py
+++ b/connectors/tests/test_es_document.py
@@ -1,0 +1,55 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+import pytest
+
+from connectors.es import ESDocument, InvalidDocumentSourceError
+
+
+@pytest.mark.parametrize(
+    "doc_source",
+    [
+        None,
+        "hahaha",
+        {},
+        {"_id": {}},
+        {"_id": "1", "_source": "hahaha"},
+    ],
+)
+def test_es_document_raise(doc_source, patch_logger):
+    with pytest.raises(InvalidDocumentSourceError):
+        ESDocument(elastic_index=None, doc_source=doc_source)
+
+
+def test_es_document_ok(patch_logger):
+    doc_source = {"_id": "1", "_source": {}}
+    es_document = ESDocument(elastic_index=None, doc_source=doc_source)
+    assert isinstance(es_document, ESDocument)
+
+
+def test_es_document_get():
+    source = {
+        "_id": "test",
+        "_source": {
+            "string": "string_value",
+            "none_value": None,
+            "empty_dict": {},
+            "nested_dict": {"string": "string_value"},
+        },
+    }
+    default_value = "default"
+    es_doc = ESDocument(elastic_index=None, doc_source=source)
+    assert es_doc.id == "test"
+    assert es_doc.get("string", default=default_value) == "string_value"
+    assert es_doc.get("non_existing") is None
+    assert es_doc.get("non_existing", default=default_value) == default_value
+    assert es_doc.get("empty_dict", default=default_value) == {}
+    assert es_doc.get("empty_dict", "string") is None
+    assert es_doc.get("empty_dict", "string", default=default_value) == default_value
+    assert es_doc.get("nested_dict", "non_existing") is None
+    assert (
+        es_doc.get("nested_dict", "non_existing", default=default_value)
+        == default_value
+    )

--- a/connectors/tests/test_job_cleanup.py
+++ b/connectors/tests/test_job_cleanup.py
@@ -5,7 +5,7 @@
 #
 
 import asyncio
-from unittest.mock import AsyncMock, Mock, call, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -35,7 +35,7 @@ def mock_connector(id="1", index_name="index_name"):
     connector = Mock()
     connector.id = id
     connector.index_name = index_name
-    connector._sync_done = AsyncMock()
+    connector.sync_done = AsyncMock()
     return connector
 
 
@@ -44,6 +44,7 @@ def mock_sync_job(id="1", connector_id="1", index_name="index_name"):
     job.job_id = id
     job.connector_id = connector_id
     job.index_name = index_name
+    job.fail = AsyncMock()
     return job
 
 
@@ -56,6 +57,7 @@ async def run_service_with_stop_after(service, stop_after):
 
 
 @pytest.mark.asyncio
+@patch("connectors.byoc.SyncJobIndex.fetch_by_id")
 @patch("connectors.byoc.SyncJobIndex.delete_jobs")
 @patch("connectors.byoc.SyncJobIndex.delete_indices")
 @patch("connectors.byoc.SyncJobIndex.idle_jobs")
@@ -66,11 +68,13 @@ async def run_service_with_stop_after(service, stop_after):
 async def test_cleanup_jobs(
     all_connectors,
     supported_connectors,
-    fetch_by_id,
+    connector_fetch_by_id,
     orphaned_jobs,
     idle_jobs,
     delete_indices,
     delete_jobs,
+    sync_job_fetch_by_id,
+    patch_logger,
 ):
     existing_index_name = "foo"
     to_be_deleted_index_name = "bar"
@@ -80,18 +84,16 @@ async def test_cleanup_jobs(
 
     all_connectors.return_value = AsyncIterator([connector])
     supported_connectors.return_value = AsyncIterator([connector])
-    fetch_by_id.return_value = connector
+    connector_fetch_by_id.return_value = connector
     orphaned_jobs.return_value = AsyncIterator([sync_job, another_sync_job])
     idle_jobs.return_value = AsyncIterator([sync_job])
     delete_jobs.return_value = {"deleted": 1, "failures": [], "total": 1}
+    sync_job_fetch_by_id.return_value = sync_job
 
     service = create_service()
     await run_service_with_stop_after(service, 0.1)
 
-    assert delete_indices.call_args_list == [call(indices=[to_be_deleted_index_name])]
-    assert delete_jobs.call_args_list == [
-        call(job_ids=[sync_job.job_id, another_sync_job.job_id])
-    ]
-    assert connector._sync_done.call_args_list == [
-        call(job=sync_job, result={}, exception=IDLE_JOB_ERROR)
-    ]
+    delete_indices.assert_called_with(indices=[to_be_deleted_index_name])
+    delete_jobs.assert_called_with(job_ids=[sync_job.id, another_sync_job.id])
+    sync_job.fail.assert_called_with(message=IDLE_JOB_ERROR)
+    connector.sync_done.assert_called_with(job=sync_job)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Refactor SyncJob class (#460)](https://github.com/elastic/connectors-python/pull/460)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)