### PR TITLE
Introduce and use ConfigurableFieldValueError

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -314,3 +314,7 @@ def get_source_klasses(config):
 def get_source_klass_dict(config):
     """Returns a service type - source klass dictionary"""
     return {name: get_source_klass(fqn) for name, fqn in config["sources"].items()}
+
+
+class ConfigurableFieldValueError(Exception):
+    pass

--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -14,12 +14,8 @@ from aiofiles.tempfile import NamedTemporaryFile
 from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
 
 from connectors.logger import logger
-from connectors.source import BaseDataSource
-from connectors.utils import (
-    TIKA_SUPPORTED_FILETYPES,
-    ConfigurableFieldValueError,
-    convert_to_b64,
-)
+from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.utils import TIKA_SUPPORTED_FILETYPES, convert_to_b64
 
 BLOB_SCHEMA = {
     "title": "name",

--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -15,7 +15,11 @@ from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClien
 
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.utils import TIKA_SUPPORTED_FILETYPES, convert_to_b64
+from connectors.utils import (
+    TIKA_SUPPORTED_FILETYPES,
+    ConfigurableFieldValueError,
+    convert_to_b64,
+)
 
 BLOB_SCHEMA = {
     "title": "name",
@@ -115,7 +119,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
 
     async def validate_config(self):
         if self.concurrent_downloads > MAX_CONCURRENT_DOWNLOADS:
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"Configured concurrent downloads can't be set more than {MAX_CONCURRENT_DOWNLOADS}."
             )
 
@@ -125,7 +129,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
         )
 
         if empty_configuration_fields:
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"Configured keys: {empty_configuration_fields} can't be empty."
             )
 

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import ProgrammingError
 
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.utils import iso_utc
+from connectors.utils import ConfigurableFieldValueError, iso_utc
 
 WILDCARD = "*"
 
@@ -204,7 +204,7 @@ class GenericBaseDataSource(BaseDataSource):
         if empty_connection_fields := [
             field for field in connection_fields if self.configuration[field] == ""
         ]:
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"Configured keys: {empty_connection_fields} can't be empty."
             )
 
@@ -212,7 +212,7 @@ class GenericBaseDataSource(BaseDataSource):
             isinstance(self.configuration["port"], str)
             and not self.configuration["port"].isnumeric()
         ):
-            raise Exception("Configured port has to be an integer.")
+            raise ConfigurableFieldValueError("Configured port has to be an integer.")
 
         if (
             self.dialect == "Postgresql"
@@ -222,7 +222,7 @@ class GenericBaseDataSource(BaseDataSource):
                 or self.configuration["ssl_ca"] is None
             )
         ):
-            raise Exception("SSL certificate must be configured.")
+            raise ConfigurableFieldValueError("SSL certificate must be configured.")
 
     async def execute_query(self, query, fetch_many=False, **kwargs):
         """Executes a query and yield rows

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -12,8 +12,8 @@ from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
 from connectors.logger import logger
-from connectors.source import BaseDataSource
-from connectors.utils import ConfigurableFieldValueError, iso_utc
+from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.utils import iso_utc
 
 WILDCARD = "*"
 

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -19,7 +19,12 @@ from aiogoogle.auth.creds import ServiceAccountCreds
 
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.utils import TIKA_SUPPORTED_FILETYPES, convert_to_b64, get_pem_format
+from connectors.utils import (
+    TIKA_SUPPORTED_FILETYPES,
+    ConfigurableFieldValueError,
+    convert_to_b64,
+    get_pem_format,
+)
 
 CLOUD_STORAGE_READ_ONLY_SCOPE = "https://www.googleapis.com/auth/devstorage.read_only"
 CLOUD_STORAGE_BASE_URL = "https://console.cloud.google.com/storage/browser/_details/"
@@ -218,11 +223,15 @@ class GoogleCloudStorageDataSource(BaseDataSource):
             self.configuration["service_account_credentials"] == ""
             or self.configuration["service_account_credentials"] is None
         ):
-            raise Exception("Google Cloud service account json can't be empty.")
+            raise ConfigurableFieldValueError(
+                "Google Cloud service account json can't be empty."
+            )
         try:
             json.loads(self.configuration["service_account_credentials"])
         except ValueError:
-            raise Exception("Google Cloud service account is not a valid JSON.")
+            raise ConfigurableFieldValueError(
+                "Google Cloud service account is not a valid JSON."
+            )
 
     @cached_property
     def _google_storage_client(self):

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -18,13 +18,8 @@ from aiogoogle import Aiogoogle
 from aiogoogle.auth.creds import ServiceAccountCreds
 
 from connectors.logger import logger
-from connectors.source import BaseDataSource
-from connectors.utils import (
-    TIKA_SUPPORTED_FILETYPES,
-    ConfigurableFieldValueError,
-    convert_to_b64,
-    get_pem_format,
-)
+from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.utils import TIKA_SUPPORTED_FILETYPES, convert_to_b64, get_pem_format
 
 CLOUD_STORAGE_READ_ONLY_SCOPE = "https://www.googleapis.com/auth/devstorage.read_only"
 CLOUD_STORAGE_BASE_URL = "https://console.cloud.google.com/storage/browser/_details/"

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -20,12 +20,11 @@ from aiofiles.tempfile import NamedTemporaryFile
 from aiohttp.client_exceptions import ServerDisconnectedError
 
 from connectors.logger import logger
-from connectors.source import BaseDataSource
+from connectors.source import BaseDataSource, ConfigurableFieldValueError
 from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     CancellableSleeps,
     ConcurrentTasks,
-    ConfigurableFieldValueError,
     MemQueue,
     convert_to_b64,
     iso_utc,

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -25,6 +25,7 @@ from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     CancellableSleeps,
     ConcurrentTasks,
+    ConfigurableFieldValueError,
     MemQueue,
     convert_to_b64,
     iso_utc,
@@ -177,15 +178,15 @@ class JiraDataSource(BaseDataSource):
             for field in connection_fields
             if self.configuration[field] == ""
         ]:
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"Configured keys: {empty_connection_fields} can't be empty."
             )
 
         if self.ssl_enabled and self.certificate == "":
-            raise Exception("SSL certificate must be configured.")
+            raise ConfigurableFieldValueError("SSL certificate must be configured.")
 
         if self.concurrent_downloads > MAX_CONCURRENT_DOWNLOADS:
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"Configured concurrent downloads can't be set more than {MAX_CONCURRENT_DOWNLOADS}."
             )
 

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -15,8 +15,7 @@ from connectors.filtering.validation import (
     SyncRuleValidationResult,
 )
 from connectors.logger import logger
-from connectors.source import BaseDataSource
-from connectors.utils import ConfigurableFieldValueError
+from connectors.source import BaseDataSource, ConfigurableFieldValueError
 
 
 class MongoAdvancedRulesValidator(AdvancedRulesValidator):

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -16,6 +16,7 @@ from connectors.filtering.validation import (
 )
 from connectors.logger import logger
 from connectors.source import BaseDataSource
+from connectors.utils import ConfigurableFieldValueError
 
 
 class MongoAdvancedRulesValidator(AdvancedRulesValidator):
@@ -198,7 +199,7 @@ class MongoDataSource(BaseDataSource):
         logger.debug(f"Existing databases: {existing_database_names}")
 
         if configured_database_name not in existing_database_names:
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"Database ({configured_database_name}) does not exist. Existing databases: {', '.join(existing_database_names)}"
             )
 
@@ -210,6 +211,6 @@ class MongoDataSource(BaseDataSource):
         )
 
         if configured_collection_name not in existing_collection_names:
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"Collection ({configured_collection_name}) does not exist within database {configured_database_name}. Existing collections: {', '.join(existing_collection_names)}"
             )

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -14,14 +14,9 @@ from connectors.filtering.validation import (
     SyncRuleValidationResult,
 )
 from connectors.logger import logger
-from connectors.source import BaseDataSource
+from connectors.source import BaseDataSource, ConfigurableFieldValueError
 from connectors.sources.generic_database import WILDCARD, configured_tables, is_wildcard
-from connectors.utils import (
-    CancellableSleeps,
-    ConfigurableFieldValueError,
-    RetryStrategy,
-    retryable,
-)
+from connectors.utils import CancellableSleeps, RetryStrategy, retryable
 
 MAX_POOL_SIZE = 10
 QUERIES = {

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -16,7 +16,12 @@ from connectors.filtering.validation import (
 from connectors.logger import logger
 from connectors.source import BaseDataSource
 from connectors.sources.generic_database import WILDCARD, configured_tables, is_wildcard
-from connectors.utils import CancellableSleeps, RetryStrategy, retryable
+from connectors.utils import (
+    CancellableSleeps,
+    ConfigurableFieldValueError,
+    RetryStrategy,
+    retryable,
+)
 
 MAX_POOL_SIZE = 10
 QUERIES = {
@@ -196,7 +201,7 @@ class MySqlDataSource(BaseDataSource):
                 empty_connection_fields.append(field)
 
         if empty_connection_fields:
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"Configured keys: {empty_connection_fields} can't be empty."
             )
 
@@ -204,10 +209,10 @@ class MySqlDataSource(BaseDataSource):
             isinstance(self.configuration["port"], str)
             and not self.configuration["port"].isnumeric()
         ):
-            raise Exception("Configured port has to be an integer.")
+            raise ConfigurableFieldValueError("Configured port has to be an integer.")
 
         if self.ssl_enabled and (self.certificate == "" or self.certificate is None):
-            raise Exception("SSL certificate must be configured.")
+            raise ConfigurableFieldValueError("SSL certificate must be configured.")
 
     def _ssl_context(self, certificate):
         """Convert string to pem format and create a SSL context

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -20,7 +20,11 @@ from botocore.exceptions import ClientError
 
 from connectors.logger import logger, set_extra_logger
 from connectors.source import BaseDataSource
-from connectors.utils import TIKA_SUPPORTED_FILETYPES, get_base64_value
+from connectors.utils import (
+    TIKA_SUPPORTED_FILETYPES,
+    ConfigurableFieldValueError,
+    get_base64_value,
+)
 
 MAX_CHUNK_SIZE = 1048576
 DEFAULT_MAX_FILE_SIZE = 10485760
@@ -79,7 +83,9 @@ class S3DataSource(BaseDataSource):
             Exception: Configured keys can't be empty
         """
         if self.configuration["buckets"] == [""]:
-            raise Exception("Configured keys: buckets can't be empty.")
+            raise ConfigurableFieldValueError(
+                "Configured keys: buckets can't be empty."
+            )
 
     async def ping(self):
         """Verify the connection with AWS"""

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -19,12 +19,8 @@ from aiohttp.client_exceptions import ServerTimeoutError
 from botocore.exceptions import ClientError
 
 from connectors.logger import logger, set_extra_logger
-from connectors.source import BaseDataSource
-from connectors.utils import (
-    TIKA_SUPPORTED_FILETYPES,
-    ConfigurableFieldValueError,
-    get_base64_value,
-)
+from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.utils import TIKA_SUPPORTED_FILETYPES, get_base64_value
 
 MAX_CHUNK_SIZE = 1048576
 DEFAULT_MAX_FILE_SIZE = 10485760

--- a/connectors/sources/sharepoint.py
+++ b/connectors/sources/sharepoint.py
@@ -18,11 +18,10 @@ from aiofiles.tempfile import NamedTemporaryFile
 from aiohttp.client_exceptions import ClientResponseError, ServerDisconnectedError
 
 from connectors.logger import logger
-from connectors.source import BaseDataSource
+from connectors.source import BaseDataSource, ConfigurableFieldValueError
 from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     CancellableSleeps,
-    ConfigurableFieldValueError,
     RetryStrategy,
     convert_to_b64,
     evaluate_timedelta,

--- a/connectors/sources/sharepoint.py
+++ b/connectors/sources/sharepoint.py
@@ -22,6 +22,7 @@ from connectors.source import BaseDataSource
 from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     CancellableSleeps,
+    ConfigurableFieldValueError,
     RetryStrategy,
     convert_to_b64,
     evaluate_timedelta,
@@ -220,11 +221,11 @@ class SharepointDataSource(BaseDataSource):
             for field in connection_fields
             if self.configuration[field] == ""
         ]:
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"Configured keys: {empty_connection_fields} can't be empty."
             )
         if self.ssl_enabled and self.certificate == "":
-            raise Exception("SSL certificate must be configured.")
+            raise ConfigurableFieldValueError("SSL certificate must be configured.")
 
     @retryable(
         retries=RETRIES,

--- a/connectors/sources/tests/test_azure_blob_storage.py
+++ b/connectors/sources/tests/test_azure_blob_storage.py
@@ -16,6 +16,7 @@ from connectors.source import DataSourceConfiguration
 from connectors.sources.azure_blob_storage import AzureBlobStorageDataSource
 from connectors.sources.tests.support import create_source
 from connectors.tests.commons import AsyncIterator
+from connectors.utils import ConfigurableFieldValueError
 
 
 def test_get_configuration():
@@ -423,7 +424,7 @@ async def test_validate_config_no_account_name():
     source = create_source(AzureBlobStorageDataSource)
     source.configuration.set_field(name="account_name", value="")
 
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         # Execute
         await source.validate_config()
 
@@ -445,13 +446,11 @@ async def test_validate_config_invalid_concurrent_downloads():
     """Test tweak_bulk_options method of BaseDataSource class with invalid concurrent downloads"""
 
     # Setup
-    source = create_source(AzureBlobStorageDataSource)
-    options = {}
-    source.concurrent_downloads = 1000
+    source = create_source(AzureBlobStorageDataSource, concurrent_downloads=1000)
 
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         # Execute
-        await source.validate_config(options)
+        await source.validate_config()
 
 
 @pytest.mark.asyncio

--- a/connectors/sources/tests/test_azure_blob_storage.py
+++ b/connectors/sources/tests/test_azure_blob_storage.py
@@ -12,11 +12,10 @@ from unittest.mock import Mock, patch
 import pytest
 from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
 
-from connectors.source import DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.azure_blob_storage import AzureBlobStorageDataSource
 from connectors.sources.tests.support import create_source
 from connectors.tests.commons import AsyncIterator
-from connectors.utils import ConfigurableFieldValueError
 
 
 def test_get_configuration():

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -22,6 +22,7 @@ from connectors.sources.generic_database import (
 from connectors.sources.postgresql import PostgreSQLDataSource
 from connectors.sources.tests.support import create_source
 from connectors.tests.commons import AsyncIterator
+from connectors.utils import ConfigurableFieldValueError
 
 POSTGRESQL_CONNECTION_STRING = (
     "postgresql+asyncpg://admin:changme@127.0.0.1:5432/testdb"
@@ -138,7 +139,7 @@ async def test_validate_config_valid_fields(patch_logger):
     # Execute
     try:
         await source.validate_config()
-    except Exception:
+    except ConfigurableFieldValueError:
         raise AssertionError("Method raised an exception")
 
 
@@ -149,7 +150,7 @@ async def test_validate_config_valid_fields(patch_logger):
 async def test_validate_config_missing_fields(field, patch_logger):
     # Setup
     source = create_source(GenericBaseDataSource)
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         source.configuration.set_field(name=field, value="")
 
         # Execute
@@ -161,7 +162,7 @@ async def test_validate_config_port(patch_logger):
     """Test validate_config method check port"""
     # Setup
     source = create_source(GenericBaseDataSource)
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         source.configuration.set_field(name="port", value="abcd")
 
         # Execute
@@ -175,7 +176,7 @@ async def test_validate_config_ssl(patch_logger):
     source = create_source(PostgreSQLDataSource)
     source.configuration.set_field(name="ssl_enabled", value=True)
 
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         # Execute
         await source.validate_config()
 

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -13,7 +13,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
-from connectors.source import DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.generic_database import (
     GenericBaseDataSource,
     configured_tables,
@@ -22,7 +22,6 @@ from connectors.sources.generic_database import (
 from connectors.sources.postgresql import PostgreSQLDataSource
 from connectors.sources.tests.support import create_source
 from connectors.tests.commons import AsyncIterator
-from connectors.utils import ConfigurableFieldValueError
 
 POSTGRESQL_CONNECTION_STRING = (
     "postgresql+asyncpg://admin:changme@127.0.0.1:5432/testdb"

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -14,9 +14,8 @@ from aiogoogle import Aiogoogle
 from aiogoogle.auth.managers import ServiceAccountManager
 from aiogoogle.models import Request, Response
 
-from connectors.source import DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.google_cloud_storage import GoogleCloudStorageDataSource
-from connectors.utils import ConfigurableFieldValueError
 
 SERVICE_ACCOUNT_CREDENTIALS = '{"project_id": "dummy123"}'
 API_NAME = "storage"

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -16,6 +16,7 @@ from aiogoogle.models import Request, Response
 
 from connectors.source import DataSourceConfiguration
 from connectors.sources.google_cloud_storage import GoogleCloudStorageDataSource
+from connectors.utils import ConfigurableFieldValueError
 
 SERVICE_ACCOUNT_CREDENTIALS = '{"project_id": "dummy123"}'
 API_NAME = "storage"
@@ -66,7 +67,8 @@ async def test_empty_configuration():
 
     # Execute
     with pytest.raises(
-        Exception, match="Google Cloud service account json can't be empty."
+        ConfigurableFieldValueError,
+        match="Google Cloud service account json can't be empty.",
     ):
         await gcs_object.validate_config()
 
@@ -81,7 +83,8 @@ async def test_raise_on_invalid_configuration():
 
     # Execute
     with pytest.raises(
-        Exception, match="Google Cloud service account is not a valid JSON"
+        ConfigurableFieldValueError,
+        match="Google Cloud service account is not a valid JSON",
     ):
         await gcs_object.validate_config()
 

--- a/connectors/sources/tests/test_jira.py
+++ b/connectors/sources/tests/test_jira.py
@@ -15,7 +15,7 @@ from aiohttp import StreamReader
 from connectors.source import DataSourceConfiguration
 from connectors.sources.jira import JiraDataSource
 from connectors.sources.tests.support import create_source
-from connectors.utils import ssl_context
+from connectors.utils import ConfigurableFieldValueError, ssl_context
 
 HOST_URL = "http://127.0.0.1:8080"
 MOCK_PROJECT = {
@@ -162,7 +162,7 @@ async def test_validate_config_for_host_url(patch_logger):
     source.configuration.set_field(name="host_url", value="")
 
     # Execute
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         await source.validate_config()
 
 
@@ -246,7 +246,7 @@ async def test_validate_config_for_ssl_enabled(patch_logger):
     source.ssl_enabled = True
 
     # Execute
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         await source.validate_config()
 
 
@@ -260,7 +260,8 @@ async def test_validate_config_with_invalid_concurrent_downloads(patch_logger):
 
     # Execute
     with pytest.raises(
-        Exception, match="Configured concurrent downloads can't be set more than *"
+        ConfigurableFieldValueError,
+        match="Configured concurrent downloads can't be set more than *",
     ):
         await source.validate_config()
 

--- a/connectors/sources/tests/test_jira.py
+++ b/connectors/sources/tests/test_jira.py
@@ -12,10 +12,10 @@ import aiohttp
 import pytest
 from aiohttp import StreamReader
 
-from connectors.source import DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.jira import JiraDataSource
 from connectors.sources.tests.support import create_source
-from connectors.utils import ConfigurableFieldValueError, ssl_context
+from connectors.utils import ssl_context
 
 HOST_URL = "http://127.0.0.1:8080"
 MOCK_PROJECT = {

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -10,9 +10,9 @@ from unittest import mock
 import pytest
 from bson.decimal128 import Decimal128
 
+from connectors.source import ConfigurableFieldValueError
 from connectors.sources.mongo import MongoAdvancedRulesValidator, MongoDataSource
 from connectors.sources.tests.support import assert_basics, create_source
-from connectors.utils import ConfigurableFieldValueError
 
 
 @pytest.mark.asyncio

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -12,6 +12,7 @@ from bson.decimal128 import Decimal128
 
 from connectors.sources.mongo import MongoAdvancedRulesValidator, MongoDataSource
 from connectors.sources.tests.support import assert_basics, create_source
+from connectors.utils import ConfigurableFieldValueError
 
 
 @pytest.mark.asyncio
@@ -167,7 +168,7 @@ async def test_validate_config_when_database_name_invalid_then_raises_exception(
         return_value=future_with_result(server_database_names),
     ):
         source = create_source(MongoDataSource, database=configured_database_name)
-        with pytest.raises(Exception) as e:
+        with pytest.raises(ConfigurableFieldValueError) as e:
             await source.validate_config()
         # assert that message contains database name from config
         assert e.match(configured_database_name)
@@ -195,7 +196,7 @@ async def test_validate_config_when_collection_name_invalid_then_raises_exceptio
             database=configured_database_name,
             collection=configured_collection_name,
         )
-        with pytest.raises(Exception) as e:
+        with pytest.raises(ConfigurableFieldValueError) as e:
             await source.validate_config()
         # assert that message contains database name from config
         assert e.match(configured_collection_name)

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -20,6 +20,7 @@ from connectors.sources.mysql import (
 )
 from connectors.sources.tests.support import create_source
 from connectors.tests.commons import AsyncIterator
+from connectors.utils import ConfigurableFieldValueError
 
 
 def immutable_doc(**kwargs):
@@ -391,22 +392,13 @@ async def test_get_docs_with_advanced_rules(
     assert yielded_docs == expected_docs
 
 
-def test_validate_configuration():
-    """This function test _validate_configuration method of MySQL"""
-    source = create_source(MySqlDataSource)
-    source.configuration.set_field(name="host", value="")
+@pytest.mark.asyncio
+async def test_validate_config():
+    """This function test validate_config method of MySQL"""
+    source = create_source(MySqlDataSource, host="")
 
-    with pytest.raises(Exception):
-        source._validate_configuration()
-
-
-def test_validate_configuration_with_port():
-    """This function test _validate_configuration method with port str input of MySQL"""
-    source = create_source(MySqlDataSource)
-    source.configuration.set_field(name="port", value="port")
-
-    with pytest.raises(Exception):
-        source._validate_configuration()
+    with pytest.raises(ConfigurableFieldValueError):
+        await source.validate_config()
 
 
 def test_ssl_context():

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -401,6 +401,16 @@ async def test_validate_config():
         await source.validate_config()
 
 
+@pytest.mark.asyncio
+async def test_validate_configuration_with_port():
+    """This function test _validate_configuration method with port str input of MySQL"""
+    source = create_source(MySqlDataSource)
+    source.configuration.set_field(name="port", value="port")
+
+    with pytest.raises(ConfigurableFieldValueError):
+        await source.validate_config()
+
+
 def test_ssl_context():
     """This function test _ssl_context with dummy certificate"""
     certificate = "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -12,7 +12,7 @@ import pytest
 
 from connectors.byoc import Filter
 from connectors.filtering.validation import SyncRuleValidationResult
-from connectors.source import DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.mysql import (
     MySQLAdvancedRulesValidator,
     MySqlDataSource,
@@ -20,7 +20,6 @@ from connectors.sources.mysql import (
 )
 from connectors.sources.tests.support import create_source
 from connectors.tests.commons import AsyncIterator
-from connectors.utils import ConfigurableFieldValueError
 
 
 def immutable_doc(**kwargs):

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -12,6 +12,7 @@ import pytest
 
 from connectors.sources.s3 import S3DataSource
 from connectors.sources.tests.support import assert_basics, create_source
+from connectors.utils import ConfigurableFieldValueError
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -328,12 +329,12 @@ def test_get_bucket_list():
 
 
 def test_validate_config_for_empty_bucket_string():
-    """This function test _validate_configuration  when buckets string is empty"""
+    """This function test validate_configwhen buckets string is empty"""
     # Setup
     source = create_source(S3DataSource)
     source.configuration.set_field(name="buckets", value=[""])
     # Execute
-    with pytest.raises(Exception) as e:
+    with pytest.raises(ConfigurableFieldValueError) as e:
         source.validate_config()
 
     assert e.match("buckets")

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -10,9 +10,9 @@ from unittest import mock
 import aioboto3
 import pytest
 
+from connectors.source import ConfigurableFieldValueError
 from connectors.sources.s3 import S3DataSource
 from connectors.sources.tests.support import assert_basics, create_source
-from connectors.utils import ConfigurableFieldValueError
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/connectors/sources/tests/test_sharepoint.py
+++ b/connectors/sources/tests/test_sharepoint.py
@@ -12,10 +12,9 @@ import aiohttp
 import pytest
 from aiohttp import StreamReader
 
-from connectors.source import DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.sharepoint import SharepointDataSource
 from connectors.sources.tests.support import create_source
-from connectors.utils import ConfigurableFieldValueError
 
 EXCEPTION_MESSAGE = "Something went wrong"
 HOST_URL = "http://127.0.0.1:8491"

--- a/connectors/sources/tests/test_sharepoint.py
+++ b/connectors/sources/tests/test_sharepoint.py
@@ -15,6 +15,7 @@ from aiohttp import StreamReader
 from connectors.source import DataSourceConfiguration
 from connectors.sources.sharepoint import SharepointDataSource
 from connectors.sources.tests.support import create_source
+from connectors.utils import ConfigurableFieldValueError
 
 EXCEPTION_MESSAGE = "Something went wrong"
 HOST_URL = "http://127.0.0.1:8491"
@@ -134,7 +135,7 @@ async def test_validate_config_when_host_url_is_empty():
     source.configuration.set_field(name="host_url", value="")
 
     # Execute
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         await source.validate_config()
 
 
@@ -146,7 +147,7 @@ async def test_validate_config_for_ssl_enabled():
     source.ssl_enabled = True
 
     # Execute
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         await source.validate_config()
 
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -472,7 +472,3 @@ def get_pem_format(key, max_split=-1):
     key = " ".join(key.split("\n", max_split))
     key = " ".join(key.rsplit("\n", max_split))
     return key
-
-
-class ConfigurableFieldValueError(Exception):
-    pass

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -472,3 +472,7 @@ def get_pem_format(key, max_split=-1):
     key = " ".join(key.split("\n", max_split))
     key = " ".join(key.rsplit("\n", max_split))
     return key
+
+
+class ConfigurableFieldValueError(Exception):
+    pass


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/601

This PR adds a new error type - `connectors.utils.ConfigurableFieldValueError` that is supposed to be used in `valdiate_config` of individual connector source files.

For now I haven't changed the way the errors are treated in the framework - framework still catches `Exception` and fails the sync, but in future I'm planning to add separate handling to also properly distinguish validation errors vs other errors (type errors, value errors, problems accessing 3rd-party system, etc).

What I also don't address - incompatible types for values are still handled in a messy way. E.g. if connector expects an integer in "port", but you give it a string, you'll get an unreadable exception message.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
