### PR TITLE
Remove incorrect use of patch_logger

### DIFF
--- a/connectors/sources/tests/test_confluence.py
+++ b/connectors/sources/tests/test_confluence.py
@@ -182,7 +182,7 @@ def test_tweak_bulk_options():
 
 
 @pytest.mark.asyncio
-async def test_close_with_client_session(patch_logger):
+async def test_close_with_client_session():
     """Test close method for closing the existing session"""
 
     # Setup
@@ -196,7 +196,7 @@ async def test_close_with_client_session(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_close_without_client_session(patch_logger):
+async def test_close_without_client_session():
     """Test close method when the session does not exist"""
     # Setup
     source = create_source(ConfluenceDataSource)
@@ -285,7 +285,7 @@ async def test_ping_for_failed_connection_exception(mock_get):
             await source.ping()
 
 
-def test_validate_configuration_for_ssl_enabled(patch_logger):
+def test_validate_configuration_for_ssl_enabled():
     """This function tests _validate_configuration when certification is empty and ssl is enabled"""
     # Setup
     source = create_source(ConfluenceDataSource)

--- a/connectors/sources/tests/test_directory.py
+++ b/connectors/sources/tests/test_directory.py
@@ -15,7 +15,7 @@ async def test_basics():
 
 
 @pytest.mark.asyncio
-async def test_get_docs(patch_logger, catch_stdout):
+async def test_get_docs(catch_stdout):
     source = create_source(DirectoryDataSource)
     num = 0
     async for (doc, dl) in source.get_docs():

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -117,7 +117,7 @@ class CursorSync:
             return [("2023-02-21T08:37:15+00:00",)]
 
 
-def test_get_configuration(patch_logger):
+def test_get_configuration():
     """Test get_configuration method of GenericBaseDataSource class"""
 
     # Setup
@@ -131,7 +131,7 @@ def test_get_configuration(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_valid_fields(patch_logger):
+async def test_validate_config_valid_fields():
     # Setup
     source = create_source(GenericBaseDataSource)
 
@@ -146,7 +146,7 @@ async def test_validate_config_valid_fields(patch_logger):
     "field", ["host", "port", "username", "password", "database", "tables"]
 )
 @pytest.mark.asyncio
-async def test_validate_config_missing_fields(field, patch_logger):
+async def test_validate_config_missing_fields(field):
     # Setup
     source = create_source(GenericBaseDataSource)
     with pytest.raises(ConfigurableFieldValueError):
@@ -157,7 +157,7 @@ async def test_validate_config_missing_fields(field, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_port(patch_logger):
+async def test_validate_config_port():
     """Test validate_config method check port"""
     # Setup
     source = create_source(GenericBaseDataSource)
@@ -169,7 +169,7 @@ async def test_validate_config_port(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_ssl(patch_logger):
+async def test_validate_config_ssl():
     """Test validate_config method check ssl"""
     # Setup
     source = create_source(PostgreSQLDataSource)
@@ -181,14 +181,14 @@ async def test_validate_config_ssl(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_close(patch_logger):
+async def test_close():
     """Test close method"""
     source = create_source(GenericBaseDataSource)
     await source.close()
 
 
 @pytest.mark.asyncio
-async def test_async_connect_negative(patch_logger):
+async def test_async_connect_negative():
     """Test _async_connect method with negative case"""
     source = create_source(GenericBaseDataSource)
     with patch.object(
@@ -202,7 +202,7 @@ async def test_async_connect_negative(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_connect_negative(patch_logger):
+async def test_sync_connect_negative():
     """Test _sync_connect method with negative case"""
     source = create_source(GenericBaseDataSource)
     with patch.object(
@@ -216,7 +216,7 @@ async def test_sync_connect_negative(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_execute_query_negative_for_internal_client_error(patch_logger):
+async def test_execute_query_negative_for_internal_client_error():
     """Test _execute_query method with negative case"""
     source = create_source(GenericBaseDataSource)
     with patch.object(
@@ -233,7 +233,7 @@ async def test_execute_query_negative_for_internal_client_error(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_fetch_documents_negative(patch_logger):
+async def test_fetch_documents_negative():
     """Test fetch_documents method with negative case"""
     source = create_source(GenericBaseDataSource)
     with patch.object(
@@ -270,7 +270,7 @@ async def test_execute_query_negative(patch_default_wait_multiplier):
 
 
 @pytest.mark.asyncio
-async def test_ping(patch_logger):
+async def test_ping():
     # Setup
     source = create_source(GenericBaseDataSource)
     source._create_engine = Mock()
@@ -282,7 +282,7 @@ async def test_ping(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_ping_negative(patch_logger):
+async def test_ping_negative():
     """Test ping method of GenericBaseDataSource class when connection is not established"""
     # Setup
     source = create_source(GenericBaseDataSource)

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -89,7 +89,7 @@ async def test_raise_on_invalid_configuration():
 
 
 @pytest.mark.asyncio
-async def test_ping_for_successful_connection(catch_stdout, patch_logger):
+async def test_ping_for_successful_connection(catch_stdout):
     """Tests the ping functionality for ensuring connection to Google Cloud Storage."""
 
     # Setup
@@ -111,7 +111,7 @@ async def test_ping_for_successful_connection(catch_stdout, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_ping_for_failed_connection(catch_stdout, patch_logger):
+async def test_ping_for_failed_connection(catch_stdout):
     """Tests the ping functionality when connection can not be established to Google Cloud Storage."""
 
     # Setup
@@ -458,7 +458,7 @@ async def test_get_content_when_type_not_supported():
 
 
 @pytest.mark.asyncio
-async def test_get_content_when_file_size_is_large(catch_stdout, patch_logger):
+async def test_get_content_when_file_size_is_large(catch_stdout):
     """Test the module responsible for fetching the content of the file if it is not extractable or doit is not true."""
 
     # Setup
@@ -502,7 +502,7 @@ async def test_get_content_when_file_size_is_large(catch_stdout, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_api_call_for_attribute_error(catch_stdout, patch_logger):
+async def test_api_call_for_attribute_error(catch_stdout):
     """Tests the api_call method when resource attribute is not present in the getattr."""
 
     # Setup

--- a/connectors/sources/tests/test_jira.py
+++ b/connectors/sources/tests/test_jira.py
@@ -163,7 +163,7 @@ def side_effect_function(url, ssl):
 
 
 @pytest.mark.asyncio
-async def test_configuration(patch_logger):
+async def test_configuration():
     """Tests the get configurations method of the Jira source class."""
     # Setup
     klass = JiraDataSource
@@ -176,7 +176,7 @@ async def test_configuration(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_for_host_url(patch_logger):
+async def test_validate_config_for_host_url():
     """This function test validate_config when host_url is invalid"""
     # Setup
     source = create_source(JiraDataSource)
@@ -211,7 +211,7 @@ async def test_api_call_negative():
 
 
 @pytest.mark.asyncio
-async def test_api_call_when_server_is_down(patch_logger):
+async def test_api_call_when_server_is_down():
     """Tests the api_call function while server gets disconnected."""
 
     # Setup
@@ -230,7 +230,9 @@ async def test_api_call_when_server_is_down(patch_logger):
 
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession.get")
-async def test_ping_with_ssl(mock_get, patch_logger):
+async def test_ping_with_ssl(
+    mock_get,
+):
     """Test ping method of JiraDataSource class with SSL"""
 
     # Execute
@@ -252,7 +254,7 @@ async def test_ping_with_ssl(mock_get, patch_logger):
 
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession.get")
-async def test_ping_for_failed_connection_exception(patch_logger):
+async def test_ping_for_failed_connection_exception(client_session_get):
     """Tests the ping functionality when connection can not be established to Jira."""
 
     # Setup
@@ -267,7 +269,7 @@ async def test_ping_for_failed_connection_exception(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_for_ssl_enabled(patch_logger):
+async def test_validate_config_for_ssl_enabled():
     """This function test _validate_configuration when certification is empty when ssl is enabled"""
     # Setup
     source = create_source(JiraDataSource)
@@ -279,7 +281,7 @@ async def test_validate_config_for_ssl_enabled(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_with_invalid_concurrent_downloads(patch_logger):
+async def test_validate_config_with_invalid_concurrent_downloads():
     """Test validate_config method of BaseDataSource class with invalid concurrent downloads"""
 
     # Setup
@@ -309,7 +311,7 @@ def test_tweak_bulk_options():
 
 
 @pytest.mark.asyncio
-async def test_close_with_client_session(patch_logger):
+async def test_close_with_client_session():
     # Setup
     source = create_source(JiraDataSource)
     source.jira_client._get_session()
@@ -321,7 +323,7 @@ async def test_close_with_client_session(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_close_without_client_session(patch_logger):
+async def test_close_without_client_session():
     """Test close method when the session does not exist"""
     # Setup
     source = create_source(JiraDataSource)
@@ -333,7 +335,7 @@ async def test_close_without_client_session(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_timezone(patch_logger):
+async def test_get_timezone():
     # Setup
     source = create_source(JiraDataSource)
 
@@ -345,7 +347,7 @@ async def test_get_timezone(patch_logger):
 
 @freeze_time("2023-01-24T04:07:19")
 @pytest.mark.asyncio
-async def test_get_projects(patch_logger):
+async def test_get_projects():
     """Test _get_projects method"""
     # Setup
     source = create_source(JiraDataSource)
@@ -360,7 +362,7 @@ async def test_get_projects(patch_logger):
 
 @freeze_time("2023-01-24T04:07:19")
 @pytest.mark.asyncio
-async def test_get_projects_for_specific_project(patch_logger):
+async def test_get_projects_for_specific_project():
     """Test _get_projects method for specific project key"""
     # Setup
     source = create_source(JiraDataSource)
@@ -382,7 +384,7 @@ async def test_get_projects_for_specific_project(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_verify_projects(patch_logger):
+async def test_verify_projects():
     """Test _verify_projects method"""
     source = create_source(JiraDataSource)
     source.jira_client.projects = ["TP", "DP"]
@@ -392,7 +394,7 @@ async def test_verify_projects(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_verify_projects_with_unavailable_project_keys(patch_logger):
+async def test_verify_projects_with_unavailable_project_keys():
     """Test _verify_projects method with unavaiable project keys"""
     source = create_source(JiraDataSource)
     source.jira_client.projects = ["TP", "AP"]
@@ -403,7 +405,7 @@ async def test_verify_projects_with_unavailable_project_keys(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_issues(patch_logger):
+async def test_get_issues():
     """Test _get_issues method"""
     # Setup
     source = create_source(JiraDataSource)
@@ -415,7 +417,7 @@ async def test_get_issues(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_attachments_positive(patch_logger):
+async def test_get_attachments_positive():
     """Test _get_attachments method"""
     # Setup
     source = create_source(JiraDataSource)
@@ -426,7 +428,7 @@ async def test_get_attachments_positive(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_content(patch_logger):
+async def test_get_content():
     """Tests the get content method."""
     # Setup
     source = create_source(JiraDataSource)
@@ -446,7 +448,7 @@ async def test_get_content(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_content_when_filesize_is_large(patch_logger):
+async def test_get_content_when_filesize_is_large():
     """Tests the get content method for file size greater than max limit."""
     # Setup
     source = create_source(JiraDataSource)
@@ -471,7 +473,7 @@ async def test_get_content_when_filesize_is_large(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_content_for_unsupported_filetype(patch_logger):
+async def test_get_content_for_unsupported_filetype():
     """Tests the get content method for file type is not supported."""
     # Setup
     source = create_source(JiraDataSource)
@@ -496,7 +498,7 @@ async def test_get_content_for_unsupported_filetype(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_grab_content(patch_logger):
+async def test_grab_content():
     """Test _grab_content method"""
     # Setup
     source = create_source(JiraDataSource)

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -144,7 +144,7 @@ def build_resp():
 @mock.patch(
     "pymongo.mongo_client.MongoClient._run_operation", lambda *xi, **kw: build_resp()
 )
-async def test_get_docs(patch_logger, *args):
+async def test_get_docs(*args):
     source = create_source(MongoDataSource)
     num = 0
     async for (doc, dl) in source.get_docs():

--- a/connectors/sources/tests/test_mssql.py
+++ b/connectors/sources/tests/test_mssql.py
@@ -52,7 +52,7 @@ def test_create_engine(mock_create_url, mock_create_engine):
 
 
 @pytest.mark.asyncio
-async def test_get_docs_mssql(patch_logger):
+async def test_get_docs_mssql():
     # Setup
     source = create_source(MSSQLDataSource)
     source.engine = MockEngine()

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -220,14 +220,14 @@ async def test_close_when_source_setup_correctly_does_not_raise_errors():
 
 
 @pytest.mark.asyncio
-async def test_ping(patch_logger, patch_connection_pool):
+async def test_ping(patch_connection_pool):
     source = await setup_mysql_source(MySqlDataSource)
 
     await source.ping()
 
 
 @pytest.mark.asyncio
-async def test_ping_negative(patch_logger):
+async def test_ping_negative():
     source = create_source(MySqlDataSource)
 
     mock_response = asyncio.Future()
@@ -241,9 +241,7 @@ async def test_ping_negative(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_connect_with_retry(
-    patch_logger, patch_connection_pool, patch_default_wait_multiplier
-):
+async def test_connect_with_retry(patch_connection_pool, patch_default_wait_multiplier):
     source = await setup_mysql_source(is_connection_lost=True)
 
     streamer = source._connect(query="select * from database.table", fetch_many=True)

--- a/connectors/sources/tests/test_network_drive.py
+++ b/connectors/sources/tests/test_network_drive.py
@@ -103,7 +103,7 @@ def test_get_configuration():
 
 
 @pytest.mark.asyncio
-async def test_ping_for_successful_connection(patch_logger):
+async def test_ping_for_successful_connection():
     """Tests the ping functionality for ensuring connection to the Network Drive."""
     # Setup
     expected_response = True
@@ -154,7 +154,7 @@ def test_create_connection_with_invalid_credentials(session_mock):
 
 @mock.patch("smbclient.scandir")
 @pytest.mark.asyncio
-async def test_get_files_with_invalid_path(dir_mock, patch_logger):
+async def test_get_files_with_invalid_path(dir_mock):
     """Tests the scandir method of smbclient throws error on invalid path
 
     Args:
@@ -213,7 +213,7 @@ async def test_get_files(dir_mock):
 
 
 @mock.patch("smbclient.open_file")
-def test_fetch_file_when_file_is_inaccessible(file_mock, patch_logger):
+def test_fetch_file_when_file_is_inaccessible(file_mock):
     """Tests the open_file method of smbclient throws error when file cannot be accessed
 
     Args:
@@ -288,7 +288,7 @@ async def test_get_content_when_doit_false():
 
 
 @pytest.mark.asyncio
-async def test_get_content_when_file_size_is_large(patch_logger):
+async def test_get_content_when_file_size_is_large():
     """Test the module responsible for fetching the content of the file if it is not extractable"""
     # Setup
     source = create_source(NASDataSource)

--- a/connectors/sources/tests/test_oracle.py
+++ b/connectors/sources/tests/test_oracle.py
@@ -49,7 +49,7 @@ async def test_create_engine_in_thin_mode(mock_fun):
 
 
 @pytest.mark.asyncio
-async def test_get_docs_oracle(patch_logger):
+async def test_get_docs_oracle():
     # Setup
     source = create_source(OracleDataSource)
 

--- a/connectors/sources/tests/test_postgresql.py
+++ b/connectors/sources/tests/test_postgresql.py
@@ -114,7 +114,7 @@ class CursorAsync:
         pass
 
 
-def test_get_connect_argss(patch_logger):
+def test_get_connect_argss():
     """This function test get_connect_args with dummy certificate"""
     # Setup
     source = create_source(PostgreSQLDataSource)
@@ -126,7 +126,7 @@ def test_get_connect_argss(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_docs_postgresql(patch_logger):
+async def test_get_docs_postgresql():
     # Setup
     source = create_source(PostgreSQLDataSource)
     with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -24,7 +24,7 @@ def execute_before_all_tests():
 
 
 @pytest.mark.asyncio
-async def test_basics(patch_logger):
+async def test_basics():
     """Test get_default_configuration method of S3DataSource"""
     with mock.patch(
         "aioboto3.resources.collection.AIOResourceCollection", AIOResourceCollection
@@ -147,7 +147,7 @@ async def create_fake_coroutine(data):
 
 
 @pytest.mark.asyncio
-async def test_ping(patch_logger):
+async def test_ping():
     """Test ping method of S3DataSource class"""
     # Setup
     source = create_source(S3DataSource)
@@ -160,7 +160,7 @@ async def test_ping(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_ping_negative(patch_logger):
+async def test_ping_negative():
     """Test ping method of S3DataSource class with negative case"""
     # Setup
     source = create_source(S3DataSource)
@@ -188,7 +188,7 @@ async def test_get_bucket_region():
 
 
 @pytest.mark.asyncio
-async def test_get_bucket_region_negative(caplog, patch_logger):
+async def test_get_bucket_region_negative(caplog):
     """Test get_bucket_region method of S3DataSource for negative case"""
     # Setup
     source = create_source(S3DataSource)
@@ -203,7 +203,7 @@ async def test_get_bucket_region_negative(caplog, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_content(patch_logger, mock_aws):
+async def test_get_content(mock_aws):
     """Test get_content method of S3DataSource"""
     # Setup
     source = create_source(S3DataSource)
@@ -217,7 +217,7 @@ async def test_get_content(patch_logger, mock_aws):
 
 
 @pytest.mark.asyncio
-async def test_get_content_with_unsupported_file(patch_logger, mock_aws):
+async def test_get_content_with_unsupported_file(mock_aws):
     """Test get_content method of S3DataSource for unsupported file"""
     # Setup
     source = create_source(S3DataSource)
@@ -229,7 +229,7 @@ async def test_get_content_with_unsupported_file(patch_logger, mock_aws):
 
 
 @pytest.mark.asyncio
-async def test_get_content_when_not_doit(patch_logger, mock_aws):
+async def test_get_content_when_not_doit(mock_aws):
     """Test get_content method of S3DataSource when doit is none"""
     # Setup
     source = create_source(S3DataSource)
@@ -241,7 +241,7 @@ async def test_get_content_when_not_doit(patch_logger, mock_aws):
 
 
 @pytest.mark.asyncio
-async def test_get_content_when_size_is_large(patch_logger, mock_aws):
+async def test_get_content_when_size_is_large(mock_aws):
     """Test get_content method of S3DataSource when size is greater than max size"""
     # Setup
     source = create_source(S3DataSource)
@@ -260,7 +260,7 @@ async def test_get_content_when_size_is_large(patch_logger, mock_aws):
 
 
 @pytest.mark.asyncio
-async def test_pdf_file(patch_logger, mock_aws):
+async def test_pdf_file(mock_aws):
     """Test get_content method of S3DataSource for pdf file"""
     # Setup
     source = create_source(S3DataSource)
@@ -283,7 +283,7 @@ async def get_roles(*args):
 
 
 @pytest.mark.asyncio
-async def test_get_docs(patch_logger, mock_aws):
+async def test_get_docs(mock_aws):
     """Test get_docs method of S3DataSource"""
     # Setup
     source = create_source(S3DataSource)

--- a/connectors/sources/tests/test_sharepoint.py
+++ b/connectors/sources/tests/test_sharepoint.py
@@ -83,7 +83,7 @@ async def async_native_coroutine_generator(item):
     yield item
 
 
-def test_get_configuration(patch_logger):
+def test_get_configuration():
     """Tests the get configurations method of the Sharepoint source class."""
     # Setup
     klass = SharepointDataSource
@@ -96,7 +96,7 @@ def test_get_configuration(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_ping_for_successful_connection(patch_logger):
+async def test_ping_for_successful_connection():
     """Tests the ping functionality for ensuring connection to the Sharepoint."""
 
     # Setup
@@ -109,7 +109,7 @@ async def test_ping_for_successful_connection(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_ping_for_failed_connection_exception(patch_logger):
+async def test_ping_for_failed_connection_exception():
     """Tests the ping functionality when connection can not be established to Sharepoint."""
 
     # Setup
@@ -151,7 +151,7 @@ async def test_validate_config_for_ssl_enabled():
 
 
 @pytest.mark.asyncio
-async def test_api_call_for_exception(patch_logger):
+async def test_api_call_for_exception():
     """This function test _api_call when credentials are incorrect"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -164,7 +164,7 @@ async def test_api_call_for_exception(patch_logger):
             await source._api_call(url_name="lists", url="abc")
 
 
-def test_prepare_drive_items_doc(patch_logger):
+def test_prepare_drive_items_doc():
     """Test the prepare drive items method"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -197,7 +197,7 @@ def test_prepare_drive_items_doc(patch_logger):
     assert target_response == expected_response
 
 
-def test_prepare_list_items_doc(patch_logger):
+def test_prepare_list_items_doc():
     """Test the prepare list items method"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -235,7 +235,7 @@ def test_prepare_list_items_doc(patch_logger):
     assert target_response == expected_response
 
 
-def test_prepare_sites_doc(patch_logger):
+def test_prepare_sites_doc():
     """Test the method for preparing sites document"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -267,7 +267,7 @@ def test_prepare_sites_doc(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_sites_when_no_site_available(patch_logger):
+async def test_get_sites_when_no_site_available():
     """Test get sites method with valid details"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -283,7 +283,7 @@ async def test_get_sites_when_no_site_available(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_list_items(patch_logger):
+async def test_get_list_items():
     """Test get list items method with valid details"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -360,7 +360,7 @@ async def test_get_list_items(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_drive_items(patch_logger):
+async def test_get_drive_items():
     """Test get drive items method with valid details"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -433,7 +433,7 @@ async def test_get_drive_items(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_lists_and_items(patch_logger):
+async def test_get_lists_and_items():
     """Test get items method with valid details"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -549,7 +549,7 @@ async def test_get_lists_and_items(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_docs(patch_logger):
+async def test_get_docs():
     """Test get docs method"""
 
     # Setup
@@ -577,7 +577,7 @@ async def test_get_docs(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_docs_when_no_site_available(patch_logger):
+async def test_get_docs_when_no_site_available():
     """Test get docs when site is not available method"""
 
     # Setup
@@ -592,7 +592,7 @@ async def test_get_docs_when_no_site_available(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_content(patch_logger):
+async def test_get_content():
     """Test the get content method"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -629,7 +629,7 @@ async def test_get_content(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_content_when_size_is_bigger(patch_logger):
+async def test_get_content_when_size_is_bigger():
     """Test the get content method when document size is greater than the allowed size limit."""
     # Setup
     document = {
@@ -652,7 +652,7 @@ async def test_get_content_when_size_is_bigger(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_content_when_doit_is_none(patch_logger):
+async def test_get_content_when_doit_is_none():
     """Test the get content method when doit is None"""
     # Setup
     document = {
@@ -672,7 +672,7 @@ async def test_get_content_when_doit_is_none(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_invoke_call_with_list(patch_logger):
+async def test_get_invoke_call_with_list():
     """Test get invoke call when param name is lists"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -707,7 +707,7 @@ async def test_get_invoke_call_with_list(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_get_invoke_call_with_drive_items(patch_logger):
+async def test_get_invoke_call_with_drive_items():
     """Test get invoke call when param name is drive_item"""
     # Setup
     source = create_source(SharepointDataSource)
@@ -749,7 +749,7 @@ class ClientSession:
 
 
 @pytest.mark.asyncio
-async def test_close_with_client_session(patch_logger):
+async def test_close_with_client_session():
     """Test close method of SharepointDataSource with client session"""
 
     # Setup
@@ -761,7 +761,7 @@ async def test_close_with_client_session(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_close_without_client_session(patch_logger):
+async def test_close_without_client_session():
     """Test close method of SharepointDataSource without client session"""
 
     # Setup

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -500,7 +500,7 @@ async def test_sync_done(job, expected_doc_source_update):
 )
 @patch("connectors.byoc.next_run")
 async def test_connector_next_sync(
-    next_run, sync_now, scheduling_enabled, expected_next_sync, patch_logger
+    next_run, sync_now, scheduling_enabled, expected_next_sync
 ):
     connector_doc = {
         "_id": "1",
@@ -593,7 +593,7 @@ async def test_sync_job_validate_filtering(
 
 
 @pytest.mark.asyncio
-async def test_sync_job_claim(patch_logger):
+async def test_sync_job_claim():
     source = {"_id": "1"}
     index = Mock()
     index.update = AsyncMock(return_value=1)
@@ -611,7 +611,7 @@ async def test_sync_job_claim(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_job_update_metadata(patch_logger):
+async def test_sync_job_update_metadata():
     source = {"_id": "1"}
     index = Mock()
     index.update = AsyncMock(return_value=1)
@@ -639,7 +639,7 @@ async def test_sync_job_update_metadata(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_job_done(patch_logger):
+async def test_sync_job_done():
     source = {"_id": "1"}
     index = Mock()
     index.update = AsyncMock(return_value=1)
@@ -657,7 +657,7 @@ async def test_sync_job_done(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_job_fail(patch_logger):
+async def test_sync_job_fail():
     source = {"_id": "1"}
     message = "something wrong"
     index = Mock()
@@ -676,7 +676,7 @@ async def test_sync_job_fail(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_job_cancel(patch_logger):
+async def test_sync_job_cancel():
     source = {"_id": "1"}
     index = Mock()
     index.update = AsyncMock(return_value=1)
@@ -695,7 +695,7 @@ async def test_sync_job_cancel(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_job_suspend(patch_logger):
+async def test_sync_job_suspend():
     source = {"_id": "1"}
     index = Mock()
     index.update = AsyncMock(return_value=1)
@@ -769,7 +769,7 @@ async def test_prepare(mock_responses):
 
 
 @pytest.mark.asyncio
-async def test_connector_validate_filtering_not_edited(patch_logger):
+async def test_connector_validate_filtering_not_edited():
     index = Mock()
     index.update = AsyncMock()
     validator = Mock()
@@ -783,7 +783,7 @@ async def test_connector_validate_filtering_not_edited(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_connector_validate_filtering_invalid(patch_logger):
+async def test_connector_validate_filtering_invalid():
     index = Mock()
     index.update = AsyncMock()
     index.fetch_response_by_id = AsyncMock()
@@ -818,7 +818,7 @@ async def test_connector_validate_filtering_invalid(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_connector_validate_filtering_valid(patch_logger):
+async def test_connector_validate_filtering_valid():
     index = Mock()
     index.update = AsyncMock()
     index.fetch_response_by_id = AsyncMock()
@@ -1162,9 +1162,7 @@ def test_nested_get(nested_dict, keys, default, expected):
     ],
 )
 @patch("connectors.byoc.SyncJobIndex.index")
-async def test_create_job(
-    index_method, sync_now, trigger_method, patch_logger, set_env
-):
+async def test_create_job(index_method, sync_now, trigger_method, set_env):
     connector = Mock()
     connector.id = "id"
     connector.index_name = "index_name"
@@ -1190,7 +1188,7 @@ async def test_create_job(
 
 @pytest.mark.asyncio
 @patch("connectors.byoc.SyncJobIndex.get_all_docs")
-async def test_pending_jobs(get_all_docs, patch_logger, set_env):
+async def test_pending_jobs(get_all_docs, set_env):
     job = Mock()
     get_all_docs.return_value = AsyncIterator([job])
     config = load_config(CONFIG)
@@ -1223,7 +1221,7 @@ async def test_pending_jobs(get_all_docs, patch_logger, set_env):
 
 @pytest.mark.asyncio
 @patch("connectors.byoc.SyncJobIndex.get_all_docs")
-async def test_orphaned_jobs(get_all_docs, patch_logger, set_env):
+async def test_orphaned_jobs(get_all_docs, set_env):
     job = Mock()
     get_all_docs.return_value = AsyncIterator([job])
     config = load_config(CONFIG)
@@ -1242,7 +1240,7 @@ async def test_orphaned_jobs(get_all_docs, patch_logger, set_env):
 
 @pytest.mark.asyncio
 @patch("connectors.byoc.SyncJobIndex.get_all_docs")
-async def test_idle_jobs(get_all_docs, patch_logger, set_env):
+async def test_idle_jobs(get_all_docs, set_env):
     job = Mock()
     get_all_docs.return_value = AsyncIterator([job])
     config = load_config(CONFIG)

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -202,7 +202,7 @@ async def test_get_existing_ids(mock_responses):
 
 
 @pytest.mark.asyncio
-async def test_async_bulk(mock_responses, patch_logger):
+async def test_async_bulk(mock_responses):
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     set_responses(mock_responses)
 

--- a/connectors/tests/test_cli.py
+++ b/connectors/tests/test_cli.py
@@ -25,7 +25,7 @@ def test_main(catch_stdout):
     assert catch_stdout.read().strip() == __version__
 
 
-def test_main_and_kill(patch_logger, mock_responses):
+def test_main_and_kill(mock_responses):
     headers = {"X-Elastic-Product": "Elasticsearch"}
     host = "http://localhost:9200"
 
@@ -47,7 +47,7 @@ def test_main_and_kill(patch_logger, mock_responses):
     main([])
 
 
-def test_run(mock_responses, patch_logger, set_env):
+def test_run(mock_responses, set_env):
     args = mock.MagicMock()
     args.log_level = "DEBUG"
     args.config_file = CONFIG
@@ -63,7 +63,7 @@ def test_run(mock_responses, patch_logger, set_env):
         assert "Bye" in output
 
 
-def test_run_snowflake(mock_responses, patch_logger, set_env):
+def test_run_snowflake(mock_responses, set_env):
     args = mock.MagicMock()
     args.log_level = "DEBUG"
     args.config_file = CONFIG
@@ -76,7 +76,7 @@ def test_run_snowflake(mock_responses, patch_logger, set_env):
 
 @patch("connectors.cli.set_logger")
 @patch("connectors.cli.load_config", side_effect=Exception("something went wrong"))
-def test_main_with_invalid_configuration(load_config, set_logger, patch_logger):
+def test_main_with_invalid_configuration(load_config, set_logger):
     args = mock.MagicMock()
     args.log_level = logging.DEBUG  # should be ignored!
     args.filebeat = True

--- a/connectors/tests/test_es_client.py
+++ b/connectors/tests/test_es_client.py
@@ -82,7 +82,7 @@ async def test_es_client_auth_error(mock_responses, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_es_client_no_server(patch_logger):
+async def test_es_client_no_server():
     # if we can't reach the server, we need to catch it cleanly
     config = {
         "username": "elastic",

--- a/connectors/tests/test_es_document.py
+++ b/connectors/tests/test_es_document.py
@@ -20,12 +20,12 @@ from connectors.es import ESDocument, InvalidDocumentSourceError
         {"_id": "1", "_source": "hahaha"},
     ],
 )
-def test_es_document_raise(doc_source, patch_logger):
+def test_es_document_raise(doc_source):
     with pytest.raises(InvalidDocumentSourceError):
         ESDocument(elastic_index=None, doc_source=doc_source)
 
 
-def test_es_document_ok(patch_logger):
+def test_es_document_ok():
     doc_source = {"_id": "1", "_source": {}}
     es_document = ESDocument(elastic_index=None, doc_source=doc_source)
     assert isinstance(es_document, ESDocument)

--- a/connectors/tests/test_es_index.py
+++ b/connectors/tests/test_es_index.py
@@ -18,7 +18,7 @@ index_name = "fake_index"
 
 
 @pytest.mark.asyncio
-async def test_es_index_create_object_error(mock_responses, patch_logger):
+async def test_es_index_create_object_error(mock_responses):
     index = ESIndex(index_name, config)
     mock_responses.post(
         f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200

--- a/connectors/tests/test_job_cleanup.py
+++ b/connectors/tests/test_job_cleanup.py
@@ -73,7 +73,6 @@ async def test_cleanup_jobs(
     idle_jobs,
     delete_indices,
     delete_jobs,
-    patch_logger,
 ):
     existing_index_name = "foo"
     to_be_deleted_index_name = "bar"

--- a/connectors/tests/test_job_scheduling.py
+++ b/connectors/tests/test_job_scheduling.py
@@ -142,9 +142,7 @@ def mock_connector(
 
 
 @pytest.mark.asyncio
-async def test_no_connector(
-    connector_index_mock, concurrent_tasks_mock, patch_logger, set_env
-):
+async def test_no_connector(connector_index_mock, concurrent_tasks_mock, set_env):
     connector_index_mock.supported_connectors.return_value = AsyncIterator([])
     await create_and_run_service()
 
@@ -156,7 +154,6 @@ async def test_connector_sync_now(
     connector_index_mock,
     concurrent_tasks_mock,
     sync_job_runner_mock,
-    patch_logger,
     set_env,
 ):
     connector = mock_connector(sync_now=True, next_sync=0)
@@ -174,7 +171,6 @@ async def test_connector_with_suspended_job(
     connector_index_mock,
     concurrent_tasks_mock,
     sync_job_runner_mock,
-    patch_logger,
     set_env,
 ):
     connector = mock_connector(next_sync=100, last_sync_status=JobStatus.SUSPENDED)
@@ -192,7 +188,6 @@ async def test_connector_ready_to_sync(
     connector_index_mock,
     concurrent_tasks_mock,
     sync_job_runner_mock,
-    patch_logger,
     set_env,
 ):
     connector = mock_connector(next_sync=0.01)
@@ -207,7 +202,7 @@ async def test_connector_ready_to_sync(
 
 @pytest.mark.asyncio
 async def test_connector_sync_disabled(
-    connector_index_mock, concurrent_tasks_mock, patch_logger, set_env
+    connector_index_mock, concurrent_tasks_mock, set_env
 ):
     connector = mock_connector()
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
@@ -228,7 +223,6 @@ async def test_connector_not_configured(
     connector_status,
     connector_index_mock,
     concurrent_tasks_mock,
-    patch_logger,
     set_env,
 ):
     connector = mock_connector(status=connector_status)
@@ -255,7 +249,6 @@ async def test_connector_prepare_failed(
     prepare_exception,
     connector_index_mock,
     concurrent_tasks_mock,
-    patch_logger,
     set_env,
 ):
     connector = mock_connector(prepare_exception=prepare_exception())

--- a/connectors/tests/test_sync_job_runner.py
+++ b/connectors/tests/test_sync_job_runner.py
@@ -109,7 +109,7 @@ def create_runner_yielding_docs(docs=None):
 
 
 @pytest.mark.asyncio
-async def test_job_claim_fail(patch_logger):
+async def test_job_claim_fail():
     sync_job_runner = create_runner()
     sync_job_runner.sync_job.claim.side_effect = Exception()
     with pytest.raises(JobClaimError):
@@ -126,7 +126,7 @@ async def test_job_claim_fail(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_connector_starts_fail(patch_logger):
+async def test_connector_starts_fail():
     sync_job_runner = create_runner()
     sync_job_runner.connector.sync_starts.side_effect = Exception()
     with pytest.raises(JobClaimError):
@@ -143,7 +143,7 @@ async def test_connector_starts_fail(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_source_not_changed(patch_logger):
+async def test_source_not_changed():
     sync_job_runner = create_runner(source_changed=False)
     await sync_job_runner.execute()
 
@@ -165,7 +165,7 @@ async def test_source_not_changed(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_source_invalid_config(patch_logger):
+async def test_source_invalid_config():
     sync_job_runner = create_runner(validate_config_exception=Exception())
     await sync_job_runner.execute()
 
@@ -189,7 +189,7 @@ async def test_source_invalid_config(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_source_not_available(patch_logger):
+async def test_source_not_available():
     sync_job_runner = create_runner(source_available=False)
     await sync_job_runner.execute()
 
@@ -213,7 +213,7 @@ async def test_source_not_available(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_invalid_filtering(patch_logger):
+async def test_invalid_filtering():
     sync_job_runner = create_runner()
     sync_job_runner.sync_job.validate_filtering.side_effect = InvalidFilteringError()
     await sync_job_runner.execute()
@@ -238,7 +238,7 @@ async def test_invalid_filtering(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_async_bulk_error(elastic_server_mock, patch_logger):
+async def test_async_bulk_error(elastic_server_mock):
     error = "something wrong"
     ingestion_stats = {
         "indexed_document_count": 0,
@@ -265,7 +265,7 @@ async def test_async_bulk_error(elastic_server_mock, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_job_runner(elastic_server_mock, patch_logger):
+async def test_sync_job_runner(elastic_server_mock):
     ingestion_stats = {
         "indexed_document_count": 25,
         "indexed_document_volume": 30,
@@ -288,7 +288,7 @@ async def test_sync_job_runner(elastic_server_mock, patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_sync_job_runner_suspend(elastic_server_mock, patch_logger):
+async def test_sync_job_runner_suspend(elastic_server_mock):
     ingestion_stats = {
         "indexed_document_count": 25,
         "indexed_document_volume": 30,
@@ -346,7 +346,7 @@ async def test_prepare_docs_when_id_below_limit_then_yield_doc(_id):
 @pytest.mark.asyncio
 @patch("connectors.sync_job_runner.JOB_REPORTING_INTERVAL", 0)
 @patch("connectors.sync_job_runner.JOB_CHECK_INTERVAL", 0)
-async def test_sync_job_runner_reporting_metadata(elastic_server_mock, patch_logger):
+async def test_sync_job_runner_reporting_metadata(elastic_server_mock):
     ingestion_stats = {
         "indexed_document_count": 15,
         "indexed_document_volume": 230,
@@ -377,7 +377,7 @@ async def test_sync_job_runner_reporting_metadata(elastic_server_mock, patch_log
 @pytest.mark.asyncio
 @patch("connectors.sync_job_runner.JOB_REPORTING_INTERVAL", 0)
 @patch("connectors.sync_job_runner.JOB_CHECK_INTERVAL", 0)
-async def test_sync_job_runner_connector_not_found(elastic_server_mock, patch_logger):
+async def test_sync_job_runner_connector_not_found(elastic_server_mock):
     ingestion_stats = {
         "indexed_document_count": 15,
         "indexed_document_volume": 230,
@@ -403,7 +403,7 @@ async def test_sync_job_runner_connector_not_found(elastic_server_mock, patch_lo
 @pytest.mark.asyncio
 @patch("connectors.sync_job_runner.JOB_REPORTING_INTERVAL", 0)
 @patch("connectors.sync_job_runner.JOB_CHECK_INTERVAL", 0)
-async def test_sync_job_runner_sync_job_not_found(elastic_server_mock, patch_logger):
+async def test_sync_job_runner_sync_job_not_found(elastic_server_mock):
     ingestion_stats = {
         "indexed_document_count": 15,
         "indexed_document_volume": 230,
@@ -423,7 +423,7 @@ async def test_sync_job_runner_sync_job_not_found(elastic_server_mock, patch_log
 @pytest.mark.asyncio
 @patch("connectors.sync_job_runner.JOB_REPORTING_INTERVAL", 0)
 @patch("connectors.sync_job_runner.JOB_CHECK_INTERVAL", 0)
-async def test_sync_job_runner_canceled(elastic_server_mock, patch_logger):
+async def test_sync_job_runner_canceled(elastic_server_mock):
     ingestion_stats = {
         "indexed_document_count": 15,
         "indexed_document_volume": 230,
@@ -454,7 +454,7 @@ async def test_sync_job_runner_canceled(elastic_server_mock, patch_logger):
 @pytest.mark.asyncio
 @patch("connectors.sync_job_runner.JOB_REPORTING_INTERVAL", 0)
 @patch("connectors.sync_job_runner.JOB_CHECK_INTERVAL", 0)
-async def test_sync_job_runner_not_running(elastic_server_mock, patch_logger):
+async def test_sync_job_runner_not_running(elastic_server_mock):
     ingestion_stats = {
         "indexed_document_count": 15,
         "indexed_document_volume": 230,

--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -66,7 +66,7 @@ def test_invalid_names():
             validate_index_name(name)
 
 
-def test_mem_queue_speed(patch_logger):
+def test_mem_queue_speed():
     def mem_queue():
         import asyncio
 
@@ -103,7 +103,7 @@ def test_mem_queue_speed(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_mem_queue_race(patch_logger):
+async def test_mem_queue_race():
     item = "small stuff"
     queue = MemQueue(
         maxmemsize=get_size(item) * 2 + 1, refresh_interval=0.01, refresh_timeout=1
@@ -134,7 +134,7 @@ async def test_mem_queue_race(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_mem_queue(patch_logger):
+async def test_mem_queue():
     queue = MemQueue(maxmemsize=1024, refresh_interval=0, refresh_timeout=0.1)
     await queue.put("small stuff")
 
@@ -168,7 +168,7 @@ async def test_mem_queue(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_mem_queue_too_large_item(patch_logger):
+async def test_mem_queue_too_large_item():
     queue = MemQueue(maxmemsize=10, refresh_interval=0, refresh_timeout=1)
 
     with pytest.raises(asyncio.QueueFull) as e:
@@ -184,7 +184,7 @@ def test_get_base64_value():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner(patch_logger):
+async def test_concurrent_runner():
     results = []
 
     def _results_callback(result):
@@ -203,7 +203,7 @@ async def test_concurrent_runner(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner_fails(patch_logger):
+async def test_concurrent_runner_fails():
     results = []
 
     def _results_callback(result):
@@ -226,7 +226,7 @@ async def test_concurrent_runner_fails(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner_high_concurrency(patch_logger):
+async def test_concurrent_runner_high_concurrency():
     results = []
 
     def _results_callback(result):


### PR DESCRIPTION
`patch_logger` is supposed to assert some messages were logged, but it's mainly used to silent logs.

This PR removes incorrect use of `patch_logger`.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)