### PR TITLE
[SharePoint] Add separate client class

### DIFF
--- a/connectors/sources/sharepoint.py
+++ b/connectors/sources/sharepoint.py
@@ -91,6 +91,213 @@ SCHEMA = {
 }
 
 
+class SharepointClient:
+    """Sharepoint client to handle API calls made to Sharepoint"""
+
+    def __init__(self, configuration):
+        self._sleeps = CancellableSleeps()
+        self.configuration = configuration
+        self.is_cloud = self.configuration["is_cloud"]
+        self.host_url = self.configuration["host_url"]
+        self.certificate = self.configuration["ssl_ca"]
+        self.ssl_enabled = self.configuration["ssl_enabled"]
+        self.retry_count = self.configuration["retry_count"]
+        self.site_collections = self.configuration["site_collections"]
+
+        self.session = None
+        self.access_token = None
+        self.token_expires_at = None
+
+        if self.ssl_enabled and self.certificate:
+            self.ssl_ctx = ssl_context(certificate=self.certificate)
+        else:
+            self.ssl_ctx = False
+
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def _set_access_token(self):
+        """Set access token using configuration fields"""
+        expires_at = self.token_expires_at
+        if self.token_expires_at and (not isinstance(expires_at, datetime)):
+            expires_at = datetime.fromisoformat(expires_at)  # pyright: ignore
+        if not is_expired(expires_at=expires_at):
+            return
+        tenant_id = self.configuration["tenant_id"]
+        logger.debug("Generating access token")
+        url = f"https://accounts.accesscontrol.windows.net/{tenant_id}/tokens/OAuth/2"
+        # GUID in resource is always a constant used to create access token
+        data = {
+            "grant_type": "client_credentials",
+            "resource": f"00000003-0000-0ff1-ce00-000000000000/{self.configuration['tenant']}.sharepoint.com@{tenant_id}",
+            "client_id": f"{self.configuration['client_id']}@{tenant_id}",
+            "client_secret": self.configuration["secret_id"],
+        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        async with aiohttp.request(
+            method="POST", url=url, data=data, headers=headers
+        ) as response:
+            json_data = await response.json()
+            self.access_token = json_data["access_token"]
+            self.token_expires_at = evaluate_timedelta(
+                seconds=int(json_data["expires_in"]), time_skew=20
+            )
+
+    def _get_session(self):
+        """Generate base client session using configuration fields
+
+        Returns:
+            ClientSession: Base client session.
+        """
+        if self.session:
+            return self.session
+        logger.info("Generating aiohttp Client Session...")
+        request_headers = {
+            "accept": "application/json",
+            "content-type": "application/json",
+        }
+        timeout = aiohttp.ClientTimeout(total=None)  # pyright: ignore
+
+        if self.is_cloud:
+            basic_auth = None
+        else:
+            basic_auth = aiohttp.BasicAuth(
+                login=self.configuration["username"],
+                password=self.configuration["password"],
+            )
+        self.session = aiohttp.ClientSession(
+            auth=basic_auth,
+            headers=request_headers,
+            timeout=timeout,
+            raise_for_status=True,
+        )
+        return self.session
+
+    async def close_session(self):
+        """Closes unclosed client session"""
+        self._sleeps.cancel()
+        if self.session is None:
+            return
+        await self.session.close()
+        self.session = None
+
+    async def api_call(self, url_name, url="", **url_kwargs):
+        """Make an API call to the Sharepoint Server/Online
+
+        Args:
+            url_name (str): Sharepoint url name to be executed.
+            url(str, optional): Paginated url for drive and list items. Defaults to "".
+            url_kwargs (dict): Url kwargs to format the query.
+        Raises:
+            exception: An instance of an exception class.
+
+        Yields:
+            data: API response.
+        """
+        retry = 0
+        # If pagination happens for list and drive items then next pagination url comes in response which will be passed in url field.
+        if url == "":
+            url = URLS[url_name].format(**url_kwargs)
+        headers = None
+
+        while True:
+            try:
+                if self.is_cloud:
+                    await self._set_access_token()
+                    headers = {"Authorization": f"Bearer {self.access_token}"}
+                async with self._get_session().get(  # pyright: ignore
+                    url=url,
+                    ssl=self.ssl_ctx,
+                    headers=headers,
+                ) as result:
+                    if url_name == ATTACHMENT:
+                        yield result
+                    else:
+                        yield await result.json()
+                    break
+            except Exception as exception:
+                if isinstance(
+                    exception,
+                    ClientResponseError,
+                ) and "token has expired" in exception.headers.get(  # pyright: ignore
+                    "x-ms-diagnostics", ""
+                ):
+                    await self._set_access_token()
+                elif isinstance(
+                    exception,
+                    ServerDisconnectedError,
+                ):
+                    await self.close_session()
+                if retry >= self.retry_count:
+                    raise exception
+                retry += 1
+
+                logger.warning(
+                    f"Retry count: {retry} out of {self.retry_count}. Exception: {exception}"
+                )
+                await self._sleeps.sleep(RETRY_INTERVAL**retry)
+
+    async def invoke_get_call(self, site_url, param_name, list_id=None):
+        """Invokes a GET call to the Sharepoint Server/Online.
+
+        Args:
+            site_url(string): site url to the sharepoint farm.
+            param_name(string): parameter name whether it is SITES, LISTS, DRIVE_ITEM, LIST_ITEM.
+            list_id(string, optional): Id of list item or drive item. Defaults to None.
+        Yields:
+            Response of the GET call.
+        """
+        skip = 0
+        next_url = ""
+        while True:
+            if param_name in [SITES, LISTS]:
+                response = await anext(
+                    self.api_call(
+                        url_name=param_name,
+                        parent_site_url=site_url,
+                        skip=skip,
+                        top=TOP,
+                        host_url=self.host_url,
+                    )
+                )
+                response_result = response.get("value", [])  # pyright: ignore
+                yield response_result
+
+                skip += TOP
+                if len(response_result) < TOP:
+                    break
+            elif param_name in [
+                DRIVE_ITEM,
+                LIST_ITEM,
+            ]:
+                if next_url != "":
+                    response = await anext(
+                        self.api_call(
+                            url_name=param_name,
+                            url=next_url,
+                        )
+                    )
+                else:
+                    response = await anext(
+                        self.api_call(
+                            url_name=param_name,
+                            parent_site_url=site_url,
+                            list_id=list_id,
+                            top=TOP,
+                            host_url=self.host_url,
+                        )
+                    )
+                response_result = response.get("value", [])  # pyright: ignore
+                yield response_result
+
+                next_url = response.get("odata.nextLink", "")  # pyright: ignore
+                if next_url == "":
+                    break
+
+
 class SharepointDataSource(BaseDataSource):
     """Sharepoint"""
 
@@ -104,18 +311,7 @@ class SharepointDataSource(BaseDataSource):
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
         super().__init__(configuration=configuration)
-        self.is_cloud = self.configuration["is_cloud"]
-        self.site_collections = self.configuration["site_collections"]
-        self.ssl_enabled = self.configuration["ssl_enabled"]
-        self.host_url = self.configuration["host_url"]
-        self.certificate = self.configuration["ssl_ca"]
-        self.enable_content_extraction = self.configuration["enable_content_extraction"]
-        self.retry_count = self.configuration["retry_count"]
-        self._sleeps = CancellableSleeps()
-        self.ssl_ctx = False
-        self.session = None
-        self.access_token = None
-        self.token_expires_at = None
+        self.sharepoint_client = SharepointClient(configuration=configuration)
 
     @classmethod
     def get_default_configuration(cls):
@@ -192,6 +388,10 @@ class SharepointDataSource(BaseDataSource):
             },
         }
 
+    async def close(self):
+        """Closes unclosed client session"""
+        await self.sharepoint_client.close_session()
+
     async def validate_config(self):
         """Validates whether user input is empty or not for configuration fields
 
@@ -209,7 +409,7 @@ class SharepointDataSource(BaseDataSource):
                 "tenant",
                 "tenant_id",
             ]
-            if self.is_cloud
+            if self.sharepoint_client.is_cloud
             else ["host_url", "site_collections", "username", "password"]
         )
 
@@ -223,132 +423,11 @@ class SharepointDataSource(BaseDataSource):
             raise ConfigurableFieldValueError(
                 f"Configured keys: {empty_connection_fields} can't be empty."
             )
-        if self.ssl_enabled and self.certificate == "":
+        if (
+            self.sharepoint_client.ssl_enabled
+            and self.sharepoint_client.certificate == ""
+        ):
             raise ConfigurableFieldValueError("SSL certificate must be configured.")
-
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def _set_access_token(self):
-        """Set access token using configuration fields"""
-        expires_at = self.token_expires_at
-        if self.token_expires_at and (not isinstance(expires_at, datetime)):
-            expires_at = datetime.fromisoformat(expires_at)  # pyright: ignore
-        if not is_expired(expires_at=expires_at):
-            return
-        tenant_id = self.configuration["tenant_id"]
-        logger.debug("Generating access token")
-        url = f"https://accounts.accesscontrol.windows.net/{tenant_id}/tokens/OAuth/2"
-        # GUID in resource is always a constant used to create access token
-        data = {
-            "grant_type": "client_credentials",
-            "resource": f"00000003-0000-0ff1-ce00-000000000000/{self.configuration['tenant']}.sharepoint.com@{tenant_id}",
-            "client_id": f"{self.configuration['client_id']}@{tenant_id}",
-            "client_secret": self.configuration["secret_id"],
-        }
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-        async with aiohttp.request(
-            method="POST", url=url, data=data, headers=headers
-        ) as response:
-            json_data = await response.json()
-            self.access_token = json_data["access_token"]
-            self.token_expires_at = evaluate_timedelta(
-                seconds=int(json_data["expires_in"]), time_skew=20
-            )
-
-    async def _generate_session(self):
-        """Generate base client session using configuration fields
-
-        Returns:
-            ClientSession: Base client session.
-        """
-        logger.info("Generating aiohttp Client Session...")
-        request_headers = {
-            "accept": "application/json",
-            "content-type": "application/json",
-        }
-        timeout = aiohttp.ClientTimeout(total=None)  # pyright: ignore
-
-        if self.is_cloud:
-            basic_auth = None
-            await self._set_access_token()
-        else:
-            basic_auth = aiohttp.BasicAuth(
-                login=self.configuration["username"],
-                password=self.configuration["password"],
-            )
-        self.session = aiohttp.ClientSession(
-            auth=basic_auth,
-            headers=request_headers,
-            timeout=timeout,
-            raise_for_status=True,
-        )
-
-    async def close(self):
-        """Closes unclosed client session"""
-        if self.session is None:
-            return
-        await self.session.close()
-
-    async def _api_call(self, url_name, url="", **url_kwargs):
-        """Make an API call to the Sharepoint Server/Online
-
-        Args:
-            url_name (str): Sharepoint url name to be executed.
-            url(str, optional): Paginated url for drive and list items. Defaults to "".
-            url_kwargs (dict): Url kwargs to format the query.
-        Raises:
-            exception: An instance of an exception class.
-
-        Yields:
-            data: API response.
-        """
-        retry = 0
-        # If pagination happens for list and drive items then next pagination url comes in response which will be passed in url field.
-        if url == "":
-            url = URLS[url_name].format(**url_kwargs)
-
-        headers = None
-
-        if self.is_cloud:
-            headers = {"Authorization": f"Bearer {self.access_token}"}
-        while True:
-            try:
-                async with self.session.get(
-                    url=url,
-                    ssl=self.ssl_ctx,
-                    headers=headers,
-                ) as result:
-                    if url_name == ATTACHMENT:
-                        yield result
-                    else:
-                        yield await result.json()
-                    break
-            except Exception as exception:
-                if isinstance(
-                    exception,
-                    ClientResponseError,
-                ) and "token has expired" in exception.headers.get(  # pyright: ignore
-                    "x-ms-diagnostics", ""
-                ):
-                    await self._set_access_token()
-                elif isinstance(
-                    exception,
-                    ServerDisconnectedError,
-                ):
-                    await self.session.close()
-                    await self._generate_session()
-                if retry >= self.retry_count:
-                    raise exception
-                retry += 1
-
-                logger.warning(
-                    f"Retry count: {retry} out of {self.retry_count}. Exception: {exception}"
-                )
-                await self._sleeps.sleep(RETRY_INTERVAL**retry)
 
     def format_document(
         self,
@@ -372,7 +451,7 @@ class SharepointDataSource(BaseDataSource):
 
         if document_type in [LISTS, DOCUMENT_LIBRARY]:
             document["url"] = urljoin(
-                self.host_url, item["RootFolder"]["ServerRelativeUrl"]
+                self.sharepoint_client.host_url, item["RootFolder"]["ServerRelativeUrl"]
             )
 
         elif document_type == DRIVE_ITEM:
@@ -380,7 +459,10 @@ class SharepointDataSource(BaseDataSource):
                 {
                     "_id": item["GUID"],
                     "size": item.get("File", {}).get("Length"),
-                    "url": urljoin(self.host_url, item[item_type]["ServerRelativeUrl"]),
+                    "url": urljoin(
+                        self.sharepoint_client.host_url,
+                        item[item_type]["ServerRelativeUrl"],
+                    ),
                     "type": item_type,
                 }
             )
@@ -406,29 +488,28 @@ class SharepointDataSource(BaseDataSource):
 
     async def ping(self):
         """Verify the connection with Sharepoint"""
-        if self.session is None:
-            await self._generate_session()
-
-        if self.ssl_enabled and (not self.ssl_ctx):
-            self.ssl_ctx = ssl_context(certificate=self.certificate)
-
         try:
             await anext(
-                self._api_call(
+                self.sharepoint_client.api_call(
                     url_name=PING,
-                    site_collections=self.site_collections[0],
-                    host_url=self.host_url,
+                    site_collections=self.sharepoint_client.site_collections[0],
+                    host_url=self.sharepoint_client.host_url,
                 )
             )
             logger.debug(
-                f"Successfully connected to the Sharepoint via {self.host_url}"
+                f"Successfully connected to the Sharepoint via {self.sharepoint_client.host_url}"
             )
         except Exception:
             logger.exception(
-                f"Error while connecting to the Sharepoint via {self.host_url}"
+                f"Error while connecting to the Sharepoint via {self.sharepoint_client.host_url}"
             )
             raise
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
     async def get_content(
         self, document, file_relative_url, site_url, timestamp=None, doit=False
     ):
@@ -445,7 +526,11 @@ class SharepointDataSource(BaseDataSource):
             dictionary: Content document with id, timestamp & text.
         """
 
-        if not (self.enable_content_extraction and doit and document["size"]):
+        if not (
+            self.configuration["enable_content_extraction"]
+            and doit
+            and document["size"]
+        ):
             return
 
         document_size = int(document["size"])
@@ -458,9 +543,9 @@ class SharepointDataSource(BaseDataSource):
         source_file_name = ""
 
         async with NamedTemporaryFile(mode="wb", delete=False) as async_buffer:
-            async for response in self._api_call(
+            async for response in self.sharepoint_client.api_call(
                 url_name=ATTACHMENT,
-                host_url=self.host_url,
+                host_url=self.sharepoint_client.host_url,
                 value=site_url,
                 file_relative_url=file_relative_url,
             ):
@@ -483,63 +568,6 @@ class SharepointDataSource(BaseDataSource):
             "_attachment": attachment_content,
         }
 
-    async def invoke_get_call(self, site_url, param_name, list_id=None):
-        """Invokes a GET call to the Sharepoint Server/Online.
-
-        Args:
-            site_url(string): site url to the sharepoint farm.
-            param_name(string): parameter name whether it is SITES, LISTS, DRIVE_ITEM, LIST_ITEM.
-            list_id(string, optional): Id of list item or drive item. Defaults to None.
-        Yields:
-            Response of the GET call.
-        """
-        skip = 0
-        next_url = ""
-        while True:
-            if param_name in [SITES, LISTS]:
-                response = await anext(
-                    self._api_call(
-                        url_name=param_name,
-                        parent_site_url=site_url,
-                        skip=skip,
-                        top=TOP,
-                        host_url=self.host_url,
-                    )
-                )
-                response_result = response.get("value", [])  # pyright: ignore
-                yield response_result
-
-                skip += TOP
-                if len(response_result) < TOP:
-                    break
-            elif param_name in [
-                DRIVE_ITEM,
-                LIST_ITEM,
-            ]:
-                if next_url != "":
-                    response = await anext(
-                        self._api_call(
-                            url_name=param_name,
-                            url=next_url,
-                        )
-                    )
-                else:
-                    response = await anext(
-                        self._api_call(
-                            url_name=param_name,
-                            parent_site_url=site_url,
-                            list_id=list_id,
-                            top=TOP,
-                            host_url=self.host_url,
-                        )
-                    )
-                response_result = response.get("value", [])  # pyright: ignore
-                yield response_result
-
-                next_url = response.get("odata.nextLink", "")  # pyright: ignore
-                if next_url == "":
-                    break
-
     async def get_sites(self, site_url):
         """Get sites from Sharepoint Server/Online
 
@@ -548,7 +576,7 @@ class SharepointDataSource(BaseDataSource):
         Yields:
             site_server_url(string): Site path.
         """
-        async for sites_data in self.invoke_get_call(
+        async for sites_data in self.sharepoint_client.invoke_get_call(
             site_url=site_url, param_name=SITES
         ):
             for data in sites_data:
@@ -569,12 +597,12 @@ class SharepointDataSource(BaseDataSource):
             dictionary: dictionary containing meta-data of the list item.
         """
         file_relative_url = None
-        async for list_items_data in self.invoke_get_call(
+        async for list_items_data in self.sharepoint_client.invoke_get_call(
             site_url=site_url, param_name=LIST_ITEM, list_id=list_id
         ):
             for result in list_items_data:
                 if not result.get("Attachments"):
-                    url = f"{self.host_url}{server_relative_url}/DispForm.aspx?ID={result['Id']}&Source={self.host_url}{server_relative_url}/AllItems.aspx&ContentTypeId={result['ContentTypeId']}"
+                    url = f"{self.sharepoint_client.host_url}{server_relative_url}/DispForm.aspx?ID={result['Id']}&Source={self.sharepoint_client.host_url}{server_relative_url}/AllItems.aspx&ContentTypeId={result['ContentTypeId']}"
                     result["url"] = url
                     yield self.format_document(
                         item=result,
@@ -588,9 +616,9 @@ class SharepointDataSource(BaseDataSource):
                     )
 
                     attachment_data = await anext(
-                        self._api_call(
+                        self.sharepoint_client.api_call(
                             url_name=ATTACHMENT_DATA,
-                            host_url=self.host_url,
+                            host_url=self.sharepoint_client.host_url,
                             parent_site_url=site_url,
                             file_relative_url=file_relative_url,
                         )
@@ -598,7 +626,8 @@ class SharepointDataSource(BaseDataSource):
                     result["size"] = attachment_data.get("Length")  # pyright: ignore
                     result["_id"] = attachment_data["UniqueId"]  # pyright: ignore
                     result["url"] = urljoin(
-                        self.host_url, attachment_file.get("ServerRelativeUrl")
+                        self.sharepoint_client.host_url,
+                        attachment_file.get("ServerRelativeUrl"),
                     )
 
                     if (
@@ -623,7 +652,7 @@ class SharepointDataSource(BaseDataSource):
         Yields:
             dictionary: dictionary containing meta-data of the drive item.
         """
-        async for drive_items_data in self.invoke_get_call(
+        async for drive_items_data in self.sharepoint_client.invoke_get_call(
             site_url=site_url, param_name=DRIVE_ITEM, list_id=list_id
         ):
             for result in drive_items_data:
@@ -653,7 +682,9 @@ class SharepointDataSource(BaseDataSource):
         Yields:
             dictionary: dictionary containing meta-data of the list, list item and drive item.
         """
-        async for list_data in self.invoke_get_call(site_url=site, param_name=LISTS):
+        async for list_data in self.sharepoint_client.invoke_get_call(
+            site_url=site, param_name=LISTS
+        ):
             for result in list_data:
                 # if BaseType value is 1 then it's document library else it's a list item
                 if result.get("BaseType") == 1:
@@ -682,27 +713,22 @@ class SharepointDataSource(BaseDataSource):
         Yields:
             dictionary: dictionary containing meta-data of the Sharepoint objects.
         """
-        if self.session is None:
-            await self._generate_session()
-
-        if self.ssl_enabled and (not self.ssl_ctx):
-            self.ssl_ctx = ssl_context(certificate=self.certificate)
 
         server_relative_url = []
 
-        for collection in self.site_collections:
+        for collection in self.sharepoint_client.site_collections:
             server_relative_url.append(f"/sites/{collection}")
             async for site_document in self.get_sites(site_url=f"/sites/{collection}"):
                 server_relative_url.append(site_document["server_relative_url"])
                 yield site_document, None
 
-            for site_url in server_relative_url:
-                async for item, file_relative_url in self.get_lists_and_items(
-                    site=site_url
-                ):
-                    if file_relative_url is None:
-                        yield item, None
-                    else:
-                        yield item, partial(
-                            self.get_content, item, file_relative_url, site_url
-                        )
+        for site_url in server_relative_url:
+            async for item, file_relative_url in self.get_lists_and_items(
+                site=site_url
+            ):
+                if file_relative_url is None:
+                    yield item, None
+                else:
+                    yield item, partial(
+                        self.get_content, item, file_relative_url, site_url
+                    )

--- a/connectors/sources/tests/test_sharepoint.py
+++ b/connectors/sources/tests/test_sharepoint.py
@@ -101,8 +101,10 @@ async def test_ping_for_successful_connection(patch_logger):
 
     # Setup
     source = create_source(SharepointDataSource)
-    source.is_cloud = False
-    source._api_call = Mock(return_value=async_native_coroutine_generator(200))
+    source.sharepoint_client.is_cloud = False
+    source.sharepoint_client.api_call = Mock(
+        return_value=async_native_coroutine_generator(200)
+    )
 
     # Execute
     await source.ping()
@@ -114,7 +116,7 @@ async def test_ping_for_failed_connection_exception(patch_logger):
 
     # Setup
     source = create_source(SharepointDataSource)
-    source.retry_count = 0
+    source.sharepoint_client.retry_count = 0
     mock_response = {"access_token": "test2344", "expires_in": "1234555"}
     async_response = MockResponse(mock_response, 200)
     with patch.object(
@@ -143,7 +145,7 @@ async def test_validate_config_for_ssl_enabled():
     """This function test validate_config when ssl is enabled and certificate is missing"""
     # Setup
     source = create_source(SharepointDataSource)
-    source.ssl_enabled = True
+    source.sharepoint_client.ssl_enabled = True
 
     # Execute
     with pytest.raises(ConfigurableFieldValueError):
@@ -151,17 +153,17 @@ async def test_validate_config_for_ssl_enabled():
 
 
 @pytest.mark.asyncio
-async def test_api_call_for_exception(patch_logger):
-    """This function test _api_call when credentials are incorrect"""
+async def testapi_call_for_exception(patch_logger):
+    """This function test api_call when credentials are incorrect"""
     # Setup
     source = create_source(SharepointDataSource)
-    source.retry_count = 0
+    source.sharepoint_client.retry_count = 0
     # Execute
     with patch.object(
         aiohttp, "ClientSession", side_effect=Exception(EXCEPTION_MESSAGE)
     ):
         with pytest.raises(Exception):
-            await source._api_call(url_name="lists", url="abc")
+            await source.sharepoint_client.api_call(url_name="lists", url="abc")
 
 
 def test_prepare_drive_items_doc(patch_logger):
@@ -273,7 +275,9 @@ async def test_get_sites_when_no_site_available(patch_logger):
     source = create_source(SharepointDataSource)
     api_response = []
     # Execute
-    source.invoke_get_call = Mock(return_value=AsyncIter(api_response))
+    source.sharepoint_client.invoke_get_call = Mock(
+        return_value=AsyncIter(api_response)
+    )
     actual_response = None
     async for item in source.get_sites(site_url="sites/collection1/ctest"):
         actual_response = item
@@ -343,8 +347,10 @@ async def test_get_list_items(patch_logger):
         },
     ]
     attachment_response = {"UniqueId": "1"}
-    source.invoke_get_call = Mock(return_value=AsyncIter(api_response))
-    source._api_call = Mock(
+    source.sharepoint_client.invoke_get_call = Mock(
+        return_value=AsyncIter(api_response)
+    )
+    source.sharepoint_client.api_call = Mock(
         return_value=async_native_coroutine_generator(attachment_response)
     )
     expected_response = []
@@ -419,7 +425,9 @@ async def test_get_drive_items(patch_logger):
         ),
     ]
 
-    source.invoke_get_call = Mock(return_value=AsyncIter(api_response))
+    source.sharepoint_client.invoke_get_call = Mock(
+        return_value=AsyncIter(api_response)
+    )
     expected_response = []
     # Execute
     async for item in source.get_drive_items(
@@ -457,7 +465,7 @@ async def test_get_lists_and_items(patch_logger):
             "RootFolder": {"ServerRelativeUrl": "/site"},
         },
     ]
-    source.invoke_get_call = Mock(return_value=AsyncIter(lists))
+    source.sharepoint_client.invoke_get_call = Mock(return_value=AsyncIter(lists))
     drive_item = [
         {
             "_id": 1,
@@ -583,7 +591,7 @@ async def test_get_docs_when_no_site_available(patch_logger):
     # Setup
     source = create_source(SharepointDataSource)
     actual_response = []
-    source.invoke_get_call = Mock(return_value=AsyncIter([]))
+    source.sharepoint_client.invoke_get_call = Mock(return_value=AsyncIter([]))
     # Execute
     async for document, _ in source.get_docs():
         actual_response.append(document)
@@ -611,7 +619,7 @@ async def test_get_content(patch_logger):
         "_attachment": "VGhpcyBpcyBhIGR1bW15IHNoYXJlcG9pbnQgYm9keSByZXNwb25zZQ==",
         "_timestamp": "2022-06-20T10:37:44Z",
     }
-    source._api_call = Mock(return_value=AsyncIter(async_response))
+    source.sharepoint_client.api_call = Mock(return_value=AsyncIter(async_response))
     with mock.patch(
         "aiohttp.StreamReader.iter_chunked",
         return_value=AsyncIter(bytes(RESPONSE_CONTENT, "utf-8")),
@@ -685,11 +693,13 @@ async def test_get_invoke_call_with_list(patch_logger):
             }
         ]
     }
-    source._api_call = Mock(return_value=async_native_coroutine_generator(get_response))
+    source.sharepoint_client.api_call = Mock(
+        return_value=async_native_coroutine_generator(get_response)
+    )
     actual_response = []
 
     # Execute
-    async for response in source.invoke_get_call(
+    async for response in source.sharepoint_client.invoke_get_call(
         site_url="/sites/collection1/_api/web/webs", param_name="lists"
     ):
         actual_response.extend(response)
@@ -721,9 +731,11 @@ async def test_get_invoke_call_with_drive_items(patch_logger):
         ]
     }
     actual_response = []
-    source._api_call = Mock(return_value=async_native_coroutine_generator(get_response))
+    source.sharepoint_client.api_call = Mock(
+        return_value=async_native_coroutine_generator(get_response)
+    )
     # Execute
-    async for response in source.invoke_get_call(
+    async for response in source.sharepoint_client.invoke_get_call(
         site_url="/sites/collection1/_api/web/webs", param_name="drive_item"
     ):
         actual_response.append(response)
@@ -754,10 +766,10 @@ async def test_close_with_client_session(patch_logger):
 
     # Setup
     source = create_source(SharepointDataSource)
-    source.session = ClientSession()
+    source.sharepoint_client.session = ClientSession()
 
     # Execute
-    await source.close()
+    await source.sharepoint_client.close_session()
 
 
 @pytest.mark.asyncio
@@ -766,32 +778,32 @@ async def test_close_without_client_session(patch_logger):
 
     # Setup
     source = create_source(SharepointDataSource)
-    source.session = None
+    source.sharepoint_client.session = None
 
     # Execute
-    await source.close()
+    await source.sharepoint_client.close_session()
 
 
 @pytest.mark.asyncio
-async def test_api_call_negative():
-    """Tests the _api_call function while getting an exception."""
+async def testapi_call_negative():
+    """Tests the api_call function while getting an exception."""
 
     # Setup
     source = create_source(SharepointDataSource)
-    source.retry_count = 0
+    source.sharepoint_client.retry_count = 0
 
     with patch.object(
         aiohttp.ClientSession, "get", side_effect=Exception(EXCEPTION_MESSAGE)
     ):
-        source.session = source._generate_session()
+        source.sharepoint_client.session = source.sharepoint_client._get_session()
         with pytest.raises(Exception):
             # Execute
-            await anext(source._api_call(url_name="ping"))
+            await anext(source.sharepoint_client.api_call(url_name="ping"))
 
 
 @pytest.mark.asyncio
-async def test_api_call_successfully():
-    """Tests the _api_call function."""
+async def testapi_call_successfully():
+    """Tests the api_call function."""
 
     # Setup
     source = create_source(SharepointDataSource)
@@ -803,35 +815,13 @@ async def test_api_call_successfully():
     with patch("aiohttp.ClientSession.get", return_value=async_response), patch(
         "aiohttp.request", return_value=async_response_token
     ):
-        await source._generate_session()
+        source.sharepoint_client._get_session()
         # Execute
-        async for response in source._api_call(
+        async for response in source.sharepoint_client.api_call(
             url_name="ping", site_collections="abc", host_url="sharepoint.com"
         ):
             # Assert
             assert response == [{"name": "dummy_project", "id": "test123"}]
-
-
-@pytest.mark.asyncio
-async def test_api_call_when_server_is_down():
-    """Tests the _api_call function while server gets disconnected."""
-
-    # Setup
-    source = create_source(SharepointDataSource)
-    source.retry_count = 0
-    mock_response = {"access_token": "test2344", "expires_in": "1234555"}
-    async_response = MockResponse(mock_response, 200)
-
-    with patch.object(
-        aiohttp.ClientSession,
-        "get",
-        side_effect=aiohttp.ServerDisconnectedError("Something went wrong"),
-    ):
-        with patch("aiohttp.request", return_value=async_response):
-            await source._generate_session()
-            with pytest.raises(aiohttp.ServerDisconnectedError):
-                # Execute
-                await anext(source._api_call(url_name="attachment", url="abc.com"))
 
 
 @pytest.mark.asyncio
@@ -844,9 +834,9 @@ async def test_set_access_token():
 
     # Execute
     with patch("aiohttp.request", return_value=async_response_token):
-        await source._set_access_token()
+        await source.sharepoint_client._set_access_token()
         # Assert
-        assert source.access_token == "test2344"
+        assert source.sharepoint_client.access_token == "test2344"
 
 
 @pytest.mark.asyncio
@@ -854,36 +844,39 @@ async def test_set_access_token_when_token_expires_at_is_str():
     """This method tests set access token  api call when token_expires_at type is str"""
     # Setup
     source = create_source(SharepointDataSource)
-    source.token_expires_at = "2023-02-10T09:02:23.629821"
+    source.sharepoint_client.token_expires_at = "2023-02-10T09:02:23.629821"
     mock_token = {"access_token": "test2344", "expires_in": "1234555"}
     async_response_token = MockResponse(mock_token, 200)
-    actual_response = source._set_access_token()
 
     # Execute
     with patch("aiohttp.request", return_value=async_response_token):
-        actual_response = await source._set_access_token()
+        actual_response = await source.sharepoint_client._set_access_token()
         # Assert
         assert actual_response is None
 
 
+@pytest.fixture
+def patch_default_wait_multiplier():
+    with mock.patch("connectors.sources.sharepoint.RETRY_INTERVAL", 0):
+        yield
+
+
 @pytest.mark.asyncio
-async def test_api_call_when_token_is_expired():
-    """Tests the _api_call function while token expire."""
+async def testapi_call_when_token_is_expired(patch_default_wait_multiplier):
+    """Tests the api_call function while token expire."""
 
     # Setup
     source = create_source(SharepointDataSource)
-    source.retry_count = 0
     mock_response = {"access_token": "test2344", "expires_in": "1234555"}
     async_response = MockResponse(mock_response, 401)
-
-    # Add a custom header to the mock response
+    source.sharepoint_client.retry_count = 0
     async_response.headers = {"x-ms-diagnostics": "token has expired"}
 
     with patch.object(
         aiohttp.ClientSession,
         "get",
-        side_effect=aiohttp.ClientResponseError(
-            request_info=None,
+        side_effect=aiohttp.client_exceptions.ClientResponseError(
+            request_info=aiohttp.client_reqrep.RequestInfo,
             history=None,
             status=401,
             message="Unauthorized",
@@ -891,7 +884,45 @@ async def test_api_call_when_token_is_expired():
         ),
     ):
         with patch("aiohttp.request", return_value=async_response):
-            await source._generate_session()
-            with pytest.raises(aiohttp.ClientResponseError):
+            with pytest.raises(aiohttp.client_exceptions.ClientResponseError):
+                source.sharepoint_client._get_session()
+
                 # Execute
-                await anext(source._api_call(url_name="attachment", url="abc.com"))
+                await anext(
+                    source.sharepoint_client.api_call(
+                        url_name="attachment", url="abc.com"
+                    )
+                )
+            await source.close()
+
+
+@pytest.mark.asyncio
+async def testapi_call_when_server_is_down(patch_default_wait_multiplier):
+    """Tests the api_call function while server gets disconnected."""
+    # Setup
+    source = create_source(SharepointDataSource)
+    mock_response = {"access_token": "test2344", "expires_in": "1234555"}
+    async_response = MockResponse(mock_response, 200)
+    source.sharepoint_client.retry_count = 1
+    with patch.object(
+        aiohttp.ClientSession,
+        "get",
+        side_effect=aiohttp.ServerDisconnectedError("Something went wrong"),
+    ):
+        with patch("aiohttp.request", return_value=async_response):
+            source.sharepoint_client._get_session()
+            with pytest.raises(aiohttp.ServerDisconnectedError):
+                # Execute
+                await anext(
+                    source.sharepoint_client.api_call(
+                        url_name="attachment", url="abc.com"
+                    )
+                )
+
+
+def test_get_session():
+    """Test that the instance of session returned is always the same for the datasource class."""
+    source = create_source(SharepointDataSource)
+    first_instance = source.sharepoint_client._get_session()
+    second_instance = source.sharepoint_client._get_session()
+    assert first_instance is second_instance


### PR DESCRIPTION
## PR Content
Includes the changes suggested by @timgrein in Confluence PR i.e. moving all low level stuffs such as generating client session, API calls to a new class called SharepointClient.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
