### PR TITLE
Add missing async/await for validate_config in s3

### DIFF
--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -72,7 +72,7 @@ class S3DataSource(BaseDataSource):
         ) as s3:
             yield s3
 
-    def validate_config(self):
+    async def validate_config(self):
         """Validates whether user input is empty or not for configuration fields
 
         Raises:

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -335,6 +335,6 @@ def test_validate_config_for_empty_bucket_string():
     source.configuration.set_field(name="buckets", value=[""])
     # Execute
     with pytest.raises(ConfigurableFieldValueError) as e:
-        source.validate_config()
+        await source.validate_config()
 
     assert e.match("buckets")

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -328,7 +328,8 @@ def test_get_bucket_list():
     assert expected_response == actual_response
 
 
-def test_validate_config_for_empty_bucket_string():
+@pytest.mark.asyncio
+async def test_validate_config_for_empty_bucket_string():
     """This function test validate_configwhen buckets string is empty"""
     # Setup
     source = create_source(S3DataSource)


### PR DESCRIPTION
Our Nightly QA pipeline caught a problem with S3 connector - it wasn't able to sync.

Investigation shown that I forgot adding `async` before `validate_config` method in S3 connector - framework expects `validate_config` to by an async function and awaits for it, and it was causing an error.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
