### PR TITLE
Use lazy evaluation for expensive function in DEBUG log

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -22,6 +22,7 @@ Elasticsearch <== Bulker <== queue <== Fetcher <== generator
 import asyncio
 import copy
 import functools
+import logging
 import time
 from collections import defaultdict
 
@@ -115,9 +116,10 @@ class Bulker:
         # TODO: treat result to retry errors like in async_streaming_bulk
         task_num = len(self.bulk_tasks)
 
-        logger.debug(
-            f"Task {task_num} - Sending a batch of {len(operations)} ops -- {get_mb_size(operations)}MiB"
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"Task {task_num} - Sending a batch of {len(operations)} ops -- {get_mb_size(operations)}MiB"
+            )
         start = time.time()
         try:
             res = await self.client.bulk(
@@ -467,7 +469,8 @@ class ElasticServer(ESClient):
             f"Found {len(existing_ids)} docs in {index} (duration "
             f"{int(time.time() - start)} seconds) "
         )
-        logger.debug(f"Size of ids in memory is {get_mb_size(existing_ids)}MiB")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Size of ids in memory is {get_mb_size(existing_ids)}MiB")
 
         # start the fetcher
         fetcher = Fetcher(


### PR DESCRIPTION
The `get_mb_size` is CPU intensive operation, and it's used in debug logging:
https://github.com/elastic/connectors-python/blob/d3736dfcc824af7bcbc7ff99d7cb39ae2163217b/connectors/byoei.py#L118-L120

A function used in f-string will be evaluated even if the message is not logged at all (e.g. the log level is set to INFO).

This PR is to make sure the `get_mb_size` is not called if the message is not to be logged, by the best practice from the official python doc: https://docs.python.org/3.10/howto/logging.html#optimization

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)