### PR TITLE
[MySQL] Use pass for noop statement in test

### DIFF
--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -261,8 +261,8 @@ async def test_connect_with_retry(patch_logger, patch_default_wait_multiplier):
         )
 
         with pytest.raises(Exception):
-            async for response in streamer:
-                response
+            async for _ in streamer:
+                pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Use `pass` for a noop statement in a test.