### PR TITLE
Increase timeout for test_mem_queue

### DIFF
--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -135,7 +135,7 @@ async def test_mem_queue_race():
 
 @pytest.mark.asyncio
 async def test_mem_queue():
-    queue = MemQueue(maxmemsize=1024, refresh_interval=0, refresh_timeout=0.1)
+    queue = MemQueue(maxmemsize=1024, refresh_interval=0, refresh_timeout=0.15)
     await queue.put("small stuff")
 
     assert not queue.full()


### PR DESCRIPTION
There's a problem that `test_mem_queue` fails often with a message:

```
E                   asyncio.queues.QueueFull: MemQueue has been full for 0.1005s. while timeout is 0.1s.

connectors/utils.py:266: QueueFull
```

I'm increasing timeout for now to make CI fail less often, but we really need to look into it.