### PR TITLE
[MySQL] Add "get_column_names" method to MySQLClient

### DIFF
--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -220,7 +220,7 @@ async def test_close_when_source_setup_correctly_does_not_raise_errors():
 
 
 @pytest.mark.asyncio
-async def test_client_get_column_names():
+async def test_client_get_column_names(patch_connection_pool):
     column_1 = "column_1"
     column_2 = "column_2"
 
@@ -237,20 +237,15 @@ async def test_client_get_column_names():
     mock_connection.cursor.return_value = mock_cursor
     mock_connection.__aenter__.return_value = mock_connection
 
-    mock_connection_pool = MagicMock(spec=aiomysql.Pool)
-    mock_connection_pool.acquire.return_value = mock_connection
-    mock_connection_pool.__aenter__.return_value = mock_connection_pool
+    patch_connection_pool.acquire.return_value = mock_connection
 
-    with patch.object(
-        MySQLClient, "with_connection_pool", return_value=mock_connection_pool
-    ):
-        client = await setup_mysql_client()
-        table = "table"
+    client = await setup_mysql_client()
+    table = "table"
 
-        result = await client.get_column_names(table)
-        expected_result = [f"{table}_{column_1}", f"{table}_{column_2}"]
+    result = await client.get_column_names(table)
+    expected_result = [f"{table}_{column_1}", f"{table}_{column_2}"]
 
-        assert result == expected_result
+    assert result == expected_result
 
 
 @pytest.mark.asyncio

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -220,6 +220,40 @@ async def test_close_when_source_setup_correctly_does_not_raise_errors():
 
 
 @pytest.mark.asyncio
+async def test_client_get_column_names():
+    column_1 = "column_1"
+    column_2 = "column_2"
+
+    description = [
+        ("column_1",),
+        ("column_2",),
+    ]
+
+    mock_cursor = MagicMock(spec=aiomysql.Cursor)
+    mock_cursor.description = description
+    mock_cursor.__aenter__.return_value = mock_cursor
+
+    mock_connection = MagicMock(spec=aiomysql.Connection)
+    mock_connection.cursor.return_value = mock_cursor
+    mock_connection.__aenter__.return_value = mock_connection
+
+    mock_connection_pool = MagicMock(spec=aiomysql.Pool)
+    mock_connection_pool.acquire.return_value = mock_connection
+    mock_connection_pool.__aenter__.return_value = mock_connection_pool
+
+    with patch.object(
+        MySQLClient, "with_connection_pool", return_value=mock_connection_pool
+    ):
+        client = await setup_mysql_client()
+        table = "table"
+
+        result = await client.get_column_names(table)
+        expected_result = [f"{table}_{column_1}", f"{table}_{column_2}"]
+
+        assert result == expected_result
+
+
+@pytest.mark.asyncio
 async def test_client_ping(patch_logger, patch_connection_pool):
     client = await setup_mysql_client()
 

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -224,13 +224,13 @@ async def test_client_get_column_names(patch_connection_pool):
     column_1 = "column_1"
     column_2 = "column_2"
 
-    description = [
-        ("column_1",),
-        ("column_2",),
+    description_response = [
+        (column_1,),
+        (column_2,),
     ]
 
     mock_cursor = MagicMock(spec=aiomysql.Cursor)
-    mock_cursor.description = description
+    mock_cursor.description = description_response
     mock_cursor.__aenter__.return_value = mock_cursor
 
     mock_connection = MagicMock(spec=aiomysql.Connection)


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4266

Note: changes with regards to the `connection_pool` will be made, if all new high-level methods are implemented, so this change can be achieved in a separate PR in a consistent way.

This method will replace the implicit `yield_once` flag in `_connect`, which returns the column names of a table in follow-up PRs. It'll also serve as the base method for fetching the primary key columns of a table as you can simply provide another `query` for `get_column_names` to narrow the result set.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~