### PR TITLE
[Generic Database Connector] Use singular for database label

### DIFF
--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -74,7 +74,7 @@ class GenericBaseDataSource(BaseDataSource):
             },
             "database": {
                 "value": "xe",
-                "label": "Databases",
+                "label": "Database",
                 "type": "str",
             },
             "fetch_size": {


### PR DESCRIPTION
We only allow one database for Oracle and PostgreSQL to be configured. This should also be reflected in the label.