### PR TITLE
[MySQL] Separate "generate_id" method

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -489,18 +489,22 @@ class MySqlDataSource(BaseDataSource):
 
         async for row in table_rows:
             row = dict(zip(column_names, row))
-            keys_value = ""
-            for key in primary_key_columns:
-                keys_value += f"{row.get(key)}_" if row.get(key) else ""
             row.update(
                 {
-                    "_id": f"{self.database}_{table}_{keys_value}",
+                    "_id": self._generate_id(table, row, primary_key_columns),
                     "_timestamp": last_update_time,
                     "Database": self.database,
                     "Table": table,
                 }
             )
             yield self.serialize(doc=row)
+
+    def _generate_id(self, table, row, primary_key_columns):
+        keys_value = ""
+        for key in primary_key_columns:
+            keys_value += f"{row.get(key)}_" if row.get(key) else ""
+
+        return f"{self.database}_{table}_{keys_value}"
 
     async def _get_primary_key_columns(self, table):
         primary_key = await anext(

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -593,3 +593,20 @@ async def test_get_primary_key_columns(
     primary_key_columns = await source._get_primary_key_columns(TABLE_ONE)
 
     assert primary_key_columns == expected_primary_key_columns
+
+
+@pytest.mark.parametrize(
+    "row, primary_key_columns, expected_id",
+    [
+        ({"key_1": 1, "key_2": 2}, ["key_1"], f"{DATABASE}_{TABLE_ONE}_1_"),
+        ({"key_1": 1, "key_2": 2}, ["key_1", "key_2"], f"{DATABASE}_{TABLE_ONE}_1_2_"),
+        ({"key_1": 1, "key_2": 2}, ["key_1", "key_3"], f"{DATABASE}_{TABLE_ONE}_1_"),
+    ],
+)
+def test_generate_id(row, primary_key_columns, expected_id):
+    source = create_source(MySqlDataSource)
+    source.database = DATABASE
+
+    row_id = source._generate_id(TABLE_ONE, row, primary_key_columns)
+
+    assert row_id == expected_id


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4263
## Related to https://github.com/elastic/enterprise-search-team/issues/4240

Create a separate `generate_id` method and test it explicitly. This enables changing the `_id` generation in a much safer way.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~