### PR TITLE
[MySQL] Introduce basic MySQLClient class

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -7,6 +7,7 @@
 import re
 import ssl
 from contextlib import asynccontextmanager
+from functools import cached_property
 
 import aiomysql
 
@@ -106,6 +107,71 @@ class MySQLAdvancedRulesValidator(AdvancedRulesValidator):
         return SyncRuleValidationResult.valid_result(
             SyncRuleValidationResult.ADVANCED_RULES
         )
+
+
+class MySQLClient:
+    def __init__(
+        self,
+        host,
+        port,
+        user,
+        password,
+        ssl_enabled,
+        ssl_certificate,
+        db=None,
+        max_pool_size=MAX_POOL_SIZE,
+    ):
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+        self.db = db
+        self.max_pool_size = max_pool_size
+        self.ssl_enabled = ssl_enabled
+        self.ssl_certificate = ssl_certificate
+
+    @asynccontextmanager
+    async def with_connection_pool(self):
+        connection_string = {
+            "host": self.host,
+            "port": int(self.port),
+            "user": self.user,
+            "password": self.password,
+            "db": self.db,
+            "maxsize": self.max_pool_size,
+            "ssl": _ssl_context(certificate=self.ssl_certificate)
+            if self.ssl_enabled
+            else None,
+        }
+
+        connection_pool = None
+
+        try:
+            connection_pool = await aiomysql.create_pool(**connection_string)
+            yield connection_pool
+        except Exception:
+            logger.error("Failed to create connection pool for MySQL.")
+            raise
+        finally:
+            connection_pool.close()
+            await connection_pool.wait_closed()
+
+
+def _ssl_context(certificate):
+    """Convert string to pem format and create a SSL context
+
+    Args:
+        certificate (str): certificate in string format
+
+    Returns:
+        ssl_context: SSL context with certificate
+    """
+    certificate = certificate.replace(" ", "\n")
+    pem_format = " ".join(certificate.split("\n", 1))
+    pem_format = " ".join(pem_format.rsplit("\n", 1))
+    ctx = ssl.create_default_context()
+    ctx.load_verify_locations(cadata=pem_format)
+    return ctx
 
 
 class MySqlDataSource(BaseDataSource):
@@ -211,6 +277,17 @@ class MySqlDataSource(BaseDataSource):
             },
         }
 
+    @cached_property
+    def _mysql_client(self):
+        return MySQLClient(
+            host=self.configuration["host"],
+            port=self.configuration["port"],
+            user=self.configuration["user"],
+            password=self.configuration["password"],
+            ssl_enabled=self.configuration["ssl_enabled"],
+            ssl_certificate=self.configuration["ssl_ca"],
+        )
+
     def advanced_rules_validators(self):
         return [MySQLAdvancedRulesValidator(self)]
 
@@ -252,7 +329,7 @@ class MySqlDataSource(BaseDataSource):
         strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
     )
     async def _remote_validation(self):
-        async with self.with_connection_pool() as connection_pool:
+        async with self._mysql_client.with_connection_pool() as connection_pool:
             async with connection_pool.acquire() as conn:
                 async with conn.cursor() as cursor:
                     await self._validate_database_accessible(cursor)
@@ -281,54 +358,10 @@ class MySqlDataSource(BaseDataSource):
                 f"The tables '{format_list(non_accessible_tables)}' are either not present or not accessible for user '{self.configuration['user']}'."
             )
 
-    def _ssl_context(self, certificate):
-        """Convert string to pem format and create a SSL context
-
-        Args:
-            certificate (str): certificate in string format
-
-        Returns:
-            ssl_context: SSL context with certificate
-        """
-        certificate = certificate.replace(" ", "\n")
-        pem_format = " ".join(certificate.split("\n", 1))
-        pem_format = " ".join(pem_format.rsplit("\n", 1))
-        ctx = ssl.create_default_context()
-        ctx.load_verify_locations(cadata=pem_format)
-        return ctx
-
-    @asynccontextmanager
-    async def with_connection_pool(self):
-        connection_string = {
-            "host": self.configuration["host"],
-            "port": int(self.configuration["port"]),
-            "user": self.configuration["user"],
-            "password": self.configuration["password"],
-            "db": None,
-            "maxsize": MAX_POOL_SIZE,
-            "ssl": self._ssl_context(certificate=self.certificate)
-            if self.ssl_enabled
-            else None,
-        }
-
-        connection_pool = None
-
-        try:
-            connection_pool = await aiomysql.create_pool(**connection_string)
-        except Exception:
-            logger.error("Failed to create connection pool.")
-            raise
-
-        try:
-            yield connection_pool
-        finally:
-            connection_pool.close()
-            await connection_pool.wait_closed()
-
     async def ping(self):
         """Verify the connection with MySQL server"""
 
-        async with self.with_connection_pool() as connection_pool:
+        async with self._mysql_client.with_connection_pool() as connection_pool:
             try:
                 async with connection_pool.acquire() as connection:
                     await connection.ping()
@@ -357,7 +390,7 @@ class MySqlDataSource(BaseDataSource):
         rows_fetched = 0
         cursor_position = 0
 
-        async with self.with_connection_pool() as connection_pool:
+        async with self._mysql_client.with_connection_pool() as connection_pool:
             while retry <= self.retry_count:
                 try:
                     async with connection_pool.acquire() as connection:

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -4,7 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
-import ssl
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import aiomysql
@@ -16,7 +15,6 @@ from connectors.source import ConfigurableFieldValueError, DataSourceConfigurati
 from connectors.sources.mysql import (
     MySQLAdvancedRulesValidator,
     MySqlDataSource,
-    _ssl_context,
     parse_tables_string_to_list_of_tables,
 )
 from connectors.sources.tests.support import create_source
@@ -397,14 +395,6 @@ async def test_validate_config_when_port_has_wrong_type_then_raise_error():
 
     with pytest.raises(ConfigurableFieldValueError):
         await source.validate_config()
-
-
-def test_ssl_context():
-    """This function test _ssl_context with dummy certificate"""
-    certificate = "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"
-
-    with patch.object(ssl, "create_default_context", return_value=MockSsl()):
-        _ssl_context(certificate=certificate)
 
 
 @pytest.mark.parametrize(

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -16,6 +16,7 @@ from connectors.source import ConfigurableFieldValueError, DataSourceConfigurati
 from connectors.sources.mysql import (
     MySQLAdvancedRulesValidator,
     MySqlDataSource,
+    _ssl_context,
     parse_tables_string_to_list_of_tables,
 )
 from connectors.sources.tests.support import create_source
@@ -401,10 +402,9 @@ async def test_validate_config_when_port_has_wrong_type_then_raise_error():
 def test_ssl_context():
     """This function test _ssl_context with dummy certificate"""
     certificate = "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"
-    source = create_source(MySqlDataSource)
 
     with patch.object(ssl, "create_default_context", return_value=MockSsl()):
-        source._ssl_context(certificate=certificate)
+        _ssl_context(certificate=certificate)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4266

Why do we need this change?

Currently too many concerns are implemented in `_connect` inside `MySQLDataSource`:
- Fetching metadata of a table (column names)
- Fetching all rows from a table
- Fetching all rows from a table using pagination

This makes it very hard to adapt the code to the new advanced rules structure as it's not too easy to understand the interaction with the database server in the first place.

We also started to introduce dedicated client classes in other data sources ([Jira Client](https://github.com/elastic/connectors-python/blob/main/connectors/sources/jira.py#L64), [Confluence Client](https://github.com/elastic/connectors-python/blob/main/connectors/sources/confluence.py#L57), etc.) for similar reasons. To further align different connectors and increase the maintainability a dedicated client class for the MySQL data source is useful.

This will also loosen the coupling between the advanced rules validator and the data source as the advanced rules validator can then use the client.

This PR only moves `with_connection_pool` for now, more high-level methods breaking up `_connect` will follow in separate PRs to keep this one small.

`ssl_context` needed to be moved outside of `MySQLDataSource` as it's needed in the new client + it doesn't need to be a method inside `MySQLDataSource` (there are no dependencies on the internal state of the data source object).

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~