### PR TITLE
Decouple job execution service

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -35,8 +35,8 @@ def _parser():
     parser.add_argument(
         "--action",
         type=str,
-        default=["poll", "cleanup"],
-        choices=["poll", "list", "cleanup"],
+        default=["schedule", "execute", "cleanup"],
+        choices=["schedule", "execute", "list", "cleanup"],
         nargs="+",
         help="What elastic-ingest should do",
     )

--- a/connectors/services/__init__.py
+++ b/connectors/services/__init__.py
@@ -5,4 +5,5 @@
 #
 from connectors.services.base import get_services  # NOQA
 from connectors.services.job_cleanup import JobCleanUpService  # NOQA
+from connectors.services.job_execution import JobExecutionService  # NOQA
 from connectors.services.job_scheduling import JobSchedulingService  # NOQA

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -5,6 +5,7 @@
 #
 from connectors.byoc import ConnectorIndex, DataSourceError, SyncJobIndex
 from connectors.byoei import ElasticServer
+from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
 from connectors.services.base import BaseService
 from connectors.source import get_source_klass_dict
@@ -41,7 +42,11 @@ class JobExecutionService(BaseService):
             )
         source_klass = self.source_klass_dict[sync_job.service_type]
 
-        connector = await self.connector_index.fetch_by_id(sync_job.connector_id)
+        try:
+            connector = await self.connector_index.fetch_by_id(sync_job.connector_id)
+        except DocumentNotFoundError:
+            logger.error(f"Couldn't find connector by id {sync_job.connector_id}")
+            return
         sync_job_runner = SyncJobRunner(
             source_klass=source_klass,
             sync_job=sync_job,

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -15,6 +15,8 @@ DEFAULT_MAX_CONCURRENT_SYNCS = 1
 
 
 class JobExecutionService(BaseService):
+    name = "execute"
+
     def __init__(self, config):
         super().__init__(config)
         self.idling = self.service_config["idling"]

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -1,0 +1,115 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+from connectors.byoc import ConnectorIndex, DataSourceError, SyncJobIndex
+from connectors.byoei import ElasticServer
+from connectors.logger import logger
+from connectors.services.base import BaseService
+from connectors.source import get_source_klass_dict
+from connectors.sync_job_runner import SyncJobRunner
+from connectors.utils import ConcurrentTasks
+
+DEFAULT_MAX_CONCURRENT_SYNCS = 1
+
+
+class JobExecutionService(BaseService):
+    def __init__(self, config):
+        super().__init__(config)
+        self.idling = self.service_config["idling"]
+        self.concurrent_syncs = self.service_config.get(
+            "max_concurrent_syncs", DEFAULT_MAX_CONCURRENT_SYNCS
+        )
+        self.bulk_options = self.es_config.get("bulk", {})
+        self.source_klass_dict = get_source_klass_dict(config)
+        self.connector_index = None
+        self.sync_job_index = None
+        self.syncs = None
+
+    def stop(self):
+        super().stop()
+        if self.syncs is not None:
+            self.syncs.cancel()
+
+    async def _sync(self, sync_job, es):
+        if sync_job.service_type not in self.source_klass_dict:
+            raise DataSourceError(
+                f"Couldn't find data source class for {sync_job.service_type}"
+            )
+        source_klass = self.source_klass_dict[sync_job.service_type]
+
+        connector = await self.connector_index.fetch_by_id(sync_job.connector_id)
+        sync_job_runner = SyncJobRunner(
+            source_klass=source_klass,
+            sync_job=sync_job,
+            connector=connector,
+            elastic_server=es,
+            bulk_options=self.bulk_options,
+        )
+        await self.syncs.put(sync_job_runner.execute)
+
+    async def _run(self):
+        self.connector_index = ConnectorIndex(self.es_config)
+        self.sync_job_index = SyncJobIndex(self.es_config)
+
+        native_service_types = self.config.get("native_service_types", [])
+        logger.debug(f"Native support for {', '.join(native_service_types)}")
+
+        # TODO: we can support multiple connectors but Ruby can't so let's use a
+        # single id
+        # connector_ids = self.config.get("connector_ids", [])
+        if "connector_id" in self.config:
+            connector_ids = [self.config.get("connector_id")]
+        else:
+            connector_ids = []
+
+        logger.info(
+            f"Service started, listening to events from {self.es_config['host']}"
+        )
+
+        es = ElasticServer(self.es_config)
+        try:
+            while self.running:
+                # creating a pool of task for every round
+                self.syncs = ConcurrentTasks(max_concurrency=self.concurrent_syncs)
+
+                try:
+                    logger.debug(f"Polling every {self.idling} seconds")
+                    supported_connector_ids = [
+                        connector.id
+                        async for connector in self.connector_index.supported_connectors(
+                            native_service_types=native_service_types,
+                            connector_ids=connector_ids,
+                        )
+                    ]
+
+                    if len(supported_connector_ids) == 0:
+                        logger.info(
+                            f"There's no supported connectors found with native service types [{', '.join(native_service_types)}] and connector ids [{', '.join(connector_ids)}]"
+                        )
+                    else:
+                        async for sync_job in self.sync_job_index.pending_jobs(
+                            connector_ids=supported_connector_ids
+                        ):
+                            await self._sync(sync_job, es)
+                except Exception as e:
+                    logger.critical(e, exc_info=True)
+                    self.raise_if_spurious(e)
+                finally:
+                    await self.syncs.join()
+
+                self.syncs = None
+                # Immediately break instead of sleeping
+                if not self.running:
+                    break
+                await self._sleeps.sleep(self.idling)
+        finally:
+            if self.connector_index is not None:
+                self.connector_index.stop_waiting()
+                await self.connector_index.close()
+            if self.sync_job_index is not None:
+                self.sync_job_index.stop_waiting()
+                await self.sync_job_index.close()
+            await es.close()
+        return 0

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -36,7 +36,7 @@ class JobSchedulingService(BaseService):
         self.connector_index = None
         self.sync_job_index = None
 
-    async def _sync(self, connector):
+    async def _schedule(self, connector):
         if self.running is False:
             logger.debug(
                 f"Skipping run for {connector.id} because service is terminating"
@@ -128,7 +128,7 @@ class JobSchedulingService(BaseService):
                         native_service_types=native_service_types,
                         connector_ids=connector_ids,
                     ):
-                        await self._sync(connector)
+                        await self._schedule(connector)
                 except Exception as e:
                     logger.critical(e, exc_info=True)
                     self.raise_if_spurious(e)

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -26,7 +26,7 @@ from connectors.source import get_source_klass_dict
 
 
 class JobSchedulingService(BaseService):
-    name = "poll"
+    name = "schedule"
 
     def __init__(self, config):
         super().__init__(config)

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -15,20 +15,14 @@ from connectors.byoc import (
     ConnectorIndex,
     ConnectorUpdateError,
     DataSourceError,
-    JobStatus,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
     Status,
     SyncJobIndex,
 )
-from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
 from connectors.services.base import BaseService
 from connectors.source import get_source_klass_dict
-from connectors.sync_job_runner import SyncJobRunner
-from connectors.utils import ConcurrentTasks
-
-DEFAULT_MAX_CONCURRENT_SYNCS = 1
 
 
 class JobSchedulingService(BaseService):
@@ -38,18 +32,9 @@ class JobSchedulingService(BaseService):
         super().__init__(config)
         self.idling = self.service_config["idling"]
         self.heartbeat_interval = self.service_config["heartbeat"]
-        self.concurrent_syncs = self.service_config.get(
-            "max_concurrent_syncs", DEFAULT_MAX_CONCURRENT_SYNCS
-        )
         self.source_klass_dict = get_source_klass_dict(config)
         self.connector_index = None
         self.sync_job_index = None
-        self.syncs = None
-
-    def stop(self):
-        super().stop()
-        if self.syncs is not None:
-            self.syncs.cancel()
 
     async def _sync(self, connector):
         if self.running is False:
@@ -111,21 +96,9 @@ class JobSchedulingService(BaseService):
         if not await self._should_sync(connector):
             return
 
-        job_id = await self.sync_job_index.create(connector)
+        await self.sync_job_index.create(connector)
         if connector.sync_now:
             await connector.reset_sync_now_flag()
-        try:
-            sync_job = await self.sync_job_index.fetch_by_id(job_id)
-        except DocumentNotFoundError:
-            logger.error(f"Couldn't load sync job by id {job_id}")
-            return
-        sync_job_runner = SyncJobRunner(
-            source_klass=source_klass,
-            sync_job=sync_job,
-            connector=connector,
-            es_config=self.es_config,
-        )
-        await self.syncs.put(sync_job_runner.execute)
 
     async def _run(self):
         """Main event loop."""
@@ -149,9 +122,6 @@ class JobSchedulingService(BaseService):
 
         try:
             while self.running:
-                # creating a pool of task for every round
-                self.syncs = ConcurrentTasks(max_concurrency=self.concurrent_syncs)
-
                 try:
                     logger.debug(f"Polling every {self.idling} seconds")
                     async for connector in self.connector_index.supported_connectors(
@@ -162,10 +132,7 @@ class JobSchedulingService(BaseService):
                 except Exception as e:
                     logger.critical(e, exc_info=True)
                     self.raise_if_spurious(e)
-                finally:
-                    await self.syncs.join()
 
-                self.syncs = None
                 # Immediately break instead of sleeping
                 if not self.running:
                     break
@@ -186,10 +153,6 @@ class JobSchedulingService(BaseService):
             if next_sync == SYNC_DISABLED:
                 logger.debug(f"Scheduling is disabled for connector {connector.id}")
                 return False
-            # Then we check if we need to restart SUSPENDED job
-            if connector.last_sync_status == JobStatus.SUSPENDED:
-                logger.debug("Restarting sync after suspension")
-                return True
             # And only then we check if we need to run sync right now or not
             if next_sync - self.idling > 0:
                 logger.debug(

--- a/connectors/tests/test_job_execution.py
+++ b/connectors/tests/test_job_execution.py
@@ -1,0 +1,173 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+import asyncio
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from connectors.config import load_config
+from connectors.services.job_execution import JobExecutionService
+from connectors.tests.commons import AsyncIterator
+
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.yml")
+
+
+def create_service(config_file):
+    config = load_config(config_file)
+    service = JobExecutionService(config)
+    service.idling = 0.05
+
+    return service
+
+
+async def run_service_with_stop_after(service, stop_after=0):
+    def _stop_running_service_without_cancelling():
+        service.running = False
+
+    async def _terminate():
+        if stop_after == 0:
+            # so we actually want the service
+            # to run current loop without interruption
+            asyncio.get_event_loop().call_soon(_stop_running_service_without_cancelling)
+        else:
+            # but if stop_after is provided we want to
+            # interrupt the service after the timeout
+            await asyncio.sleep(stop_after)
+            service.stop()
+
+        await asyncio.sleep(0)
+
+    await asyncio.gather(service.run(), _terminate())
+
+
+async def create_and_run_service(config_file=CONFIG_FILE, stop_after=0):
+    service = create_service(config_file)
+    await run_service_with_stop_after(service, stop_after)
+
+
+@pytest.fixture(autouse=True)
+def connector_index_mock():
+    with patch(
+        "connectors.services.job_execution.ConnectorIndex"
+    ) as connector_index_klass_mock:
+        connector_index_mock = Mock()
+        connector_index_mock.stop_waiting = Mock()
+        connector_index_mock.close = AsyncMock()
+        connector_index_klass_mock.return_value = connector_index_mock
+
+        yield connector_index_mock
+
+
+@pytest.fixture(autouse=True)
+def sync_job_index_mock():
+    with patch(
+        "connectors.services.job_execution.SyncJobIndex"
+    ) as sync_job_index_klass_mock:
+        sync_job_index_mock = Mock()
+        sync_job_index_mock.stop_waiting = Mock()
+        sync_job_index_mock.close = AsyncMock()
+        sync_job_index_klass_mock.return_value = sync_job_index_mock
+
+        yield sync_job_index_mock
+
+
+@pytest.fixture(autouse=True)
+def concurrent_tasks_mock():
+    with patch(
+        "connectors.services.job_execution.ConcurrentTasks"
+    ) as concurrent_tasks_klass_mock:
+        concurrent_tasks_mock = Mock()
+        concurrent_tasks_mock.put = AsyncMock()
+        concurrent_tasks_mock.join = AsyncMock()
+        concurrent_tasks_mock.cancel = Mock()
+        concurrent_tasks_klass_mock.return_value = concurrent_tasks_mock
+
+        yield concurrent_tasks_mock
+
+
+@pytest.fixture(autouse=True)
+def sync_job_runner_mock():
+    with patch(
+        "connectors.services.job_execution.SyncJobRunner"
+    ) as sync_job_runner_klass_mock:
+        sync_job_runner_mock = Mock()
+        sync_job_runner_mock.execute = AsyncMock()
+        sync_job_runner_klass_mock.return_value = sync_job_runner_mock
+
+        yield sync_job_runner_mock
+
+
+def mock_connector():
+    connector = Mock()
+    connector.id = "1"
+
+    return connector
+
+
+def mock_sync_job(service_type="fake"):
+    sync_job = Mock()
+    sync_job.service_type = service_type
+    sync_job.connector_id = "1"
+
+    return sync_job
+
+
+@pytest.mark.asyncio
+async def test_no_connector(connector_index_mock, concurrent_tasks_mock, set_env):
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([])
+    await create_and_run_service()
+
+    concurrent_tasks_mock.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_pending_jobs(
+    connector_index_mock,
+    sync_job_index_mock,
+    concurrent_tasks_mock,
+    set_env,
+):
+    connector = mock_connector()
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([])
+    await create_and_run_service()
+
+    concurrent_tasks_mock.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_job_execution(
+    connector_index_mock,
+    sync_job_index_mock,
+    concurrent_tasks_mock,
+    sync_job_runner_mock,
+    set_env,
+):
+    connector = mock_connector()
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
+    connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
+    sync_job = mock_sync_job()
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
+    await create_and_run_service()
+
+    concurrent_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
+
+
+@pytest.mark.asyncio
+async def test_job_execution_with_supported_source(
+    connector_index_mock,
+    sync_job_index_mock,
+    concurrent_tasks_mock,
+    set_env,
+):
+    connector = mock_connector()
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
+    sync_job = mock_sync_job(service_type="mysql")
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
+    await create_and_run_service()
+
+    concurrent_tasks_mock.put.assert_not_awaited()

--- a/connectors/tests/test_job_scheduling.py
+++ b/connectors/tests/test_job_scheduling.py
@@ -216,7 +216,7 @@ async def test_connector_prepare_failed(
 
 @pytest.mark.asyncio
 async def test_run_when_sync_fails_then_continues_service_execution(
-    connector_index_mock, concurrent_tasks_mock, set_env
+    connector_index_mock, set_env
 ):
     connector = mock_connector(sync_now=True, next_sync=0)
     another_connector = mock_connector(sync_now=True, next_sync=0)

--- a/connectors/tests/test_job_scheduling.py
+++ b/connectors/tests/test_job_scheduling.py
@@ -13,7 +13,6 @@ from connectors.byoc import (
     SYNC_DISABLED,
     ConnectorUpdateError,
     DataSourceError,
-    JobStatus,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
     Status,
@@ -79,7 +78,6 @@ def sync_job_index_mock():
     ) as sync_job_index_klass_mock:
         sync_job_index_mock = Mock()
         sync_job_index_mock.create = AsyncMock(return_value="1")
-        sync_job_index_mock.fetch_by_id = AsyncMock(return_value=Mock())
         sync_job_index_mock.stop_waiting = Mock()
         sync_job_index_mock.close = AsyncMock()
         sync_job_index_klass_mock.return_value = sync_job_index_mock
@@ -87,37 +85,10 @@ def sync_job_index_mock():
         yield sync_job_index_mock
 
 
-@pytest.fixture(autouse=True)
-def concurrent_tasks_mock():
-    with patch(
-        "connectors.services.job_scheduling.ConcurrentTasks"
-    ) as concurrent_tasks_klass_mock:
-        concurrent_tasks_mock = Mock()
-        concurrent_tasks_mock.put = AsyncMock()
-        concurrent_tasks_mock.join = AsyncMock()
-        concurrent_tasks_mock.cancel = Mock()
-        concurrent_tasks_klass_mock.return_value = concurrent_tasks_mock
-
-        yield concurrent_tasks_mock
-
-
-@pytest.fixture(autouse=True)
-def sync_job_runner_mock():
-    with patch(
-        "connectors.services.job_scheduling.SyncJobRunner"
-    ) as sync_job_runner_klass_mock:
-        sync_job_runner_mock = Mock()
-        sync_job_runner_mock.execute = AsyncMock()
-        sync_job_runner_klass_mock.return_value = sync_job_runner_mock
-
-        yield sync_job_runner_mock
-
-
 def mock_connector(
     status=Status.CONNECTED,
     service_type="fake",
     next_sync=SYNC_DISABLED,
-    last_sync_status=JobStatus.COMPLETED,
     sync_now=False,
     prepare_exception=None,
 ):
@@ -126,7 +97,6 @@ def mock_connector(
     connector.service_type = service_type
     connector.status = status
     connector.configuration = DataSourceConfiguration({})
-    connector.last_sync_status = last_sync_status
     connector.sync_now = sync_now
 
     connector.features.sync_rules_enabled = Mock(return_value=True)
@@ -142,18 +112,19 @@ def mock_connector(
 
 
 @pytest.mark.asyncio
-async def test_no_connector(connector_index_mock, concurrent_tasks_mock, set_env):
+async def test_no_connector(
+    connector_index_mock, sync_job_index_mock, set_env
+):
     connector_index_mock.supported_connectors.return_value = AsyncIterator([])
     await create_and_run_service()
 
-    concurrent_tasks_mock.put.assert_not_awaited()
+    sync_job_index_mock.create.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_connector_sync_now(
     connector_index_mock,
-    concurrent_tasks_mock,
-    sync_job_runner_mock,
+    sync_job_index_mock,
     set_env,
 ):
     connector = mock_connector(sync_now=True, next_sync=0)
@@ -163,31 +134,13 @@ async def test_connector_sync_now(
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
     connector.reset_sync_now_flag.assert_awaited()
-    concurrent_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
-
-
-@pytest.mark.asyncio
-async def test_connector_with_suspended_job(
-    connector_index_mock,
-    concurrent_tasks_mock,
-    sync_job_runner_mock,
-    set_env,
-):
-    connector = mock_connector(next_sync=100, last_sync_status=JobStatus.SUSPENDED)
-    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    await create_and_run_service()
-
-    connector.prepare.assert_awaited()
-    connector.heartbeat.assert_awaited()
-    connector.reset_sync_now_flag.assert_not_awaited()
-    concurrent_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
+    sync_job_index_mock.create.assert_awaited_once_with(connector)
 
 
 @pytest.mark.asyncio
 async def test_connector_ready_to_sync(
     connector_index_mock,
-    concurrent_tasks_mock,
-    sync_job_runner_mock,
+    sync_job_index_mock,
     set_env,
 ):
     connector = mock_connector(next_sync=0.01)
@@ -197,12 +150,12 @@ async def test_connector_ready_to_sync(
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited
     connector.reset_sync_now_flag.assert_not_awaited()
-    concurrent_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
+    sync_job_index_mock.create.assert_awaited_once_with(connector)
 
 
 @pytest.mark.asyncio
 async def test_connector_sync_disabled(
-    connector_index_mock, concurrent_tasks_mock, set_env
+    connector_index_mock, sync_job_index_mock, set_env
 ):
     connector = mock_connector()
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
@@ -211,7 +164,7 @@ async def test_connector_sync_disabled(
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
     connector.reset_sync_now_flag.assert_not_awaited()
-    concurrent_tasks_mock.put.assert_not_awaited()
+    sync_job_index_mock.create.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -222,7 +175,7 @@ async def test_connector_sync_disabled(
 async def test_connector_not_configured(
     connector_status,
     connector_index_mock,
-    concurrent_tasks_mock,
+    sync_job_index_mock,
     set_env,
 ):
     connector = mock_connector(status=connector_status)
@@ -232,7 +185,7 @@ async def test_connector_not_configured(
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
     connector.reset_sync_now_flag.assert_not_awaited()
-    concurrent_tasks_mock.put.assert_not_awaited()
+    sync_job_index_mock.create.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -248,7 +201,7 @@ async def test_connector_not_configured(
 async def test_connector_prepare_failed(
     prepare_exception,
     connector_index_mock,
-    concurrent_tasks_mock,
+    sync_job_index_mock,
     set_env,
 ):
     connector = mock_connector(prepare_exception=prepare_exception())
@@ -258,7 +211,7 @@ async def test_connector_prepare_failed(
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_not_awaited()
     connector.reset_sync_now_flag.assert_not_awaited()
-    concurrent_tasks_mock.put.assert_not_awaited()
+    sync_job_index_mock.create.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_job_scheduling.py
+++ b/connectors/tests/test_job_scheduling.py
@@ -112,9 +112,7 @@ def mock_connector(
 
 
 @pytest.mark.asyncio
-async def test_no_connector(
-    connector_index_mock, sync_job_index_mock, set_env
-):
+async def test_no_connector(connector_index_mock, sync_job_index_mock, set_env):
     connector_index_mock.supported_connectors.return_value = AsyncIterator([])
     await create_and_run_service()
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4155

This PR decouples the job execution to a separate service.

1. The `JobSchedulingService` will only be responsible for scheduling jobs. It will create a job for a connector when the connector is scheduled to sync, but won't execute the job.
2. The `JobExecutionService` will only be responsible for executing jobs. It will periodically query jobs with `pending`/`suspended` status, and try to execute them.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference