### PR TITLE
Fix small errors with MongoDB advanced filtering

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -71,7 +71,7 @@ class MongoAdvancedRulesValidator(AdvancedRulesValidator):
 
     SCHEMA = fastjsonschema.compile(definition=SCHEMA_DEFINITION)
 
-    def validate(self, advanced_rules):
+    async def validate(self, advanced_rules):
         try:
             MongoAdvancedRulesValidator.SCHEMA(advanced_rules)
 
@@ -140,7 +140,7 @@ class MongoDataSource(BaseDataSource):
         }
 
     def advanced_rules_validators(self):
-        return MongoAdvancedRulesValidator()
+        return [MongoAdvancedRulesValidator()]
 
     async def ping(self):
         await self.client.admin.command("ping")


### PR DESCRIPTION
2 small errors introduced in Advanced Filtering Rules:

1. `validate` method for validator should be async
2. `advanced_rules_validators` is expected to return an array.

This small PR just fixes these 2 errors.