### PR TITLE
Allow wildcards in MySQL table accessibility validation

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -236,8 +236,9 @@ class MySqlDataSource(BaseDataSource):
 
     async def _validate_tables_accessible(self, cursor):
         non_accessible_tables = []
+        tables_to_validate = await self.get_tables_to_fetch()
 
-        for table in self.tables:
+        for table in tables_to_validate:
             try:
                 await cursor.execute(f"SELECT 1 FROM {table} LIMIT 1;")
             except aiomysql.Error:

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -525,6 +525,7 @@ async def test_validate_tables_accessible_when_accessible_then_no_error_raised()
 
     await source._validate_tables_accessible(cursor)
 
+
 @pytest.mark.asyncio
 async def test_validate_tables_accessible_when_accessible_and_wildcard_then_no_error_raised():
     source = create_source(MySqlDataSource)
@@ -537,6 +538,7 @@ async def test_validate_tables_accessible_when_accessible_and_wildcard_then_no_e
     await source._validate_tables_accessible(cursor)
 
     assert source.fetch_all_tables.call_count == 1
+
 
 @pytest.mark.asyncio
 async def test_validate_tables_accessible_when_not_accessible_then_error_raised():

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -525,6 +525,18 @@ async def test_validate_tables_accessible_when_accessible_then_no_error_raised()
 
     await source._validate_tables_accessible(cursor)
 
+@pytest.mark.asyncio
+async def test_validate_tables_accessible_when_accessible_and_wildcard_then_no_error_raised():
+    source = create_source(MySqlDataSource)
+    source.tables = ["*"]
+    source.fetch_all_tables = AsyncMock(return_value=["table_1", "table_2", "table_3"])
+
+    cursor = AsyncMock()
+    cursor.execute.return_value = None
+
+    await source._validate_tables_accessible(cursor)
+
+    assert source.fetch_all_tables.call_count == 1
 
 @pytest.mark.asyncio
 async def test_validate_tables_accessible_when_not_accessible_then_error_raised():

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -529,7 +529,9 @@ async def test_validate_tables_accessible_when_accessible_then_no_error_raised()
 
 @pytest.mark.parametrize("tables", ["*", ["*"]])
 @pytest.mark.asyncio
-async def test_validate_tables_accessible_when_accessible_and_wildcard_then_no_error_raised(tables):
+async def test_validate_tables_accessible_when_accessible_and_wildcard_then_no_error_raised(
+    tables,
+):
     source = create_source(MySqlDataSource)
     source.tables = tables
     source.fetch_all_tables = AsyncMock(return_value=["table_1", "table_2", "table_3"])

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -519,6 +519,7 @@ async def test_validate_database_accessible_when_not_accessible_then_error_raise
 async def test_validate_tables_accessible_when_accessible_then_no_error_raised():
     source = create_source(MySqlDataSource)
     source.tables = ["table_1", "table_2", "table_3"]
+    source.fetch_all_tables = AsyncMock(return_value=["table_1", "table_2", "table_3"])
 
     cursor = AsyncMock()
     cursor.execute.return_value = None
@@ -526,10 +527,11 @@ async def test_validate_tables_accessible_when_accessible_then_no_error_raised()
     await source._validate_tables_accessible(cursor)
 
 
+@pytest.mark.parametrize("tables", ["*", ["*"]])
 @pytest.mark.asyncio
-async def test_validate_tables_accessible_when_accessible_and_wildcard_then_no_error_raised():
+async def test_validate_tables_accessible_when_accessible_and_wildcard_then_no_error_raised(tables):
     source = create_source(MySqlDataSource)
-    source.tables = ["*"]
+    source.tables = tables
     source.fetch_all_tables = AsyncMock(return_value=["table_1", "table_2", "table_3"])
 
     cursor = AsyncMock()
@@ -543,6 +545,8 @@ async def test_validate_tables_accessible_when_accessible_and_wildcard_then_no_e
 @pytest.mark.asyncio
 async def test_validate_tables_accessible_when_not_accessible_then_error_raised():
     source = create_source(MySqlDataSource)
+    source.tables = ["table1"]
+    source.fetch_all_tables = AsyncMock(return_value=["table1"])
 
     cursor = AsyncMock()
     cursor.execute.side_effect = aiomysql.Error("Error")


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4237

Wildcards are supported by MySQL connector but they fail the validation step `_validate_tables_accessible`.
This was also causing [nightly e2e tests to fail](https://buildkite.com/elastic/connectors-python-nightly/builds/452#01872c9e-794f-47b1-9d2e-cd475208640b).

This PR updates `_validate_tables_accessible` so that wildcards fetch all of the database tables, which can then be tested individually for accessibility.

Reviewers can confirm that this fixes the nightly build by running `NAME=mysql make ftest` locally.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

## Related Pull Requests

* https://github.com/elastic/connectors-python/pull/662#issuecomment-1488837434

