### PR TITLE
Refactor the prepare connector to a separate method

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -586,8 +586,7 @@ class Connector(ESDocument):
             yield doc, lazy_download
 
     async def prepare(self, config):
-        """
-        Prepares the custom connector
+        """Prepares the custom connector
 
         When a custom connector is configured in the config.yml, this method updates service type and the default
         configuration when they are absent.

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -586,9 +586,11 @@ class Connector(ESDocument):
             yield doc, lazy_download
 
     async def prepare(self, config):
-        """Prepares the connector, given a configuration
-        If the connector id and the service type is in the config, we want to
-        populate the service type and then sets the default configuration.
+        """
+        Prepares the custom connector
+
+        When a custom connector is configured in the config.yml, this method updates service type and the default
+        configuration when they are absent.
         """
         configured_connector_id = config.get("connector_id", "")
         if self.id != configured_connector_id:


### PR DESCRIPTION
This PR did a small refactoring, to extract the prepare connector logic into a separate method.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference