### PR TITLE
Rename param filter to filter_

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -749,7 +749,7 @@ class Connector(ESDocument):
                 job.index_name,
                 self.prepare_docs(data_provider, job.pipeline, job.filtering),
                 job.pipeline,
-                filter=job.filtering,
+                filter_=job.filtering,
                 sync_rules_enabled=sync_rules_enabled,
                 options=bulk_options,
             )

--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -177,14 +177,14 @@ class Fetcher:
         queue,
         index,
         existing_ids,
-        filter=None,
+        filter_=None,
         sync_rules_enabled=False,
         queue_size=DEFAULT_QUEUE_SIZE,
         display_every=DEFAULT_DISPLAY_EVERY,
         concurrent_downloads=DEFAULT_CONCURRENT_DOWNLOADS,
     ):
-        if filter is None:
-            filter = Filter()
+        if filter_ is None:
+            filter_ = Filter()
         self.client = client
         self.queue = queue
         self.bulk_time = 0
@@ -198,9 +198,9 @@ class Fetcher:
         self.total_docs_created = 0
         self.total_docs_deleted = 0
         self.fetch_error = None
-        self.filter = filter
+        self.filter_ = filter_
         self.basic_rule_engine = (
-            BasicRuleEngine(parse(filter.basic_rules)) if sync_rules_enabled else None
+            BasicRuleEngine(parse(filter_.basic_rules)) if sync_rules_enabled else None
         )
         self.display_every = display_every
         self.concurrent_downloads = concurrent_downloads
@@ -414,12 +414,12 @@ class ElasticServer(ESClient):
         index,
         generator,
         pipeline,
-        filter=None,
+        filter_=None,
         sync_rules_enabled=False,
         options=None,
     ):
-        if filter is None:
-            filter = Filter()
+        if filter_ is None:
+            filter_ = Filter()
         if options is None:
             options = {}
         queue_size = options.get("queue_max_size", DEFAULT_QUEUE_SIZE)
@@ -447,7 +447,7 @@ class ElasticServer(ESClient):
             stream,
             index,
             existing_ids,
-            filter=filter,
+            filter_=filter_,
             sync_rules_enabled=sync_rules_enabled,
             queue_size=queue_size,
             display_every=display_every,

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -357,7 +357,7 @@ async def setup_fetcher(basic_rule_engine, existing_docs, queue, sync_rules_enab
     # filtering content doesn't matter as the BasicRuleEngine behavior is mocked
     filter_mock = Mock()
     filter_mock.get_active_filter = Mock(return_value={})
-    fetcher = Fetcher(client, queue, INDEX, existing_ids, filter=filter_mock)
+    fetcher = Fetcher(client, queue, INDEX, existing_ids, filter_=filter_mock)
     fetcher.basic_rule_engine = basic_rule_engine if sync_rules_enabled else None
     return fetcher
 


### PR DESCRIPTION
This PR is to rename the param `filter` in `Fetcher` class and `async_bulk` method to `filter_`, as `filter` is a built-in name.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference