### PR TITLE
Make MySQL connector terminate faster when connector is retrying

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -4,7 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """MySQL source module responsible to fetch documents from MySQL"""
-import asyncio
 import ssl
 from collections import OrderedDict
 
@@ -16,7 +15,7 @@ from connectors.filtering.validation import (
 )
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.utils import RetryStrategy, retryable
+from connectors.utils import CancellableSleeps, RetryStrategy, retryable
 
 MAX_POOL_SIZE = 10
 QUERIES = {
@@ -126,6 +125,7 @@ class MySqlDataSource(BaseDataSource):
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
         super().__init__(configuration=configuration)
+        self._sleeps = CancellableSleeps()
         self.retry_count = self.configuration["retry_count"]
         self.connection_pool = None
         self.ssl_disabled = self.configuration["ssl_disabled"]
@@ -190,9 +190,10 @@ class MySqlDataSource(BaseDataSource):
         return [MySQLAdvancedRulesValidator(self)]
 
     async def close(self):
+        self._sleeps.cancel()
         if self.connection_pool is None:
             return
-        self.connection_pool.close()
+        self.connection_pool.terminate()
         await self.connection_pool.wait_closed()
         self.connection_pool = None
 
@@ -319,7 +320,7 @@ class MySqlDataSource(BaseDataSource):
                                     yield row
 
                                 rows_fetched += rows_length
-                                await asyncio.sleep(0)
+                                await self._sleeps.sleep(0)
                         else:
                             yield await cursor.fetchall()
                         break
@@ -336,7 +337,7 @@ class MySqlDataSource(BaseDataSource):
                 if retry == self.retry_count:
                     raise exception
                 cursor_position = rows_fetched
-                await asyncio.sleep(RETRY_INTERVAL**retry)
+                await self._sleeps.sleep(RETRY_INTERVAL**retry)
                 retry += 1
 
     async def fetch_tables(self, database):
@@ -506,9 +507,9 @@ class MySqlDataSource(BaseDataSource):
                                 query=query,
                             ):
                                 yield row, None
-                            await asyncio.sleep(0)
+                            await self._sleeps.sleep(0)
         else:
             for database in databases:
                 async for row in self.fetch_rows_from_all_tables(database=database):
                     yield row, None
-                await asyncio.sleep(0)
+                await self._sleeps.sleep(0)

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -193,7 +193,7 @@ class MySqlDataSource(BaseDataSource):
         self._sleeps.cancel()
         if self.connection_pool is None:
             return
-        self.connection_pool.terminate()
+        self.connection_pool.close()
         await self.connection_pool.wait_closed()
         self.connection_pool = None
 

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -197,6 +197,9 @@ class ConnectionPool:
     def close(self):
         pass
 
+    def terminate(self):
+        pass
+
     async def wait_closed(self):
         pass
 

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -197,9 +197,6 @@ class ConnectionPool:
     def close(self):
         pass
 
-    def terminate(self):
-        pass
-
     async def wait_closed(self):
         pass
 


### PR DESCRIPTION
Small fix for a sleep line in MySQL connector:

```
RETRY_INTERVAL = 2

await asyncio.sleep(RETRY_INTERVAL**retry)
```

Retry count is user's input. What it means is that if something goes wrong and connector has to retry, let's say, 5 times, last sleep will be 2^5 = 32 seconds. If service is interrupted during this time, it'll have to wait until these 32 seconds pass.

This change makes use of CancellableSleep so that if service is stopped, user won't have to wait for remaining sleep time until service is interrupted.


## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
