### PR TITLE
Move validations from connector to framework

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -227,7 +227,7 @@ class DataSourceConfiguration:
                 return (
                     value is None
                     or len(value) <= 0
-                    or "".join(str(x or "") for x in value) == ""
+                    or all([x in (None, "") for x in value])
                 )
             case _:
                 # int and bool

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -223,7 +223,12 @@ class DataSourceConfiguration:
             case "str":
                 return value is None or value == ""
             case "list":
-                return value is None or len(value) <= 0
+                # also check if list contains only empty strings or None values
+                return (
+                    value is None
+                    or len(value) <= 0
+                    or "".join(str(x or "") for x in value) == ""
+                )
             case _:
                 # int and bool
                 return value is None

--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -103,7 +103,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
                 "type": "int",
                 "ui_restrictions": ["advanced"],
                 "validations": [
-                    {"type": "less_than", "constraint": MAX_CONCURRENT_DOWNLOADS}
+                    {"type": "less_than", "constraint": MAX_CONCURRENT_DOWNLOADS + 1}
                 ],
                 "value": MAX_CONCURRENT_DOWNLOADS,
             },

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
 from connectors.logger import logger
-from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.source import BaseDataSource
 from connectors.utils import iso_utc
 
 WILDCARD = "*"
@@ -187,44 +187,6 @@ class GenericBaseDataSource(BaseDataSource):
                 "value": DEFAULT_RETRY_COUNT,
             },
         }
-
-    async def validate_config(self):
-        """Validates the configuration parameters
-
-        Raises:
-            Exception: Configured keys can't be empty
-        """
-        connection_fields = [
-            "host",
-            "port",
-            "username",
-            "password",
-            "database",
-            "tables",
-        ]
-
-        if empty_connection_fields := [
-            field for field in connection_fields if self.configuration[field] == ""
-        ]:
-            raise ConfigurableFieldValueError(
-                f"Configured keys: {empty_connection_fields} can't be empty."
-            )
-
-        if (
-            isinstance(self.configuration["port"], str)
-            and not self.configuration["port"].isnumeric()
-        ):
-            raise ConfigurableFieldValueError("Configured port has to be an integer.")
-
-        if (
-            self.dialect == "Postgresql"
-            and self.configuration["ssl_enabled"]
-            and (
-                self.configuration["ssl_ca"] == ""
-                or self.configuration["ssl_ca"] is None
-            )
-        ):
-            raise ConfigurableFieldValueError("SSL certificate must be configured.")
 
     async def execute_query(self, query, fetch_many=False, **kwargs):
         """Executes a query and yield rows

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -203,16 +203,10 @@ class GoogleCloudStorageDataSource(BaseDataSource):
         """Validates whether user inputs are valid or not for configuration field.
 
         Raises:
-            Exception: The service account json is empty.
             Exception: The format of service account json is invalid.
         """
-        if (
-            self.configuration["service_account_credentials"] == ""
-            or self.configuration["service_account_credentials"] is None
-        ):
-            raise ConfigurableFieldValueError(
-                "Google Cloud service account json can't be empty."
-            )
+        self.configuration.check_valid()
+
         try:
             json.loads(self.configuration["service_account_credentials"])
         except ValueError:

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -20,7 +20,7 @@ from aiofiles.tempfile import NamedTemporaryFile
 from aiohttp.client_exceptions import ServerDisconnectedError
 
 from connectors.logger import logger
-from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.source import BaseDataSource
 from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     CancellableSleeps,
@@ -296,14 +296,17 @@ class JiraDataSource(BaseDataSource):
                 "value": 3,
             },
             "concurrent_downloads": {
-                "default_value": 100,
+                "default_value": MAX_CONCURRENT_DOWNLOADS,
                 "display": "numeric",
                 "label": "Number of concurrent downloads for fetching attachment content",
                 "order": 10,
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": 50,
+                "validations": [
+                    {"type": "less_than", "constraint": MAX_CONCURRENT_DOWNLOADS + 1}
+                ],
+                "value": MAX_CONCURRENT_DOWNLOADS,
             },
         }
 
@@ -314,40 +317,6 @@ class JiraDataSource(BaseDataSource):
             options (dictionary): Config bulker options
         """
         options["concurrent_downloads"] = self.concurrent_downloads
-
-    async def validate_config(self):
-        """Validates whether user input is empty or not for configuration fields
-
-        Raises:
-            Exception: Configured keys can't be empty
-        """
-        logger.info("Validating Jira Configuration")
-        connection_fields = (
-            ["host_url", "service_account_id", "api_token", "projects"]
-            if self.jira_client.is_cloud
-            else ["host_url", "username", "password", "projects"]
-        )
-
-        default_config = self.get_default_configuration()
-
-        if empty_connection_fields := [
-            default_config[field]["label"]
-            for field in connection_fields
-            if self.configuration[field] in ["", [""]]
-        ]:
-            raise ConfigurableFieldValueError(
-                f"Configured keys: {empty_connection_fields} can't be empty."
-            )
-
-        if self.jira_client.ssl_enabled and (
-            self.jira_client.certificate == "" or self.jira_client.certificate is None
-        ):
-            raise ConfigurableFieldValueError("SSL certificate must be configured.")
-
-        if self.concurrent_downloads > MAX_CONCURRENT_DOWNLOADS:
-            raise ConfigurableFieldValueError(
-                f"Configured concurrent downloads can't be set more than {MAX_CONCURRENT_DOWNLOADS}."
-            )
 
     async def close(self):
         """Closes unclosed client session"""

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -196,6 +196,8 @@ class MongoDataSource(BaseDataSource):
         self._dirty = False
 
     async def validate_config(self):
+        self.configuration.check_valid()
+
         client = self.client
         configured_database_name = self.configuration["database"]
         configured_collection_name = self.configuration["collection"]

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -275,6 +275,7 @@ class MySqlDataSource(BaseDataSource):
                 "value": DEFAULT_SSL_ENABLED,
             },
             "ssl_ca": {
+                "depends_on": [{"field": "ssl_enabled", "value": True}],
                 "label": "SSL certificate",
                 "order": 8,
                 "type": "str",
@@ -327,26 +328,7 @@ class MySqlDataSource(BaseDataSource):
         Raises:
             Exception: Configured keys can't be empty
         """
-        connection_fields = ["host", "port", "user", "password", "database", "tables"]
-        empty_connection_fields = []
-        for field in connection_fields:
-            if self.configuration[field] == "":
-                empty_connection_fields.append(field)
-
-        if empty_connection_fields:
-            raise ConfigurableFieldValueError(
-                f"Configured keys: {empty_connection_fields} can't be empty."
-            )
-
-        if (
-            isinstance(self.configuration["port"], str)
-            and not self.configuration["port"].isnumeric()
-        ):
-            raise ConfigurableFieldValueError("Configured port has to be an integer.")
-
-        if self.ssl_enabled and (self.certificate == "" or self.certificate is None):
-            raise ConfigurableFieldValueError("SSL certificate must be configured.")
-
+        self.configuration.check_valid()
         await self._remote_validation()
 
     @retryable(

--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -87,6 +87,7 @@ class PostgreSQLDataSource(GenericBaseDataSource):
                     "value": DEFAULT_SSL_ENABLED,
                 },
                 "ssl_ca": {
+                    "depends_on": [{"field": "ssl_enabled", "value": True}],
                     "label": "SSL certificate",
                     "order": 10,
                     "type": "str",

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -19,7 +19,7 @@ from aiohttp.client_exceptions import ServerTimeoutError
 from botocore.exceptions import ClientError
 
 from connectors.logger import logger, set_extra_logger
-from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.source import BaseDataSource
 from connectors.utils import TIKA_SUPPORTED_FILETYPES, get_base64_value
 
 MAX_CHUNK_SIZE = 1048576
@@ -69,17 +69,6 @@ class S3DataSource(BaseDataSource):
             service_name="s3", config=self.config, endpoint_url=AWS_ENDPOINT, **kwargs
         ) as s3:
             yield s3
-
-    async def validate_config(self):
-        """Validates whether user input is empty or not for configuration fields
-
-        Raises:
-            Exception: Configured keys can't be empty
-        """
-        if self.configuration["buckets"] == [""]:
-            raise ConfigurableFieldValueError(
-                "Configured keys: buckets can't be empty."
-            )
 
     async def ping(self):
         """Verify the connection with AWS"""

--- a/connectors/sources/sharepoint.py
+++ b/connectors/sources/sharepoint.py
@@ -18,7 +18,7 @@ from aiofiles.tempfile import NamedTemporaryFile
 from aiohttp.client_exceptions import ClientResponseError, ServerDisconnectedError
 
 from connectors.logger import logger
-from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.source import BaseDataSource
 from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     CancellableSleeps,
@@ -219,40 +219,6 @@ class SharepointDataSource(BaseDataSource):
                 "value": RETRIES,
             },
         }
-
-    async def validate_config(self):
-        """Validates whether user input is empty or not for configuration fields
-
-        Raises:
-            Exception: Configured keys can't be empty.
-        """
-        logger.info("Validating SharePoint Configuration")
-
-        connection_fields = (
-            [
-                "host_url",
-                "site_collections",
-                "client_id",
-                "secret_id",
-                "tenant",
-                "tenant_id",
-            ]
-            if self.is_cloud
-            else ["host_url", "site_collections", "username", "password"]
-        )
-
-        default_config = self.get_default_configuration()
-
-        if empty_connection_fields := [
-            default_config[field]["label"]
-            for field in connection_fields
-            if self.configuration[field] == ""
-        ]:
-            raise ConfigurableFieldValueError(
-                f"Configured keys: {empty_connection_fields} can't be empty."
-            )
-        if self.ssl_enabled and self.certificate == "":
-            raise ConfigurableFieldValueError("SSL certificate must be configured.")
 
     @retryable(
         retries=RETRIES,

--- a/connectors/sources/tests/test_confluence.py
+++ b/connectors/sources/tests/test_confluence.py
@@ -234,7 +234,6 @@ async def test_validate_configuration_with_invalid_dependency_fields_raises_erro
             # SSL certificate not enabled (empty ssl_ca okay)
             {"ssl_enabled": False, "ssl_ca": ""}
         ),
-        # TODO: add test case with a mocked SSL cert
     ],
 )
 async def test_validate_config_with_valid_dependency_fields_does_not_raise_error(
@@ -242,8 +241,7 @@ async def test_validate_config_with_valid_dependency_fields_does_not_raise_error
 ):
     source = create_source(ConfluenceDataSource, **extras)
 
-    with patch.object(connectors.utils, "ssl_context", return_value=MockSSL()):
-        await source.validate_config()
+    await source.validate_config()
 
 
 @pytest.mark.asyncio
@@ -251,10 +249,12 @@ async def test_validate_config_with_valid_dependency_fields_does_not_raise_error
 async def test_validate_config_when_ssl_enabled_and_ssl_ca_not_empty_does_not_raise_error(
     mock_get,
 ):
-    cert = "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"
-
     with patch.object(ssl, "create_default_context", return_value=MockSSL()):
-        source = create_source(ConfluenceDataSource, ssl_enabled=True, ssl_ca=cert)
+        source = create_source(
+            ConfluenceDataSource,
+            ssl_enabled=True,
+            ssl_ca="-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----",
+        )
         await source.validate_config()
 
 

--- a/connectors/sources/tests/test_confluence.py
+++ b/connectors/sources/tests/test_confluence.py
@@ -237,12 +237,24 @@ async def test_validate_configuration_with_invalid_dependency_fields_raises_erro
         # TODO: add test case with a mocked SSL cert
     ],
 )
-async def test_validate_configuration_with_valid_dependency_fields_does_not_raise_error(
+async def test_validate_config_with_valid_dependency_fields_does_not_raise_error(
     extras,
 ):
     source = create_source(ConfluenceDataSource, **extras)
-    await source.validate_config()
 
+    with patch.object(connectors.utils, "ssl_context", return_value=MockSSL()):
+        await source.validate_config()
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.get")
+async def test_validate_config_when_ssl_enabled_and_ssl_ca_not_empty_does_not_raise_error(mock_get):
+    cert = (
+        "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"
+    )
+
+    with patch.object(ssl, "create_default_context", return_value=MockSSL()):
+        source = create_source(ConfluenceDataSource, ssl_enabled=True, ssl_ca=cert)
+        await source.validate_config()
 
 def test_tweak_bulk_options():
     """Test tweak_bulk_options method of BaseDataSource class"""

--- a/connectors/sources/tests/test_confluence.py
+++ b/connectors/sources/tests/test_confluence.py
@@ -245,16 +245,18 @@ async def test_validate_config_with_valid_dependency_fields_does_not_raise_error
     with patch.object(connectors.utils, "ssl_context", return_value=MockSSL()):
         await source.validate_config()
 
+
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession.get")
-async def test_validate_config_when_ssl_enabled_and_ssl_ca_not_empty_does_not_raise_error(mock_get):
-    cert = (
-        "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"
-    )
+async def test_validate_config_when_ssl_enabled_and_ssl_ca_not_empty_does_not_raise_error(
+    mock_get,
+):
+    cert = "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"
 
     with patch.object(ssl, "create_default_context", return_value=MockSSL()):
         source = create_source(ConfluenceDataSource, ssl_enabled=True, ssl_ca=cert)
         await source.validate_config()
+
 
 def test_tweak_bulk_options():
     """Test tweak_bulk_options method of BaseDataSource class"""

--- a/connectors/sources/tests/test_confluence.py
+++ b/connectors/sources/tests/test_confluence.py
@@ -240,7 +240,6 @@ async def test_validate_configuration_with_invalid_dependency_fields_raises_erro
 async def test_validate_configuration_with_valid_dependency_fields_does_not_raise_error(
     extras,
 ):
-    # Setup
     source = create_source(ConfluenceDataSource, **extras)
     await source.validate_config()
 

--- a/connectors/sources/tests/test_confluence.py
+++ b/connectors/sources/tests/test_confluence.py
@@ -13,8 +13,13 @@ import pytest
 from aiohttp import StreamReader
 from freezegun import freeze_time
 
-from connectors.source import DataSourceConfiguration
-from connectors.sources.confluence import ConfluenceClient, ConfluenceDataSource
+from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
+from connectors.sources.confluence import (
+    CONFLUENCE_CLOUD,
+    CONFLUENCE_SERVER,
+    ConfluenceClient,
+    ConfluenceDataSource,
+)
 from connectors.sources.tests.support import create_source
 from connectors.tests.commons import AsyncIterator
 from connectors.utils import ssl_context
@@ -157,14 +162,87 @@ async def test_validate_configuration_with_invalid_concurrent_downloads():
     """Test validate configuration method of BaseDataSource class with invalid concurrent downloads"""
 
     # Setup
-    source = create_source(ConfluenceDataSource)
-    source.concurrent_downloads = 1000
+    source = create_source(ConfluenceDataSource, concurrent_downloads=1000)
 
     # Execute
-    with pytest.raises(
-        Exception, match="Configured concurrent downloads can't be set more than *"
-    ):
+    with pytest.raises(ConfigurableFieldValueError):
         await source.validate_config()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extras",
+    [
+        (
+            # Confluence Server with blank dependent fields
+            {
+                "data_source": CONFLUENCE_SERVER,
+                "username": "",
+                "password": "",
+                "account_email": "foo@bar.me",
+                "api_token": "foo",
+            }
+        ),
+        (
+            # Confluence Cloud with blank dependent fields
+            {
+                "data_source": CONFLUENCE_CLOUD,
+                "username": "foo",
+                "password": "bar",
+                "account_email": "",
+                "api_token": "",
+            }
+        ),
+    ],
+)
+async def test_validate_configuration_with_invalid_dependency_fields_raises_error(
+    extras,
+):
+    # Setup
+    source = create_source(ConfluenceDataSource, **extras)
+
+    # Execute
+    with pytest.raises(ConfigurableFieldValueError):
+        await source.validate_config()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extras",
+    [
+        (
+            # Confluence Server with blank non-dependent fields
+            {
+                "data_source": CONFLUENCE_SERVER,
+                "username": "foo",
+                "password": "bar",
+                "account_email": "",
+                "api_token": "",
+            }
+        ),
+        (
+            # Confluence Cloud with blank non-dependent fields
+            {
+                "data_source": CONFLUENCE_CLOUD,
+                "username": "",
+                "password": "",
+                "account_email": "foo@bar.me",
+                "api_token": "foobar",
+            }
+        ),
+        (
+            # SSL certificate not enabled (empty ssl_ca okay)
+            {"ssl_enabled": False, "ssl_ca": ""}
+        ),
+        # TODO: add test case with a mocked SSL cert
+    ],
+)
+async def test_validate_configuration_with_valid_dependency_fields_does_not_raise_error(
+    extras,
+):
+    # Setup
+    source = create_source(ConfluenceDataSource, **extras)
+    await source.validate_config()
 
 
 def test_tweak_bulk_options():

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -157,18 +157,6 @@ async def test_validate_config_missing_fields(field):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_port():
-    """Test validate_config method check port"""
-    # Setup
-    source = create_source(GenericBaseDataSource)
-    with pytest.raises(ConfigurableFieldValueError):
-        source.configuration.set_field(name="port", value="abcd")
-
-        # Execute
-        await source.validate_config()
-
-
-@pytest.mark.asyncio
 async def test_validate_config_ssl():
     """Test validate_config method check ssl"""
     # Setup

--- a/connectors/sources/tests/test_google_cloud_storage.py
+++ b/connectors/sources/tests/test_google_cloud_storage.py
@@ -67,7 +67,7 @@ async def test_empty_configuration():
     # Execute
     with pytest.raises(
         ConfigurableFieldValueError,
-        match="Google Cloud service account json can't be empty.",
+        match="Field validation errors: `Service_account_credentials` cannot be empty.",
     ):
         await gcs_object.validate_config()
 

--- a/connectors/sources/tests/test_jira.py
+++ b/connectors/sources/tests/test_jira.py
@@ -279,11 +279,10 @@ async def test_ping_for_failed_connection_exception(client_session_get):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_for_ssl_enabled():
+async def test_validate_config_for_ssl_enabled_when_ssl_ca_empty_raises_error():
     """This function test _validate_configuration when certification is empty when ssl is enabled"""
     # Setup
-    source = create_source(JiraDataSource)
-    source.jira_client.ssl_enabled = True
+    source = create_source(JiraDataSource, ssl_enabled=True)
 
     # Execute
     with pytest.raises(ConfigurableFieldValueError):
@@ -295,13 +294,12 @@ async def test_validate_config_with_invalid_concurrent_downloads():
     """Test validate_config method of BaseDataSource class with invalid concurrent downloads"""
 
     # Setup
-    source = create_source(JiraDataSource)
-    source.concurrent_downloads = 1000
+    source = create_source(JiraDataSource, concurrent_downloads=1000)
 
     # Execute
     with pytest.raises(
         ConfigurableFieldValueError,
-        match="Configured concurrent downloads can't be set more than *",
+        match="Field validation errors: `Number of concurrent downloads for fetching attachment content` value `1000` should be less than 101.",
     ):
         await source.validate_config()
 

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -290,6 +290,8 @@ async def test_validate_config_when_collection_name_invalid_then_raises_exceptio
         source = create_source(
             MongoDataSource,
             host="mongodb://127.0.0.1:27021",
+            user="foo",
+            password="bar",
             database=configured_database_name,
             collection=configured_collection_name,
         )
@@ -319,6 +321,8 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise():
         source = create_source(
             MongoDataSource,
             host="mongodb://127.0.0.1:27021",
+            user="foo",
+            password="bar",
             database=configured_database_name,
             collection=configured_collection_name,
         )

--- a/connectors/sources/tests/test_mongo.py
+++ b/connectors/sources/tests/test_mongo.py
@@ -259,6 +259,8 @@ async def test_validate_config_when_database_name_invalid_then_raises_exception(
         source = create_source(
             MongoDataSource,
             host="mongodb://127.0.0.1:27021",
+            user="foo",
+            password="password",
             database=configured_database_name,
             collection="something",
         )

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -453,15 +453,6 @@ async def test_validate_config_when_host_empty_then_raise_error():
         await source.validate_config()
 
 
-@pytest.mark.asyncio
-async def test_validate_config_when_port_has_wrong_type_then_raise_error():
-    source = create_source(MySqlDataSource)
-    source.configuration.set_field(name="port", value="port")
-
-    with pytest.raises(ConfigurableFieldValueError):
-        await source.validate_config()
-
-
 @pytest.mark.parametrize(
     "datasource, advanced_rules, expected_validation_result",
     [

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -330,7 +330,6 @@ def test_get_bucket_list():
 
 @pytest.mark.asyncio
 async def test_validate_config_for_empty_bucket_string_raises_error():
-    """This function test validate_config when buckets string is empty"""
     # Setup
     source = create_source(S3DataSource)
     source.configuration.set_field(name="buckets", value=[None, ""], type="list")

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -329,8 +329,8 @@ def test_get_bucket_list():
 
 
 @pytest.mark.asyncio
-async def test_validate_config_for_empty_bucket_string():
-    """This function test validate_configwhen buckets string is empty"""
+async def test_validate_config_for_empty_bucket_string_raises_error():
+    """This function test validate_config when buckets string is empty"""
     # Setup
     source = create_source(S3DataSource)
     source.configuration.set_field(name="buckets", value=[""])

--- a/connectors/sources/tests/test_s3.py
+++ b/connectors/sources/tests/test_s3.py
@@ -333,7 +333,7 @@ async def test_validate_config_for_empty_bucket_string_raises_error():
     """This function test validate_config when buckets string is empty"""
     # Setup
     source = create_source(S3DataSource)
-    source.configuration.set_field(name="buckets", value=[""])
+    source.configuration.set_field(name="buckets", value=[None, ""], type="list")
     # Execute
     with pytest.raises(ConfigurableFieldValueError) as e:
         await source.validate_config()

--- a/connectors/sources/tests/test_sharepoint.py
+++ b/connectors/sources/tests/test_sharepoint.py
@@ -144,14 +144,11 @@ async def test_validate_config_for_ssl_enabled_when_ssl_ca_not_empty_does_not_ra
     # Setup
     source = create_source(SharepointDataSource, ssl_enabled=True, ssl_ca="test")
 
-    # Execute
     await source.validate_config()
 
 
 @pytest.mark.asyncio
 async def test_validate_config_for_ssl_enabled_when_ssl_ca_empty_raises_error():
-    """This function test validate_config when ssl is enabled and certificate is missing"""
-    # Setup
     source = create_source(SharepointDataSource, ssl_enabled=True)
 
     # Execute

--- a/connectors/sources/tests/test_sharepoint.py
+++ b/connectors/sources/tests/test_sharepoint.py
@@ -139,11 +139,20 @@ async def test_validate_config_when_host_url_is_empty():
 
 
 @pytest.mark.asyncio
-async def test_validate_config_for_ssl_enabled():
+async def test_validate_config_for_ssl_enabled_when_ssl_ca_not_empty_does_not_raise_error():
     """This function test validate_config when ssl is enabled and certificate is missing"""
     # Setup
-    source = create_source(SharepointDataSource)
-    source.ssl_enabled = True
+    source = create_source(SharepointDataSource, ssl_enabled=True, ssl_ca="test")
+
+    # Execute
+    await source.validate_config()
+
+
+@pytest.mark.asyncio
+async def test_validate_config_for_ssl_enabled_when_ssl_ca_empty_raises_error():
+    """This function test validate_config when ssl is enabled and certificate is missing"""
+    # Setup
+    source = create_source(SharepointDataSource, ssl_enabled=True)
 
     # Execute
     with pytest.raises(ConfigurableFieldValueError):


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4196

Swap all connector validations to framework level.
If a unique validation exists for a connector (e.g. checking JSON structure) that isn't covered by the new validations, I have left it in the connector.

Majority of validations should now be handled by simply having the appropriate `validations` added to the configuration.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
