### PR TITLE
Add update_last_sync_scheduled_at method

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -503,6 +503,20 @@ class Connector(ESDocument):
         resp = await self.index.update_by_script(doc_id=self.id, script=script)
         return resp["result"] == "updated"
 
+    async def update_last_sync_scheduled_at(self, new_ts):
+        """Update last_sync_scheduled_at with update_by_script, and return True only if last_sync_scheduled_at is
+        updated."""
+        script = {
+            "lang": "painless",
+            "source": "if (ctx._source.last_sync_scheduled_at == params['old_ts']) { ctx._source.last_sync_scheduled_at = params['new_ts'] } else { ctx.op = 'noop' }",
+            "params": {
+                "old_ts": self.last_sync_scheduled_at,
+                "new_ts": new_ts,
+            },
+        }
+        resp = await self.index.update_by_script(doc_id=self.id, script=script)
+        return resp["result"] == "updated"
+
     async def sync_starts(self):
         doc = {
             "last_sync_status": JobStatus.IN_PROGRESS.value,

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -498,6 +498,7 @@ class Connector(ESDocument):
 
         script = {
             "lang": "painless",
+            # only reset sync_now flag if it's set, otherwise set op to 'noop' (the returned 'result' will be 'noop')
             "source": "if (ctx._source.sync_now) { ctx._source.sync_now = false } else { ctx.op = 'noop' }",
         }
         resp = await self.index.update_by_script(doc_id=self.id, script=script)
@@ -508,6 +509,7 @@ class Connector(ESDocument):
         updated."""
         script = {
             "lang": "painless",
+            # only update last_sync_scheduled_at to new_ts if it's not updated by other instances, otherwise set op to 'noop' (the returned 'result' will be 'noop')
             "source": "if (ctx._source.last_sync_scheduled_at == params['old_ts']) { ctx._source.last_sync_scheduled_at = params['new_ts'] } else { ctx.op = 'noop' }",
             "params": {
                 "old_ts": self.last_sync_scheduled_at,

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -774,11 +774,56 @@ async def test_prepare(mock_responses):
     [(False, None, False), (True, "updated", True), (True, "noop", False)],
 )
 async def test_connector_reset_sync_now_flag(sync_now, updated, expected_result):
-    connector_doc = {"_id": "1", "_source": {"sync_now": sync_now}}
+    doc_id = "1"
+    connector_doc = {"_id": doc_id, "_source": {"sync_now": sync_now}}
+    expected_script = {
+        "lang": "painless",
+        "source": "if (ctx._source.sync_now) { ctx._source.sync_now = false } else { ctx.op = 'noop' }",
+    }
     index = Mock()
     index.update_by_script = AsyncMock(return_value={"result": updated})
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    assert await connector.reset_sync_now_flag() == expected_result
+    result = await connector.reset_sync_now_flag()
+
+    if updated is None:
+        index.update_by_script.assert_not_awaited()
+    else:
+        index.update_by_script.assert_awaited_once_with(
+            doc_id=doc_id, script=expected_script
+        )
+    assert result == expected_result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "updated, expected_result",
+    [("updated", True), ("noop", False)],
+)
+async def test_connector_update_last_sync_scheduled_at(updated, expected_result):
+    doc_id = "1"
+    old_ts = datetime.utcnow()
+    new_ts = datetime.utcnow() + timedelta(seconds=20)
+    connector_doc = {
+        "_id": doc_id,
+        "_source": {"last_sync_scheduled_at": old_ts.isoformat()},
+    }
+    expected_script = {
+        "lang": "painless",
+        "source": "if (ctx._source.last_sync_scheduled_at == params['old_ts']) { ctx._source.last_sync_scheduled_at = params['new_ts'] } else { ctx.op = 'noop' }",
+        "params": {
+            "old_ts": old_ts,
+            "new_ts": new_ts,
+        },
+    }
+    index = Mock()
+    index.update_by_script = AsyncMock(return_value={"result": updated})
+    connector = Connector(elastic_index=index, doc_source=connector_doc)
+    result = await connector.update_last_sync_scheduled_at(new_ts)
+
+    index.update_by_script.assert_awaited_once_with(
+        doc_id=doc_id, script=expected_script
+    )
+    assert result == expected_result
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -784,7 +784,7 @@ async def test_connector_reset_sync_now_flag(sync_now, updated, expected_result)
 @pytest.mark.asyncio
 async def test_connector_update_last_sync_scheduled_at():
     doc_id = "1"
-    seq_no = (1,)
+    seq_no = 1
     primary_term = 2
     new_ts = datetime.utcnow() + timedelta(seconds=20)
     connector_doc = {

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -774,24 +774,11 @@ async def test_prepare(mock_responses):
     [(False, None, False), (True, "updated", True), (True, "noop", False)],
 )
 async def test_connector_reset_sync_now_flag(sync_now, updated, expected_result):
-    doc_id = "1"
-    connector_doc = {"_id": doc_id, "_source": {"sync_now": sync_now}}
-    expected_script = {
-        "lang": "painless",
-        "source": "if (ctx._source.sync_now) { ctx._source.sync_now = false } else { ctx.op = 'noop' }",
-    }
+    connector_doc = {"_id": "1", "_source": {"sync_now": sync_now}}
     index = Mock()
     index.update_by_script = AsyncMock(return_value={"result": updated})
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    result = await connector.reset_sync_now_flag()
-
-    if updated is None:
-        index.update_by_script.assert_not_awaited()
-    else:
-        index.update_by_script.assert_awaited_once_with(
-            doc_id=doc_id, script=expected_script
-        )
-    assert result == expected_result
+    assert await connector.reset_sync_now_flag() == expected_result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4158

This PR adds the method `update_last_sync_scheduled_at` to the `Connector` class and this method will work in multi-instances environment, and will make sure only one instance can update `last_sync_scheduled_at` successfully.

The new method will be used in the subsequent PRs.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)