### PR TITLE
Pass trigger_method explicitly to SyncJobIndex create method

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -647,12 +647,7 @@ class SyncJobIndex(ESIndex):
             doc_source=doc_source,
         )
 
-    async def create(self, connector):
-        trigger_method = (
-            JobTriggerMethod.ON_DEMAND
-            if connector.sync_now
-            else JobTriggerMethod.SCHEDULED
-        )
+    async def create(self, connector, trigger_method):
         filtering = connector.filtering.get_active_filter().transform_filtering()
         job_def = {
             "connector": {
@@ -669,7 +664,7 @@ class SyncJobIndex(ESIndex):
             "created_at": iso_utc(),
             "last_seen": iso_utc(),
         }
-        return await self.index(job_def)
+        await self.index(job_def)
 
     async def pending_jobs(self, connector_ids):
         query = {

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -65,11 +65,10 @@ class ESIndex(ESClient):
         return resp.body
 
     async def index(self, doc):
-        resp = await self.client.index(index=self.index_name, document=doc)
-        return resp["_id"]
+        return await self.client.index(index=self.index_name, document=doc)
 
     async def update(self, doc_id, doc, if_seq_no=None, if_primary_term=None):
-        await self.client.update(
+        return await self.client.update(
             index=self.index_name,
             id=doc_id,
             doc=doc,

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -15,6 +15,7 @@ from connectors.byoc import (
     ConnectorIndex,
     ConnectorUpdateError,
     DataSourceError,
+    JobTriggerMethod,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
     Status,
@@ -96,7 +97,14 @@ class JobSchedulingService(BaseService):
         if not await self._should_sync(connector):
             return
 
-        await self.sync_job_index.create(connector)
+        trigger_method = (
+            JobTriggerMethod.ON_DEMAND
+            if connector.sync_now
+            else JobTriggerMethod.SCHEDULED
+        )
+        await self.sync_job_index.create(
+            connector=connector, trigger_method=trigger_method
+        )
         if connector.sync_now:
             await connector.reset_sync_now_flag()
 

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -1155,20 +1155,19 @@ def test_nested_get(nested_dict, keys, default, expected):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "sync_now, trigger_method",
+    "trigger_method",
     [
-        (True, JobTriggerMethod.ON_DEMAND),
-        (False, JobTriggerMethod.SCHEDULED),
+        JobTriggerMethod.ON_DEMAND,
+        JobTriggerMethod.SCHEDULED,
     ],
 )
 @patch("connectors.byoc.SyncJobIndex.index")
-async def test_create_job(index_method, sync_now, trigger_method, set_env):
+async def test_create_job(index_method, trigger_method, set_env):
     connector = Mock()
     connector.id = "id"
     connector.index_name = "index_name"
     connector.language = "en"
     config = load_config(CONFIG)
-    connector.sync_now = sync_now
     connector.filtering.get_active_filter.transform_filtering.return_value = Filter()
     connector.pipeline = Pipeline({})
 
@@ -1181,7 +1180,7 @@ async def test_create_job(index_method, sync_now, trigger_method, set_env):
     }
 
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
-    await sync_job_index.create(connector=connector)
+    await sync_job_index.create(connector=connector, trigger_method=trigger_method)
 
     index_method.assert_called_with(expected_index_doc)
 

--- a/connectors/tests/test_es_index.py
+++ b/connectors/tests/test_es_index.py
@@ -144,8 +144,8 @@ async def test_index(mock_responses):
         payload={"_id": doc_id},
     )
 
-    indexed_id = await index.index({})
-    assert indexed_id == doc_id
+    resp = await index.index({})
+    assert resp["_id"] == doc_id
 
     await index.close()
 

--- a/connectors/tests/test_job_scheduling.py
+++ b/connectors/tests/test_job_scheduling.py
@@ -13,6 +13,7 @@ from connectors.byoc import (
     SYNC_DISABLED,
     ConnectorUpdateError,
     DataSourceError,
+    JobTriggerMethod,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
     Status,
@@ -132,7 +133,9 @@ async def test_connector_sync_now(
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
     connector.reset_sync_now_flag.assert_awaited()
-    sync_job_index_mock.create.assert_awaited_once_with(connector)
+    sync_job_index_mock.create.assert_awaited_once_with(
+        connector=connector, trigger_method=JobTriggerMethod.ON_DEMAND
+    )
 
 
 @pytest.mark.asyncio
@@ -148,7 +151,9 @@ async def test_connector_ready_to_sync(
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited
     connector.reset_sync_now_flag.assert_not_awaited()
-    sync_job_index_mock.create.assert_awaited_once_with(connector)
+    sync_job_index_mock.create.assert_awaited_once_with(
+        connector=connector, trigger_method=JobTriggerMethod.SCHEDULED
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4158

This PR passes `trigger_method` to the `create` method of `SyncJobIndex` explicitly, instead of relying on `connector.sync_now`. Because in the following PRs, `connector.sync_now` will be reset first.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)