### PR TITLE
Make search api always return seq_no and primary_term

### DIFF
--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -87,6 +87,7 @@ class ESIndex(ESClient):
                     from_=offset,
                     size=page_size,
                     expand_wildcards="hidden",
+                    seq_no_primary_term=True,
                 )
             except ApiError as e:
                 logger.critical(f"The server returned {e.status_code}")


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4157

This PR makes the `get_all_docs` method of `ESIndex` to always retrieve `_seq_no` and `_primary_term`

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference