### PR TITLE
Replace print with logger.info for directory connector

### DIFF
--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -75,7 +75,7 @@ class DirectoryDataSource(BaseDataSource):
         ):
             return
 
-        print(f"Reading {path}")
+        logger.info(f"Reading {path}")
         with open(file=path, mode="rb") as f:
             return {
                 "_id": self.get_id(path),


### PR DESCRIPTION
Minor change - it's the only place in code where `print` is used instead of `logger.info`, thus this PR contains only 1 line of change :)