### PR TITLE
Add concurrency control functionality

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -389,22 +389,9 @@ class Connector(ESDocument):
     def status(self):
         return Status(self.get("status"))
 
-    @status.setter
-    def status(self, value):
-        if isinstance(value, str):
-            value = Status(value)
-        if not isinstance(value, Status):
-            raise TypeError(value)
-
-        self._source["status"] = value
-
     @property
     def service_type(self):
         return self.get("service_type")
-
-    @service_type.setter
-    def service_type(self, value):
-        self._source["service_type"] = value
 
     @property
     def last_seen(self):
@@ -429,10 +416,6 @@ class Connector(ESDocument):
     def configuration(self):
         return DataSourceConfiguration(self.get("configuration"))
 
-    @configuration.setter
-    def configuration(self, value):
-        self._source["configuration"] = value
-
     @property
     def index_name(self):
         return self.get("index_name")
@@ -444,10 +427,6 @@ class Connector(ESDocument):
     @property
     def filtering(self):
         return Filtering(self.get("filtering"))
-
-    @filtering.setter
-    def filtering(self, value):
-        self._source["filtering"] = value
 
     @property
     def pipeline(self):
@@ -544,7 +523,7 @@ class Connector(ESDocument):
                     f"Service type is not configured for connector {configured_connector_id}"
                 )
                 raise ServiceTypeNotConfiguredError("Service type is not configured.")
-            self.service_type = doc["service_type"] = configured_service_type
+            doc["service_type"] = configured_service_type
             logger.debug(
                 f"Populated service type {configured_service_type} for connector {self.id}"
             )
@@ -557,10 +536,8 @@ class Connector(ESDocument):
                 source_klass = get_source_klass(fqn)
 
                 # sets the defaults and the flag to NEEDS_CONFIGURATION
-                self.configuration = doc[
-                    "configuration"
-                ] = source_klass.get_simple_configuration()
-                self.status = doc["status"] = Status.NEEDS_CONFIGURATION.value
+                doc["configuration"] = source_klass.get_simple_configuration()
+                doc["status"] = Status.NEEDS_CONFIGURATION.value
                 logger.debug(f"Populated configuration for connector {self.id}")
             except Exception as e:
                 logger.critical(e, exc_info=True)
@@ -570,6 +547,7 @@ class Connector(ESDocument):
 
         try:
             await self.index.update(doc_id=self.id, doc=doc)
+            await self.reload()
         except Exception as e:
             logger.critical(e, exc_info=True)
             raise ConnectorUpdateError(
@@ -601,8 +579,8 @@ class Connector(ESDocument):
                 if validation_result.state == FilteringValidationState.VALID:
                     filter_["active"] = filter_.get("draft")
 
-        self.filtering = filtering
         await self.index.update(doc_id=self.id, doc={"filtering": filtering})
+        await self.reload()
 
     async def document_count(self):
         await self.index.client.indices.refresh(

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -547,12 +547,12 @@ class Connector(ESDocument):
 
         try:
             await self.index.update(doc_id=self.id, doc=doc)
-            await self.reload()
         except Exception as e:
             logger.critical(e, exc_info=True)
             raise ConnectorUpdateError(
                 f"Could not update service type/configuration for connector {self.id}"
             )
+        await self.reload()
 
     async def validate_filtering(self, validator):
         draft_filter = self.filtering.get_draft_filter()

--- a/connectors/es/document.py
+++ b/connectors/es/document.py
@@ -42,4 +42,7 @@ class ESDocument:
         return value
 
     async def reload(self):
-        return await self.index.fetch_by_id(self.id)
+        doc_source = await self.index.fetch_response_by_id(self.id)
+        self._seq_no = doc_source.get("_seq_no")
+        self._primary_term = doc_source.get("_primary_term")
+        self._source = doc_source.get("_source", {})

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -54,12 +54,23 @@ class ESIndex(ESClient):
 
         return self._create_object(resp.body)
 
+    async def fetch_response_by_id(self, doc_id):
+        await self.client.indices.refresh(index=self.index_name)
+        resp = await self.client.get(index=self.index_name, id=doc_id)
+        return resp.body
+
     async def index(self, doc):
         resp = await self.client.index(index=self.index_name, document=doc)
         return resp["_id"]
 
-    async def update(self, doc_id, doc):
-        await self.client.update(index=self.index_name, id=doc_id, doc=doc)
+    async def update(self, doc_id, doc, if_seq_no=None, if_primary_term=None):
+        await self.client.update(
+            index=self.index_name,
+            id=doc_id,
+            doc=doc,
+            if_seq_no=if_seq_no,
+            if_primary_term=if_primary_term,
+        )
 
     async def get_all_docs(self, query=None, page_size=DEFAULT_PAGE_SIZE):
         """

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -11,6 +11,10 @@ from connectors.logger import logger
 DEFAULT_PAGE_SIZE = 100
 
 
+class DocumentNotFoundError(Exception):
+    pass
+
+
 class ESIndex(ESClient):
     """
     Encapsulates the work with Elasticsearch index.
@@ -41,6 +45,10 @@ class ESIndex(ESClient):
         raise NotImplementedError
 
     async def fetch_by_id(self, doc_id):
+        resp_body = await self.fetch_response_by_id(doc_id)
+        return self._create_object(resp_body)
+
+    async def fetch_response_by_id(self, doc_id):
         await self.client.indices.refresh(index=self.index_name)
 
         try:
@@ -49,14 +57,11 @@ class ESIndex(ESClient):
             logger.critical(f"The server returned {e.status_code}")
             logger.critical(e.body, exc_info=True)
             if e.status_code == 404:
-                return None
+                raise DocumentNotFoundError(
+                    f"Couldn't find document in {self.index_name} by id {doc_id}"
+                )
             raise
 
-        return self._create_object(resp.body)
-
-    async def fetch_response_by_id(self, doc_id):
-        await self.client.indices.refresh(index=self.index_name)
-        resp = await self.client.get(index=self.index_name, id=doc_id)
         return resp.body
 
     async def index(self, doc):

--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -8,6 +8,7 @@ A task periodically clean up orphaned and idle jobs.
 """
 
 from connectors.byoc import ConnectorIndex, SyncJobIndex
+from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
 from connectors.services.base import BaseService
 
@@ -106,15 +107,20 @@ class JobCleanUpService(BaseService):
                     await job.fail(message=IDLE_JOB_ERROR)
                     marked_count += 1
 
-                    connector = await self.connector_index.fetch_by_id(
-                        doc_id=connector_id
-                    )
-                    if connector is None:
+                    try:
+                        connector = await self.connector_index.fetch_by_id(
+                            doc_id=connector_id
+                        )
+                    except DocumentNotFoundError:
                         logger.warning(
                             f"Could not found connector by id #{connector_id}"
                         )
                         continue
-                    job = await self.sync_job_index.fetch_by_id(doc_id=job_id)
+                    try:
+                        await job.reload()
+                    except DocumentNotFoundError:
+                        logger.warning(f"Could not reload sync job #{job_id}")
+                        job = None
                     await connector.sync_done(job=job)
                 except Exception as e:
                     logger.error(f"Failed to mark idle job #{job_id} as error: {e}")

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -22,6 +22,7 @@ from connectors.byoc import (
     SyncJobIndex,
 )
 from connectors.byoei import ElasticServer
+from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
 from connectors.services.base import BaseService
 from connectors.source import get_source_klass_dict
@@ -108,7 +109,12 @@ class JobSchedulingService(BaseService):
         job_id = await self.sync_job_index.create(connector)
         if connector.sync_now:
             await connector.reset_sync_now_flag()
-        sync_job = await self.sync_job_index.fetch_by_id(job_id)
+        try:
+            sync_job = await self.sync_job_index.fetch_by_id(job_id)
+        except DocumentNotFoundError:
+            logger.error(f"Couldn't load sync job by id {job_id}")
+            return
+
         sync_job_runner = SyncJobRunner(
             source_klass=source_klass,
             sync_job=sync_job,

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -144,7 +144,11 @@ class SyncJobRunner:
         else:
             await self.sync_job.done(ingestion_stats=ingestion_stats)
 
-        self.sync_job = await self.sync_job.reload()
+        try:
+            await self.sync_job.reload()
+        except Exception as e:
+            logger.error(f"Failed to reload sync job {self.job_id}. Error: {e}")
+            self.sync_job = None
         await self.connector.sync_done(self.sync_job)
         logger.info(
             f"[{self.job_id}] Sync done: {indexed_count} indexed, {doc_deleted} "

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -8,6 +8,7 @@ import time
 
 from connectors.byoc import JobStatus
 from connectors.es import Mappings
+from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
 
 
@@ -146,7 +147,7 @@ class SyncJobRunner:
 
         try:
             await self.sync_job.reload()
-        except Exception as e:
+        except DocumentNotFoundError as e:
             logger.error(f"Failed to reload sync job {self.job_id}. Error: {e}")
             self.sync_job = None
         await self.connector.sync_done(self.sync_job)

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -702,11 +702,8 @@ async def test_prepare(mock_responses):
         async def update(self, doc_id, doc):
             pass
 
-        async def fetch_by_id(self, doc_id):
-            return Connector(
-                self,
-                connector_doc_after_prepare,
-            )
+        async def fetch_response_by_id(self, doc_id):
+            return connector_doc_after_prepare
 
     # generic empty doc created by the user through the Kibana UI
     # when it's created that way, the service type is None,
@@ -761,6 +758,7 @@ async def test_connector_validate_filtering_not_edited(patch_logger):
 async def test_connector_validate_filtering_invalid(patch_logger):
     index = Mock()
     index.update = AsyncMock()
+    index.fetch_response_by_id = AsyncMock()
     validation_result = FilteringValidationResult(
         state=FilteringValidationState.INVALID,
         errors=[FilterValidationError(ids=[1], messages="something wrong")],
@@ -788,12 +786,14 @@ async def test_connector_validate_filtering_invalid(patch_logger):
     index.update.assert_awaited_with(
         doc_id=CONNECTOR_ID, doc=expected_validation_update_doc
     )
+    index.fetch_response_by_id.assert_awaited()
 
 
 @pytest.mark.asyncio
 async def test_connector_validate_filtering_valid(patch_logger):
     index = Mock()
     index.update = AsyncMock()
+    index.fetch_response_by_id = AsyncMock()
     validation_result = FilteringValidationResult()
     validator = Mock()
     validator.validate_filtering = AsyncMock(return_value=validation_result)
@@ -813,13 +813,13 @@ async def test_connector_validate_filtering_valid(patch_logger):
     connector = Connector(
         elastic_index=index, doc_source=deepcopy(DOC_SOURCE_WITH_EDITED_FILTERING)
     )
-    index.fetch_by_id = AsyncMock(return_value=connector)
     await connector.validate_filtering(validator=validator)
 
     validator.validate_filtering.assert_awaited()
     index.update.assert_awaited_with(
         doc_id=CONNECTOR_ID, doc=expected_validation_update_doc
     )
+    index.fetch_response_by_id.assert_awaited()
 
 
 @pytest.mark.parametrize(

--- a/connectors/tests/test_es_index.py
+++ b/connectors/tests/test_es_index.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import pytest
-from elasticsearch import ApiError
+from elasticsearch import ApiError, ConflictError
 
 from connectors.es.index import ESIndex
 
@@ -106,6 +106,34 @@ async def test_fetch_by_id_api_error(mock_responses):
 
 
 @pytest.mark.asyncio
+async def test_fetch_response_by_id(mock_responses):
+    doc_id = "1"
+    index = ESIndex(index_name, config)
+    doc_source = {
+        "_index": index_name,
+        "_id": doc_id,
+        "_seq_no": 1,
+        "_primary_term": 1,
+        "_source": {},
+    }
+    mock_responses.post(
+        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
+    )
+
+    mock_responses.get(
+        f"http://nowhere.com:9200/{index_name}/_doc/{doc_id}",
+        headers=headers,
+        status=200,
+        payload=doc_source,
+    )
+
+    result = await index.fetch_response_by_id(doc_id)
+    assert result == doc_source
+
+    await index.close()
+
+
+@pytest.mark.asyncio
 async def test_index(mock_responses):
     doc_id = "1"
     index = ESIndex(index_name, config)
@@ -134,6 +162,22 @@ async def test_update(mock_responses):
 
     # the test will fail if any error is raised
     await index.update(doc_id, {})
+
+    await index.close()
+
+
+@pytest.mark.asyncio
+async def test_update_with_concurrency_control(mock_responses):
+    doc_id = "1"
+    index = ESIndex(index_name, config)
+    mock_responses.post(
+        f"http://nowhere.com:9200/{index_name}/_update/{doc_id}?if_seq_no=1&if_primary_term=1",
+        headers=headers,
+        status=409,
+    )
+
+    with pytest.raises(ConflictError):
+        await index.update(doc_id, {}, if_seq_no=1, if_primary_term=1)
 
     await index.close()
 

--- a/connectors/tests/test_job_cleanup.py
+++ b/connectors/tests/test_job_cleanup.py
@@ -45,6 +45,7 @@ def mock_sync_job(id="1", connector_id="1", index_name="index_name"):
     job.connector_id = connector_id
     job.index_name = index_name
     job.fail = AsyncMock()
+    job.reload = AsyncMock()
     return job
 
 
@@ -57,7 +58,6 @@ async def run_service_with_stop_after(service, stop_after):
 
 
 @pytest.mark.asyncio
-@patch("connectors.byoc.SyncJobIndex.fetch_by_id")
 @patch("connectors.byoc.SyncJobIndex.delete_jobs")
 @patch("connectors.byoc.SyncJobIndex.delete_indices")
 @patch("connectors.byoc.SyncJobIndex.idle_jobs")
@@ -73,7 +73,6 @@ async def test_cleanup_jobs(
     idle_jobs,
     delete_indices,
     delete_jobs,
-    sync_job_fetch_by_id,
     patch_logger,
 ):
     existing_index_name = "foo"
@@ -88,7 +87,6 @@ async def test_cleanup_jobs(
     orphaned_jobs.return_value = AsyncIterator([sync_job, another_sync_job])
     idle_jobs.return_value = AsyncIterator([sync_job])
     delete_jobs.return_value = {"deleted": 1, "failures": [], "total": 1}
-    sync_job_fetch_by_id.return_value = sync_job
 
     service = create_service()
     await run_service_with_stop_after(service, 0.1)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4157

This PR:
1. adds new instance variable `_seq_no` and `_primary_field` to `ESDocument` class
2. makes the `reload` method of `ESDocument` class update the instance variables directly
3. removes `@setter` methods, and makes `prepare` and `validate_filtering` methods of `Connector` class to `reload`.
4. makes the `get_all_docs` method of `ESIndex` to retrieve `_seq_no` and `_primary_field`
5. makes the `update` method of `ESIndex` to accept `if_seq_no` and `if_primary_field` paremeters

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference