### PR TITLE
[MySQL] Separate get_primary_key_columns

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -472,44 +472,50 @@ class MySqlDataSource(BaseDataSource):
             Dict: Document to be indexed
         """
 
+        primary_key_columns = await self._get_primary_key_columns(table)
+
+        if not primary_key_columns:
+            logger.warning(
+                f"Skipping {table} table from database {self.database} since no primary key is associated with it. Assign primary key to the table to index it in the next sync interval."
+            )
+            return
+
+        last_update_time = await anext(
+            self._connect(
+                query=self.queries.table_last_update_time(table),
+                table=table,
+            )
+        )
+        last_update_time = last_update_time[0][0]
+
+        table_rows = self._connect(query=query, fetch_many=True, table=table)
+        column_names = await anext(table_rows)
+
+        async for row in table_rows:
+            row = dict(zip(column_names, row))
+            keys_value = ""
+            for key in primary_key_columns:
+                keys_value += f"{row.get(key)}_" if row.get(key) else ""
+            row.update(
+                {
+                    "_id": f"{self.database}_{table}_{keys_value}",
+                    "_timestamp": last_update_time,
+                    "Database": self.database,
+                    "Table": table,
+                }
+            )
+            yield self.serialize(doc=row)
+
+    async def _get_primary_key_columns(self, table):
         primary_key = await anext(
             self._connect(query=self.queries.table_primary_key(table), table=table)
         )
 
-        keys = []
+        columns = []
         for column_name in primary_key:
-            keys.append(f"{self.database}_{table}_{column_name[0]}")
+            columns.append(f"{self.database}_{table}_{column_name[0]}")
 
-        if keys:
-            last_update_time = await anext(
-                self._connect(
-                    query=self.queries.table_last_update_time(table),
-                    table=table,
-                )
-            )
-            last_update_time = last_update_time[0][0]
-
-            table_rows = self._connect(query=query, fetch_many=True, table=table)
-            column_names = await anext(table_rows)
-
-            async for row in table_rows:
-                row = dict(zip(column_names, row))
-                keys_value = ""
-                for key in keys:
-                    keys_value += f"{row.get(key)}_" if row.get(key) else ""
-                row.update(
-                    {
-                        "_id": f"{self.database}_{table}_{keys_value}",
-                        "_timestamp": last_update_time,
-                        "Database": self.database,
-                        "Table": table,
-                    }
-                )
-                yield self.serialize(doc=row)
-        else:
-            logger.warning(
-                f"Skipping {table} table from database {self.database} since no primary key is associated with it. Assign primary key to the table to index it in the next sync interval."
-            )
+        return columns
 
     async def get_docs(self, filtering=None):
         """Executes the logic to fetch tables and rows in async manner.

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -574,3 +574,32 @@ async def test_validate_tables_accessible_when_not_accessible_then_error_raised(
 )
 def test_parse_tables_string_to_list(tables_string, expected_tables_list):
     assert parse_tables_string_to_list_of_tables(tables_string) == expected_tables_list
+
+
+@pytest.mark.parametrize(
+    "primary_key_tuples, expected_primary_key_columns",
+    [
+        ([], []),
+        ([("id",)], [f"{DATABASE}_{TABLE_ONE}_id"]),
+        (
+            [("group",), ("class",), ("name",)],
+            [
+                f"{DATABASE}_{TABLE_ONE}_group",
+                f"{DATABASE}_{TABLE_ONE}_class",
+                f"{DATABASE}_{TABLE_ONE}_name",
+            ],
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_primary_key_columns(
+    primary_key_tuples, expected_primary_key_columns
+):
+    source = create_source(MySqlDataSource)
+
+    source.database = DATABASE
+    source._connect = AsyncIterator([primary_key_tuples])
+
+    primary_key_columns = await source._get_primary_key_columns(TABLE_ONE)
+
+    assert primary_key_columns == expected_primary_key_columns


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4263
## Related to https://github.com/elastic/enterprise-search-team/issues/4240

The current implementation is a bit unclear how ids are generated at a first look. To safely be able to change these ids in the future, which is needed for https://github.com/elastic/enterprise-search-team/issues/4263 and https://github.com/elastic/enterprise-search-team/issues/4240 I want to separate out the generation of ids to make the code more readable and to be able to test the id generation in isolation. 

This will also make it easier to reuse this code as it's conceptually the same in other SQL-like connectors.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~