### PR TITLE
Add concurrency control to job scheduling

### DIFF
--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -22,6 +22,8 @@ from connectors.byoc import (
     Status,
     SyncJobIndex,
 )
+from connectors.es.client import with_concurrency_control
+from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
 from connectors.services.base import BaseService
 from connectors.source import get_source_klass
@@ -145,56 +147,68 @@ class JobSchedulingService(BaseService):
         return 0
 
     async def _on_demand_sync(self, connector):
-        if not connector.sync_now:
-            return
+        @with_concurrency_control()
+        async def _should_schedule_on_demand_sync():
+            try:
+                await connector.reload()
+            except DocumentNotFoundError:
+                logger.error(f"Couldn't reload connector {connector.id}")
+                return False
 
-        if not await connector.reset_sync_now_flag():
-            logger.debug(
-                f"Failed to reset sync_now flag for connector {connector.id}, the on demand sync will be created by other connector service."
+            if not connector.sync_now:
+                return False
+
+            await connector.reset_sync_now_flag()
+            return True
+
+        if await _should_schedule_on_demand_sync():
+            logger.info(f"Creating an on demand sync for connector {connector.id}...")
+            await self.sync_job_index.create(
+                connector=connector, trigger_method=JobTriggerMethod.ON_DEMAND
             )
-            return
-
-        logger.info(f"Creating an on demand sync for connector {connector.id}...")
-        await self.sync_job_index.create(
-            connector=connector, trigger_method=JobTriggerMethod.ON_DEMAND
-        )
 
     async def _scheduled_sync(self, connector):
-        now = datetime.utcnow()
-        if (
-            connector.last_sync_scheduled_at is not None
-            and connector.last_sync_scheduled_at > now
-        ):
-            logger.debug(
-                "A scheduled sync is created by another connector instance, skipping..."
+        @with_concurrency_control()
+        async def _should_schedule_scheduled_sync():
+            try:
+                await connector.reload()
+            except DocumentNotFoundError:
+                logger.error(f"Couldn't reload connector {connector.id}")
+                return False
+
+            now = datetime.utcnow()
+            if (
+                connector.last_sync_scheduled_at is not None
+                and connector.last_sync_scheduled_at > now
+            ):
+                logger.debug(
+                    "A scheduled sync is created by another connector instance, skipping..."
+                )
+                return False
+
+            try:
+                next_sync = connector.next_sync()
+            except Exception as e:
+                logger.critical(e, exc_info=True)
+                await connector.error(str(e))
+                return False
+
+            if next_sync is None:
+                logger.debug(f"Scheduling is disabled for connector {connector.id}")
+                return False
+
+            next_sync_due = (next_sync - now).total_seconds()
+            if next_sync_due - self.idling > 0:
+                logger.debug(
+                    f"Next sync for connector {connector.id} due in {int(next_sync_due)} seconds"
+                )
+                return False
+
+            await connector.update_last_sync_scheduled_at(next_sync)
+            return True
+
+        if await _should_schedule_scheduled_sync():
+            logger.info(f"Creating a scheduled sync for connector {connector.id}...")
+            await self.sync_job_index.create(
+                connector=connector, trigger_method=JobTriggerMethod.SCHEDULED
             )
-            return
-
-        try:
-            next_sync = connector.next_sync()
-        except Exception as e:
-            logger.critical(e, exc_info=True)
-            await connector.error(str(e))
-            return
-
-        if next_sync is None:
-            logger.debug(f"Scheduling is disabled for connector {connector.id}")
-            return
-
-        next_sync_due = (next_sync - now).total_seconds()
-        if next_sync_due - self.idling > 0:
-            logger.debug(
-                f"Next sync for connector {connector.id} due in {int(next_sync_due)} seconds"
-            )
-            return
-
-        if not await connector.update_last_sync_scheduled_at(next_sync):
-            logger.debug(
-                f"Failed to update last_sync_scheduled_at for connector {connector.id}, the scheduled sync will be created by other connector service."
-            )
-            return
-
-        logger.info(f"Creating a scheduled sync for connector {connector.id}...")
-        await self.sync_job_index.create(
-            connector=connector, trigger_method=JobTriggerMethod.SCHEDULED
-        )


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4158

This PR adds concurrency control to job scheduling:
1. an `on_demand` sync is created only when `sync_now` flag is reset successfully
2. a `scheduled` sync is created only when `last_sync_scheduled_at` is updated successfully

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)