### PR TITLE
Rename _validate_confuration -> validate_config and remove internal usage of it from connector

### DIFF
--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -72,7 +72,7 @@ class S3DataSource(BaseDataSource):
         ) as s3:
             yield s3
 
-    def _validate_configuration(self):
+    def validate_config(self):
         """Validates whether user input is empty or not for configuration fields
 
         Raises:
@@ -83,8 +83,6 @@ class S3DataSource(BaseDataSource):
 
     async def ping(self):
         """Verify the connection with AWS"""
-        logger.info("Validating Amazon S3 Configuration...")
-        self._validate_configuration()
         try:
             async with self.client() as s3:
                 self.bucket_list = await s3.list_buckets()


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors-python/issues/601

As a part of standardisation effort, we're moving all validation of connector configurations into `validate_config` method of the connector.

There was already a `_validate_configuration` method in the connector, so I've renamed it to `validate_config` and removed usage of `_validate_configuration` from `ping` method.

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)