### PR TITLE
[8.7] Minor refactor of SyncService (#558)

### DIFF
--- a/connectors/services/sync.py
+++ b/connectors/services/sync.py
@@ -10,13 +10,14 @@ Event loop
 - instantiates connector plugins
 - mirrors an Elasticsearch index with a collection of documents
 """
-import asyncio
 import functools
 
 from connectors.byoc import (
+    SYNC_DISABLED,
     ConnectorIndex,
     ConnectorUpdateError,
     DataSourceError,
+    JobStatus,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
     Status,
@@ -35,13 +36,13 @@ class SyncService(BaseService):
     def __init__(self, config):
         super().__init__(config)
         self.idling = self.service_config["idling"]
-        self.hb = self.service_config["heartbeat"]
+        self.heartbeat_interval = self.service_config["heartbeat"]
         self.concurrent_syncs = self.service_config.get(
             "max_concurrent_syncs", DEFAULT_MAX_CONCURRENT_SYNCS
         )
         self.bulk_options = self.es_config.get("bulk", {})
         self.source_klass_dict = get_source_klass_dict(config)
-        self.connectors = None
+        self.connector_index = None
         self.sync_job_index = None
         self.syncs = None
 
@@ -50,7 +51,7 @@ class SyncService(BaseService):
         if self.syncs is not None:
             self.syncs.cancel()
 
-    async def _one_sync(self, connector, es):
+    async def _sync(self, connector, es):
         if self.running is False:
             logger.debug(
                 f"Skipping run for {connector.id} because service is terminating"
@@ -76,11 +77,10 @@ class SyncService(BaseService):
         except DataSourceError as e:
             await connector.error(e)
             logger.critical(e, exc_info=True)
-            self.raise_if_spurious(e)
-            return
+            raise
 
         # the heartbeat is always triggered
-        await connector.heartbeat(self.hb)
+        await connector.heartbeat(self.heartbeat_interval)
 
         logger.debug(f"Connector status is {connector.status}")
 
@@ -88,36 +88,37 @@ class SyncService(BaseService):
         if connector.status in (Status.CREATED, Status.NEEDS_CONFIGURATION):
             # we can't sync in that state
             logger.info(f"Can't sync with status `{connector.status.value}`")
-        else:
-            if connector.service_type not in self.source_klass_dict:
-                raise DataSourceError(
-                    f"Couldn't find data source class for {connector.service_type}"
-                )
-            source_klass = self.source_klass_dict[connector.service_type]
-            if connector.features.sync_rules_enabled():
-                await connector.validate_filtering(
-                    validator=source_klass(connector.configuration)
-                )
+            return
 
-            await connector.sync(
-                self.sync_job_index,
-                source_klass,
-                es,
-                self.idling,
-                self.bulk_options,
+        if connector.service_type not in self.source_klass_dict:
+            raise DataSourceError(
+                f"Couldn't find data source class for {connector.service_type}"
             )
 
-        await asyncio.sleep(0)
+        source_klass = self.source_klass_dict[connector.service_type]
+        if connector.features.sync_rules_enabled():
+            await connector.validate_filtering(
+                validator=source_klass(connector.configuration)
+            )
+
+        if not await self._should_sync(connector):
+            return
+
+        await self.syncs.put(
+            functools.partial(
+                connector.sync, self.sync_job_index, source_klass, es, self.bulk_options
+            )
+        )
 
     async def _run(self):
         """Main event loop."""
-        self.connectors = ConnectorIndex(self.es_config)
+        self.connector_index = ConnectorIndex(self.es_config)
         self.sync_job_index = SyncJobIndex(self.es_config)
 
         native_service_types = self.config.get("native_service_types", [])
         logger.debug(f"Native support for {', '.join(native_service_types)}")
 
-        # XXX we can support multiple connectors but Ruby can't so let's use a
+        # TODO: we can support multiple connectors but Ruby can't so let's use a
         # single id
         # connector_ids = self.config.get("connector_ids", [])
         if "connector_id" in self.config:
@@ -137,13 +138,11 @@ class SyncService(BaseService):
 
                 try:
                     logger.debug(f"Polling every {self.idling} seconds")
-                    async for connector in self.connectors.supported_connectors(
+                    async for connector in self.connector_index.supported_connectors(
                         native_service_types=native_service_types,
                         connector_ids=connector_ids,
                     ):
-                        await self.syncs.put(
-                            functools.partial(self._one_sync, connector, es)
-                        )
+                        await self._sync(connector, es)
                 except Exception as e:
                     logger.critical(e, exc_info=True)
                     self.raise_if_spurious(e)
@@ -156,11 +155,34 @@ class SyncService(BaseService):
                     break
                 await self._sleeps.sleep(self.idling)
         finally:
-            if self.connectors is not None:
-                self.connectors.stop_waiting()
-                await self.connectors.close()
+            if self.connector_index is not None:
+                self.connector_index.stop_waiting()
+                await self.connector_index.close()
             if self.sync_job_index is not None:
                 self.sync_job_index.stop_waiting()
                 await self.sync_job_index.close()
             await es.close()
         return 0
+
+    async def _should_sync(self, connector):
+        try:
+            next_sync = connector.next_sync()
+            # First we check if sync is disabled, and it terminates all other conditions
+            if next_sync == SYNC_DISABLED:
+                logger.debug(f"Scheduling is disabled for connector {connector.id}")
+                return False
+            # Then we check if we need to restart SUSPENDED job
+            if connector.last_sync_status == JobStatus.SUSPENDED:
+                logger.debug("Restarting sync after suspension")
+                return True
+            # And only then we check if we need to run sync right now or not
+            if next_sync - self.idling > 0:
+                logger.debug(
+                    f"Next sync for connector {connector.id} due in {int(next_sync)} seconds"
+                )
+                return False
+            return True
+        except Exception as e:
+            logger.critical(e, exc_info=True)
+            await connector.error(str(e))
+            return False


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Minor refactor of SyncService (#558)](https://github.com/elastic/connectors-python/pull/558)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)