### PR TITLE
added a 2mn pause to give a chanche to perf8 to wrap up

### DIFF
--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -55,7 +55,11 @@ else
     $ELASTIC_INGEST --debug & PID=$!
 fi
 
+
 $PYTHON fixture.py --name $NAME --action monitor --pid $PID
+
+# breathe for 2 minutes
+sleep 120
 
 $PYTHON fixture.py --name $NAME --action remove
 $PYTHON fixture.py --name $NAME --action sync


### PR DESCRIPTION
Perf8 has no time to wrap up its work sometimes (when memray has a lot of work) and the current ftest moves on once the sync is over and does not wait.

We end up getting incomplete reports in BK for this reason.

This is a fast fix, a better fix would be to make sure the process running with perf8 has a chance to finish before we move to the next step in the script