### PR TITLE
[8.7] Set logger before parsing config (#524)

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -113,7 +113,17 @@ def run(args):
     """Runner"""
 
     # load config
-    config = load_config(args.config_file)
+    config = {}
+    try:
+        config = load_config(args.config_file)
+    except Exception as e:
+        # If something goes wrong while parsing config file, we still want
+        # to set up the logger so that Cloud deployments report errors to
+        # logs properly
+        set_logger(logging.INFO, filebeat=args.filebeat)
+        logger.exception(f"Could not parse {args.config_file}:\n{e}")
+        raise
+
     # Precedence: CLI args >> Config Setting >> INFO
     set_logger(
         args.log_level or config["service"]["log_level"] or logging.INFO,

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -4,11 +4,14 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
+import logging
 import os
 import signal
 from io import StringIO
 from unittest import mock
 from unittest.mock import patch
+
+import pytest
 
 from connectors import __version__
 from connectors.cli import main, run
@@ -58,3 +61,16 @@ def test_run(mock_responses, patch_logger, set_env):
         assert "- Fakey" in output
         assert "- Phatey" in output
         assert "Bye" in output
+
+
+@patch("connectors.cli.set_logger")
+@patch("connectors.cli.load_config", side_effect=Exception("something went wrong"))
+def test_main_with_invalid_configuration(load_config, set_logger, patch_logger):
+    args = mock.MagicMock()
+    args.log_level = logging.DEBUG  # should be ignored!
+    args.filebeat = True
+
+    with pytest.raises(Exception):
+        run(args)
+
+    set_logger.assert_called_with(logging.INFO, filebeat=True)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Set logger before parsing config (#524)](https://github.com/elastic/connectors-python/pull/524)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)