### PR TITLE
service factory metaclass

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -35,8 +35,8 @@ def _parser():
     parser.add_argument(
         "--action",
         type=str,
-        default=["poll"],
-        choices=["poll", "list"],
+        default=["poll", "cleanup"],
+        choices=["poll", "list", "cleanup"],
         nargs="+",
         help="What elastic-ingest should do",
     )

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -21,9 +21,7 @@ from connectors import __version__
 from connectors.config import load_config
 from connectors.logger import logger, set_logger
 from connectors.preflight_check import PreflightCheck
-from connectors.services.base import MultiService
-from connectors.services.job_cleanup import JobCleanUpService
-from connectors.services.job_scheduling import JobSchedulingService
+from connectors.services import get_services
 from connectors.source import get_source_klasses
 from connectors.utils import get_event_loop
 
@@ -37,8 +35,9 @@ def _parser():
     parser.add_argument(
         "--action",
         type=str,
-        default="poll",
+        default=["poll"],
         choices=["poll", "list"],
+        nargs="+",
         help="What elastic-ingest should do",
     )
 
@@ -90,7 +89,7 @@ def _parser():
     return parser
 
 
-async def _start_service(config, loop):
+async def _start_service(actions, config, loop):
     """Starts the service.
 
     Steps:
@@ -107,7 +106,7 @@ async def _start_service(config, loop):
         for sig in (signal.SIGINT, signal.SIGTERM):
             loop.remove_signal_handler(sig)
 
-    multiservice = MultiService(JobSchedulingService(config), JobCleanUpService(config))
+    multiservice = get_services(actions, config)
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, functools.partial(multiservice.shutdown, sig.name))
 
@@ -147,15 +146,19 @@ def run(args):
     )
 
     # just display the list of connectors
-    if args.action == "list":
+    if args.action == ["list"]:
         print("Registered connectors:")
         for source in get_source_klasses(config):
             print(f"- {source.name}")
         print("Bye")
         return 0
 
+    if "list" in args.action:
+        print("Cannot use the `list` action with other actions")
+        return -1
+
     loop = get_event_loop(args.uvloop)
-    coro = _start_service(config, loop)
+    coro = _start_service(args.action, config, loop)
 
     try:
         return loop.run_until_complete(coro)

--- a/connectors/services/__init__.py
+++ b/connectors/services/__init__.py
@@ -5,4 +5,4 @@
 #
 from connectors.services.base import get_services  # NOQA
 from connectors.services.job_cleanup import JobCleanUpService  # NOQA
-from connectors.services.sync import SyncService  # NOQA
+from connectors.services.job_scheduling import JobSchedulingService  # NOQA

--- a/connectors/services/__init__.py
+++ b/connectors/services/__init__.py
@@ -3,3 +3,6 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+from connectors.services.base import get_services  # NOQA
+from connectors.services.job_cleanup import JobCleanUpService  # NOQA
+from connectors.services.sync import SyncService  # NOQA

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -14,7 +14,29 @@ class ServiceAlreadyRunningError(Exception):
     pass
 
 
-class BaseService:
+_SERVICES = {}
+
+
+def get_services(names, config):
+    return MultiService(*[get_service(name, config) for name in names])
+
+
+def get_service(name, config):
+    return _SERVICES[name](config)
+
+
+class _Registry(type):
+    def __new__(cls, name, bases, dct):
+        service_name = dct.get("name")
+        class_instance = super().__new__(cls, name, bases, dct)
+        if service_name is not None:
+            _SERVICES[service_name] = class_instance
+        return class_instance
+
+
+class BaseService(metaclass=_Registry):
+    name = None
+
     def __init__(self, config):
         self.config = config
         self.service_config = self.config["service"]

--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -15,6 +15,8 @@ IDLE_JOB_ERROR = "The job has not seen any update for some time."
 
 
 class JobCleanUpService(BaseService):
+    name = "cleanup"
+
     def __init__(self, config):
         super().__init__(config)
         self.idling = int(self.service_config.get("job_cleanup_interval", 60 * 5))

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -32,6 +32,8 @@ DEFAULT_MAX_CONCURRENT_SYNCS = 1
 
 
 class JobSchedulingService(BaseService):
+    name = "poll"
+
     def __init__(self, config):
         super().__init__(config)
         self.idling = self.service_config["idling"]

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -51,7 +51,7 @@ def test_run(mock_responses, patch_logger, set_env):
     args = mock.MagicMock()
     args.log_level = "DEBUG"
     args.config_file = CONFIG
-    args.action = "list"
+    args.action = ["list"]
     with patch("sys.stdout", new=StringIO()) as patched_stdout:
         assert run(args) == 0
 

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -63,6 +63,17 @@ def test_run(mock_responses, patch_logger, set_env):
         assert "Bye" in output
 
 
+def test_run_snowflake(mock_responses, patch_logger, set_env):
+    args = mock.MagicMock()
+    args.log_level = "DEBUG"
+    args.config_file = CONFIG
+    args.action = ["list", "poll"]
+    with patch("sys.stdout", new=StringIO()) as patched_stdout:
+        assert run(args) == -1
+        output = patched_stdout.getvalue().strip()
+        assert "Cannot use the `list` action with other actions" in output
+
+
 @patch("connectors.cli.set_logger")
 @patch("connectors.cli.load_config", side_effect=Exception("something went wrong"))
 def test_main_with_invalid_configuration(load_config, set_logger, patch_logger):


### PR DESCRIPTION
This patch prepares https://github.com/elastic/connectors-python/pull/220/files where I'll add a new service.

It introduces a simple metaclass to simplify the registry of services in the CLI (one service == one action)

It allows running the CLI like this:

```
elastic-ingest --action sync cleanup upload
```

And automatically create a `MultiService` instance with the two services -- removing the need to define services in CLI.
To add a new service, you just create the class and name the action 

