### PR TITLE
[8.7] Fix issues raising from base service swallowing errors (#551)

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -591,6 +591,8 @@ class Connector(ESDocument):
         populate the service type and then sets the default configuration.
         """
         configured_connector_id = config.get("connector_id", "")
+        configured_service_type = config.get("service_type", "")
+
         if self.id != configured_connector_id:
             return
 
@@ -599,7 +601,6 @@ class Connector(ESDocument):
 
         doc = {}
         if self.service_type is None:
-            configured_service_type = config.get("service_type", "")
             if not configured_service_type:
                 logger.error(
                     f"Service type is not configured for connector {configured_connector_id}"

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -128,12 +128,14 @@ FAIL_FILTERING_ERRORS_PRESENT_CONFIG = copy.deepcopy(FAKE_CONFIG)
 FAIL_FILTERING_ERRORS_PRESENT_CONFIG["service_type"] = "filtering_errors_present"
 
 ALL_SYNC_RULES_FEATURES_DISABLED = {
-    "sync_rules": {"advanced": {"enabled": False}, "basic": {"enabled": False}},
-    "filtering_advanced_config": False,
-    "filtering_rules": False,
+    "features": {
+        "sync_rules": {"advanced": {"enabled": False}, "basic": {"enabled": False}},
+        "filtering_advanced_config": False,
+        "filtering_rules": False,
+    }
 }
 
-NO_FEATURES_PRESENT = {}
+NO_FEATURES_PRESENT = {"features": {}}
 
 FAKE_CONFIG_FAIL_SERVICE = {
     "api_key_id": "",
@@ -225,6 +227,7 @@ def create_service(config_file):
     config = load_config(config_file)
     service = SyncService(config)
     service.idling = 0
+    service.service_config["max_errors"] = 0
 
     return service
 
@@ -638,8 +641,9 @@ async def test_connector_service_filtering(
     )
 
     if should_raise_filtering_error:
-        await create_and_run_service(CONFIG_FILE)
-        patch_logger.assert_check(lambda log: isinstance(log, InvalidFilteringError))
+        with pytest.raises(InvalidFilteringError) as e:
+            await create_and_run_service(CONFIG_FILE)
+        assert e is not None
     else:
         try:
             await create_and_run_service(CONFIG_FILE)
@@ -665,13 +669,11 @@ async def test_connector_service_poll_buggy_service(
         mock_responses, [FAKE_CONFIG_BUGGY_SERVICE], connectors_update=connectors_update
     )
 
-    await create_and_run_service(CONFIG_FILE)
+    with pytest.raises(DataSourceError) as e:
+        await create_and_run_service(CONFIG_FILE)
 
-    for log in patch_logger.logs:
-        if isinstance(log, DataSourceError):
-            return
-
-    raise AssertionError
+    if e is None:
+        raise AssertionError("No exception raised when expected one")
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_sync.py
+++ b/connectors/tests/test_sync.py
@@ -486,27 +486,6 @@ async def test_connector_service_poll_no_sync_but_status_updated(
 
 
 @pytest.mark.asyncio
-async def test_connector_service_poll_cron_broken(
-    mock_responses, patch_logger, set_env
-):
-    calls = []
-
-    def upd(url, **kw):
-        doc = json.loads(kw["data"])["doc"]
-        calls.append(doc)
-
-    # if a connector is correctly configured but we don't sync because the cron
-    # is broken
-    # we still want to tell kibana we are connected
-    await set_server_responses(
-        mock_responses, [FAKE_CONFIG_CRON_BROKEN], connectors_update=upd
-    )
-    await create_and_run_service(CONFIG_FILE)
-    patch_logger.assert_not_present("Sync done")
-    assert calls[-1]["status"] == "error"
-
-
-@pytest.mark.asyncio
 async def test_connector_service_poll_suspended_restarts_sync(
     mock_responses, patch_logger, set_env
 ):


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Fix issues raising from base service swallowing errors (#551)](https://github.com/elastic/connectors-python/pull/551)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)