### PR TITLE
[Sync Job] Parse "_id" to string before executing the length check

### DIFF
--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -197,7 +197,7 @@ class SyncJobRunner:
         async for doc, lazy_download in self.data_provider.get_docs(
             filtering=self.sync_job.filtering
         ):
-            doc_id = doc.get("_id", "")
+            doc_id = str(doc.get("_id", ""))
             doc_id_size = len(doc_id.encode("utf-8"))
 
             if doc_id_size > ES_ID_SIZE_LIMIT:

--- a/connectors/tests/test_sync_job_runner.py
+++ b/connectors/tests/test_sync_job_runner.py
@@ -316,8 +316,8 @@ async def test_prepare_docs_when_id_too_long_then_skip_doc():
     assert len(docs) == 0
 
 
-@patch("connectors.sync_job_runner.ES_ID_SIZE_LIMIT", 2)
-@pytest.mark.parametrize("_id", ["ab", 1])
+@patch("connectors.sync_job_runner.ES_ID_SIZE_LIMIT", 10)
+@pytest.mark.parametrize("_id", ["ab", 1, 1.5])
 @pytest.mark.asyncio
 async def test_prepare_docs_when_id_below_limit_then_yield_doc(_id):
     sync_job_runner = create_runner_yielding_docs(docs=[({"_id": _id}, None)])

--- a/connectors/tests/test_sync_job_runner.py
+++ b/connectors/tests/test_sync_job_runner.py
@@ -317,20 +317,17 @@ async def test_prepare_docs_when_id_too_long_then_skip_doc():
 
 
 @patch("connectors.sync_job_runner.ES_ID_SIZE_LIMIT", 2)
+@pytest.mark.parametrize("_id", ["ab", 1])
 @pytest.mark.asyncio
-async def test_prepare_docs_when_id_below_limit_then_yield_doc():
-    _id_within_limit = "ab"
-
-    sync_job_runner = create_runner_yielding_docs(
-        docs=[({"_id": _id_within_limit}, None)]
-    )
+async def test_prepare_docs_when_id_below_limit_then_yield_doc(_id):
+    sync_job_runner = create_runner_yielding_docs(docs=[({"_id": _id}, None)])
 
     docs = []
     async for doc, _ in sync_job_runner.prepare_docs():
         docs.append(doc)
 
     assert len(docs) == 1
-    assert docs[0]["_id"] == _id_within_limit
+    assert docs[0]["_id"] == _id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/694

The "_id" field can be any type as it's under control of a connector implementation. "_id"s are stored as strings in elasticsearch, therefore we can simply convert the "_id" to a string for the length check. 

This PR also fixes an e2e-test failure as network drive "_id"s are integers.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~