### PR TITLE
Add last_sync_scheduled_at to connector index

### DIFF
--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -153,6 +153,7 @@ async def prepare(service_type, index_name, config, filtering=None):
             # Last sync
             "last_sync_status": None,
             "last_sync_error": None,
+            "last_sync_scheduled_at": None,
             "last_synced": None,
             # Written by connector on each operation,
             # used by Kibana to hint to user about status of connector

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -100,6 +100,7 @@ This is our main communication index, used to communicate the connector's config
   last_sync_error: string;   -> Optional last job error message
   last_sync_status: string;  -> Status of the last job, or null if no job has been executed
   last_synced: date;    -> Date/time of last job (UTC)
+  last_sync_scheduled_at: date;    -> Date/time when the last job is scheduled (UTC)
   name: string; -> the name to use for the connector
   pipeline: {
     extract_binary_content: boolean; -> Whether the `request_pipeline` should handle binary data
@@ -228,6 +229,7 @@ This is our main communication index, used to communicate the connector's config
     "last_indexed_document_count" : { "type" : "long" },
     "last_seen" : { "type" : "date" },
     "last_sync_error" : { "type" : "keyword" },
+    "last_sync_scheduled_at" : { "type" : "date" },
     "last_sync_status" : { "type" : "keyword" },
     "last_synced" : { "type" : "date" },
     "name" : { "type" : "keyword" },


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4156

This PR adds a new field `last_sync_scheduled_at` to index `.elastic-connectors`.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference