### PR TITLE
[8.7] [Generic Database Connector] Added documentation for PostgreSQL in developing.md (#549)

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -331,6 +331,146 @@ $ make ftest NAME=azure_blob_storage
 
 ℹ️ The e2e test uses default values defined in [configure Azure Blob Storage connector](#configure-azure-blob-storage-connector)
 
+
+## PostgreSQL Connector
+
+The [Elastic PostgreSQL connector](../connectors/sources/postgresql.py) is provided in the Elastic connectors python framework and can be used via [build a connector](https://www.elastic.co/guide/en/enterprise-search/current/build-connector.html).
+
+### Availability and prerequisites
+
+⚠️ _Currently, this connector is available in **beta** starting in 8.7_.
+Features in beta are subject to change and are not covered by the service level agreement (SLA) of features that have reached general availability (GA).
+
+Elastic versions 8.6.0+ are compatible with Elastic connector frameworks. Your deployment must include the Elasticsearch, Kibana, and Enterprise Search services.
+
+PostgreSQL versions 11 to 15 are compatible with Elastic connector frameworks.
+
+**Prerequisites**
+
+- The Tables which user wants to index should be owned by a PostgreSQL user.
+- PostgreSQL user needs superuser privilges to index all the tables of the database.
+- User needs to set `track_commit_timestamp` to `on`. User will set `track_commit_timestamp` to `on` by executing `ALTER SYSTEM SET track_commit_timestamp = on;` query in PostgreSQL server.
+
+### Setup and basic usage
+
+Complete the following steps to deploy the connector:
+
+1. [Gather PostgreSQL details](#gather-postgresql-details)
+2. [Configure PostgreSQL connector](#configure-postgresql-connector)
+
+#### Gather PostgreSQL details
+
+Collect the information that is required to connect to your PostgreSQL server:
+
+- The server host address where the PostgreSQL server is hosted.
+- The port where the PostgreSQL server is hosted.
+- The username the connector will use to log in to the PostgreSQL server.
+- The password the connector will use to log in to the PostgreSQL server.
+- The database name the connector will query.
+- SSL certificate if you want to establish secured connections.
+
+#### Configure PostgreSQL connector
+
+The following configuration fields need to be provided for setting up the connector:
+
+##### `host`
+
+The server host address where the PostgreSQL is hosted. Default value is `127.0.0.1`. Examples:
+
+  - `192.158.1.38`
+  - `demo.instance.demo-region.demo.service.com`
+
+##### `port`
+
+The port where the PostgreSQL is hosted. Default value is `9090`. Examples:
+
+  - `5432`
+  - `9090`
+
+##### `username`
+
+The username of the account for PostgreSQL. Default value is `admin`.
+
+##### `password`
+
+The password of the account to be used for the PostgreSQL. Default value is `Password_123`.
+
+##### `database`
+
+Name of the PostgreSQL database. Default value is `xe`. Examples:
+
+  - `employee_database`
+  - `customer_database`
+
+##### `tables`
+
+Comma-separated list of tables. The PostgreSQL connector will fetch data from all tables present in the configured database, if the value is `*` . Default value is `*`. Examples:
+
+  - `table_1, table_2`
+  - `*`
+
+##### `fetch_size`
+
+The number of rows to fetch on each request to the PostgreSQL. Default value is `50`.
+
+##### `retry_count`
+
+The number of retry attempts after failed request to the PostgreSQL. Default value is `3`.
+
+##### `ssl_disabled`
+
+Whether SSL verification will be disabled. Default value is `True`.
+
+##### `ssl_ca`
+
+Content of SSL certificate. If SSL is disabled, keep the `ssl_ca` field empty. Example certificate:
+
+  - ```
+    -----BEGIN CERTIFICATE-----
+    MIID+jCCAuKgAwIBAgIGAJJMzlxLMA0GCSqGSIb3DQEBCwUAMHoxCzAJBgNVBAYT
+    AlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHROb2RlMDExFjAUBgNV
+    BAsTDURlZmF1bHRDZWxsMDExGTAXBgNVBAsTEFJvb3QgQ2VydGlmaWNhdGUxEjAQ
+    BgNVBAMTCWxvY2FsaG9zdDAeFw0yMTEyMTQyMjA3MTZaFw0yMjEyMTQyMjA3MTZa
+    MF8xCzAJBgNVBAYTAlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHRO
+    b2RlMDExFjAUBgNVBAsTDURlZmF1bHRDZWxsMDExEjAQBgNVBAMTCWxvY2FsaG9z
+    dDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMv5HCsJZIpI5zCy+jXV
+    z6lmzNc9UcVSEEHn86h6zT6pxuY90TYeAhlZ9hZ+SCKn4OQ4GoDRZhLPTkYDt+wW
+    CV3NTIy9uCGUSJ6xjCKoxClJmgSQdg5m4HzwfY4ofoEZ5iZQ0Zmt62jGRWc0zuxj
+    hegnM+eO2reBJYu6Ypa9RPJdYJsmn1RNnC74IDY8Y95qn+WZj//UALCpYfX41hko
+    i7TWD9GKQO8SBmAxhjCDifOxVBokoxYrNdzESl0LXvnzEadeZTd9BfUtTaBHhx6t
+    njqqCPrbTY+3jAbZFd4RiERPnhLVKMytw5ot506BhPrUtpr2lusbN5svNXjuLeea
+    MMUCAwEAAaOBoDCBnTATBgNVHSMEDDAKgAhOatpLwvJFqjAdBgNVHSUEFjAUBggr
+    BgEFBQcDAQYIKwYBBQUHAwIwVAYDVR0RBE0wS4E+UHJvZmlsZVVVSUQ6QXBwU3J2
+    MDEtQkFTRS05MDkzMzJjMC1iNmFiLTQ2OTMtYWI5NC01Mjc1ZDI1MmFmNDiCCWxv
+    Y2FsaG9zdDARBgNVHQ4ECgQITzqhA5sO8O4wDQYJKoZIhvcNAQELBQADggEBAKR0
+    gY/BM69S6BDyWp5dxcpmZ9FS783FBbdUXjVtTkQno+oYURDrhCdsfTLYtqUlP4J4
+    CHoskP+MwJjRIoKhPVQMv14Q4VC2J9coYXnePhFjE+6MaZbTjq9WaekGrpKkMaQA
+    iQt5b67jo7y63CZKIo9yBvs7sxODQzDn3wZwyux2vPegXSaTHR/rop/s/mPk3YTS
+    hQprs/IVtPoWU4/TsDN3gIlrAYGbcs29CAt5q9MfzkMmKsuDkTZD0ry42VjxjAmk
+    xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
+    7RhLQyWn2u00L7/9Omw=
+    -----END CERTIFICATE-----
+    ```
+
+ℹ️ Default values exist for end-to-end testing only.
+
+### Connector Limitations
+
+- To fetch the last updated time in PostgreSQL, `track_commit_timestamp` must be set to `on`. Otherwise, all data will be indexed in every sync.
+- Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
+- Filtering rules are not available in the present version. Currently, the filtering is controlled via ingest pipelines.
+
+### E2E Tests
+
+The framework provides a way to test ingestion through a connector against a real data source. This is called a functional test. To execute a functional test for the PostgreSQL connector, run the following command:
+```shell
+$ make ftest NAME=postgresql
+```
+
+ℹ️ Users do not need to have a running Elasticsearch instance or a PostgreSQL source to run this test. The docker compose file manages the complete setup of the development environment, i.e. both the mock Elastic instance and mock PostgreSQL source using the docker image.
+
+ℹ️ The e2e test uses default values defined in [Configure PostgreSQL connector](#configure-postgresql-connector)
+
 ## General Configuration
 
 The details of Elastic instance and other relevant fields such as `service` and `source` needs to be provided in the [config.yml](https://github.com/elastic/connectors-python/blob/8.6/config.yml) file. For more details check out the following [documentation](https://github.com/elastic/connectors-python/blob/8.6/docs/CONFIG.md).


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Generic Database Connector] Added documentation for PostgreSQL in developing.md (#549)](https://github.com/elastic/connectors-python/pull/549)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)