### PR TITLE
Update reset_sync_now_flag

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -492,16 +492,12 @@ class Connector(ESDocument):
         return next_run(self.scheduling.get("interval"))
 
     async def reset_sync_now_flag(self):
-        """Reset sync_now flag to False, and return True only if the flag is updated."""
-        if not self.sync_now:
-            return False
-
-        script = {
-            "lang": "painless",
-            "source": "if (ctx._source.sync_now) { ctx._source.sync_now = false } else { ctx.op = 'noop' }",
-        }
-        resp = await self.index.update_by_script(doc_id=self.id, script=script)
-        return resp["result"] == "updated"
+        await self.index.update(
+            doc_id=self.id,
+            doc={"sync_now": False},
+            if_seq_no=self._seq_no,
+            if_primary_term=self._primary_term,
+        )
 
     async def sync_starts(self):
         doc = {

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -769,16 +769,27 @@ async def test_prepare(mock_responses):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "sync_now, updated, expected_result",
-    [(False, None, False), (True, "updated", True), (True, "noop", False)],
-)
-async def test_connector_reset_sync_now_flag(sync_now, updated, expected_result):
-    connector_doc = {"_id": "1", "_source": {"sync_now": sync_now}}
+async def test_connector_reset_sync_now_flag():
+    doc_id = "1"
+    seq_no = 1
+    primary_term = 2
+    connector_doc = {
+        "_id": doc_id,
+        "_seq_no": seq_no,
+        "_primary_term": primary_term,
+        "_source": {},
+    }
     index = Mock()
-    index.update_by_script = AsyncMock(return_value={"result": updated})
+    index.update = AsyncMock()
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    assert await connector.reset_sync_now_flag() == expected_result
+    await connector.reset_sync_now_flag()
+
+    index.update.assert_awaited_once_with(
+        doc_id=doc_id,
+        doc={"sync_now": False},
+        if_seq_no=seq_no,
+        if_primary_term=primary_term,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4158

This PR updates `reset_sync_now_flag` method to use optimistic concurrency control, instead of update by script.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)