### PR TITLE
Fix typo in `oracle.py`

### DIFF
--- a/connectors/sources/oracle.py
+++ b/connectors/sources/oracle.py
@@ -21,7 +21,7 @@ QUERIES = {
 }
 DEFAULT_PROTOCOL = "TCP"
 DEFAULT_ORACLE_HOME = ""
-DEFAUTL_WALLET_CONFIGURATION_PATH = ""
+DEFAULT_WALLET_CONFIGURATION_PATH = ""
 
 
 class OracleDataSource(GenericBaseDataSource):
@@ -69,7 +69,7 @@ class OracleDataSource(GenericBaseDataSource):
                     "type": "str",
                 },
                 "wallet_configuration_path": {
-                    "value": DEFAUTL_WALLET_CONFIGURATION_PATH,
+                    "value": DEFAULT_WALLET_CONFIGURATION_PATH,
                     "label": "Path of oracle service configuration files",
                     "type": "str",
                 },

--- a/connectors/sources/oracle.py
+++ b/connectors/sources/oracle.py
@@ -21,7 +21,6 @@ QUERIES = {
 }
 DEFAULT_PROTOCOL = "TCP"
 DEFAULT_ORACLE_HOME = ""
-DEFAULT_WALLET_CONFIGURATION_PATH = ""
 
 
 class OracleDataSource(GenericBaseDataSource):
@@ -69,7 +68,7 @@ class OracleDataSource(GenericBaseDataSource):
                     "type": "str",
                 },
                 "wallet_configuration_path": {
-                    "value": DEFAULT_WALLET_CONFIGURATION_PATH,
+                    "value": "",
                     "label": "Path of oracle service configuration files",
                     "type": "str",
                 },


### PR DESCRIPTION
 ~`DEFAUTL_WALLET_CONFIGURATION_PATH`~ -> `DEFAULT_WALLET_CONFIGURATION_PATH`

Not sure about **backports**, _iff_ this typo needs correcting.