### PR TITLE
[Network Drive] Add support for e2e in Macbook with m1 chip

### DIFF
--- a/connectors/sources/tests/fixtures/network_drive/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/network_drive/docker-compose.yml
@@ -31,8 +31,6 @@ services:
     ports:
       - "445:445/tcp"
     restart: unless-stopped
-    volumes:
-      - /tmp/mnt:/mnt:z
     command: '-s "Folder1;/mnt;yes;no;yes;admin" -u "admin;abc@123" -p'
 
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/547 ##

Removing Volumes since the data used for e2e test does not need to be stored permanently in the device, it thus allows e2e test to execute irrespective of the device configuration, since devices like macbook with m1 chip provide enhanced security features such as sticky bit preventing deletion of files.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
