### PR TITLE
Add more tests for ESIndex class

### DIFF
--- a/connectors/tests/test_es_index.py
+++ b/connectors/tests/test_es_index.py
@@ -14,20 +14,21 @@ config = {
     "password": "changeme",
     "host": "http://nowhere.com:9200",
 }
+index_name = "fake_index"
 
 
 @pytest.mark.asyncio
 async def test_es_index_create_object_error(mock_responses, patch_logger):
-    index = ESIndex("index", config)
+    index = ESIndex(index_name, config)
     mock_responses.post(
-        "http://nowhere.com:9200/index/_refresh", headers=headers, status=200
+        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
     )
 
     mock_responses.post(
-        "http://nowhere.com:9200/index/_search?expand_wildcards=hidden",
+        f"http://nowhere.com:9200/{index_name}/_search?expand_wildcards=hidden",
         headers=headers,
         status=200,
-        payload={"hits": {"total": {"value": 1}, "hits": [{"id": 1}]}},
+        payload={"hits": {"total": {"value": 1}, "hits": [{"_id": 1}]}},
     )
     with pytest.raises(NotImplementedError) as _:
         async for doc_ in index.get_all_docs():
@@ -45,7 +46,6 @@ class FakeIndex(ESIndex):
 
 @pytest.mark.asyncio
 async def test_fetch_by_id(mock_responses):
-    index_name = "fake_index"
     doc_id = "1"
     index = FakeIndex(index_name, config)
     mock_responses.post(
@@ -67,7 +67,6 @@ async def test_fetch_by_id(mock_responses):
 
 @pytest.mark.asyncio
 async def test_fetch_by_id_not_found(mock_responses):
-    index_name = "fake_index"
     doc_id = "1"
     index = FakeIndex(index_name, config)
     mock_responses.post(
@@ -88,7 +87,6 @@ async def test_fetch_by_id_not_found(mock_responses):
 
 @pytest.mark.asyncio
 async def test_fetch_by_id_api_error(mock_responses):
-    index_name = "fake_index"
     doc_id = "1"
     index = FakeIndex(index_name, config)
     mock_responses.post(
@@ -109,7 +107,6 @@ async def test_fetch_by_id_api_error(mock_responses):
 
 @pytest.mark.asyncio
 async def test_index(mock_responses):
-    index_name = "fake_index"
     doc_id = "1"
     index = ESIndex(index_name, config)
     mock_responses.post(
@@ -127,7 +124,6 @@ async def test_index(mock_responses):
 
 @pytest.mark.asyncio
 async def test_update(mock_responses):
-    index_name = "fake_index"
     doc_id = "1"
     index = ESIndex(index_name, config)
     mock_responses.post(
@@ -144,7 +140,6 @@ async def test_update(mock_responses):
 
 @pytest.mark.asyncio
 async def test_get_all_docs_with_error(mock_responses):
-    index_name = "fake_index"
     index = FakeIndex(index_name, config)
     mock_responses.post(
         f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
@@ -164,7 +159,6 @@ async def test_get_all_docs_with_error(mock_responses):
 
 @pytest.mark.asyncio
 async def test_get_all_docs(mock_responses):
-    index_name = "fake_index"
     index = FakeIndex(index_name, config)
     total = 3
     mock_responses.post(

--- a/connectors/tests/test_es_index.py
+++ b/connectors/tests/test_es_index.py
@@ -3,20 +3,25 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+from unittest.mock import Mock, AsyncMock
 
 import pytest
 
 from connectors.es.index import ESIndex
 
+from elasticsearch import ApiError
+
+
+headers = {"X-Elastic-Product": "Elasticsearch"}
+config = {
+    "username": "elastic",
+    "password": "changeme",
+    "host": "http://nowhere.com:9200",
+}
+
 
 @pytest.mark.asyncio
 async def test_es_index_create_object_error(mock_responses, patch_logger):
-    headers = {"X-Elastic-Product": "Elasticsearch"}
-    config = {
-        "username": "elastic",
-        "password": "changeme",
-        "host": "http://nowhere.com:9200",
-    }
     index = ESIndex("index", config)
     mock_responses.post(
         "http://nowhere.com:9200/index/_refresh", headers=headers, status=200
@@ -31,3 +36,113 @@ async def test_es_index_create_object_error(mock_responses, patch_logger):
     with pytest.raises(NotImplementedError) as _:
         async for doc_ in index.get_all_docs():
             pass
+
+
+class FakeDocument:
+    pass
+
+
+class FakeIndex(ESIndex):
+    def _create_object(self, doc):
+        return FakeDocument()
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_id(mock_responses):
+    index_name = "fake_index"
+    doc_id = "1"
+    index = FakeIndex(index_name, config)
+    mock_responses.post(
+        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
+    )
+
+    mock_responses.get(
+        f"http://nowhere.com:9200/{index_name}/_doc/{doc_id}",
+        headers=headers,
+        status=200,
+        payload={"_index": index_name, "_id": doc_id, "_source": {}}
+    )
+
+    result = await index.fetch_by_id(doc_id)
+    assert isinstance(result, FakeDocument)
+
+    await index.close()
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_id_not_found(mock_responses):
+    index_name = "fake_index"
+    doc_id = "1"
+    index = FakeIndex(index_name, config)
+    mock_responses.post(
+        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
+    )
+
+    mock_responses.get(
+        f"http://nowhere.com:9200/{index_name}/_doc/{doc_id}",
+        headers=headers,
+        status=404,
+    )
+
+    result = await index.fetch_by_id(doc_id)
+    assert result is None
+
+    await index.close()
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_id_api_error(mock_responses):
+    index_name = "fake_index"
+    doc_id = "1"
+    index = FakeIndex(index_name, config)
+    mock_responses.post(
+        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
+    )
+
+    mock_responses.get(
+        f"http://nowhere.com:9200/{index_name}/_doc/{doc_id}",
+        headers=headers,
+        status=500,
+    )
+
+    with pytest.raises(ApiError):
+        await index.fetch_by_id(doc_id)
+
+    await index.close()
+
+
+@pytest.mark.asyncio
+async def test_index(mock_responses):
+    index_name = "fake_index"
+    doc_id = "1"
+    index = ESIndex(index_name, config)
+    mock_responses.post(
+        f"http://nowhere.com:9200/{index_name}/_doc",
+        headers=headers,
+        status=200,
+        payload={"_id": doc_id},
+    )
+
+    indexed_id = await index.index({})
+    assert indexed_id == doc_id
+
+    await index.close()
+
+
+@pytest.mark.asyncio
+async def test_update(mock_responses):
+    index_name = "fake_index"
+    doc_id = "1"
+    index = ESIndex(index_name, config)
+    mock_responses.post(
+        f"http://nowhere.com:9200/{index_name}/_update/{doc_id}",
+        headers=headers,
+        status=200,
+    )
+
+    try:
+        await index.update(doc_id, {})
+    except Exception as e:
+        assert False, f"'update' raised an exception {e}"
+
+    await index.close()


### PR DESCRIPTION
Tarek pointed out ([slack link](https://elastic.slack.com/archives/C01795T48LQ/p1678209151786269)) that the test coverage for the ESIndex class is only 62%. This PR improves the coverage to 100%

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference