### PR TITLE
Set logger before parsing config

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -113,7 +113,17 @@ def run(args):
     """Runner"""
 
     # load config
-    config = load_config(args.config_file)
+    config = {}
+    try:
+        config = load_config(args.config_file)
+    except Exception as e:
+        # If something goes wrong while parsing config file, we still want
+        # to set up the logger so that Cloud deployments report errors to
+        # logs properly
+        set_logger(logging.INFO, filebeat=args.filebeat)
+        logger.exception(f"Could not parse {args.config_file}:\n{e}")
+        raise
+
     # Precedence: CLI args >> Config Setting >> INFO
     set_logger(
         args.log_level or config["service"]["log_level"] or logging.INFO,

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -4,14 +4,18 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
+import logging
 import os
 import signal
 from io import StringIO
 from unittest import mock
 from unittest.mock import patch
 
+import pytest
+
 from connectors import __version__
 from connectors.cli import main, run
+from connectors.logger import logger
 
 CONFIG = os.path.join(os.path.dirname(__file__), "config.yml")
 
@@ -58,3 +62,16 @@ def test_run(mock_responses, patch_logger, set_env):
         assert "- Fakey" in output
         assert "- Phatey" in output
         assert "Bye" in output
+
+
+@patch("connectors.cli.set_logger")
+@patch("connectors.cli.load_config", side_effect=Exception("something went wrong"))
+def test_main_with_invalid_configuration(load_config, set_logger, patch_logger):
+    args = mock.MagicMock()
+    args.log_level = logging.DEBUG  # should be ignored!
+    args.filebeat = True
+
+    with pytest.raises(Exception):
+        run(args)
+
+    set_logger.assert_called_with(logging.INFO, filebeat=True)

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -15,7 +15,6 @@ import pytest
 
 from connectors import __version__
 from connectors.cli import main, run
-from connectors.logger import logger
 
 CONFIG = os.path.join(os.path.dirname(__file__), "config.yml")
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3900

Quoting:

> Certain logging like connectors yml parsing errors have no logger or log level specification so it is easy to be missed by admins/support.

We want Cloud (and other) deployments to properly report errors about parsing config files. To do so, I'm wrapping parsing of config file in try/except and in case error happens use provided `--filebeat` option + set log level to INFO (can actually do DEBUG, doesn't matter as long as it reports errors).

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
