### PR TITLE
[MySQL] Remove unnecessary database information from ids and docs

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -370,7 +370,7 @@ class MySqlDataSource(BaseDataSource):
                                 # sending back column names only once
                                 if yield_once:
                                     yield [
-                                        f"{self.database}_{query_kwargs['table']}_{column[0]}"
+                                        f"{query_kwargs['table']}_{column[0]}"
                                         for column in cursor.description
                                     ]
                                     yield_once = False
@@ -493,7 +493,6 @@ class MySqlDataSource(BaseDataSource):
                 {
                     "_id": self._generate_id(table, row, primary_key_columns),
                     "_timestamp": last_update_time,
-                    "Database": self.database,
                     "Table": table,
                 }
             )
@@ -504,7 +503,7 @@ class MySqlDataSource(BaseDataSource):
         for key in primary_key_columns:
             keys_value += f"{row.get(key)}_" if row.get(key) else ""
 
-        return f"{self.database}_{table}_{keys_value}"
+        return f"{table}_{keys_value}"
 
     async def _get_primary_key_columns(self, table):
         primary_key = await anext(
@@ -513,7 +512,7 @@ class MySqlDataSource(BaseDataSource):
 
         columns = []
         for column_name in primary_key:
-            columns.append(f"{self.database}_{table}_{column_name[0]}")
+            columns.append(f"{table}_{column_name[0]}")
 
         return columns
 

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -268,11 +268,10 @@ async def test_fetch_documents(patch_connection_pool):
         document_list.append(document)
 
     assert {
-        "Database": f"{DATABASE}",
         "Table": "table_name",
-        "_id": f"{DATABASE}_table_name_",
+        "_id": "table_name_",
         "_timestamp": "table1",
-        f"{DATABASE}_table_name_Database": "table1",
+        "table_name_Database": "table1",
     } in document_list
 
 
@@ -570,13 +569,13 @@ def test_parse_tables_string_to_list(tables_string, expected_tables_list):
     "primary_key_tuples, expected_primary_key_columns",
     [
         ([], []),
-        ([("id",)], [f"{DATABASE}_{TABLE_ONE}_id"]),
+        ([("id",)], [f"{TABLE_ONE}_id"]),
         (
             [("group",), ("class",), ("name",)],
             [
-                f"{DATABASE}_{TABLE_ONE}_group",
-                f"{DATABASE}_{TABLE_ONE}_class",
-                f"{DATABASE}_{TABLE_ONE}_name",
+                f"{TABLE_ONE}_group",
+                f"{TABLE_ONE}_class",
+                f"{TABLE_ONE}_name",
             ],
         ),
     ],
@@ -586,8 +585,6 @@ async def test_get_primary_key_columns(
     primary_key_tuples, expected_primary_key_columns
 ):
     source = create_source(MySqlDataSource)
-
-    source.database = DATABASE
     source._connect = AsyncIterator([primary_key_tuples])
 
     primary_key_columns = await source._get_primary_key_columns(TABLE_ONE)
@@ -598,14 +595,13 @@ async def test_get_primary_key_columns(
 @pytest.mark.parametrize(
     "row, primary_key_columns, expected_id",
     [
-        ({"key_1": 1, "key_2": 2}, ["key_1"], f"{DATABASE}_{TABLE_ONE}_1_"),
-        ({"key_1": 1, "key_2": 2}, ["key_1", "key_2"], f"{DATABASE}_{TABLE_ONE}_1_2_"),
-        ({"key_1": 1, "key_2": 2}, ["key_1", "key_3"], f"{DATABASE}_{TABLE_ONE}_1_"),
+        ({"key_1": 1, "key_2": 2}, ["key_1"], f"{TABLE_ONE}_1_"),
+        ({"key_1": 1, "key_2": 2}, ["key_1", "key_2"], f"{TABLE_ONE}_1_2_"),
+        ({"key_1": 1, "key_2": 2}, ["key_1", "key_3"], f"{TABLE_ONE}_1_"),
     ],
 )
 def test_generate_id(row, primary_key_columns, expected_id):
     source = create_source(MySqlDataSource)
-    source.database = DATABASE
 
     row_id = source._generate_id(TABLE_ONE, row, primary_key_columns)
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4263

This PR changes the `_id` to not contain the `database` a row came from as the MySQL connector only allows one database to be configured, which makes this information obsolete. Therefore the `Database` field is also removed from the docs to ingest as it does not provide any useful information and only takes up space.

Note: After a discussion with Product it's fine that this change leads to a reindex as all `_id`s will change, when a previous MySQL connector version was used to ingest documents.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~