### PR TITLE
Illustrative change to newer test conventions

### DIFF
--- a/connectors/conftest.py
+++ b/connectors/conftest.py
@@ -145,3 +145,20 @@ def assert_re(expr, items):
             return
 
     raise AssertionError(f"{expr} not found in {items}")
+
+
+def pytest_itemcollected(item):
+    def _collect_recursively(n):
+        from _pytest.python import Module
+
+        if isinstance(n, Module):
+            return n.obj.__doc__.strip() if n.obj.__doc__ else n.obj.__class__.__name__
+
+        parent = n.parent
+
+        parent_description = _collect_recursively(parent) if parent else ""
+        node_description = n.obj.__doc__.strip() if n.obj.__doc__ else n.obj.__name__
+
+        return ".".join((parent_description, node_description))
+
+    item._nodeid = _collect_recursively(item)

--- a/connectors/conftest.py
+++ b/connectors/conftest.py
@@ -148,6 +148,22 @@ def assert_re(expr, items):
 
 
 def pytest_itemcollected(item):
+    """
+    This code is here to format the output of verbose run of pytest.
+
+    What it does is - it receives a object representing a test that will be ran in {item} argument.
+    Test can be located either just in the module, or inside of the class,
+    or inside of the class inside of the class inside of the class, etc.
+
+    So the idea of the code inside is to collect the name/docstring of current node
+    and then repeat it recursively until an instance of _pytest.python.Module is met.
+
+    It gives the following results:
+    <module>.<class>.<test> or <module>.<test> or <module>.<class>.<class>.<test>
+
+    It tries to use node's docstring if there's one, otherwise its name (or class name for modules)
+    """
+
     def _collect_recursively(n):
         from _pytest.python import Module
 

--- a/connectors/tests/test_base_service.py
+++ b/connectors/tests/test_base_service.py
@@ -117,6 +117,7 @@ async def test_get_service_when_services_with_called_with_invalid_names_then_rai
 
     assert e.match("nonexisting")
 
+
 @pytest.mark.asyncio
 async def test_get_service_when_services_with_called_with_valid_names_then_returns_multiservice_wrapping_these_services(
     self,

--- a/connectors/tests/test_base_service.py
+++ b/connectors/tests/test_base_service.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+"""connectors.services.base"""
 import asyncio
 import functools
 from collections import defaultdict
@@ -12,46 +13,53 @@ import pytest
 from connectors.services.base import BaseService, MultiService, get_services
 
 
-class StubService:
-    def __init__(self):
-        self.running = False
-        self.cancelled = False
-        self.exploding = False
-        self.run_sleep_delay = 0
-        self.stopped = False
-        self.handle_cancellation = True
-
-    async def run(self):
-        if self.handle_cancellation:
-            try:
-                await self._run()
-            except asyncio.CancelledError:
-                self.running = False
-                self.cancelled = True
-        else:
-            await self._run()
-
-    async def _run(self):
-        self.running = True
-        while self.running:
-            if self.exploding:
-                raise Exception("Something went wrong")
-            await asyncio.sleep(self.run_sleep_delay)
-
-    def stop(self):
-        self.running = False
-        self.stopped = True
-
-    def explode(self):
-        self.exploding = True
-
-
 class TestMultiservice:
+    """
+    Multiservice
+    """
+
+    class StubService:
+        def __init__(self):
+            self.running = False
+            self.cancelled = False
+            self.exploding = False
+            self.run_sleep_delay = 0
+            self.stopped = False
+            self.handle_cancellation = True
+
+        async def run(self):
+            if self.handle_cancellation:
+                try:
+                    await self._run()
+                except asyncio.CancelledError:
+                    self.running = False
+                    self.cancelled = True
+            else:
+                await self._run()
+
+        async def _run(self):
+            self.running = True
+            while self.running:
+                if self.exploding:
+                    raise Exception("Something went wrong")
+                await asyncio.sleep(self.run_sleep_delay)
+
+        def stop(self):
+            self.running = False
+            self.stopped = True
+
+        def explode(self):
+            self.exploding = True
+
     @pytest.mark.asyncio
-    async def test_run_when_one_raises_exception_then_stops_all_services(self):
-        service_1 = StubService()
-        service_2 = StubService()
-        service_3 = StubService()
+    async def test_run_with_service_exception(self):
+        """
+        run() when one of services raises an error then all services are forcefully stopped
+        """
+
+        service_1 = TestMultiservice.StubService()
+        service_2 = TestMultiservice.StubService()
+        service_3 = TestMultiservice.StubService()
 
         multiservice = MultiService(service_1, service_2, service_3)
 
@@ -64,10 +72,14 @@ class TestMultiservice:
         assert service_3.cancelled
 
     @pytest.mark.asyncio
-    async def test_run_when_shutdown_happens_then_stops_all_services(self):
-        service_1 = StubService()
-        service_2 = StubService()
-        service_3 = StubService()
+    async def test_run_with_graceful_shutdown(self):
+        """
+        run() when multiservice is shutdown then all services are gracefully stopped
+        """
+
+        service_1 = TestMultiservice.StubService()
+        service_2 = TestMultiservice.StubService()
+        service_3 = TestMultiservice.StubService()
 
         multiservice = MultiService(service_1, service_2, service_3)
 
@@ -82,12 +94,16 @@ class TestMultiservice:
         assert service_3.stopped
 
     @pytest.mark.asyncio
-    async def test_stop_when_service_takes_too_long_to_stol_then_gracefully_stops_service(
+    async def test_run_when_service_stops_too_slowly(
         self,
     ):
-        service_1 = StubService()
+        """
+        run() when service takes too long to stop then all services are gracefully stopped anyway
+        """
 
-        service_2 = StubService()
+        service_1 = TestMultiservice.StubService()
+
+        service_2 = TestMultiservice.StubService()
         service_2.run_sleep_delay = 0.3  # large enough
 
         multiservice = MultiService(service_1, service_2)
@@ -106,9 +122,11 @@ class TestMultiservice:
 
 
 @pytest.mark.asyncio
-async def test_get_service_when_services_with_called_with_invalid_names_then_raises(
-    self,
-):
+async def test_get_service_with_invalid_names():
+    """
+    get_services() when one of service names is invalid then raises an error
+    """
+
     class SomeService(BaseService):
         name = "existing"
 
@@ -119,9 +137,10 @@ async def test_get_service_when_services_with_called_with_invalid_names_then_rai
 
 
 @pytest.mark.asyncio
-async def test_get_service_when_services_with_called_with_valid_names_then_returns_multiservice_wrapping_these_services(
-    self,
-):
+async def test_get_service_with_valid_names():
+    """
+    get_services() when called with valid service names then runs these services
+    """
     ran = []
 
     # creating a class using the BaseService as its base

--- a/connectors/tests/test_base_service.py
+++ b/connectors/tests/test_base_service.py
@@ -105,40 +105,39 @@ class TestMultiservice:
         )  # we're not supposed to cancel it as it's already stopping
 
 
-class TestGetServices:
-    @pytest.mark.asyncio
-    async def test_when_services_with_called_with_invalid_names_then_raises(
-        self,
-    ):
-        class SomeService(BaseService):
-            name = "existing"
+@pytest.mark.asyncio
+async def test_get_service_when_services_with_called_with_invalid_names_then_raises(
+    self,
+):
+    class SomeService(BaseService):
+        name = "existing"
 
-        with pytest.raises(KeyError) as e:
-            _ = get_services(["existing", "nonexisting"], config=defaultdict(dict))
+    with pytest.raises(KeyError) as e:
+        _ = get_services(["existing", "nonexisting"], config=defaultdict(dict))
 
-        assert e.match("nonexisting")
+    assert e.match("nonexisting")
 
-    @pytest.mark.asyncio
-    async def test_when_services_with_called_with_valid_names_then_returns_multiservice_wrapping_these_services(
-        self,
-    ):
-        ran = []
+@pytest.mark.asyncio
+async def test_get_service_when_services_with_called_with_valid_names_then_returns_multiservice_wrapping_these_services(
+    self,
+):
+    ran = []
 
-        # creating a class using the BaseService as its base
-        # will register the class using its name
-        class TestService(BaseService):
-            async def run(self):
-                nonlocal ran
-                ran.append(self.name)
+    # creating a class using the BaseService as its base
+    # will register the class using its name
+    class TestService(BaseService):
+        async def run(self):
+            nonlocal ran
+            ran.append(self.name)
 
-        class SomeService(TestService):
-            name = "kool"
+    class SomeService(TestService):
+        name = "kool"
 
-        class SomeOtherService(TestService):
-            name = "beans"
+    class SomeOtherService(TestService):
+        name = "beans"
 
-        # and make it available when we call get_services()
-        multiservice = get_services(["kool", "beans"], config=defaultdict(dict))
+    # and make it available when we call get_services()
+    multiservice = get_services(["kool", "beans"], config=defaultdict(dict))
 
-        await multiservice.run()
-        assert ran == ["kool", "beans"]
+    await multiservice.run()
+    assert ran == ["kool", "beans"]


### PR DESCRIPTION
For discussion - changing `connectors/tests/test_base_service.py` to follow the new test convention:

1. Tests for specific class of the module are wrapped in test class with name `Test_<CLASS_NAME>`.
2. Test cases have format of `test_<method_name>_when_<condition>_then_<outcome>`

Some additional notes:

1. We can actually keep names of tests short and instead provide description of the test in the docstring, for example:

```
@pytest.mark.asyncio
    async def test_run_stops_on_exception(self):
        """
        When one service raises exception then all services are stopped
        """
        # ...
```
It's possible to change pytest in such a way, that it would output these docstrings instead of method names when running pytest in verbose mode, and I kinda like it.

2. Not reflected in the PR, but I think that we can just move all tests in <ROOT>/tests instead of having different directories. Later we can put different codeowners rules for connectors and framework if needed, but for now I don't see a major problem having tests fully in a separate directory. When it's done, the structure of `tests` directory will fully repeat the structure of `connectors` directory, so test for `connectors/sources/mysql.py` will be located in `tests/sources/test_mysql.py`.

Let's use this PR to finalise the approach, and I'll create an issue afterwards to move all existing tests under this structure.