### PR TITLE
[MySQL] Use ConfigurableFieldError in validate_config

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -228,8 +228,7 @@ class MySqlDataSource(BaseDataSource):
         try:
             await cursor.execute(f"USE {self.database};")
         except aiomysql.Error:
-            # TODO: replace with future ValidationError
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"The database '{self.database}' is either not present or not accessible for the user '{self.configuration['user']}'."
             )
 
@@ -243,8 +242,7 @@ class MySqlDataSource(BaseDataSource):
                 non_accessible_tables.append(table)
 
         if len(non_accessible_tables) > 0:
-            # TODO: replace with future ValidationError
-            raise Exception(
+            raise ConfigurableFieldValueError(
                 f"The tables '{format_list(non_accessible_tables)}' are either not present or not accessible for user '{self.configuration['user']}'."
             )
 

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -513,7 +513,7 @@ async def test_validate_database_accessible_when_not_accessible_then_error_raise
     cursor = AsyncMock()
     cursor.execute.side_effect = aiomysql.Error("Error")
 
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         await source._validate_database_accessible(cursor)
 
 
@@ -535,5 +535,5 @@ async def test_validate_tables_accessible_when_not_accessible_then_error_raised(
     cursor = AsyncMock()
     cursor.execute.side_effect = aiomysql.Error("Error")
 
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurableFieldValueError):
         await source._validate_tables_accessible(cursor)


### PR DESCRIPTION
Use the newly introduced `ConfigurableFieldError`, if the config is invalid.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~