### PR TITLE
[Generic Database Connector] Make tables configurable

### DIFF
--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -13,9 +13,27 @@ from connectors.logger import logger
 from connectors.source import BaseDataSource
 from connectors.utils import iso_utc
 
+ALL_TABLES = "*"
+
 DEFAULT_FETCH_SIZE = 50
 DEFAULT_RETRY_COUNT = 3
 DEFAULT_WAIT_MULTIPLIER = 2
+
+
+def configured_tables(tables):
+    def table_filter(table):
+        return table is not None and len(table) > 0
+
+    return (
+        list(
+            filter(
+                lambda table: table_filter(table),
+                map(lambda table: table.strip(), tables.split(",")),
+            )
+        )
+        if isinstance(tables, str)
+        else list(filter(lambda table: table_filter(table), tables))
+    )
 
 
 class GenericBaseDataSource(BaseDataSource):
@@ -38,6 +56,7 @@ class GenericBaseDataSource(BaseDataSource):
         self.host = self.configuration["host"]
         self.port = self.configuration["port"]
         self.database = self.configuration["database"]
+        self.tables = self.configuration["tables"]
         self.is_async = False
         self.engine = None
         self.dialect = ""
@@ -77,6 +96,7 @@ class GenericBaseDataSource(BaseDataSource):
                 "label": "Databases",
                 "type": "str",
             },
+            "tables": {"value": ALL_TABLES, "label": "Tables", "type": "list"},
             "fetch_size": {
                 "value": DEFAULT_FETCH_SIZE,
                 "label": "Rows fetched per request",
@@ -95,13 +115,7 @@ class GenericBaseDataSource(BaseDataSource):
         Raises:
             Exception: Configured keys can't be empty
         """
-        connection_fields = [
-            "host",
-            "port",
-            "user",
-            "password",
-            "database",
-        ]
+        connection_fields = ["host", "port", "user", "password", "database", "tables"]
 
         if empty_connection_fields := [
             field for field in connection_fields if self.configuration[field] == ""
@@ -362,23 +376,15 @@ class GenericBaseDataSource(BaseDataSource):
         Yields:
             Dict: Row document to index
         """
-        # Query to get all table names from a database
-        list_of_tables = await anext(
-            self.execute_query(
-                query_name="ALL_TABLE",
-                user=self.user.upper(),
-                database=self.database,
+        tables_to_fetch = await self.get_tables_to_fetch(schema)
+
+        for table in tables_to_fetch:
+            logger.debug(f"Found table: {table} in database: {self.database}.")
+            async for row in self.fetch_documents(
+                table=table,
                 schema=schema,
-            )
-        )
-        if len(list_of_tables) > 0:
-            for [table_name] in list_of_tables:
-                logger.debug(f"Found table: {table_name} in database: {self.database}.")
-                async for row in self.fetch_documents(
-                    table=table_name,
-                    schema=schema,
-                ):
-                    yield row
+            ):
+                yield row
         else:
             if schema:
                 logger.warning(
@@ -386,3 +392,27 @@ class GenericBaseDataSource(BaseDataSource):
                 )
             else:
                 logger.warning(f"Fetched 0 tables for the database: {self.database}")
+
+    async def get_tables_to_fetch(self, schema):
+        tables = configured_tables(self.tables)
+        fetch_all_tables = tables == ALL_TABLES or (
+            isinstance(tables, list) and tables == [ALL_TABLES]
+        )
+
+        tables_to_fetch = (
+            map(
+                lambda table: table[0],
+                await anext(
+                    self.execute_query(
+                        query_name="ALL_TABLE",
+                        user=self.user.upper(),
+                        database=self.database,
+                        schema=schema,
+                    )
+                ),
+            )
+            if fetch_all_tables
+            else tables
+        )
+
+        return tables_to_fetch

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -14,10 +14,11 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
 from connectors.source import DataSourceConfiguration
-from connectors.sources.generic_database import GenericBaseDataSource
+from connectors.sources.generic_database import GenericBaseDataSource, configured_tables
 from connectors.sources.oracle import OracleDataSource
 from connectors.sources.postgresql import PostgreSQLDataSource
 from connectors.sources.tests.support import create_source
+from connectors.tests.commons import AsyncIterator
 
 POSTGRESQL_CONNECTION_STRING = (
     "postgresql+asyncpg://admin:changme@127.0.0.1:5432/testdb"
@@ -314,7 +315,7 @@ async def test_sync_connect_negative(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_execute_query_negative_for_internalclienterror(patch_logger):
+async def test_execute_query_negative_for_internal_client_error(patch_logger):
     """Test _execute_query method with negative case"""
     source = create_source(PostgreSQLDataSource)
     with patch.object(
@@ -360,3 +361,39 @@ async def test_execute_query_negative():
         # Execute
         with pytest.raises(Exception):
             await anext(source.execute_query("PING"))
+
+
+@pytest.mark.parametrize(
+    "tables, expected_tables",
+    [
+        ("", []),
+        ("table", ["table"]),
+        ("table_1, table_2", ["table_1", "table_2"]),
+        (["table_1", "table_2"], ["table_1", "table_2"]),
+        (["table_1", "table_2", ""], ["table_1", "table_2"]),
+    ],
+)
+def test_configured_tables(tables, expected_tables):
+    actual_tables = configured_tables(tables)
+
+    assert actual_tables == expected_tables
+
+
+@pytest.mark.parametrize("tables", ["*", ["*"]])
+@pytest.mark.asyncio
+async def test_get_tables_to_fetch_remote_tables(tables):
+    source = create_source(GenericBaseDataSource)
+    source.execute_query = AsyncIterator(["table"])
+
+    await source.get_tables_to_fetch("schema")
+
+    assert "ALL_TABLE" == source.execute_query.call_kwargs[0]["query_name"]
+
+
+@pytest.mark.asyncio
+async def test_get_tables_to_fetch_configured_tables():
+    source = create_source(GenericBaseDataSource)
+    tables = ["table_1", "table_2"]
+    source.tables = tables
+
+    assert tables == await source.get_tables_to_fetch("schema")

--- a/connectors/tests/commons.py
+++ b/connectors/tests/commons.py
@@ -22,9 +22,9 @@ class AsyncIterator:
 
     def __call__(self, *args, **kwargs):
         if args:
-            self.call_args.append(*args)
+            self.call_args.append(args)
 
         if kwargs:
-            self.call_kwargs.append(*kwargs.items())
+            self.call_kwargs.append(kwargs)
 
         return self

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -1142,12 +1142,9 @@ async def test_prepare_docs(filtering, expected_filtering_calls):
         assert yielded_doc is not None
 
     assert docs_generator_fake.call_kwargs == [
-        ("filtering", expected_filtering)
+        {"filtering": expected_filtering}
         for expected_filtering in expected_filtering_calls
     ]
-    assert all(
-        type(filter_) == Filter for _, filter_ in docs_generator_fake.call_kwargs
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3996
## Closes https://github.com/elastic/enterprise-search-team/issues/3997

This PR adds a new configuration to the generic database connector. This will be inherited by the oracle and PostgreSQL connector. 
The default value is set to fetch all tables, which is aligned with the previous behavior.

The PR contains a needed modification to `AsyncIterator`, which influenced one test in `test_byoc.py` therefore the change in that file.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~