### PR TITLE
[8.7] Sleep for 2 minutes only if PERF8 is yes (#723)

### DIFF
--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -59,7 +59,9 @@ fi
 $PYTHON fixture.py --name $NAME --action monitor --pid $PID
 
 # breathe for 2 minutes
-sleep 120
+if [[ $PERF8 == "yes" ]]; then
+    sleep 120
+fi
 
 $PYTHON fixture.py --name $NAME --action remove
 $PYTHON fixture.py --name $NAME --action sync


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Sleep for 2 minutes only if PERF8 is yes (#723)](https://github.com/elastic/connectors-python/pull/723)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)