### PR TITLE
[Filtering] Allow a single advanced rule validator

### DIFF
--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -177,8 +177,13 @@ class FilteringValidator:
 
         if filtering.has_advanced_rules():
             advanced_rules = filtering.get_advanced_rules()
+            advanced_rules_validators = (
+                self.advanced_rules_validators
+                if isinstance(self.advanced_rules_validators, list)
+                else [self.advanced_rules_validators]
+            )
 
-            for validator in self.advanced_rules_validators:
+            for validator in advanced_rules_validators:
                 filtering_validation_result += await validator.validate(advanced_rules)
 
         logger.info(f"Filtering validation result: {filtering_validation_result.state}")

--- a/connectors/tests/test_validation.py
+++ b/connectors/tests/test_validation.py
@@ -1027,3 +1027,31 @@ def test_basic_rules_set_no_conflicting_policies_validation(
 )
 def test_filtering_validation_state_from_string(string, expected_state):
     assert FilteringValidationState(string) == expected_state
+
+
+@pytest.mark.asyncio
+async def test_filtering_validator_validate_single_advanced_rules_validator():
+    invalid_validation_result = SyncRuleValidationResult(
+        rule_id=RULE_TWO_ID,
+        is_valid=False,
+        validation_message=RULE_TWO_VALIDATION_MESSAGE,
+    )
+
+    # single validator, not wrapped in a list
+    advanced_rule_validator = validator_fakes(
+        [invalid_validation_result],
+        is_basic_rule_validator=False,
+    )[0]
+
+    filtering_validator = FilteringValidator([], advanced_rule_validator)
+
+    validation_result = await filtering_validator.validate(
+        Filter(
+            {
+                "basic_rules": [],
+                "advanced_snippet": {"value": {"query": "SELECT * FROM table;"}},
+            }
+        )
+    )
+
+    assert validation_result.state == FilteringValidationState.INVALID


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4180

For convenience it's not necessary for a connector implementation to wrap a single advanced rules validator in a list. This is now handled by the framework internally.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~