### PR TITLE
Introduce "validate_configuration" method to BaseSource and use it

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -698,7 +698,6 @@ class Connector(ESDocument):
 
             logger.debug(f"Validating configuration for {data_provider}")
             await data_provider.validate_configuration()
-            await asyncio.sleep(0)
 
             logger.debug(f"Pinging the {data_provider} backend")
             await data_provider.ping()

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -697,7 +697,7 @@ class Connector(ESDocument):
                 return
 
             logger.debug(f"Validating configuration for {data_provider}")
-            await data_provider.validate_configuration()
+            await data_provider.validate_config()
 
             logger.debug(f"Pinging the {data_provider} backend")
             await data_provider.ping()

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -700,6 +700,10 @@ class Connector(ESDocument):
             await data_provider.ping()
             await asyncio.sleep(0)
 
+            logger.debug(f"Validating configuration for {data_provider}")
+            await data_provider.validate_configuration()
+            await asyncio.sleep(0)
+
             mappings = Mappings.default_text_fields_mappings(
                 is_connectors_index=True,
             )

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -696,12 +696,12 @@ class Connector(ESDocument):
                 await self._sync_done(job, JobStatus.COMPLETED, {}, start_time)
                 return
 
-            logger.debug(f"Pinging the {data_provider} backend")
-            await data_provider.ping()
-            await asyncio.sleep(0)
-
             logger.debug(f"Validating configuration for {data_provider}")
             await data_provider.validate_configuration()
+            await asyncio.sleep(0)
+
+            logger.debug(f"Pinging the {data_provider} backend")
+            await data_provider.ping()
             await asyncio.sleep(0)
 
             mappings = Mappings.default_text_fields_mappings(

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -186,13 +186,13 @@ class BaseDataSource:
         """
         return True
 
-    async def validate_configuration(self):
+    async def validate_config(self):
         """When called, validates configuration of the connector that is contained in self.configuration
 
         If connector configuration is invalid, this method will raise an exception
         with human-friendly and actionable description
         """
-        # TODO: when validate_configuration is implemented everywhere, we should make this method raise NotImplementedError
+        # TODO: when validate_config is implemented everywhere, we should make this method raise NotImplementedError
         pass
 
     async def ping(self):

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -186,6 +186,15 @@ class BaseDataSource:
         """
         return True
 
+    async def validate_configuration(self):
+        """When called, validates configuration of the connector that is contained in self.configuration
+
+        If connector configuration is invalid, this method will raise an exception
+        with human-friendly and actionable description
+        """
+        # TODO: when validate_configuration is implemented everywhere, we should make this method raise NotImplementedError
+        pass
+
     async def ping(self):
         """When called, pings the backend
 

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -161,7 +161,7 @@ class MySqlDataSource(BaseDataSource):
         await self.connection_pool.wait_closed()
         self.connection_pool = None
 
-    async def validate_configuration(self):
+    async def validate_config(self):
         """Validates whether user input is empty or not for configuration fields and validate type for port
 
         Raises:

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -161,7 +161,7 @@ class MySqlDataSource(BaseDataSource):
         await self.connection_pool.wait_closed()
         self.connection_pool = None
 
-    def _validate_configuration(self):
+    async def validate_configuration(self):
         """Validates whether user input is empty or not for configuration fields and validate type for port
 
         Raises:
@@ -206,7 +206,6 @@ class MySqlDataSource(BaseDataSource):
     async def ping(self):
         """Verify the connection with MySQL server"""
         logger.info("Validating MySQL Configuration...")
-        self._validate_configuration()
         connection_string = {
             "host": self.configuration["host"],
             "port": int(self.configuration["port"]),

--- a/connectors/tests/fake_sources.py
+++ b/connectors/tests/fake_sources.py
@@ -26,6 +26,7 @@ class FakeSource:
         if configuration.has_field("raise"):
             raise Exception("I break on init")
         self.fail = configuration.has_field("fail")
+        self.configuration_invalid = configuration.has_field("configuration_invalid")
 
     async def changed(self):
         return True
@@ -56,6 +57,11 @@ class FakeSource:
         return FilteringValidationResult(
             state=FilteringValidationState.VALID, errors=[]
         )
+
+    async def validate_configuration(self):
+        if self.configuration_invalid:
+            raise ValueError("I fail when validating configuration")
+        pass
 
     def tweak_bulk_options(self, options):
         pass

--- a/connectors/tests/fake_sources.py
+++ b/connectors/tests/fake_sources.py
@@ -58,7 +58,7 @@ class FakeSource:
             state=FilteringValidationState.VALID, errors=[]
         )
 
-    async def validate_configuration(self):
+    async def validate_config(self):
         if self.configuration_invalid:
             raise ValueError("I fail when validating configuration")
 

--- a/connectors/tests/fake_sources.py
+++ b/connectors/tests/fake_sources.py
@@ -61,7 +61,6 @@ class FakeSource:
     async def validate_configuration(self):
         if self.configuration_invalid:
             raise ValueError("I fail when validating configuration")
-        pass
 
     def tweak_bulk_options(self, options):
         pass

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -137,6 +137,10 @@ ALL_SYNC_RULES_FEATURES_DISABLED = {
 
 NO_FEATURES_PRESENT = {"features": {}}
 
+CONFIGURATION_INVALID = {
+    "configuration": {"configuration_invalid": {"value": True, "label": ""}}
+}
+
 FAKE_CONFIG_FAIL_SERVICE = {
     "api_key_id": "",
     "configuration": {"fail": {"value": True, "label": ""}},
@@ -745,3 +749,14 @@ async def test_concurrent_syncs(mock_responses, patch_logger, set_env):
     patch_logger.assert_present("[1] Sync done: 1 indexed, 0  deleted. (0 seconds)")
     patch_logger.assert_present("[2] Sync done: 1 indexed, 0  deleted. (0 seconds)")
     patch_logger.assert_present("[3] Sync done: 1 indexed, 0  deleted. (0 seconds)")
+
+
+@pytest.mark.asyncio
+async def test_invalid_configuration(mock_responses, set_env):
+    await set_server_responses(mock_responses, [FAKE_CONFIG | CONFIGURATION_INVALID])
+
+    with pytest.raises(ValueError) as e:
+        await create_and_run_service(CONFIG_FILE)
+
+    assert e is not None
+    assert e.match(".*validating configuration.*")


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4023

We want to be able to validate connector configuration meaningfully on the level of the framework - not as a part of other methods like `ping` or `get_docs`.

This PR introduces new method `validate_configuration` to BaseSource that does nothing when called. Individual sources can override it to validate configuration and raise errors if configuration was invalid. If configuration was invalid and exception was raised, framework will just handle this error as any other errors - it will update connector status to `ERROR` and display error message coming from `validate_configuration` in UI.

It would have been a large change to implement for all connectors, so this PR only implements the change for MySQL connector. Later I'm planning to follow-up with this change for all other connectors and make `validate_configuration` raise an error if not implemented.

Thinking out loud - should we provide an error class `ValidationError` and ask raising it in `validate_configuration`? I think it's a good idea, since any other errors can happen in the code - typos, bad error handling - and we want to separate them from Validation errors.


## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
