### PR TITLE
[Docs] Document the filtering module

### DIFF
--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -328,7 +328,7 @@ class BasicRule:
         return self.policy == Policy.INCLUDE
 
     def coerce_rule_value_based_on_document_value(self, doc_value):
-        """Method coercing the value inside the basic rule.
+        """Coerce the value inside the basic rule.
 
         This method tries to coerce the value inside the basic rule to the type used in the document.
 

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -96,6 +96,7 @@ def try_coerce(value):
 
 class RuleMatchStats:
     """Class to record how many documents a basic rule matched and which policy it used."""
+
     def __init__(self, policy, matches_count):
         self.policy = policy
         self.matches_count = matches_count
@@ -117,6 +118,7 @@ class RuleMatchStats:
 
 class BasicRuleEngine:
     """Class executing a list of basic rules in order against a document."""
+
     def __init__(self, rules):
         self.rules = rules
         self.rules_match_stats = {

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -288,7 +288,7 @@ class BasicRule:
             - GREATER_THAN: Is the document's field value greater than the basic rule's value?
             - EQUALS: Is the document's field value equal to the basic rule's value?
 
-        If the basic rule is the default rule it's always a match.
+        If the basic rule is the default rule it's always a match (the default rule matches every document).
         If the field is not in the document it's always a no match.
 
         Arguments:

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -132,7 +132,7 @@ class BasicRuleEngine:
     def should_ingest(self, document):
         """Check, whether a document should be ingested or not.
 
-        By default the document will be ingested, if it doesn't match any rule.
+        By default, the document will be ingested, if it doesn't match any rule.
 
         Arguments:
         - `document`: document matched against the basic rules

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -95,7 +95,7 @@ def try_coerce(value):
 
 
 class RuleMatchStats:
-    """Class to record how many documents a basic rule matched and which policy it used."""
+    """RuleMatchStats records how many documents a basic rule matched and which policy it used."""
 
     def __init__(self, policy, matches_count):
         self.policy = policy

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -117,7 +117,11 @@ class RuleMatchStats:
 
 
 class BasicRuleEngine:
-    """Class executing a list of basic rules in order against a document."""
+    """BasicRuleEngine matches a document against a list of basic rules in order.
+
+    The main concern of the engine is to decide, whether a document should be ingested during a sync or not.
+    It also records stats, which basic rule matched how many documents with a certain policy.
+    """
 
     def __init__(self, rules):
         self.rules = rules
@@ -126,7 +130,7 @@ class BasicRuleEngine:
         }
 
     def should_ingest(self, document):
-        """Method to check, whether a document should be ingested or not.
+        """Check, whether a document should be ingested or not.
 
         On default the document will be ingested, if it doesn't match any rule.
 

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -119,7 +119,10 @@ class RuleMatchStats:
 class BasicRuleEngine:
     """BasicRuleEngine matches a document against a list of basic rules in order.
 
-    The main concern of the engine is to decide, whether a document should be ingested during a sync or not.
+    The main concern of the engine is to decide, whether a document should be ingested during a sync or not:
+        - If a document matches a basic rule and the basic rule uses the `INCLUDE` policy the document will be ingested
+        - If a document matches a basic rule and the basic rule uses the `EXCLUDE` policy the document won't be ingested
+
     It also records stats, which basic rule matched how many documents with a certain policy.
     """
 
@@ -236,7 +239,7 @@ class Policy(Enum):
 
 
 class BasicRule:
-    """Class representing a basic rule, which is part of the connector's filtering."""
+    """A BasicRule is used to match documents based on different comparisons (see `matches` method)."""
 
     DEFAULT_RULE_ID = "DEFAULT"
 
@@ -271,7 +274,7 @@ class BasicRule:
         )
 
     def matches(self, document):
-        """Method to check whether a document matches the basic rule.
+        """Check whether a document matches the basic rule.
 
         A basic rule matches or doesn't match a document based on the following comparisons:
             - STARTS_WITH: Does the document's field value start with the basic rule's value?

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -95,7 +95,10 @@ def try_coerce(value):
 
 
 class RuleMatchStats:
-    """RuleMatchStats records how many documents a basic rule matched and which policy it used."""
+    """RuleMatchStats records how many documents a basic rule matched and which policy it used.
+
+    It's an internal class and is not expected to be used outside the module.
+    """
 
     def __init__(self, policy, matches_count):
         self.policy = policy

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -323,7 +323,7 @@ class BasicRule:
         This method tries to coerce the value inside the basic rule to the type used in the document.
 
         Arguments:
-        - `doc_value`: one value of a document
+        - `doc_value`: value of the field in the document to coerce
 
         """
         try:

--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -200,6 +200,8 @@ class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
 
     A semantic duplicate is defined as two basic rules having the same values for `field`, `rule` and `value`.
     Therefore, two basic rules are also seen as semantic duplicates, if their `policy` values differ.
+
+    If a semantic duplicate is detected both rules will be marked as invalid.
     """
 
     @classmethod

--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -196,7 +196,7 @@ class BasicRulesSetValidator:
 
 
 class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
-    """Class validating, that a set of rules does not contain semantic duplicates.
+    """BasicRulesSetSemanticValidator can be used to validate that a set of filtering rules does not contain semantic duplicates.
 
     A semantic duplicate is defined as two basic rules having the same values for `field`, `rule` and `value`.
     Therefore, two basic rules are also seen as semantic duplicates, if their `policy` values differ.

--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -287,7 +287,7 @@ class BasicRuleNoMatchAllRegexValidator(BasicRuleValidator):
 
 
 class BasicRuleAgainstSchemaValidator(BasicRuleValidator):
-    """Class validating if a basic rule follows the specified json schema."""
+    """BasicRuleAgainstSchemaValidator can be used to check if basic rule follows specified json schema."""
 
     SCHEMA_DEFINITION = {
         "type": "object",

--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -21,6 +21,13 @@ class ValidationTarget(Enum):
 async def validate_filtering(
     connector, source_klass, validation_target=ValidationTarget.ACTIVE
 ):
+    """Validate filtering by calling the corresponding `validate_filtering` method of the `source_klass`.
+
+    Arguments:
+    - `connector`: connector instance
+    - `source_klass`: data source class
+    - `validation_target`: validation target to specify whether active or draft filtering should be validated
+    """
     filter_to_validate = (
         connector.filtering.get_active_filter()
         if validation_target == ValidationTarget.ACTIVE
@@ -223,6 +230,11 @@ class BasicRulesSetValidator:
 
 
 class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
+    """Class validating, that a set of rules does not contain semantic duplicates.
+
+    A semantic duplicate is defined as two basic rules having the same values for `field`, `rule` and `value`.
+    Therefore, two basic rules are also seen as semantic duplicates, if their `policy` values differ.
+    """
     @classmethod
     def validate(cls, rules):
         rules_dict = {}
@@ -282,6 +294,8 @@ class BasicRuleValidator:
 
 
 class BasicRuleNoMatchAllRegexValidator(BasicRuleValidator):
+    """Class validating that a basic rule does not use a match all regex."""
+
     MATCH_ALL_REGEXPS = [".*", "(.*)"]
 
     @classmethod
@@ -306,6 +320,8 @@ class BasicRuleNoMatchAllRegexValidator(BasicRuleValidator):
 
 
 class BasicRuleAgainstSchemaValidator(BasicRuleValidator):
+    """Class validating if a basic rule follows the specified json schema."""
+
     SCHEMA_DEFINITION = {
         "type": "object",
         "properties": {

--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -235,6 +235,7 @@ class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
     A semantic duplicate is defined as two basic rules having the same values for `field`, `rule` and `value`.
     Therefore, two basic rules are also seen as semantic duplicates, if their `policy` values differ.
     """
+
     @classmethod
     def validate(cls, rules):
         rules_dict = {}

--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -261,7 +261,7 @@ class BasicRuleValidator:
 
 
 class BasicRuleNoMatchAllRegexValidator(BasicRuleValidator):
-    """Class validating that a basic rule does not use a match all regex."""
+    """BasicRuleNoMatchAllRegexValidator can be used to check that a basic rule does not use a match all regex."""
 
     MATCH_ALL_REGEXPS = [".*", "(.*)"]
 

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -8,7 +8,6 @@ import json
 import os
 from copy import deepcopy
 from datetime import datetime
-from unittest import mock
 from unittest.mock import ANY, AsyncMock, Mock, call, patch
 
 import pytest
@@ -196,14 +195,6 @@ ADVANCED_AND_BASIC_RULES_NON_EMPTY = {
     "advanced_snippet": {"db": {"table": "SELECT * FROM db.table"}},
     "rules": RULES,
 }
-
-
-@pytest.fixture(autouse=True)
-def patch_validate_filtering_in_byoc():
-    with mock.patch(
-        "connectors.byoc.SyncJob.validate_filtering", return_value=AsyncMock()
-    ) as validate_filtering_mock:
-        yield validate_filtering_mock
 
 
 def test_utc():


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4017

Add documentation for the most important classes and methods in the filtering module. Skipped on the documentation, where it doesn't add any information, which can not be derived from the class name.