### PR TITLE
[8.7] Report ingestion stats during job execution (#515)

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -204,6 +204,20 @@ class SyncJob(ESDocument):
         }
         await self.index.update(doc_id=self.id, doc=doc)
 
+    async def update_metadata(self, ingestion_stats=None, connector_metadata=None):
+        if ingestion_stats is None:
+            ingestion_stats = {}
+        if connector_metadata is None:
+            connector_metadata = {}
+
+        doc = {
+            "last_seen": iso_utc(),
+        }
+        doc.update(ingestion_stats)
+        if len(connector_metadata) > 0:
+            doc["metadata"] = connector_metadata
+        await self.index.update(doc_id=self.id, doc=doc)
+
     async def done(self, ingestion_stats=None, connector_metadata=None):
         await self._terminate(
             JobStatus.COMPLETED, None, ingestion_stats, connector_metadata

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -12,6 +12,7 @@ from connectors.es import Mappings
 from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
 
+JOB_REPORTING_INTERVAL = 10
 JOB_CHECK_INTERVAL = 1
 
 
@@ -52,6 +53,7 @@ class SyncJobRunner:
         self.connector_id = self.connector.id
         self.es_config = es_config
         self.elastic_server = None
+        self.job_reporting_task = None
         self.bulk_options = self.es_config.get("bulk", {})
         self._start_time = None
         self.running = False
@@ -113,6 +115,9 @@ class SyncJobRunner:
                 options=bulk_options,
             )
 
+            self.job_reporting_task = asyncio.create_task(
+                self.update_ingestion_stats(JOB_REPORTING_INTERVAL)
+            )
             while not self.elastic_server.done():
                 await asyncio.sleep(JOB_CHECK_INTERVAL)
             fetch_error = self.elastic_server.fetch_error()
@@ -134,6 +139,12 @@ class SyncJobRunner:
     async def _sync_done(self, sync_status, sync_error=None):
         if self.elastic_server is not None and not self.elastic_server.done():
             await self.elastic_server.cancel()
+        if self.job_reporting_task is not None and not self.job_reporting_task.done():
+            self.job_reporting_task.cancel()
+            try:
+                await self.job_reporting_task
+            except asyncio.CancelledError:
+                logger.info("Job reporting task is stopped.")
 
         result = (
             {} if self.elastic_server is None else self.elastic_server.ingestion_stats()
@@ -189,3 +200,28 @@ class SyncJobRunner:
             doc["_reduce_whitespace"] = self.sync_job.pipeline["reduce_whitespace"]
             doc["_run_ml_inference"] = self.sync_job.pipeline["run_ml_inference"]
             yield doc, lazy_download
+
+    async def update_ingestion_stats(self, interval):
+        while True:
+            await asyncio.sleep(interval)
+
+            if not await self.reload_sync_job():
+                break
+
+            result = self.elastic_server.ingestion_stats()
+            ingestion_stats = {
+                "indexed_document_count": result.get("indexed_document_count", 0),
+                "indexed_document_volume": result.get("indexed_document_volume", 0),
+                "deleted_document_count": result.get("deleted_document_count", 0),
+            }
+            await self.sync_job.update_metadata(ingestion_stats=ingestion_stats)
+
+    async def reload_sync_job(self):
+        if self.sync_job is None:
+            return False
+        try:
+            await self.sync_job.reload()
+        except DocumentNotFoundError:
+            logger.error(f"Couldn't find sync job by id {self.job_id}")
+            self.sync_job = None
+        return self.sync_job is not None

--- a/connectors/tests/test_sync_job_runner.py
+++ b/connectors/tests/test_sync_job_runner.py
@@ -45,6 +45,7 @@ def create_runner(
     sync_job.suspend = AsyncMock()
     sync_job.reload = AsyncMock(return_value=sync_job)
     sync_job.validate_filtering = AsyncMock()
+    sync_job.update_metadata = AsyncMock()
 
     connector = Mock()
     connector.id = "1"
@@ -282,5 +283,36 @@ async def test_sync_job_runner_suspend(elastic_server_mock, patch_logger):
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_awaited_with(
         ingestion_stats=ingestion_stats
+    )
+    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job)
+
+
+@pytest.mark.asyncio
+@patch("connectors.sync_job_runner.JOB_REPORTING_INTERVAL", 0)
+@patch("connectors.sync_job_runner.JOB_CHECK_INTERVAL", 0)
+async def test_sync_job_runner_reporting_metadata(elastic_server_mock, patch_logger):
+    ingestion_stats = {
+        "indexed_document_count": 15,
+        "indexed_document_volume": 230,
+        "deleted_document_count": 10,
+    }
+    elastic_server_mock.ingestion_stats.return_value = ingestion_stats
+    elastic_server_mock.done.return_value = False
+    sync_job_runner = create_runner()
+    task = asyncio.create_task(sync_job_runner.execute())
+    asyncio.get_event_loop().call_later(0.1, task.cancel)
+    await task
+
+    sync_job_runner.sync_job.claim.assert_awaited()
+    sync_job_runner.connector.sync_starts.assert_awaited()
+    sync_job_runner.elastic_server.async_bulk.assert_awaited()
+    sync_job_runner.sync_job.update_metadata.assert_awaited_with(
+        ingestion_stats=ingestion_stats
+    )
+    sync_job_runner.sync_job.done.assert_not_awaited()
+    sync_job_runner.sync_job.fail.assert_not_awaited()
+    sync_job_runner.sync_job.cancel.assert_not_awaited()
+    sync_job_runner.sync_job.suspend.assert_awaited_with(
+        ingestion_stats=ingestion_stats | {"total_document_count": total_document_count}
     )
     sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Report ingestion stats during job execution (#515)](https://github.com/elastic/connectors-python/pull/515)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)