### PR TITLE
Extract ready_to_sync method from Connector to SyncService

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -675,50 +675,8 @@ class Connector(ESDocument):
         return result["count"]
 
     # TODO: Part of this method will be moved to SyncService once it's refactored, and the rest will be moved to the new SyncJobRunner class.
-    async def sync(
-        self, sync_job_index, source_klass, elastic_server, idling, bulk_options
-    ):
-        # If anything bad happens before we create a sync job
-        # (like bad scheduling config, etc.)
-        #
-        # we will raise the error in the logs here and let Kibana knows
-        # by toggling the status and setting the error and status field
-        if source_klass is None:
-            raise Exception("Can't call `sync()` before `prepare()`")
-
-        try:
-            service_type = self.service_type
-            next_sync = self.next_sync()
-            # First we check if sync is disabled, and it terminates all other conditions
-            if next_sync == SYNC_DISABLED:
-                logger.debug(f"Scheduling is disabled for {service_type}")
-                return
-            # Then we check if we need to restart SUSPENDED job
-            elif self.last_sync_status == JobStatus.SUSPENDED:
-                logger.info("Restarting sync after suspension")
-            # And only then we check if we need to run sync right now or not
-            elif next_sync - idling > 0:
-                logger.debug(
-                    f"Next sync for {service_type} due in {int(next_sync)} seconds"
-                )
-                return
-
-            try:
-                data_provider = source_klass(self.configuration)
-            except Exception as e:
-                logger.critical(e, exc_info=True)
-                raise DataSourceError(
-                    f"Could not instantiate {source_klass} for {service_type}"
-                )
-
-            if not await data_provider.changed():
-                logger.debug(f"No change in {service_type} data provider, skipping...")
-                return
-        except Exception as exc:
-            await self.error(str(exc))
-            raise
-
-        logger.debug(f"Syncing '{service_type}'")
+    async def sync(self, sync_job_index, data_provider, elastic_server, bulk_options):
+        logger.debug(f"Syncing '{self.service_type}'")
         job = await self._sync_starts(sync_job_index)
         start_time = time.time()
         try:

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -14,9 +14,11 @@ import asyncio
 import functools
 
 from connectors.byoc import (
+    SYNC_DISABLED,
     ConnectorIndex,
     ConnectorUpdateError,
     DataSourceError,
+    JobStatus,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
     Status,
@@ -88,24 +90,35 @@ class SyncService(BaseService):
         if connector.status in (Status.CREATED, Status.NEEDS_CONFIGURATION):
             # we can't sync in that state
             logger.info(f"Can't sync with status `{connector.status.value}`")
-        else:
-            if connector.service_type not in self.source_klass_dict:
-                raise DataSourceError(
-                    f"Couldn't find data source class for {connector.service_type}"
-                )
-            source_klass = self.source_klass_dict[connector.service_type]
-            if connector.features.sync_rules_enabled():
-                await connector.validate_filtering(
-                    validator=source_klass(connector.configuration)
-                )
+            return
 
-            await connector.sync(
-                self.sync_job_index,
-                source_klass,
-                es,
-                self.idling,
-                self.bulk_options,
+        if connector.service_type not in self.source_klass_dict:
+            raise DataSourceError(
+                f"Couldn't find data source class for {connector.service_type}"
             )
+
+        source_klass = self.source_klass_dict[connector.service_type]
+
+        try:
+            data_provider = source_klass(connector.configuration)
+        except Exception as e:
+            logger.critical(e, exc_info=True)
+            raise DataSourceError(
+                f"Could not instantiate {source_klass} for {connector.service_type}"
+            )
+
+        if connector.features.sync_rules_enabled():
+            await connector.validate_filtering(validator=data_provider)
+
+        if not await self._ready_to_sync(connector, data_provider):
+            return
+
+        await connector.sync(
+            self.sync_job_index,
+            data_provider,
+            es,
+            self.bulk_options,
+        )
 
         await asyncio.sleep(0)
 
@@ -164,3 +177,32 @@ class SyncService(BaseService):
                 await self.sync_job_index.close()
             await es.close()
         return 0
+
+    async def _ready_to_sync(self, connector, data_provider):
+        try:
+            next_sync = connector.next_sync()
+            # First we check if sync is disabled, and it terminates all other conditions
+            if next_sync == SYNC_DISABLED:
+                logger.debug(f"Scheduling is disabled for connector {connector.id}")
+                return False
+            # Then we check if we need to restart SUSPENDED job
+            if connector.last_sync_status == JobStatus.SUSPENDED:
+                logger.debug("Restarting sync after suspension")
+                return True
+            # And only then we check if we need to run sync right now or not
+            if next_sync - self.idling > 0:
+                logger.debug(
+                    f"Next sync for connector {connector.id} due in {int(next_sync)} seconds"
+                )
+                return False
+            # Lastly we skip job scheduling if there's no change in the remote source
+            if not await data_provider.changed():
+                logger.debug(
+                    f"No change in the remote source of connector {connector.id}, skipping..."
+                )
+                return False
+            return True
+        except Exception as e:
+            logger.critical(e, exc_info=True)
+            await connector.error(str(e))
+            return False

--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -103,7 +103,7 @@ class SyncService(BaseService):
                 validator=source_klass(connector.configuration)
             )
 
-        if not await self._ready_to_sync(connector):
+        if not await self._should_sync(connector):
             return
 
         await connector.sync(
@@ -171,7 +171,7 @@ class SyncService(BaseService):
             await es.close()
         return 0
 
-    async def _ready_to_sync(self, connector):
+    async def _should_sync(self, connector):
         try:
             next_sync = connector.next_sync()
             # First we check if sync is disabled, and it terminates all other conditions


### PR DESCRIPTION
This PR extracts this part of `Connector.sync` method to `SyncService`:

https://github.com/elastic/connectors-python/blob/a5976d20cd8277ae46511f7176662afc889e56ec/connectors/byoc.py#L686-L719

The logic checks whether the connector is ready to sync (on-demand, scheduled or restart a suspended job), and whether there's any change in the remote source. The logic should not be part of `sync` method.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference