### PR TITLE
Fix issues raising from base service swallowing errors

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -591,6 +591,8 @@ class Connector(ESDocument):
         populate the service type and then sets the default configuration.
         """
         configured_connector_id = config.get("connector_id", "")
+        configured_service_type = config.get("service_type", "")
+
         if self.id != configured_connector_id:
             return
 
@@ -599,7 +601,6 @@ class Connector(ESDocument):
 
         doc = {}
         if self.service_type is None:
-            configured_service_type = config.get("service_type", "")
             if not configured_service_type:
                 logger.error(
                     f"Service type is not configured for connector {configured_connector_id}"

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -135,9 +135,7 @@ ALL_SYNC_RULES_FEATURES_DISABLED = {
     }
 }
 
-NO_FEATURES_PRESENT = {
-    "features": {}
-}
+NO_FEATURES_PRESENT = {"features": {}}
 
 FAKE_CONFIG_FAIL_SERVICE = {
     "api_key_id": "",

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -128,12 +128,16 @@ FAIL_FILTERING_ERRORS_PRESENT_CONFIG = copy.deepcopy(FAKE_CONFIG)
 FAIL_FILTERING_ERRORS_PRESENT_CONFIG["service_type"] = "filtering_errors_present"
 
 ALL_SYNC_RULES_FEATURES_DISABLED = {
-    "sync_rules": {"advanced": {"enabled": False}, "basic": {"enabled": False}},
-    "filtering_advanced_config": False,
-    "filtering_rules": False,
+    "features": {
+        "sync_rules": {"advanced": {"enabled": False}, "basic": {"enabled": False}},
+        "filtering_advanced_config": False,
+        "filtering_rules": False,
+    }
 }
 
-NO_FEATURES_PRESENT = {}
+NO_FEATURES_PRESENT = {
+    "features": {}
+}
 
 FAKE_CONFIG_FAIL_SERVICE = {
     "api_key_id": "",
@@ -225,6 +229,7 @@ def create_service(config_file):
     config = load_config(config_file)
     service = SyncService(config)
     service.idling = 0
+    service.service_config["max_errors"] = 0
 
     return service
 
@@ -638,8 +643,9 @@ async def test_connector_service_filtering(
     )
 
     if should_raise_filtering_error:
-        await create_and_run_service(CONFIG_FILE)
-        patch_logger.assert_check(lambda log: isinstance(log, InvalidFilteringError))
+        with pytest.raises(InvalidFilteringError) as e:
+            await create_and_run_service(CONFIG_FILE)
+        assert e is not None
     else:
         try:
             await create_and_run_service(CONFIG_FILE)
@@ -665,13 +671,11 @@ async def test_connector_service_poll_buggy_service(
         mock_responses, [FAKE_CONFIG_BUGGY_SERVICE], connectors_update=connectors_update
     )
 
-    await create_and_run_service(CONFIG_FILE)
+    with pytest.raises(DataSourceError) as e:
+        await create_and_run_service(CONFIG_FILE)
 
-    for log in patch_logger.logs:
-        if isinstance(log, DataSourceError):
-            return
-
-    raise AssertionError
+    if e is None:
+        raise AssertionError("No exception raised when expected one")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Raised from problems in https://github.com/elastic/connectors-python/pull/514

Found a problem while doing refactoring. BaseService actually swallows terminal errors - ones that make service stops. Due to change in https://github.com/elastic/connectors-python/pull/514 removing this code, some tests break - I decided to fix them in separate PR (this one).

This PR does the following:

1. Makes `test_sync.py` create service that does not swallow errors with config["service_config"]["max_errors"] = 0
2. Pull instantiation of `configured_service_type` higher - it's used in a method later and it's possible that this variable won't be defined by the time it's used
3. Fix setup of tests for validation of config - nesting was incorrect for changing the features

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)