### PR TITLE
Bump Elasticsearch to 8.7.0

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,5 +1,5 @@
 aiohttp==3.8.3
-elasticsearch[async]==8.6.1
+elasticsearch[async]==8.7.0
 elastic-transport==8.4.0
 pyyaml==6.0
 envyaml==1.10.211231


### PR DESCRIPTION
Bumps Elasticsearch to 8.7.0 . Part of [Enterprise Search 8.7.0 release](https://github.com/elastic/enterprise-search-team/issues/3687).

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)