### PR TITLE
Make sync_starts use optimistic concurrency control

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -504,12 +504,19 @@ class Connector(ESDocument):
         return resp["result"] == "updated"
 
     async def sync_starts(self):
-        doc = {
-            "last_sync_status": JobStatus.IN_PROGRESS.value,
-            "last_sync_error": None,
-            "status": Status.CONNECTED.value,
+        """Update last_sync_status with update_by_script, and return True only if last_sync_status is updated."""
+        script = {
+            "lang": "painless",
+            # only update last_sync_status to in_progress if it's not updated by other instances, otherwise set op to 'noop' (the returned 'result' will be 'noop')
+            "source": "if (ctx._source.last_sync_status == params['old_sync_status']) { ctx._source.last_sync_status = params['new_sync_status']; ctx._source.last_sync_error = null; ctx._source.status = params['connector_status'] } else { ctx.op = 'noop' }",
+            "params": {
+                "old_sync_status": self.last_sync_status.value,
+                "new_sync_status": JobStatus.IN_PROGRESS.value,
+                "connector_status": Status.CONNECTED.value,
+            },
         }
-        await self.index.update(doc_id=self.id, doc=doc)
+        resp = await self.index.update_by_script(doc_id=self.id, script=script)
+        return resp["result"] == "updated"
 
     async def error(self, error):
         doc = {

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -373,35 +373,27 @@ async def test_heartbeat(interval, last_seen, should_send_heartbeat):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "updated, expected_result",
-    [("updated", True), ("noop", False)],
-)
-async def test_sync_starts(updated, expected_result):
+async def test_sync_starts():
     doc_id = "1"
-    old_sync_status = JobStatus.COMPLETED.value
-    connector_doc = {
-        "_id": doc_id,
-        "_source": {"last_sync_status": old_sync_status},
-    }
-    expected_script = {
-        "lang": "painless",
-        "source": "if (ctx._source.last_sync_status == params['old_sync_status']) { ctx._source.last_sync_status = params['new_sync_status']; ctx._source.last_sync_error = null; ctx._source.status = params['connector_status'] } else { ctx.op = 'noop' }",
-        "params": {
-            "old_sync_status": old_sync_status,
-            "new_sync_status": JobStatus.IN_PROGRESS.value,
-            "connector_status": Status.CONNECTED.value,
-        },
-    }
+    seq_no = 1
+    primary_term = 2
+    connector_doc = {"_id": doc_id, "_seq_no": seq_no, "_primary_term": primary_term}
     index = Mock()
-    index.update_by_script = AsyncMock(return_value={"result": updated})
-    connector = Connector(elastic_index=index, doc_source=connector_doc)
-    result = await connector.sync_starts()
+    index.update = AsyncMock()
+    expected_doc_source_update = {
+        "last_sync_status": JobStatus.IN_PROGRESS.value,
+        "last_sync_error": None,
+        "status": Status.CONNECTED.value,
+    }
 
-    index.update_by_script.assert_awaited_once_with(
-        doc_id=doc_id, script=expected_script
+    connector = Connector(elastic_index=index, doc_source=connector_doc)
+    await connector.sync_starts()
+    index.update.assert_called_with(
+        doc_id=connector.id,
+        doc=expected_doc_source_update,
+        if_seq_no=seq_no,
+        if_primary_term=primary_term,
     )
-    assert result == expected_result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4159

This PR makes the method `sync_starts` of the `Connector` class use optimistic concurrency control, so that it will work in multi-instances environment, and will make sure only one instance can start the sync for a connector successfully.

This will be used in the subsequent PRs.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)