### PR TITLE
[MySQL] Add method fetching rows from a table in batches

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -188,6 +188,22 @@ class MySQLClient:
 
             return [f"{table}_{column[0]}" for column in cursor.description]
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -4,6 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """MySQL source module responsible to fetch documents from MySQL"""
+import asyncio
 import re
 
 import aiomysql
@@ -120,6 +121,7 @@ class MySQLClient:
         ssl_certificate,
         database=None,
         max_pool_size=MAX_POOL_SIZE,
+        fetch_size=DEFAULT_FETCH_SIZE,
     ):
         self.host = host
         self.port = port
@@ -127,6 +129,7 @@ class MySQLClient:
         self.password = password
         self.database = database
         self.max_pool_size = max_pool_size
+        self.fetch_size = fetch_size
         self.ssl_enabled = ssl_enabled
         self.ssl_certificate = ssl_certificate
         self.queries = MySQLQueries(self.database)
@@ -203,6 +206,41 @@ class MySQLClient:
                 return result[0]
 
             return None
+
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def yield_rows_for_table(self, table):
+        async for row in self._fetchmany_in_batches(self.queries.table_data(table)):
+            yield row
+
+    async def _fetchmany_in_batches(self, query):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(query)
+
+            try:
+                fetched_rows = 0
+                successful_batches = 0
+
+                while True:
+                    rows = await cursor.fetchmany(self.fetch_size)
+
+                    if not rows:
+                        break
+
+                    for row in rows:
+                        yield row
+
+                    fetched_rows += len(rows)
+                    successful_batches += 1
+
+                    await asyncio.sleep(0)
+            except IndexError as e:
+                logger.exception(
+                    f"Fetched {fetched_rows} rows in {successful_batches} batches. Encountered exception {e} in batch {successful_batches + 1}."
+                )
 
 
 class MySqlDataSource(BaseDataSource):

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -220,10 +220,10 @@ class MySQLClient:
         async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
             await cursor.execute(query)
 
-            try:
-                fetched_rows = 0
-                successful_batches = 0
+            fetched_rows = 0
+            successful_batches = 0
 
+            try:
                 while True:
                     rows = await cursor.fetchmany(self.fetch_size)
 

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -353,6 +353,7 @@ class MySqlDataSource(BaseDataSource):
             user=self.configuration["user"],
             password=self.configuration["password"],
             database=self.configuration["database"],
+            fetch_size=self.configuration["fetch_size"],
             ssl_enabled=self.configuration["ssl_enabled"],
             ssl_certificate=self.configuration["ssl_ca"],
         )

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -294,6 +294,32 @@ async def test_client_get_last_update_time(patch_connection_pool):
 
 
 @pytest.mark.asyncio
+async def test_client_yield_rows_for_table(patch_connection_pool):
+    rows_per_batch = [[DOC_ONE], [DOC_TWO], [DOC_THREE]]
+
+    mock_cursor = MagicMock(spec=aiomysql.Cursor)
+    mock_cursor.fetchmany.side_effect = AsyncMock(side_effect=[*rows_per_batch, None])
+    mock_cursor.__aenter__.return_value = mock_cursor
+
+    patch_connection_pool.acquire.return_value = await mock_connection(mock_cursor)
+
+    client = await setup_mysql_client()
+    client.fetch_size = 1
+
+    async with client:
+        yielded_docs = []
+
+        async for doc in client.yield_rows_for_table("table"):
+            yielded_docs.append(doc)
+
+        # 3 batches with rows, 4th batch empty
+        num_batches = len(rows_per_batch) / client.fetch_size + 1
+
+        assert len(yielded_docs) == len(rows_per_batch)
+        assert mock_cursor.fetchmany.call_count == num_batches
+
+
+@pytest.mark.asyncio
 async def test_client_ping(patch_logger, patch_connection_pool):
     client = await setup_mysql_client()
 


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4266

This PR adds `yield_for_rows` wrapping `_fetchmany_in_batches`. There will be additional high-level methods wrapping `_fetchmany_in_batches` therefore it's already introduced in this PR.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~