### PR TITLE
[MySQL] Add "get_all_table_names" to "MySQLClient"

### DIFF
--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -231,16 +231,19 @@ async def test_client_get_tables(patch_connection_pool):
 
     mock_cursor = MagicMock(spec=aiomysql.Cursor)
     mock_cursor.fetchall = AsyncMock(return_value=fetchall_tables_response)
-    
+    mock_cursor.__aenter__.return_value = mock_cursor
+
     mock_connection = MagicMock(spec=aiomysql.Connection)
     mock_connection.cursor.return_value = mock_cursor
     mock_connection.__aenter__.return_value = mock_connection
 
     patch_connection_pool.acquire.return_value = mock_connection
-    
+
+    client = await setup_mysql_client()
+
     result = await client.get_all_table_names()
     expected_result = [table_1, table_2]
-    
+
     assert result == expected_result
 
 

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -220,6 +220,34 @@ async def test_close_when_source_setup_correctly_does_not_raise_errors():
 
 
 @pytest.mark.asyncio
+async def test_client_get_tables(patch_connection_pool):
+    table_1 = "table_1"
+    table_2 = "table_2"
+
+    fetchall_tables_response = [
+        (table_1,),
+        (table_2,),
+    ]
+
+    mock_cursor = MagicMock(spec=aiomysql.Cursor)
+    mock_cursor.fetchall = AsyncMock(return_value=fetchall_tables_response)
+    mock_cursor.__aenter__.return_value = mock_cursor
+
+    mock_connection = MagicMock(spec=aiomysql.Connection)
+    mock_connection.cursor.return_value = mock_cursor
+    mock_connection.__aenter__.return_value = mock_connection
+
+    patch_connection_pool.acquire.return_value = mock_connection
+
+    client = await setup_mysql_client()
+
+    result = await client.get_all_table_names()
+    expected_result = [table_1, table_2]
+
+    assert result == expected_result
+
+
+@pytest.mark.asyncio
 async def test_client_ping(patch_logger, patch_connection_pool):
     client = await setup_mysql_client()
 


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4266


Note: changes with regards to the connection_pool will be made, if all new high-level methods are implemented, so this change can be achieved in a separate PR in a consistent way.

This method will replace the `fetch_all_tables` method in a follow-up PR.


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x]  Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~
