### PR TITLE
[8.7] Make async_bulk a task (#513)

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -47,6 +47,8 @@ from connectors.utils import (
     iso_utc,
 )
 
+__all__ = ["ElasticServer"]
+
 OP_INDEX = "index"
 OP_UPSERT = "update"
 OP_DELETE = "delete"
@@ -64,13 +66,14 @@ class Bulker:
     This class runs a coroutine that gets operations out of a `queue` and collects them to
     build and send bulk requests using a `client`
 
-    The bulk requests are controlled in several ways:
+    Arguments:
+
+    - `client` -- an instance of `connectors.es.ESClient`
+    - `queue` -- an instance of `asyncio.Queue` to pull docs from
     - `chunk_size` -- a maximum number of operations to send per request
+    - `pipeline` -- ingest pipeline settings to pass to the bulk API
     - `chunk_mem_size` -- a maximum size in MiB for each bulk request
     - `max_concurrency` -- a maximum number of concurrent bulk requests
-
-    Extra options:
-    - `pipeline` -- ingest pipeline settings to pass to the bulk API
     """
 
     def __init__(
@@ -158,6 +161,21 @@ class Bulker:
         )
 
     async def run(self):
+        try:
+            await self._run()
+        except asyncio.CancelledError:
+            logger.info("Task is canceled, stop Bulker...")
+            raise
+
+    async def _run(self):
+        """Creates batches of bulk calls given a queue of items.
+
+        An item is a (size, object) tuple. Exits when the
+        item is the `END_DOCS` or `FETCH_ERROR` string.
+
+        Bulk calls are executed concurrently with a maximum number of concurrent
+        requests.
+        """
         batch = []
         # stats is a dictionary containing stats for 3 operations. In each sub-dictionary, it is a doc id to size map.
         stats = {OP_INDEX: {}, OP_UPSERT: {}, OP_DELETE: {}}
@@ -211,25 +229,30 @@ class Bulker:
 class Fetcher:
     """Grabs data and adds them in the queue for the bulker.
 
-    This class runs a coroutine that puts docs in `queue`, given
-    a document generator.
+    This class runs a coroutine that puts docs in `queue`, given a document generator.
+
+    Arguments:
+    - queue: an `asyncio.Queue` to put docs in
+    - index: the target Elasticsearch index
+    - existing_ids: a list of existing Elasticsearch document ids found in the index
+    - filter_: an instance of `Filter` to apply on the fetched document -- default: `None`
+    - sync_rules_enabled: if `True`, we apply rules -- default: `False`
+    - display_every -- display a log every `display_every` doc -- default: `DEFAULT_DISPLAY_EVERY`
+    - concurrent_downloads: -- concurrency level for downloads -- default: `DEFAULT_CONCURRENT_DOWNLOADS`
     """
 
     def __init__(
         self,
-        client,
         queue,
         index,
         existing_ids,
         filter_=None,
         sync_rules_enabled=False,
-        queue_size=DEFAULT_QUEUE_SIZE,
         display_every=DEFAULT_DISPLAY_EVERY,
         concurrent_downloads=DEFAULT_CONCURRENT_DOWNLOADS,
     ):
         if filter_ is None:
             filter_ = Filter()
-        self.client = client
         self.queue = queue
         self.bulk_time = 0
         self.bulking = False
@@ -257,9 +280,6 @@ class Fetcher:
             f"delete: {self.total_docs_deleted}>"
         )
 
-    async def run(self, generator):
-        await self.get_docs(generator)
-
     async def _deferred_index(self, lazy_download, doc_id, doc, operation):
         data = await lazy_download(doit=True, timestamp=doc[TIMESTAMP_FIELD])
 
@@ -278,7 +298,19 @@ class Fetcher:
             }
         )
 
+    async def run(self, generator):
+        try:
+            await self.get_docs(generator)
+        except asyncio.CancelledError:
+            logger.info("Task is canceled, stop Fetcher...")
+            raise
+
     async def get_docs(self, generator):
+        """Iterate on a generator of documents to fill a queue of bulk operations for the `Bulker` to consume.
+
+        A document might be discarded if its timestamp has not changed.
+        Extraction happens in a separate task, when a document contains files.
+        """
         logger.info("Starting doc lookups")
         self.sync_runs = True
         count = 0
@@ -376,6 +408,10 @@ class ContentIndexNameInvalid(Exception):
     pass
 
 
+class AsyncBulkRunningError(Exception):
+    pass
+
+
 class ElasticServer(ESClient):
     """This class is the sync orchestrator.
 
@@ -391,6 +427,10 @@ class ElasticServer(ESClient):
         logger.debug(f"ElasticServer connecting to {elastic_config['host']}")
         super().__init__(elastic_config)
         self.loop = asyncio.get_event_loop()
+        self._fetcher = None
+        self._fetcher_task = None
+        self._bulker = None
+        self._bulker_task = None
 
     async def prepare_content_index(self, index, *, mappings=None):
         """Creates the index, given a mapping if it does not exists."""
@@ -453,6 +493,54 @@ class ElasticServer(ESClient):
             ts = doc["_source"].get(TIMESTAMP_FIELD)
             yield doc_id, ts
 
+    def done(self):
+        if self._fetcher_task is not None and not self._fetcher_task.done():
+            return False
+        if self._bulker_task is not None and not self._bulker_task.done():
+            return False
+        return True
+
+    async def cancel(self):
+        if self._fetcher_task is not None and not self._fetcher_task.done():
+            self._fetcher_task.cancel()
+            try:
+                await self._fetcher_task
+            except asyncio.CancelledError:
+                logger.info("Fetcher is stopped.")
+        if self._bulker_task is not None and not self._bulker_task.done():
+            self._bulker_task.cancel()
+            try:
+                await self._bulker_task
+            except asyncio.CancelledError:
+                logger.info("Bulker is stopped.")
+
+    def ingestion_stats(self):
+        stats = {}
+        if self._fetcher is not None:
+            stats.update(
+                {
+                    "doc_created": self._fetcher.total_docs_created,
+                    "attachment_extracted": self._fetcher.total_downloads,
+                    "doc_updated": self._fetcher.total_docs_updated,
+                    "doc_deleted": self._fetcher.total_docs_deleted,
+                }
+            )
+        if self._bulker is not None:
+            stats.update(
+                {
+                    "bulk_operations": dict(self._bulker.ops),
+                    "indexed_document_count": self._bulker.indexed_document_count,
+                    "indexed_document_volume": round(
+                        self._bulker.indexed_document_volume
+                    ),
+                    "deleted_document_count": self._bulker.deleted_document_count,
+                }
+            )
+        return stats
+
+    def fetch_error(self):
+        return None if self._fetcher is None else self._fetcher.fetch_error
+
     async def async_bulk(
         self,
         index,
@@ -462,6 +550,18 @@ class ElasticServer(ESClient):
         sync_rules_enabled=False,
         options=None,
     ):
+        """Performs a batch of `_bulk` calls, given a generator of documents
+
+        Arguments:
+        - index: target index
+        - generator: documents generator
+        - pipeline: ingest pipeline settings to pass to the bulk API
+        - filter_: an instance of `Filter` to apply on the fetched document  -- default: `None`
+        - sync_rules_enabled: if enabled, applies rules -- default: `False`
+        - options: dict of options (from `elasticsearch.bulk` in the config file)
+        """
+        if self._fetcher_task is not None or self._bulker_task is not None:
+            raise AsyncBulkRunningError("Async bulk task has already started.")
         if filter_ is None:
             filter_ = Filter()
         if options is None:
@@ -487,21 +587,19 @@ class ElasticServer(ESClient):
             logger.debug(f"Size of ids in memory is {get_mb_size(existing_ids)}MiB")
 
         # start the fetcher
-        fetcher = Fetcher(
-            self.client,
+        self._fetcher = Fetcher(
             stream,
             index,
             existing_ids,
             filter_=filter_,
             sync_rules_enabled=sync_rules_enabled,
-            queue_size=queue_size,
             display_every=display_every,
             concurrent_downloads=concurrent_downloads,
         )
-        fetcher_task = asyncio.create_task(fetcher.run(generator))
+        self._fetcher_task = asyncio.create_task(self._fetcher.run(generator))
 
         # start the bulker
-        bulker = Bulker(
+        self._bulker = Bulker(
             self.client,
             stream,
             chunk_size,
@@ -509,19 +607,4 @@ class ElasticServer(ESClient):
             chunk_mem_size=chunk_mem_size,
             max_concurrency=max_concurrency,
         )
-        bulker_task = asyncio.create_task(bulker.run())
-
-        await asyncio.gather(fetcher_task, bulker_task)
-
-        # we return a number for each operation type
-        return {
-            "bulk_operations": dict(bulker.ops),
-            "doc_created": fetcher.total_docs_created,
-            "attachment_extracted": fetcher.total_downloads,
-            "doc_updated": fetcher.total_docs_updated,
-            "doc_deleted": fetcher.total_docs_deleted,
-            "fetch_error": fetcher.fetch_error,
-            "indexed_document_count": bulker.indexed_document_count,
-            "indexed_document_volume": bulker.indexed_document_volume,
-            "deleted_document_count": bulker.deleted_document_count,
-        }
+        self._bulker_task = asyncio.create_task(self._bulker.run())

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -21,7 +21,6 @@ from connectors.byoc import (
     Status,
     SyncJobIndex,
 )
-from connectors.byoei import ElasticServer
 from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
 from connectors.services.base import BaseService
@@ -40,7 +39,6 @@ class JobSchedulingService(BaseService):
         self.concurrent_syncs = self.service_config.get(
             "max_concurrent_syncs", DEFAULT_MAX_CONCURRENT_SYNCS
         )
-        self.bulk_options = self.es_config.get("bulk", {})
         self.source_klass_dict = get_source_klass_dict(config)
         self.connector_index = None
         self.sync_job_index = None
@@ -51,7 +49,7 @@ class JobSchedulingService(BaseService):
         if self.syncs is not None:
             self.syncs.cancel()
 
-    async def _sync(self, connector, es):
+    async def _sync(self, connector):
         if self.running is False:
             logger.debug(
                 f"Skipping run for {connector.id} because service is terminating"
@@ -116,8 +114,7 @@ class JobSchedulingService(BaseService):
             source_klass=source_klass,
             sync_job=sync_job,
             connector=connector,
-            elastic_server=es,
-            bulk_options=self.bulk_options,
+            es_config=self.es_config,
         )
         await self.syncs.put(sync_job_runner.execute)
 
@@ -141,7 +138,6 @@ class JobSchedulingService(BaseService):
             f"Service started, listening to events from {self.es_config['host']}"
         )
 
-        es = ElasticServer(self.es_config)
         try:
             while self.running:
                 # creating a pool of task for every round
@@ -153,7 +149,7 @@ class JobSchedulingService(BaseService):
                         native_service_types=native_service_types,
                         connector_ids=connector_ids,
                     ):
-                        await self._sync(connector, es)
+                        await self._sync(connector)
                 except Exception as e:
                     logger.critical(e, exc_info=True)
                     self.raise_if_spurious(e)
@@ -172,7 +168,6 @@ class JobSchedulingService(BaseService):
             if self.sync_job_index is not None:
                 self.sync_job_index.stop_waiting()
                 await self.sync_job_index.close()
-            await es.close()
         return 0
 
     async def _should_sync(self, connector):

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -7,9 +7,12 @@ import asyncio
 import time
 
 from connectors.byoc import JobStatus
+from connectors.byoei import ElasticServer
 from connectors.es import Mappings
 from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
+
+JOB_CHECK_INTERVAL = 1
 
 
 class SyncJobRunningError(Exception):
@@ -30,8 +33,7 @@ class SyncJobRunner:
         - `source_klass`: The source class of the connector
         - `sync_job`: The sync job to run
         - `connector`: The connector of the sync job
-        - `elastic_server`: The sync orchestrator used to fetch data from 3rd-party source and ingest into Elasticsearch
-        - `bulk_options`: The bulk options used for the ingestion
+        - `es_config`: The elasticsearch configuration to build connection to Elasticsearch server
 
     """
 
@@ -40,8 +42,7 @@ class SyncJobRunner:
         source_klass,
         sync_job,
         connector,
-        elastic_server,
-        bulk_options,
+        es_config,
     ):
         self.source_klass = source_klass
         self.data_provider = None
@@ -49,8 +50,9 @@ class SyncJobRunner:
         self.job_id = self.sync_job.id
         self.connector = connector
         self.connector_id = self.connector.id
-        self.elastic_server = elastic_server
-        self.bulk_options = bulk_options
+        self.es_config = es_config
+        self.elastic_server = None
+        self.bulk_options = self.es_config.get("bulk", {})
         self._start_time = None
         self.running = False
 
@@ -71,7 +73,7 @@ class SyncJobRunner:
                 logger.debug(
                     f"No change in {self.sync_job.service_type} data provider, skipping..."
                 )
-                await self._sync_done(sync_status=JobStatus.COMPLETED, result={})
+                await self._sync_done(sync_status=JobStatus.COMPLETED)
                 return
 
             logger.debug(f"Validating configuration for {self.data_provider}")
@@ -91,6 +93,8 @@ class SyncJobRunner:
                 is_connectors_index=True,
             )
 
+            self.elastic_server = ElasticServer(self.es_config)
+
             logger.debug("Preparing the content index")
             await self.elastic_server.prepare_content_index(
                 self.sync_job.index_name, mappings=mappings
@@ -100,7 +104,7 @@ class SyncJobRunner:
             bulk_options = self.bulk_options.copy()
             self.data_provider.tweak_bulk_options(bulk_options)
 
-            result = await self.elastic_server.async_bulk(
+            await self.elastic_server.async_bulk(
                 self.sync_job.index_name,
                 self.prepare_docs(),
                 self.sync_job.pipeline,
@@ -108,31 +112,36 @@ class SyncJobRunner:
                 sync_rules_enabled=sync_rules_enabled,
                 options=bulk_options,
             )
-            sync_error = result.get("fetch_error")
-            sync_status = JobStatus.COMPLETED if sync_error is None else JobStatus.ERROR
-            await self._sync_done(
-                sync_status=sync_status, result=result, sync_error=sync_error
+
+            while not self.elastic_server.done():
+                await asyncio.sleep(JOB_CHECK_INTERVAL)
+            fetch_error = self.elastic_server.fetch_error()
+            sync_status = (
+                JobStatus.COMPLETED if fetch_error is None else JobStatus.ERROR
             )
+            await self._sync_done(sync_status=sync_status, sync_error=fetch_error)
         except asyncio.CancelledError:
-            await self._sync_done(sync_status=JobStatus.SUSPENDED, result={})
+            await self._sync_done(sync_status=JobStatus.SUSPENDED)
         except Exception as e:
-            await self._sync_done(sync_status=JobStatus.ERROR, result={}, sync_error=e)
+            await self._sync_done(sync_status=JobStatus.ERROR, sync_error=e)
         finally:
+            self.running = False
+            if self.elastic_server is not None:
+                await self.elastic_server.close()
             if self.data_provider is not None:
                 await self.data_provider.close()
 
-    async def _sync_done(self, sync_status, result=None, sync_error=None):
-        if result is None:
-            result = {}
-        doc_updated = result.get("doc_updated", 0)
-        doc_created = result.get("doc_created", 0)
-        doc_deleted = result.get("doc_deleted", 0)
-        indexed_count = doc_updated + doc_created
+    async def _sync_done(self, sync_status, sync_error=None):
+        if self.elastic_server is not None and not self.elastic_server.done():
+            await self.elastic_server.cancel()
 
+        result = (
+            {} if self.elastic_server is None else self.elastic_server.ingestion_stats()
+        )
         ingestion_stats = {
-            "indexed_document_count": indexed_count,
-            "indexed_document_volume": 0,
-            "deleted_document_count": doc_deleted,
+            "indexed_document_count": result.get("indexed_document_count", 0),
+            "indexed_document_volume": result.get("indexed_document_volume", 0),
+            "deleted_document_count": result.get("deleted_document_count", 0),
             "total_document_count": await self.connector.document_count(),
         }
 
@@ -152,8 +161,9 @@ class SyncJobRunner:
             self.sync_job = None
         await self.connector.sync_done(self.sync_job)
         logger.info(
-            f"[{self.job_id}] Sync done: {indexed_count} indexed, {doc_deleted} "
-            f" deleted. ({int(time.time() - self._start_time)} seconds)"  # pyright: ignore
+            f"[{self.job_id}] Sync done: {ingestion_stats.get('indexed_document_count')} indexed, "
+            f"{ingestion_stats.get('deleted_document_count')} deleted. "
+            f"({int(time.time() - self._start_time)} seconds)"  # pyright: ignore
         )
 
     async def _claim_job(self):

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -324,13 +324,12 @@ async def lazy_downloads_mock():
 
 
 async def setup_fetcher(basic_rule_engine, existing_docs, queue, sync_rules_enabled):
-    client = Mock()
     existing_ids = {doc["_id"]: doc["_timestamp"] for doc in existing_docs}
 
     # filtering content doesn't matter as the BasicRuleEngine behavior is mocked
     filter_mock = Mock()
     filter_mock.get_active_filter = Mock(return_value={})
-    fetcher = Fetcher(client, queue, INDEX, existing_ids, filter_=filter_mock)
+    fetcher = Fetcher(queue, INDEX, existing_ids, filter_=filter_mock)
     fetcher.basic_rule_engine = basic_rule_engine if sync_rules_enabled else None
     return fetcher
 

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -13,6 +13,7 @@ import pytest
 
 from connectors.byoc import Pipeline
 from connectors.byoei import (
+    AsyncBulkRunningError,
     Bulker,
     ContentIndexNameInvalid,
     ElasticServer,
@@ -72,6 +73,8 @@ async def test_prepare_content_index_raise_error_when_index_does_not_exist(
 
     with pytest.raises(IndexMissing):
         await es.prepare_content_index("search-new-index")
+
+    await es.close()
 
 
 @pytest.mark.asyncio
@@ -216,84 +219,27 @@ async def test_async_bulk(mock_responses, patch_logger):
         yield {"_id": "1", "_timestamp": datetime.datetime.now().isoformat()}, _dl
         yield {"_id": "3"}, _dl_none
 
-    res = await es.async_bulk("search-some-index", get_docs(), pipeline)
+    await es.async_bulk("search-some-index", get_docs(), pipeline)
+    while not es.done():
+        await asyncio.sleep(0.1)
 
-    assert res == {
-        "bulk_operations": {"index": 2, "delete": 1},
+    ingestion_stats = es.ingestion_stats()
+
+    assert ingestion_stats == {
         "doc_created": 1,
-        "doc_deleted": 1,
         "attachment_extracted": 1,
         "doc_updated": 1,
-        "fetch_error": None,
+        "doc_deleted": 1,
+        "bulk_operations": {"index": 2, "delete": 1},
         "indexed_document_count": 2,
         "indexed_document_volume": ANY,
         "deleted_document_count": 1,
     }
 
-    # two syncs
+    # 2nd sync
     set_responses(mock_responses)
-    res = await es.async_bulk("search-some-index", get_docs(), pipeline)
-
-    assert res == {
-        "bulk_operations": {"index": 2, "delete": 1},
-        "doc_created": 1,
-        "doc_deleted": 1,
-        "attachment_extracted": 1,
-        "doc_updated": 1,
-        "fetch_error": None,
-        "indexed_document_count": 2,
-        "indexed_document_volume": ANY,
-        "deleted_document_count": 1,
-    }
-
-    await es.close()
-
-
-@pytest.mark.asyncio
-async def test_async_bulk_same_ts(mock_responses, patch_logger):
-    ts = datetime.datetime.now().isoformat()
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
-    set_responses(mock_responses, ts)
-    es = ElasticServer(config)
-    pipeline = Pipeline({})
-
-    async def get_docs():
-        async def _dl(doit=True, timestamp=None):
-            if not doit:
-                return  # Canceled
-            return {"TEXT": "DATA", "_timestamp": timestamp, "_id": "1"}
-
-        yield {"_id": "1", "_timestamp": ts}, _dl
-        yield {"_id": "3", "_timestamp": ts}, None
-
-    res = await es.async_bulk("search-some-index", get_docs(), pipeline)
-
-    assert res == {
-        "bulk_operations": {"index": 1, "delete": 1},
-        "doc_created": 1,
-        "doc_deleted": 1,
-        "attachment_extracted": 0,
-        "doc_updated": 0,
-        "fetch_error": None,
-        "indexed_document_count": 1,
-        "indexed_document_volume": ANY,
-        "deleted_document_count": 1,
-    }
-
-    set_responses(mock_responses, ts)
-    res = await es.async_bulk("search-some-index", get_docs(), pipeline)
-
-    assert res == {
-        "bulk_operations": {"index": 1, "delete": 1},
-        "doc_created": 1,
-        "doc_deleted": 1,
-        "attachment_extracted": 0,
-        "doc_updated": 0,
-        "fetch_error": None,
-        "indexed_document_count": 1,
-        "indexed_document_volume": ANY,
-        "deleted_document_count": 1,
-    }
+    with pytest.raises(AsyncBulkRunningError):
+        await es.async_bulk("search-some-index", get_docs(), pipeline)
 
     await es.close()
 
@@ -706,3 +652,36 @@ def test_bulk_populate_stats(res, expected_result):
     assert bulker.indexed_document_count == expected_result["indexed_document_count"]
     assert bulker.indexed_document_volume == expected_result["indexed_document_volume"]
     assert bulker.deleted_document_count == expected_result["deleted_document_count"]
+
+
+@pytest.mark.parametrize(
+    "fetcher_task, fetcher_task_done, bulker_task, bulker_task_done, expected_result",
+    [
+        (None, False, None, False, True),
+        (Mock(), False, None, False, False),
+        (Mock(), True, None, False, True),
+        (None, False, Mock(), False, False),
+        (None, False, Mock(), True, True),
+        (Mock(), False, Mock(), False, False),
+        (Mock(), False, Mock(), True, False),
+        (Mock(), True, Mock(), False, False),
+        (Mock(), True, Mock(), True, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_elastic_server_done(
+    fetcher_task, fetcher_task_done, bulker_task, bulker_task_done, expected_result
+):
+    if fetcher_task is not None:
+        fetcher_task.done.return_value = fetcher_task_done
+    if bulker_task is not None:
+        bulker_task.done.return_value = bulker_task_done
+
+    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
+    es = ElasticServer(config)
+    es._fetcher_task = fetcher_task
+    es._bulker_task = bulker_task
+
+    assert es.done() == expected_result
+
+    await es.close()

--- a/connectors/tests/test_sync_job_runner.py
+++ b/connectors/tests/test_sync_job_runner.py
@@ -19,7 +19,6 @@ def create_runner(
     source_changed=True,
     source_available=True,
     validate_config_exception=None,
-    async_bulk_result=None,
 ):
     source_klass = Mock()
     data_provider = Mock()
@@ -54,19 +53,30 @@ def create_runner(
     connector.sync_starts = AsyncMock()
     connector.sync_done = AsyncMock()
 
-    elastic_server = Mock()
-    elastic_server.prepare_content_index = AsyncMock()
-    elastic_server.async_bulk = AsyncMock(return_value=async_bulk_result)
-
-    bulk_options = {}
+    es_config = {}
 
     return SyncJobRunner(
         source_klass=source_klass,
         sync_job=sync_job,
         connector=connector,
-        elastic_server=elastic_server,
-        bulk_options=bulk_options,
+        es_config=es_config,
     )
+
+
+@pytest.fixture(autouse=True)
+def elastic_server_mock():
+    with patch("connectors.sync_job_runner.ElasticServer") as elastic_server_klass_mock:
+        elastic_server_mock = Mock()
+        elastic_server_mock.prepare_content_index = AsyncMock()
+        elastic_server_mock.async_bulk = AsyncMock()
+        elastic_server_mock.done = Mock(return_value=True)
+        elastic_server_mock.fetch_error = Mock(return_value=None)
+        elastic_server_mock.cancel = AsyncMock()
+        elastic_server_mock.ingestion_stats = Mock()
+        elastic_server_mock.close = AsyncMock()
+        elastic_server_klass_mock.return_value = elastic_server_mock
+
+        yield elastic_server_mock
 
 
 @pytest.mark.asyncio
@@ -76,9 +86,9 @@ async def test_job_claim_fail(patch_logger):
     with pytest.raises(JobClaimError):
         await sync_job_runner.execute()
 
+    assert sync_job_runner.elastic_server is None
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.connector.sync_starts.assert_not_awaited()
-    sync_job_runner.elastic_server.async_bulk.assert_not_awaited()
     sync_job_runner.sync_job.done.assert_not_awaited()
     sync_job_runner.sync_job.fail.assert_not_awaited()
     sync_job_runner.sync_job.cancel.assert_not_awaited()
@@ -93,9 +103,9 @@ async def test_connector_starts_fail(patch_logger):
     with pytest.raises(JobClaimError):
         await sync_job_runner.execute()
 
+    assert sync_job_runner.elastic_server is None
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.connector.sync_starts.assert_awaited()
-    sync_job_runner.elastic_server.async_bulk.assert_not_awaited()
     sync_job_runner.sync_job.done.assert_not_awaited()
     sync_job_runner.sync_job.fail.assert_not_awaited()
     sync_job_runner.sync_job.cancel.assert_not_awaited()
@@ -115,9 +125,9 @@ async def test_source_not_changed(patch_logger):
         "total_document_count": total_document_count,
     }
 
+    assert sync_job_runner.elastic_server is None
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.connector.sync_starts.assert_awaited()
-    sync_job_runner.elastic_server.async_bulk.assert_not_awaited()
     sync_job_runner.sync_job.done.assert_awaited_with(ingestion_stats=ingestion_stats)
     sync_job_runner.sync_job.fail.assert_not_awaited()
     sync_job_runner.sync_job.cancel.assert_not_awaited()
@@ -137,9 +147,9 @@ async def test_source_invalid_config(patch_logger):
         "total_document_count": total_document_count,
     }
 
+    assert sync_job_runner.elastic_server is None
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.connector.sync_starts.assert_awaited()
-    sync_job_runner.elastic_server.async_bulk.assert_not_awaited()
     sync_job_runner.sync_job.done.assert_not_awaited
     sync_job_runner.sync_job.fail.assert_awaited_with(
         ANY, ingestion_stats=ingestion_stats
@@ -161,9 +171,9 @@ async def test_source_not_available(patch_logger):
         "total_document_count": total_document_count,
     }
 
+    assert sync_job_runner.elastic_server is None
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.connector.sync_starts.assert_awaited()
-    sync_job_runner.elastic_server.async_bulk.assert_not_awaited()
     sync_job_runner.sync_job.done.assert_not_awaited
     sync_job_runner.sync_job.fail.assert_awaited_with(
         ANY, ingestion_stats=ingestion_stats
@@ -186,9 +196,9 @@ async def test_invalid_filtering(patch_logger):
         "total_document_count": total_document_count,
     }
 
+    assert sync_job_runner.elastic_server is None
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.connector.sync_starts.assert_awaited()
-    sync_job_runner.elastic_server.async_bulk.assert_not_awaited()
     sync_job_runner.sync_job.done.assert_not_awaited
     sync_job_runner.sync_job.fail.assert_awaited_with(
         ANY, ingestion_stats=ingestion_stats
@@ -199,18 +209,19 @@ async def test_invalid_filtering(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_async_bulk_error(patch_logger):
+async def test_async_bulk_error(elastic_server_mock, patch_logger):
     error = "something wrong"
-    async_bulk_result = {"fetch_error": error}
-    sync_job_runner = create_runner(async_bulk_result=async_bulk_result)
-    await sync_job_runner.execute()
-
     ingestion_stats = {
         "indexed_document_count": 0,
         "indexed_document_volume": 0,
         "deleted_document_count": 0,
-        "total_document_count": total_document_count,
     }
+    elastic_server_mock.fetch_error.return_value = error
+    elastic_server_mock.ingestion_stats.return_value = ingestion_stats
+    sync_job_runner = create_runner()
+    await sync_job_runner.execute()
+
+    ingestion_stats["total_document_count"] = total_document_count
 
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.connector.sync_starts.assert_awaited()
@@ -225,24 +236,17 @@ async def test_async_bulk_error(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_job_runner(patch_logger):
-    doc_updated = 10
-    doc_created = 15
-    doc_deleted = 20
-    async_bulk_result = {
-        "doc_updated": doc_updated,
-        "doc_created": doc_created,
-        "doc_deleted": doc_deleted,
+async def test_sync_job_runner(elastic_server_mock, patch_logger):
+    ingestion_stats = {
+        "indexed_document_count": 25,
+        "indexed_document_volume": 30,
+        "deleted_document_count": 20,
     }
-    sync_job_runner = create_runner(async_bulk_result=async_bulk_result)
+    elastic_server_mock.ingestion_stats.return_value = ingestion_stats
+    sync_job_runner = create_runner()
     await sync_job_runner.execute()
 
-    ingestion_stats = {
-        "indexed_document_count": doc_updated + doc_created,
-        "indexed_document_volume": 0,
-        "deleted_document_count": doc_deleted,
-        "total_document_count": total_document_count,
-    }
+    ingestion_stats["total_document_count"] = total_document_count
 
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.connector.sync_starts.assert_awaited()
@@ -255,24 +259,20 @@ async def test_sync_job_runner(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_job_runner_suspend(patch_logger):
+async def test_sync_job_runner_suspend(elastic_server_mock, patch_logger):
+    ingestion_stats = {
+        "indexed_document_count": 25,
+        "indexed_document_volume": 30,
+        "deleted_document_count": 20,
+    }
+    elastic_server_mock.done.return_value = False
+    elastic_server_mock.ingestion_stats.return_value = ingestion_stats
     sync_job_runner = create_runner()
-
-    async def _simulate_sync(*args, **kwargs):
-        await asyncio.sleep(0.3)
-        return {}
-
-    sync_job_runner.elastic_server.async_bulk.side_effect = _simulate_sync
     task = asyncio.create_task(sync_job_runner.execute())
     asyncio.get_event_loop().call_later(0.1, task.cancel)
     await task
 
-    ingestion_stats = {
-        "indexed_document_count": 0,
-        "indexed_document_volume": 0,
-        "deleted_document_count": 0,
-        "total_document_count": total_document_count,
-    }
+    ingestion_stats["total_document_count"] = total_document_count
 
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.connector.sync_starts.assert_awaited()

--- a/connectors/tests/test_sync_job_runner.py
+++ b/connectors/tests/test_sync_job_runner.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
-from unittest.mock import ANY, AsyncMock, Mock
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Make async_bulk a task (#513)](https://github.com/elastic/connectors-python/pull/513)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)