### PR TITLE
Allow multiple ".digit" postfixes after major.minor in .backportrc

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -8,7 +8,7 @@
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v8.8.0$": "main",
-    "^v(\\d+).(\\d+).\\d+$": "$1.$2"
+    "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
   },
   "upstream": "elastic/connectors-python"
 }


### PR DESCRIPTION
Currently we only matched versions like "8.7.0", but not "8.7.0.0", which lead to some missing backports. 