### PR TITLE
Log service version once real service starts

### DIFF
--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -96,6 +96,8 @@ async def _start_service(actions, config, loop):
     - performs a preflight check using `PreflightCheck`
     - instantiates a `MultiService` instance and runs its `run` async function
     """
+    logger.info(f"Running connector service version {__version__}")
+
     preflight = PreflightCheck(config)
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, functools.partial(preflight.shutdown, sig))

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -96,8 +96,6 @@ async def _start_service(actions, config, loop):
     - performs a preflight check using `PreflightCheck`
     - instantiates a `MultiService` instance and runs its `run` async function
     """
-    logger.info(f"Running connector service version {__version__}")
-
     preflight = PreflightCheck(config)
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, functools.partial(preflight.shutdown, sig))
@@ -128,6 +126,7 @@ def run(args):
     - list: prints out a list of all connectors and exits
     - poll: starts the event loop and run forever (default)
     """
+    logger.info(f"Running connector service version {__version__}")
 
     # load config
     config = {}


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/614

When running connector service with default arguments OR not with "list" action, we want to output service version into console.

Example output with this change:

```
artemshelkovnikov@Artems-MacBook-Pro connectors-py % make run
bin/elastic-ingest
[FMWK][14:36:39][INFO] Loading config from /Users/artemshelkovnikov/git_tree/connectors-py/connectors/../config.yml
[FMWK][14:36:39][INFO] Running connector service version 8.8.0.0
[FMWK][14:36:39][INFO] Preflight checks...
[FMWK][14:36:39][INFO] Waiting for NodeConfig(scheme='http', host='localhost', port=9200, path_prefix='', headers={}, connections_per_node=10, request_timeout=10.0, http_compress=False, verify_certs=True, ca_certs=None, client_cert=None, client_key=None, ssl_assert_hostname=None, ssl_assert_fingerprint=None, ssl_version=None, ssl_context=None, ssl_show_warn=True, _extras={}) (so far: 0 secs)
[FMWK][14:36:40][INFO] Service started, listening to events from http://localhost:9200
[FMWK][14:36:40][INFO] Successfully started Job cleanup task...
[FMWK][14:36:40][INFO] Start cleaning up orphaned jobs...
[FMWK][14:36:40][INFO] No orphaned jobs found. Skipping...
...
```

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
