### PR TITLE
Add more explicit messages for connector errors when status is unexpected

### DIFF
--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -86,9 +86,16 @@ class JobSchedulingService(BaseService):
         logger.debug(f"Connector status is {connector.status}")
 
         # we trigger a sync
-        if connector.status in (Status.CREATED, Status.NEEDS_CONFIGURATION):
-            # we can't sync in that state
-            logger.info(f"Can't sync with status `{connector.status.value}`")
+        if connector.status == Status.CREATED:
+            logger.info(
+                f'Connector for {connector.service_type}(id: "{connector.id}") has just been created and cannot sync. Wait for Kibana to initialise connector correctly before proceeding.'
+            )
+            return
+
+        if connector.status == Status.NEEDS_CONFIGURATION:
+            logger.info(
+                f'Connector for {connector.service_type}(id: "{connector.id}") is not configured yet. Finish connector configuration in Kibana to make it possible to run a sync.'
+            )
             return
 
         if connector.service_type not in self.source_klass_dict:


### PR DESCRIPTION
## Attempting to close https://github.com/elastic/connectors-python/issues/602

This change separates the messaging for situations when connector cannot sync due to it being in invalid status. Now there's a different message for connector status `CREATED` and `NEEDS_CONFIGURATION`, and this message is trying hard to be user-friendly and actionable!

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
