### PR TITLE
[Filtering] Empty advanced rules shouldn't be validated

### DIFF
--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -160,7 +160,6 @@ class FilteringValidator:
     async def validate(self, filtering):
         logger.info("Filtering validation started")
         basic_rules = filtering.basic_rules
-        advanced_rules = filtering.get_advanced_rules()
 
         filtering_validation_result = FilteringValidationResult()
 
@@ -176,8 +175,11 @@ class FilteringValidator:
                     # pass rule by rule (validate rule in isolation)
                     filtering_validation_result += validator.validate(basic_rule)
 
-        for validator in self.advanced_rules_validators:
-            filtering_validation_result += await validator.validate(advanced_rules)
+        if filtering.has_advanced_rules():
+            advanced_rules = filtering.get_advanced_rules()
+
+            for validator in self.advanced_rules_validators:
+                filtering_validation_result += await validator.validate(advanced_rules)
 
         logger.info(f"Filtering validation result: {filtering_validation_result.state}")
         logger.info(

--- a/connectors/tests/test_validation.py
+++ b/connectors/tests/test_validation.py
@@ -63,7 +63,7 @@ RULE_TWO = {
 FILTERING_ONE_BASIC_RULE_WITH_ADVANCED_RULE = Filter(
     {
         "rules": [RULE_ONE],
-        "advanced_snippet": {"query": {}},
+        "advanced_snippet": {"value": {"query": {}}},
     }
 )
 
@@ -699,6 +699,28 @@ async def test_filtering_validator(
         advanced_rule_validators,
         FILTERING_ONE_BASIC_RULE_WITH_ADVANCED_RULE["advanced_snippet"],
     )
+
+
+@pytest.mark.asyncio
+async def test_filtering_validator_validate_when_advanced_rules_empty_then_skip_validation():
+    invalid_validation_result = SyncRuleValidationResult(
+        rule_id=RULE_TWO_ID,
+        is_valid=False,
+        validation_message=RULE_TWO_VALIDATION_MESSAGE,
+    )
+
+    advanced_rule_validators = validator_fakes(
+        [invalid_validation_result],
+        is_basic_rule_validator=False,
+    )
+
+    filtering_validator = FilteringValidator([], advanced_rule_validators)
+
+    validation_result = await filtering_validator.validate(
+        Filter({"basic_rules": [], "advanced_snippet": {"value": {}}})
+    )
+
+    assert validation_result.state == FilteringValidationState.VALID
 
 
 def validator_fakes(results, is_basic_rule_validator=True):


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4183

Empty advanced rules shouldn't be validated, because that would imply that every connector implementation needs to handle the special case of advanced rules being empty correctly.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~