### PR TITLE
[Generic Database Connector] Make validate_configuration a top-level function and use it for composition

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -82,12 +82,7 @@ class Field:
         elif type_ == "bool":
             return value.lower() in ("y", "yes", "true", "1")
         elif type_ == "list":
-            return list(
-                filter(
-                    lambda item: len(item) > 0,
-                    [item.strip() for item in value.split(",")],
-                )
-            )
+            return [item.strip() for item in value.split(",") if len(item.strip()) > 0]
         return value
 
 
@@ -133,7 +128,7 @@ class DataSourceConfiguration:
         if any(not self.has_field(name) for name in names):
             raise ConfigurationFieldMissingError
 
-        empty_fields = list(filter(lambda name: self._config[name].is_empty(), names))
+        empty_fields = [name for name in names if self._config[name].is_empty()]
 
         return len(empty_fields) > 0, empty_fields
 

--- a/connectors/sources/oracle.py
+++ b/connectors/sources/oracle.py
@@ -9,7 +9,11 @@ from urllib.parse import quote
 
 from sqlalchemy import create_engine
 
-from connectors.sources.generic_database import GenericBaseDataSource
+from connectors.source import validate_non_empty_config_fields
+from connectors.sources.generic_database import (
+    GenericBaseDataSource,
+    validate_db_connection_fields,
+)
 
 QUERIES = {
     "PING": "SELECT 1+1 FROM DUAL",
@@ -47,6 +51,10 @@ class OracleDataSource(GenericBaseDataSource):
         )
         self.queries = QUERIES
         self.dialect = "Oracle"
+
+    def _validate_configuration(self):
+        validate_db_connection_fields(self.configuration)
+        validate_non_empty_config_fields(["database", "tables"], self.configuration)
 
     @classmethod
     def get_default_configuration(cls):

--- a/connectors/sources/tests/support.py
+++ b/connectors/sources/tests/support.py
@@ -6,10 +6,9 @@
 from connectors.source import DataSourceConfiguration
 
 
-def create_source(klass, **extras):
-    config = klass.get_default_configuration()
-    for k, v in extras.items():
-        config[k] = {"value": v}
+def create_source(klass, config=None):
+    if config is None:
+        config = klass.get_default_configuration()
 
     return klass(configuration=DataSourceConfiguration(config))
 


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4067

**\~ 80% of LOC is due to parametrized testing**

- Created a new function `validate_non_empty_config_fields`, which can be used by arbitrary sources to validate, that mandatory configuration fields are non-empty
- Created a new function `validate_db_connection_fields`, which specifies validation for common database connection fields (`host`, `port`, `user`, `password`)
- Remove the datasource specific checks from the `generic_database` module and implement them at the right places in `oracle.py` and `postgresql.py`
- Mark two places with TODOs, which are currently depending on open PRs (will be removed by me as soon as the PRs are merged)
- Add error classes specific for the validation of a configuration:
  - `ConfigurationFieldMissingError`
  - `ConfigurationFieldEmptyError`
  - `ConfigurationFieldTypeError`
  - `ConfigurationValueError`

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~