### PR TITLE
[MongoDB] Advanced rules "aggregate"

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -17,3 +17,4 @@ SQLAlchemy==2.0.1
 oracledb==1.2.2
 asyncpg==0.27.0
 pyodbc==4.0.34 # Latest version is v4.0.35. However it is not compatible with MAC M1 chip so pining this version
+pymongo[srv]==3.13.0


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4232

This PR adds the capability for executing aggregation pipelines to the MongoDB connector. As pipeline is a non-optional parameters it's extracted and passed separately to the `aggregate` method of `Collection`. Using `deepcopy` ensures, that the original `Filter` object won't be changed.

Also add `pymongo[srv]`, which is needed to connect to a MongoDB instance using a host with the following format "mongodb+srv://...".

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~