### PR TITLE
[8.7] Upgrade SQLAlchemy v2.0 to use python-oracledb and improve performance (#447)

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -42,3 +42,8 @@ steps:
       - ".buildkite/run_nigthly.sh dir"
     artifact_paths:
       - "perf8-report-*/**/*"
+  - label: "🔨 Oracle Database"
+    command:
+      - ".buildkite/run_nigthly.sh oracle"
+    artifact_paths:
+      - "perf8-report-*/**/*"

--- a/connectors/sources/oracle.py
+++ b/connectors/sources/oracle.py
@@ -3,7 +3,8 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-"""SQLAlchemy source module is responsible to fetch documents from Oracle."""
+"""Oracle source module is responsible to fetch documents from Oracle."""
+import os
 from urllib.parse import quote
 
 from sqlalchemy import create_engine
@@ -13,11 +14,14 @@ from connectors.sources.generic_database import GenericBaseDataSource
 QUERIES = {
     "PING": "SELECT 1+1 FROM DUAL",
     "ALL_TABLE": "SELECT TABLE_NAME FROM all_tables where OWNER = '{user}'",
-    "TABLE_PRIMARY_KEY": "SELECT cols.column_name FROM all_constraints cons, all_cons_columns cols WHERE cols.table_name = '{table}' AND cons.constraint_type = 'P' AND cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner ORDER BY cols.table_name, cols.position",
+    "TABLE_PRIMARY_KEY": "SELECT cols.column_name FROM all_constraints cons, all_cons_columns cols WHERE cols.table_name = '{table}' AND cons.constraint_type = 'P' AND cons.constraint_name = cols.constraint_name AND cons.owner = '{user}' AND cons.owner = cols.owner ORDER BY cols.table_name, cols.position",
     "TABLE_DATA": "SELECT * FROM {table}",
     "TABLE_LAST_UPDATE_TIME": "SELECT SCN_TO_TIMESTAMP(MAX(ora_rowscn)) from {table}",
     "TABLE_DATA_COUNT": "SELECT COUNT(*) FROM {table}",
 }
+DEFAULT_PROTOCOL = "TCP"
+DEFAULT_ORACLE_HOME = ""
+DEFAUTL_WALLET_CONFIGURATION_PATH = ""
 
 
 class OracleDataSource(GenericBaseDataSource):
@@ -34,16 +38,58 @@ class OracleDataSource(GenericBaseDataSource):
         """
         super().__init__(configuration=configuration)
         self.is_async = False
+        self.oracle_home = self.configuration["oracle_home"]
+        self.wallet_config = self.configuration["wallet_configuration_path"]
+        self.protocol = self.configuration["oracle_protocol"]
         self.dsn = f"(DESCRIPTION=(ADDRESS=(PROTOCOL={self.protocol})(HOST={self.host})(PORT={self.port}))(CONNECT_DATA=(SID={self.database})))"
         self.connection_string = (
-            f"oracle://{self.user}:{quote(self.password)}@{self.dsn}"
+            f"oracle+oracledb://{self.user}:{quote(self.password)}@{self.dsn}"
         )
         self.queries = QUERIES
         self.dialect = "Oracle"
 
+    @classmethod
+    def get_default_configuration(cls):
+        """Get the default configuration for database-server configured by user
+
+        Returns:
+            dictionary: Default configuration
+        """
+        oracle_configuration = super().get_default_configuration().copy()
+        oracle_configuration.update(
+            {
+                "oracle_protocol": {
+                    "value": DEFAULT_PROTOCOL,
+                    "label": "Oracle connection protocol (TCP/TCPS)",
+                    "type": "str",
+                },
+                "oracle_home": {
+                    "value": DEFAULT_ORACLE_HOME,
+                    "label": "Path of Oracle Service",
+                    "type": "str",
+                },
+                "wallet_configuration_path": {
+                    "value": DEFAUTL_WALLET_CONFIGURATION_PATH,
+                    "label": "Path of oracle service configuration files",
+                    "type": "str",
+                },
+            }
+        )
+        return oracle_configuration
+
     def _create_engine(self):
         """Create sync engine for oracle"""
-        self.engine = create_engine(self.connection_string)
+        if self.oracle_home != "":
+            os.environ["ORACLE_HOME"] = self.oracle_home
+            self.engine = create_engine(
+                self.connection_string,
+                thick_mode={
+                    "lib_dir": f"{self.oracle_home}/lib",
+                    "config_dir": self.wallet_config,
+                },
+            )
+        else:
+            self.engine = create_engine(self.connection_string)
 
     async def get_docs(self, filtering=None):
         """Executes the logic to fetch databases, tables and rows in async manner.

--- a/connectors/sources/tests/fixtures/oracle/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/oracle/docker-compose.yml
@@ -74,12 +74,12 @@ services:
       - esnet
 
   oracle:
-    image: oracleinanutshell/oracle-xe-11g:latest
+    image: gvenzl/oracle-xe:latest
     ports:
       - 9090:1521
     environment: 
-      - ORACLE_ALLOW_REMOTE=true
-      - ORACLE_ENABLE_XDB=true
+      - ORACLE_PASSWORD=Password_123
+    restart: always
 
 networks:
   esnet:

--- a/connectors/sources/tests/fixtures/oracle/requirements.txt
+++ b/connectors/sources/tests/fixtures/oracle/requirements.txt
@@ -1,1 +1,1 @@
-cx-Oracle==7.3.0
+oracledb==1.2.2

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -19,6 +19,11 @@ from connectors.sources.oracle import OracleDataSource
 from connectors.sources.postgresql import PostgreSQLDataSource
 from connectors.sources.tests.support import create_source
 
+POSTGRESQL_CONNECTION_STRING = (
+    "postgresql+asyncpg://admin:changme@127.0.0.1:5432/testdb"
+)
+ORACLE_CONNECTION_STRING = "oracle+oracledb://admin:changme@127.0.0.1:1521/testdb"
+
 
 class ConnectionAsync:
     """This class creates dummy connection with database and return dummy cursor"""
@@ -191,7 +196,7 @@ def test_validate_configuration_port(patch_logger):
 def test_validate_configuration_ssl(patch_logger):
     """Test _validate_configuration method check port"""
     # Setup
-    source = create_source(GenericBaseDataSource)
+    source = create_source(PostgreSQLDataSource)
     source.configuration.set_field(name="ssl_disabled", value=False)
 
     with pytest.raises(Exception):
@@ -205,9 +210,7 @@ async def test_get_docs_postgresql(patch_logger):
     # Setup
     source = create_source(PostgreSQLDataSource)
     with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
-        source.engine = create_async_engine(
-            "postgresql+asyncpg://admin:changme@127.0.0.1:5432/testdb"
-        )
+        source.engine = create_async_engine(POSTGRESQL_CONNECTION_STRING)
         actual_response = []
         expected_response = [
             {
@@ -245,7 +248,7 @@ async def test_get_docs_oracle(patch_logger):
     # Setup
     source = create_source(OracleDataSource)
     with patch.object(Engine, "connect", return_value=ConnectionSync()):
-        source.engine = create_engine("oracle://admin:changme@127.0.0.1:1521/testdb")
+        source.engine = create_engine(ORACLE_CONNECTION_STRING)
         actual_response = []
         expected_response = [
             {
@@ -289,9 +292,7 @@ async def test_async_connect_negative(patch_logger):
     with patch.object(
         AsyncEngine, "connect", side_effect=InternalClientError("Something went wrong")
     ):
-        source.engine = create_async_engine(
-            "postgresql+asyncpg://admin:changme@127.0.0.1:5432/testdb"
-        )
+        source.engine = create_async_engine(POSTGRESQL_CONNECTION_STRING)
 
         # Execute
         with pytest.raises(InternalClientError):
@@ -305,7 +306,7 @@ async def test_sync_connect_negative(patch_logger):
     with patch.object(
         Engine, "connect", side_effect=InternalClientError("Something went wrong")
     ):
-        source.engine = create_engine("oracle://admin:changme@127.0.0.1:1521/testdb")
+        source.engine = create_engine(ORACLE_CONNECTION_STRING)
 
         # Execute
         with pytest.raises(InternalClientError):
@@ -320,7 +321,7 @@ async def test_execute_query_negative_for_internalclienterror(patch_logger):
         AsyncEngine, "connect", side_effect=InternalClientError("Something went wrong")
     ):
         source.engine = source.engine = create_async_engine(
-            "postgresql+asyncpg://admin:changme@127.0.0.1:5432/testdb"
+            POSTGRESQL_CONNECTION_STRING
         )
         source.is_async = True
 
@@ -338,7 +339,7 @@ async def test_fetch_documents_negative(patch_logger):
         "execute_query",
         side_effect=InternalClientError("Something went wrong"),
     ):
-        source.engine = create_engine("oracle://admin:changme@127.0.0.1:1521/testdb")
+        source.engine = create_engine(ORACLE_CONNECTION_STRING)
 
         # Execute
         with pytest.raises(Exception):

--- a/connectors/sources/tests/test_oracle.py
+++ b/connectors/sources/tests/test_oracle.py
@@ -12,6 +12,8 @@ from connectors.sources.oracle import OracleDataSource
 from connectors.sources.tests.support import create_source
 from connectors.tests.commons import AsyncIterator
 
+DSN = "oracle+oracledb://admin:Password_123@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=9090))(CONNECT_DATA=(SID=xe)))"
+
 
 @pytest.mark.asyncio
 async def test_ping(patch_logger):
@@ -36,3 +38,34 @@ async def test_ping_negative(patch_logger):
         # Execute
         with pytest.raises(Exception):
             await source.ping()
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.oracle.create_engine")
+async def test_create_engine_in_thick_mode(mock_fun):
+    """Test create_engine method of OracleDataSource class in thick mode"""
+    # Setup
+    source = create_source(OracleDataSource)
+    config_file_path = {"lib_dir": "/home/devuser/lib", "config_dir": ""}
+    source.oracle_home = "/home/devuser"
+    mock_fun.return_value = "Mock Response"
+
+    # Execute
+    source._create_engine()
+
+    # Assert
+    mock_fun.assert_called_with(DSN, thick_mode=config_file_path)
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.oracle.create_engine")
+async def test_create_engine_in_thin_mode(mock_fun):
+    """Test create_engine method of OracleDataSource class in thin mode"""
+    # Setup
+    source = create_source(OracleDataSource)
+
+    # Execute
+    source._create_engine()
+
+    # Assert
+    mock_fun.assert_called_with(DSN)

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -13,6 +13,6 @@ uvloop==0.17.0; sys_platform != 'win32'
 fastjsonschema==2.16.2
 base64io==1.0.3
 azure-storage-blob==12.13.0
-SQLAlchemy==1.4.44
-cx-Oracle==7.3.0
+SQLAlchemy==2.0.1
+oracledb==1.2.2
 asyncpg==0.27.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Upgrade SQLAlchemy v2.0 to use python-oracledb and improve performance (#447)](https://github.com/elastic/connectors-python/pull/447)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)