### PR TITLE
[MongoDB] Allow empty advanced rules

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -62,7 +62,7 @@ class MongoAdvancedRulesValidator(AdvancedRulesValidator):
             "find": FIND_SCHEMA_DEFINITION,
         },
         "additionalProperties": False,
-        # exactly one property -> only "aggregate" OR "find" allowed
+        # max one property -> only "aggregate" OR "find" allowed
         "maxProperties": 1,
     }
 

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -17,8 +17,6 @@ from connectors.filtering.validation import (
 from connectors.logger import logger
 from connectors.source import BaseDataSource
 
-#
-
 
 class MongoAdvancedRulesValidator(AdvancedRulesValidator):
     """
@@ -65,7 +63,6 @@ class MongoAdvancedRulesValidator(AdvancedRulesValidator):
         },
         "additionalProperties": False,
         # exactly one property -> only "aggregate" OR "find" allowed
-        "minProperties": 1,
         "maxProperties": 1,
     }
 

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -62,7 +62,7 @@ class MongoAdvancedRulesValidator(AdvancedRulesValidator):
             "find": FIND_SCHEMA_DEFINITION,
         },
         "additionalProperties": False,
-        # max one property -> only "aggregate" OR "find" allowed
+        # at most one property -> only "aggregate" OR "find" allowed
         "maxProperties": 1,
     }
 

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -18,6 +18,11 @@ from connectors.sources.tests.support import assert_basics, create_source
     "advanced_rules, is_valid",
     [
         (
+            # empty advanced rules
+            {},
+            True,
+        ),
+        (
             # valid aggregate
             {
                 "aggregate": {


### PR DESCRIPTION
Empty advanced rules should be valid for MongoDB.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~