### PR TITLE
[Network Drive] Convert `_id` of document to string type

### DIFF
--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -125,7 +125,7 @@ class NASDataSource(BaseDataSource):
             yield {
                 "path": file.path,
                 "size": file_details["allocation_size"].get_value(),
-                "_id": file_details["file_id"].get_value(),
+                "_id": str(file_details["file_id"].get_value()),
                 "created_at": iso_utc(file_details["creation_time"].get_value()),
                 "_timestamp": iso_utc(file_details["change_time"].get_value()),
                 "type": "folder" if file.is_dir() else "file",


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/694

Since the framework now expects _id field to be a string type due a change added in commit https://github.com/elastic/connectors-python/commit/76bb53a0a1f5fb891e412366a5346d84f3b01dec, we need to store _id for a document as a string for source: Network Drive

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

https://github.com/elastic/connectors-python/pull/673
