### PR TITLE
Add human-readable error messages to QueueFull

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -227,7 +227,7 @@ class MemQueue(asyncio.Queue):
             if elapsed_time >= self.refresh_timeout:
                 putter.set_result(
                     asyncio.QueueFull(
-                        f"MemQueue has been full for {elapsed_time}s. while timeout is {self.refresh_timeout}s."
+                        f"MemQueue has been full for {round(elapsed_time, 4)}s. while timeout is {self.refresh_timeout}s."
                     )
                 )
                 return
@@ -287,7 +287,7 @@ class MemQueue(asyncio.Queue):
         item_size = get_size(item)
         if self.full(item_size):
             raise asyncio.QueueFull(
-                f"Queue is full: attempting to add item of size {item_size} bytes to queue with {self.maxmemsize - self._current_memsize} bytes capacity left."
+                f"Queue is full: attempting to add item of size {item_size} bytes while {self.maxmemsize - self._current_memsize} free bytes left."
             )
         super().put_nowait((item_size, item))
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -227,7 +227,7 @@ class MemQueue(asyncio.Queue):
             if elapsed_time >= self.refresh_timeout:
                 putter.set_result(
                     asyncio.QueueFull(
-                        f"MemQueue has been full for {elapsed_time} while timeout is {self.refresh_timeout}. Check if consumer of the queue is healthy."
+                        f"MemQueue has been full for {elapsed_time}s. while timeout is {self.refresh_timeout}s."
                     )
                 )
                 return
@@ -287,7 +287,7 @@ class MemQueue(asyncio.Queue):
         item_size = get_size(item)
         if self.full(item_size):
             raise asyncio.QueueFull(
-                "Queue is full: attempting to add item of size {item_size} to queue with capacity [{self._current_memsize}/{self.maxmemsize}]."
+                f"Queue is full: attempting to add item of size {item_size} bytes to queue with {self.maxmemsize - self._current_memsize} bytes capacity left."
             )
         super().put_nowait((item_size, item))
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/154

Attempting to improve error messages for QueueFull error. There are 2 possible cases:

1. MemQueue has not been dequeued for a while and is still full after a timeout. Example message:

```
MemQueue has been full for 1.005s. while timeout is 1s.
```

2. MemQueue is almost full and a consumer is attempting to forcefully add a large enough object to it. Example message:

```
Queue is full: attempting to add item of size 4056 bytes while 10 free bytes left."
```

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
