### PR TITLE
Set default stats when creating a sync job

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -671,6 +671,9 @@ class SyncJobIndex(ESIndex):
             },
             "trigger_method": trigger_method.value,
             "status": JobStatus.PENDING.value,
+            "indexed_document_count": 0,
+            "indexed_document_volume": 0,
+            "deleted_document_count": 0,
             "created_at": iso_utc(),
             "last_seen": iso_utc(),
         }

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -1188,6 +1188,9 @@ async def test_create_job(index_method, trigger_method, set_env):
         "connector": ANY,
         "trigger_method": trigger_method.value,
         "status": JobStatus.PENDING.value,
+        "indexed_document_count": 0,
+        "indexed_document_volume": 0,
+        "deleted_document_count": 0,
         "created_at": ANY,
         "last_seen": ANY,
     }


### PR DESCRIPTION
When a sync job is created by the connector service, there's no ingestion stats set, which will be defaulted to `null`. Before the first ingestion stats are reported back by connector service, they are displayed empty in Kibana:

![image](https://user-images.githubusercontent.com/54903978/230321405-2480f4a4-ae1a-4328-9da1-dec195120c54.png)


This PR sets the default ingestion stats to 0.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)