### PR TITLE
[MySQL] Make tables configurable

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -8,7 +8,7 @@
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v8.8.0$": "main",
-    "^v(\\d+).(\\d+).\\d+$": "$1.$2"
+    "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
   },
   "upstream": "elastic/connectors-python"
 }

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -46,7 +46,7 @@ def configured_tables(tables):
 
 
 def should_fetch_all_tables(tables):
-    return tables == ALL_TABLES or (isinstance(tables, list) and tables == [ALL_TABLES])
+    return tables in (ALL_TABLES, [ALL_TABLES])
 
 
 class GenericBaseDataSource(BaseDataSource):

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -13,7 +13,7 @@ from connectors.logger import logger
 from connectors.source import BaseDataSource
 from connectors.utils import iso_utc
 
-ALL_TABLES = "*"
+WILDCARD = "*"
 
 DEFAULT_FETCH_SIZE = 50
 DEFAULT_RETRY_COUNT = 3
@@ -45,8 +45,8 @@ def configured_tables(tables):
     )
 
 
-def should_fetch_all_tables(tables):
-    return tables in (ALL_TABLES, [ALL_TABLES])
+def is_wildcard(tables):
+    return tables in (WILDCARD, [WILDCARD])
 
 
 class GenericBaseDataSource(BaseDataSource):
@@ -110,7 +110,7 @@ class GenericBaseDataSource(BaseDataSource):
                 "type": "str",
             },
             "tables": {
-                "value": ALL_TABLES,
+                "value": WILDCARD,
                 "label": "Comma-separated list of tables",
                 "type": "list",
             },
@@ -425,6 +425,6 @@ class GenericBaseDataSource(BaseDataSource):
                     )
                 ),
             )
-            if should_fetch_all_tables(tables)
+            if is_wildcard(tables)
             else tables
         )

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -21,6 +21,15 @@ DEFAULT_WAIT_MULTIPLIER = 2
 
 
 def configured_tables(tables):
+    """Split a string containing a comma-seperated list of tables by comma and strip the table names.
+
+    Filter out `None` and zero-length values from the tables.
+    If `tables` is a list return the list also without `None` and zero-length values.
+
+    Arguments:
+    - `tables`: string containing a comma-seperated list of tables or a list of tables
+    """
+
     def table_filter(table):
         return table is not None and len(table) > 0
 
@@ -34,6 +43,10 @@ def configured_tables(tables):
         if isinstance(tables, str)
         else list(filter(lambda table: table_filter(table), tables))
     )
+
+
+def should_fetch_all_tables(tables):
+    return tables == ALL_TABLES or (isinstance(tables, list) and tables == [ALL_TABLES])
 
 
 class GenericBaseDataSource(BaseDataSource):
@@ -399,11 +412,8 @@ class GenericBaseDataSource(BaseDataSource):
 
     async def get_tables_to_fetch(self, schema):
         tables = configured_tables(self.tables)
-        fetch_all_tables = tables == ALL_TABLES or (
-            isinstance(tables, list) and tables == [ALL_TABLES]
-        )
 
-        tables_to_fetch = (
+        return (
             map(
                 lambda table: table[0],
                 await anext(
@@ -415,8 +425,6 @@ class GenericBaseDataSource(BaseDataSource):
                     )
                 ),
             )
-            if fetch_all_tables
+            if should_fetch_all_tables(tables)
             else tables
         )
-
-        return tables_to_fetch

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -15,9 +15,9 @@ from connectors.filtering.validation import (
 from connectors.logger import logger
 from connectors.source import BaseDataSource
 from connectors.sources.generic_database import (
-    ALL_TABLES,
+    WILDCARD,
     configured_tables,
-    should_fetch_all_tables,
+    is_wildcard,
 )
 from connectors.utils import CancellableSleeps, RetryStrategy, retryable
 
@@ -135,7 +135,7 @@ class MySqlDataSource(BaseDataSource):
                 "type": "str",
             },
             "tables": {
-                "value": ALL_TABLES,
+                "value": WILDCARD,
                 "label": "Comma-separated list of tables",
                 "type": "list",
             },
@@ -446,6 +446,6 @@ class MySqlDataSource(BaseDataSource):
 
         return (
             map(lambda table: table_name(table), await self.fetch_all_tables())
-            if should_fetch_all_tables(tables)
+            if is_wildcard(tables)
             else tables
         )

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -14,6 +14,11 @@ from connectors.filtering.validation import (
 )
 from connectors.logger import logger
 from connectors.source import BaseDataSource
+from connectors.sources.generic_database import (
+    ALL_TABLES,
+    configured_tables,
+    should_fetch_all_tables,
+)
 from connectors.utils import CancellableSleeps, RetryStrategy, retryable
 
 MAX_POOL_SIZE = 10
@@ -56,7 +61,7 @@ class MySQLAdvancedRulesValidator(AdvancedRulesValidator):
         tables = set(
             map(
                 lambda table: table[0],
-                await self.source.fetch_tables(),
+                await self.source.fetch_all_tables(),
             )
         )
         tables_to_filter = set(advanced_rules.keys())
@@ -94,6 +99,7 @@ class MySqlDataSource(BaseDataSource):
         self.ssl_disabled = self.configuration["ssl_disabled"]
         self.certificate = self.configuration["ssl_ca"]
         self.database = self.configuration["database"]
+        self.tables = self.configuration["tables"]
 
     @classmethod
     def get_default_configuration(cls):
@@ -127,6 +133,11 @@ class MySqlDataSource(BaseDataSource):
                 "value": "customerinfo",
                 "label": "Database",
                 "type": "str",
+            },
+            "tables": {
+                "value": ALL_TABLES,
+                "label": "Comma-separated list of tables",
+                "type": "list",
             },
             "fetch_size": {
                 "value": DEFAULT_FETCH_SIZE,
@@ -167,7 +178,7 @@ class MySqlDataSource(BaseDataSource):
         Raises:
             Exception: Configured keys can't be empty
         """
-        connection_fields = ["host", "port", "user", "password", "database"]
+        connection_fields = ["host", "port", "user", "password", "database", "tables"]
         empty_connection_fields = []
         for field in connection_fields:
             if self.configuration[field] == "":
@@ -305,7 +316,7 @@ class MySqlDataSource(BaseDataSource):
                 await self._sleeps.sleep(RETRY_INTERVAL**retry)
                 retry += 1
 
-    async def fetch_tables(self):
+    async def fetch_all_tables(self):
         return await anext(self._connect(query=QUERIES["ALL_TABLE"]))
 
     async def fetch_rows_for_table(self, table=None, query=None):
@@ -327,21 +338,18 @@ class MySqlDataSource(BaseDataSource):
                 f"Fetched 0 rows for the table: {table}. As table has no rows."
             )
 
-    async def fetch_rows_from_all_tables(self):
+    async def fetch_rows_from_tables(self, tables):
         """Fetches all the rows from all the tables of the database.
 
         Yields:
             Dict: Row document to index
         """
-        tables = await self.fetch_tables()
-
         if tables:
             for table in tables:
-                table_name = table[0]
-                logger.debug(f"Found table: {table_name} in database: {self.database}.")
+                logger.debug(f"Found table: {table} in database: {self.database}.")
 
                 async for row in self.fetch_rows_for_table(
-                    table=table_name,
+                    table=table,
                     query=QUERIES["TABLE_DATA"],
                 ):
                     yield row
@@ -424,6 +432,20 @@ class MySqlDataSource(BaseDataSource):
                     yield row, None
                 await self._sleeps.sleep(0)
         else:
-            async for row in self.fetch_rows_from_all_tables():
+            tables_to_fetch = await self.get_tables_to_fetch()
+
+            async for row in self.fetch_rows_from_tables(tables_to_fetch):
                 yield row, None
             await self._sleeps.sleep(0)
+
+    async def get_tables_to_fetch(self):
+        tables = configured_tables(self.tables)
+
+        def table_name(table):
+            return table[0]
+
+        return (
+            map(lambda table: table_name(table), await self.fetch_all_tables())
+            if should_fetch_all_tables(tables)
+            else tables
+        )

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -14,11 +14,7 @@ from connectors.filtering.validation import (
 )
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.sources.generic_database import (
-    WILDCARD,
-    configured_tables,
-    is_wildcard,
-)
+from connectors.sources.generic_database import WILDCARD, configured_tables, is_wildcard
 from connectors.utils import CancellableSleeps, RetryStrategy, retryable
 
 MAX_POOL_SIZE = 10

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -17,7 +17,7 @@ from connectors.source import DataSourceConfiguration
 from connectors.sources.generic_database import (
     GenericBaseDataSource,
     configured_tables,
-    should_fetch_all_tables,
+    is_wildcard,
 )
 from connectors.sources.oracle import OracleDataSource
 from connectors.sources.postgresql import PostgreSQLDataSource
@@ -404,5 +404,5 @@ async def test_get_tables_to_fetch_configured_tables():
 
 
 @pytest.mark.parametrize("tables", ["*", ["*"]])
-def test_should_fetch_all_tables(tables):
-    assert should_fetch_all_tables(tables)
+def test_is_wildcard(tables):
+    assert is_wildcard(tables)

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -14,7 +14,11 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
 from connectors.source import DataSourceConfiguration
-from connectors.sources.generic_database import GenericBaseDataSource, configured_tables
+from connectors.sources.generic_database import (
+    GenericBaseDataSource,
+    configured_tables,
+    should_fetch_all_tables,
+)
 from connectors.sources.oracle import OracleDataSource
 from connectors.sources.postgresql import PostgreSQLDataSource
 from connectors.sources.tests.support import create_source
@@ -397,3 +401,8 @@ async def test_get_tables_to_fetch_configured_tables():
     source.tables = tables
 
     assert tables == await source.get_tables_to_fetch("schema")
+
+
+@pytest.mark.parametrize("tables", ["*", ["*"]])
+def test_should_fetch_all_tables(tables):
+    assert should_fetch_all_tables(tables)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3993

This PR adds a new configurable field for the MySQL connector to be able to configure the tables, where we ingest from. Remote validation (do the configured tables exist, does the database user has access?) of configured tables will happen separate from this PR and is tracked by this issue: https://github.com/elastic/enterprise-search-team/issues/4052.

I've reused some functionality from `generic_database.py` to avoid duplication and make it easier to migrate the mysql connector to use `GenericDatabaseSource` class (if we decide to).

The corresponding frontend change for the native MySQL connector is tracked by https://github.com/elastic/enterprise-search-team/issues/4032.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference