### PR TITLE
[MongoDB] Advanced rules validator

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -25,7 +25,7 @@ class MongoAdvancedRulesValidator(AdvancedRulesValidator):
     Validate advanced rules for MongoDB, so that they're adhering to the motor asyncio API (see: https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_collection.html)
     """
 
-    # see: https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_collection.html
+    # see: https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_collection.html#motor.motor_asyncio.AsyncIOMotorCollection.aggregate
     AGGREGATE_SCHEMA_DEFINITION = {
         "type": "object",
         "properties": {

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -5,11 +5,85 @@
 #
 from datetime import datetime
 
+import fastjsonschema
 from bson import Decimal128, ObjectId
+from fastjsonschema import JsonSchemaValueException
 from motor.motor_asyncio import AsyncIOMotorClient
 
+from connectors.filtering.validation import (
+    AdvancedRulesValidator,
+    SyncRuleValidationResult,
+)
 from connectors.logger import logger
 from connectors.source import BaseDataSource
+
+#
+
+
+class MongoAdvancedRulesValidator(AdvancedRulesValidator):
+    """
+    Validate advanced rules for MongoDB, so that they're adhering to the motor asyncio API (see: https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_collection.html)
+    """
+
+    # see: https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_collection.html
+    AGGREGATE_SCHEMA_DEFINITION = {
+        "type": "object",
+        "properties": {
+            "allowDiskUse": {"type": "boolean"},
+            "maxTimeMS": {"type": "integer"},
+            "batchSize": {"type": "integer"},
+            "let": {"type": "object"},
+            "pipeline": {"type": "array", "minItems": 1},
+        },
+        "additionalProperties": False,
+    }
+
+    # see: https://pymongo.readthedocs.io/en/4.3.2/api/pymongo/collection.html#pymongo.collection.Collection.find
+    FIND_SCHEMA_DEFINITION = {
+        "type": "object",
+        "properties": {
+            "filter": {"type": "object"},
+            "projection": {"type": ["array", "object"], "minItems": 1},
+            "skip": {"type": "integer"},
+            "limit": {"type": "integer"},
+            "no_cursor_timeout": {"type": "boolean"},
+            "allow_partial_results": {"type": "boolean"},
+            "batch_size": {"type": "integer"},
+            "return_key": {"type": "boolean"},
+            "show_record_id": {"type": "boolean"},
+            "max_time_ms": {"type": "integer"},
+            "allow_disk_use": {"type": "boolean"},
+        },
+        "additionalProperties": False,
+    }
+
+    ADVANCED_RULES_SCHEMA_DEFINITION = {
+        "type": "object",
+        "properties": {
+            "aggregate": AGGREGATE_SCHEMA_DEFINITION,
+            "find": FIND_SCHEMA_DEFINITION,
+        },
+        "additionalProperties": False,
+        # exactly one property -> only "aggregate" OR "find" allowed
+        "minProperties": 1,
+        "maxProperties": 1,
+    }
+
+    SCHEMA = fastjsonschema.compile(definition=ADVANCED_RULES_SCHEMA_DEFINITION)
+
+    def validate(self, advanced_rules):
+        try:
+            MongoAdvancedRulesValidator.SCHEMA(advanced_rules)
+
+            return SyncRuleValidationResult.valid_result(
+                rule_id=SyncRuleValidationResult.ADVANCED_RULES
+            )
+        except JsonSchemaValueException as e:
+            return SyncRuleValidationResult(
+                rule_id=SyncRuleValidationResult.ADVANCED_RULES,
+                is_valid=False,
+                validation_message=e.message,
+            )
 
 
 class MongoDataSource(BaseDataSource):
@@ -64,6 +138,9 @@ class MongoDataSource(BaseDataSource):
                 "value": True,
             },
         }
+
+    def advanced_rules_validators(self):
+        return MongoAdvancedRulesValidator()
 
     async def ping(self):
         await self.client.admin.command("ping")

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -57,7 +57,7 @@ class MongoAdvancedRulesValidator(AdvancedRulesValidator):
         "additionalProperties": False,
     }
 
-    ADVANCED_RULES_SCHEMA_DEFINITION = {
+    SCHEMA_DEFINITION = {
         "type": "object",
         "properties": {
             "aggregate": AGGREGATE_SCHEMA_DEFINITION,
@@ -69,7 +69,7 @@ class MongoAdvancedRulesValidator(AdvancedRulesValidator):
         "maxProperties": 1,
     }
 
-    SCHEMA = fastjsonschema.compile(definition=ADVANCED_RULES_SCHEMA_DEFINITION)
+    SCHEMA = fastjsonschema.compile(definition=SCHEMA_DEFINITION)
 
     def validate(self, advanced_rules):
         try:


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4171

Add the advanced rules validator for the MongoDB connector.
The advanced rules validator checks, that the provided advanced rules adhere to the motor asyncio API (see: https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_collection.html).

Note that some lower-level options, which require f.e. a python object are not exposed.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~