### PR TITLE
[MySQL] Use database field instead of a method parameter

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -343,7 +343,6 @@ class MySqlDataSource(BaseDataSource):
             list: Column names and query response
         """
 
-        query_kwargs["database"] = self.database
         formatted_query = query.format(**query_kwargs)
         size = self.configuration["fetch_size"]
         retry = 1
@@ -365,7 +364,7 @@ class MySqlDataSource(BaseDataSource):
                                 # sending back column names only once
                                 if yield_once:
                                     yield [
-                                        f"{query_kwargs['database']}_{query_kwargs['table']}_{column[0]}"
+                                        f"{self.database}_{query_kwargs['table']}_{column[0]}"
                                         for column in cursor.description
                                     ]
                                     yield_once = False


### PR DESCRIPTION
As `database` is already present in the `MySQLQueries` object there's no need to format the query again with a `database` kwarg.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
~- [ ] this PR links to all relevant github issues that it fixes or partially addresses~
- [x] this PR has a thorough description
~- [ ] Covered the changes with automated tests~
~- [ ] Tested the changes locally~
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~