### PR TITLE
[MySQL] Add assertions to "close" tests

### DIFF
--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -6,7 +6,7 @@
 import asyncio
 import ssl
 from unittest import mock
-from unittest.mock import AsyncMock, Mock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import aiomysql
 import pytest

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -6,7 +6,7 @@
 import asyncio
 import ssl
 from unittest import mock
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, MagicMock
 
 import aiomysql
 import pytest
@@ -173,14 +173,6 @@ class Connection:
         pass
 
 
-class ConnectionPool:
-    def close(self):
-        pass
-
-    async def wait_closed(self):
-        pass
-
-
 class MockSsl:
     """This class contains methods which returns dummy ssl context"""
 
@@ -209,15 +201,23 @@ async def test_close_without_connection_pool():
 
     await source.close()
 
+    assert source.connection_pool is None
+
 
 @pytest.mark.asyncio
 async def test_close_with_connection_pool():
     source = create_source(MySqlDataSource)
-    source.connection_pool = ConnectionPool()
-    source.connection_pool.acquire = Connection
+    connection_pool = MagicMock()
+    connection_pool.close = Mock()
+    connection_pool.wait_closed = AsyncMock()
 
-    # Execute
+    source.connection_pool = connection_pool
+
     await source.close()
+
+    connection_pool.close.assert_called()
+    connection_pool.wait_closed.assert_awaited()
+    assert source.connection_pool is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I've noticed, that the tests regarding `close` for the MySQL connector didn't have any assertions, that a connection pool was actually closed. They've relied on the absence of an exception implying that the connection pool was closed correctly. 

Also removed the fake class `ConnectionPool` as this object/class is mocked now.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~