### PR TITLE
Introduce validate_config to ABS connector

### DIFF
--- a/connectors/sources/tests/test_azure_blob_storage.py
+++ b/connectors/sources/tests/test_azure_blob_storage.py
@@ -415,7 +415,8 @@ async def test_get_content_when_type_not_supported():
     assert actual_response is None
 
 
-def test_configure_connection_string():
+@pytest.mark.asyncio
+async def test_validate_config_no_account_name():
     """Test configure connection string method of AzureBlobStorageDataSource class"""
 
     # Setup
@@ -424,7 +425,7 @@ def test_configure_connection_string():
 
     with pytest.raises(Exception):
         # Execute
-        source._configure_connection_string()
+        await source.validate_config()
 
 
 def test_tweak_bulk_options():
@@ -439,7 +440,8 @@ def test_tweak_bulk_options():
     source.tweak_bulk_options(options)
 
 
-def test_tweak_bulk_options_with_invalid():
+@pytest.mark.asyncio
+async def test_validate_config_invalid_concurrent_downloads():
     """Test tweak_bulk_options method of BaseDataSource class with invalid concurrent downloads"""
 
     # Setup
@@ -449,7 +451,7 @@ def test_tweak_bulk_options_with_invalid():
 
     with pytest.raises(Exception):
         # Execute
-        source.tweak_bulk_options(options)
+        await source.validate_config(options)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors-python/issues/601

As a part of standardisation effort, we're moving all validation of connector configurations into `validate_config` method of the connector.

This PR does it for ABS connector - validation was happening in multiple methods in the connector, i moved it to a single `validate_config` method.

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)