### PR TITLE
Add _seq_no and _primary_term to ESDocument

### DIFF
--- a/connectors/es/document.py
+++ b/connectors/es/document.py
@@ -23,6 +23,8 @@ class ESDocument:
             raise InvalidDocumentSourceError(
                 f"Invalid type found for id: {type(self.id).__name__}, expected: {str.__name__}"
             )
+        self._seq_no = doc_source.get("_seq_no")
+        self._primary_term = doc_source.get("_primary_term")
         self._source = doc_source.get("_source", {})
         if not isinstance(self._source, dict):
             raise InvalidDocumentSourceError(

--- a/connectors/tests/test_es_document.py
+++ b/connectors/tests/test_es_document.py
@@ -32,6 +32,8 @@ def test_es_document_ok(patch_logger):
 def test_es_document_get():
     source = {
         "_id": "test",
+        "_seq_no": 1,
+        "_primary_term": 2,
         "_source": {
             "string": "string_value",
             "none_value": None,
@@ -42,6 +44,8 @@ def test_es_document_get():
     default_value = "default"
     es_doc = ESDocument(elastic_index=None, doc_source=source)
     assert es_doc.id == "test"
+    assert es_doc._seq_no == 1
+    assert es_doc._primary_term == 2
     assert es_doc.get("string", default=default_value) == "string_value"
     assert es_doc.get("non_existing") is None
     assert es_doc.get("non_existing", default=default_value) == default_value


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4157

This PR adds new instance variable `_seq_no` and `_primary_term` to `ESDocument` class

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
