### PR TITLE
[MySQL] Validate that configured database and tables are accessible~

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -184,7 +184,8 @@ class MySqlDataSource(BaseDataSource):
         self._sleeps.cancel()
 
     async def validate_config(self):
-        """Validates whether user input is empty or not for configuration fields and validate type for port
+        """Validates whether user input is empty or not for configuration fields and validate type for port.
+        Also validate, if the configured database and the configured tables are present and accessible by the configured user.
 
         Raises:
             Exception: Configured keys can't be empty
@@ -208,6 +209,44 @@ class MySqlDataSource(BaseDataSource):
 
         if self.ssl_enabled and (self.certificate == "" or self.certificate is None):
             raise Exception("SSL certificate must be configured.")
+
+        await self._remote_validation()
+
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def _remote_validation(self):
+        async with self.with_connection_pool() as connection_pool:
+            async with connection_pool.acquire() as conn:
+                async with conn.cursor() as cursor:
+                    await self._validate_database_accessible(cursor)
+                    await self._validate_tables_accessible(cursor)
+
+    async def _validate_database_accessible(self, cursor):
+        try:
+            await cursor.execute(f"USE {self.database};")
+        except aiomysql.Error:
+            # TODO: replace with future ValidationError
+            raise Exception(
+                f"The database '{self.database}' is either not present or not accessible for the user '{self.configuration['user']}'."
+            )
+
+    async def _validate_tables_accessible(self, cursor):
+        non_accessible_tables = []
+
+        for table in self.tables:
+            try:
+                await cursor.execute(f"SELECT 1 FROM {table} LIMIT 1;")
+            except aiomysql.Error:
+                non_accessible_tables.append(table)
+
+        if len(non_accessible_tables) > 0:
+            # TODO: replace with future ValidationError
+            raise Exception(
+                f"The {'tables'} '{format_list(non_accessible_tables)}' are either not present or not accessible for user '{self.configuration['user']}'."
+            )
 
     def _ssl_context(self, certificate):
         """Convert string to pem format and create a SSL context

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -491,3 +491,48 @@ async def test_get_tables_to_fetch_remote_tables(tables):
     await source.get_tables_to_fetch()
 
     assert source.fetch_all_tables.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_validate_database_accessible_when_accessible_then_no_error_raised():
+    source = create_source(MySqlDataSource)
+    source.database = "test_database"
+
+    cursor = AsyncMock()
+    cursor.execute.return_value = None
+
+    await source._validate_database_accessible(cursor)
+    cursor.execute.assert_called_with(f"USE {source.database};")
+
+
+@pytest.mark.asyncio
+async def test_validate_database_accessible_when_not_accessible_then_error_raised():
+    source = create_source(MySqlDataSource)
+
+    cursor = AsyncMock()
+    cursor.execute.side_effect = aiomysql.Error("Error")
+
+    with pytest.raises(Exception):
+        await source._validate_database_accessible(cursor)
+
+
+@pytest.mark.asyncio
+async def test_validate_tables_accessible_when_accessible_then_no_error_raised():
+    source = create_source(MySqlDataSource)
+    source.tables = ["table_1", "table_2", "table_3"]
+
+    cursor = AsyncMock()
+    cursor.execute.return_value = None
+
+    await source._validate_tables_accessible(cursor)
+
+
+@pytest.mark.asyncio
+async def test_validate_tables_accessible_when_not_accessible_then_error_raised():
+    source = create_source(MySqlDataSource)
+
+    cursor = AsyncMock()
+    cursor.execute.side_effect = aiomysql.Error("Error")
+
+    with pytest.raises(Exception):
+        await source._validate_tables_accessible(cursor)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4052

Introduce remote validation, which checks, whether the configured database and the configured tables are present/accessible. Also add two TODOs to replace the generic `Exception` with the a new `ValidationError` class.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~