### PR TITLE
Speed up CI by not sleeping if PERF8 is not enabled

### DIFF
--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -59,7 +59,9 @@ fi
 $PYTHON fixture.py --name $NAME --action monitor --pid $PID
 
 # breathe for 2 minutes
-sleep 120
+if [[ $PERF8 == "yes" ]]; then
+    sleep 120
+fi
 
 $PYTHON fixture.py --name $NAME --action remove
 $PYTHON fixture.py --name $NAME --action sync


### PR DESCRIPTION
There was a change recently so that Nightly builds were able to produce PERF8 artifacts: https://github.com/elastic/connectors-python/pull/682

This change also increased the run time of our regular CI. This change makes it so that our CI run time would not be affected by the change mentioned simply by putting the added `sleep 120` statement to be executed only if performance is actually measured with PERF8.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)