### PR TITLE
Fix pyright errors

### DIFF
--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -104,7 +104,10 @@ async def prepare(service_type, index_name, config, filtering=None):
         )
     except elasticsearch.NotFoundError:
         await es.client.ingest.put_pipeline(
-            id="ent-search-generic-ingestion", body=DEFAULT_PIPELINE
+            id="ent-search-generic-ingestion",
+            version=DEFAULT_PIPELINE["version"],
+            description=DEFAULT_PIPELINE["description"],
+            processors=DEFAULT_PIPELINE["processors"],
         )
 
     try:
@@ -126,7 +129,9 @@ async def prepare(service_type, index_name, config, filtering=None):
         }
 
         await es.client.ingest.put_pipeline(
-            id="ent-search-generic-ingestion", body=pipeline
+            id="ent-search-generic-ingestion",
+            description=pipeline["description"],
+            processors=pipeline["processors"],
         )
 
     try:

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -135,7 +135,7 @@ class S3DataSource(BaseDataSource):
                 }
             except (ClientError, ServerTimeoutError, AioReadTimeoutError) as exception:
                 if (
-                    exception.response.get("Error", {}).get("Code")
+                    getattr(exception, "response", {}).get("Error", {}).get("Code")
                     == "InvalidObjectState"
                 ):
                     logger.warning(


### PR DESCRIPTION
When I run `make lint` I see the below `pyright` errors, and this PR tries to fix them:

```shell
pyright 1.1.295
/Users/chenhui.wang/src/github.com/elastic/connectors-python/connectors/kibana.py
  /Users/chenhui.wang/src/github.com/elastic/connectors-python/connectors/kibana.py:107:48 - error: No parameter named "body" (reportGeneralTypeIssues)
  /Users/chenhui.wang/src/github.com/elastic/connectors-python/connectors/kibana.py:129:48 - error: No parameter named "body" (reportGeneralTypeIssues)
/Users/chenhui.wang/src/github.com/elastic/connectors-python/connectors/sources/s3.py
  /Users/chenhui.wang/src/github.com/elastic/connectors-python/connectors/sources/s3.py:138:31 - error: Cannot access member "response" for type "ServerTimeoutError"
    Member "response" is unknown (reportGeneralTypeIssues)
3 errors, 0 warnings, 0 informations 
```

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference