### PR TITLE
Remove `pyodbc` library from requirements.txt

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -36,7 +36,7 @@ native_service_types:
   - postgresql
   - oracle
   - dir
-  - mssql
+  # - mssql # temporary not working, migrating it to a different library
 
 
 # Connector client settings
@@ -53,5 +53,5 @@ sources:
   azure_blob_storage: connectors.sources.azure_blob_storage:AzureBlobStorageDataSource
   postgresql: connectors.sources.postgresql:PostgreSQLDataSource
   oracle: connectors.sources.oracle:OracleDataSource
-  mssql: connectors.sources.mssql:MSSQLDataSource
+  # mssql: connectors.sources.mssql:MSSQLDataSource # temporary not working, migrating it to a different library
 

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -16,4 +16,3 @@ azure-storage-blob==12.13.0
 SQLAlchemy==2.0.1
 oracledb==1.2.2
 asyncpg==0.27.0
-pyodbc==4.0.34 # Latest version is v4.0.35. However it is not compatible with MAC M1 chip so pining this version


### PR DESCRIPTION
Our CI is currently blocked because `pyodbc` is not installed in Cloud docker image.

We're getting rid of this library and migrating to `pytds` here: https://github.com/elastic/connectors-python/pull/624#discussion_r1150295132

The migration is not finished yet, but soon will be. Meanwhile we need to unblock our CI by removing the dependency. On-prem SQL connectors using generic sql connector code will be broken with this change and repaired with the mentioned PR.