### PR TITLE
[MySQL] Use MySQLClient for interacting with the configured db server

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -188,6 +188,22 @@ class MySQLClient:
 
             return [f"{table}_{column[0]}" for column in cursor.description]
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -185,7 +185,12 @@ class MySQLClient:
         async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
             await cursor.execute(query)
 
-            return [f"{table}_{column[0]}" for column in cursor.description]
+            return [f"{table}_{column[0]}" for column in await cursor.fetchall()]
+
+    async def get_primary_key_column_names(self, table):
+        return await self.get_column_names(
+            table, query=self.queries.table_primary_key(table)
+        )
 
     @retryable(
         retries=RETRIES,
@@ -210,6 +215,15 @@ class MySQLClient:
     )
     async def yield_rows_for_table(self, table):
         async for row in self._fetchmany_in_batches(self.queries.table_data(table)):
+            yield row
+
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def yield_rows_for_query(self, query):
+        async for row in self._fetchmany_in_batches(query):
             yield row
 
     async def _fetchmany_in_batches(self, query):
@@ -551,35 +565,33 @@ class MySqlDataSource(BaseDataSource):
             Dict: Document to be indexed
         """
 
-        primary_key_columns = await self._get_primary_key_columns(table)
+        async with self.mysql_client() as client:
+            primary_key_columns = await client.get_primary_key_column_names(table)
 
-        if not primary_key_columns:
-            logger.warning(
-                f"Skipping {table} table from database {self.database} since no primary key is associated with it. Assign primary key to the table to index it in the next sync interval."
+            if not primary_key_columns:
+                logger.warning(
+                    f"Skipping {table} table from database {self.database} since no primary key is associated with it. Assign primary key to the table to index it in the next sync interval."
+                )
+                return
+
+            last_update_time = await client.get_last_update_time(table)
+            column_names = await client.get_column_names(table)
+            row_generator = (
+                client.yield_rows_for_table(table)
+                if query is None
+                else client.yield_rows_for_query(query)
             )
-            return
 
-        last_update_time = await anext(
-            self._connect(
-                query=self.queries.table_last_update_time(table),
-                table=table,
-            )
-        )
-        last_update_time = last_update_time[0][0]
-
-        table_rows = self._connect(query=query, fetch_many=True, table=table)
-        column_names = await anext(table_rows)
-
-        async for row in table_rows:
-            row = dict(zip(column_names, row))
-            row.update(
-                {
-                    "_id": self._generate_id(table, row, primary_key_columns),
-                    "_timestamp": last_update_time,
-                    "Table": table,
-                }
-            )
-            yield self.serialize(doc=row)
+            async for row in row_generator:
+                row = dict(zip(column_names, row))
+                row.update(
+                    {
+                        "_id": self._generate_id(table, row, primary_key_columns),
+                        "_timestamp": last_update_time,
+                        "Table": table,
+                    }
+                )
+                yield self.serialize(doc=row)
 
     def _generate_id(self, table, row, primary_key_columns):
         keys_value = ""
@@ -613,18 +625,16 @@ class MySqlDataSource(BaseDataSource):
                 logger.debug(
                     f"Fetching rows from table '{table}' in database '{self.database}' with a custom query."
                 )
-                async for row in self.fetch_rows_for_table(
-                    table=table,
-                    query=query,
-                ):
+                async for row in self.fetch_documents(table, query):
                     yield row, None
                 await self._sleeps.sleep(0)
         else:
             tables_to_fetch = await self.get_tables_to_fetch()
 
-            async for row in self.fetch_rows_from_tables(tables_to_fetch):
-                yield row, None
-            await self._sleeps.sleep(0)
+            for table in tables_to_fetch:
+                async for row in self.fetch_documents(table):
+                    yield row, None
+                await self._sleeps.sleep(0)
 
     async def get_tables_to_fetch(self):
         tables = configured_tables(self.tables)

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -73,16 +73,18 @@ def future_with_result(result):
     return future
 
 
+def wrap_mock_client_in_context_manager(mock_client):
+    context_manager = MagicMock()
+    context_manager.__aenter__.return_value = mock_client
+    context_manager.__aexit__.return_value = None
+
+    return MagicMock(return_value=context_manager)
+
+
 @pytest.fixture
 def patch_ping():
     with patch.object(MySqlDataSource, "ping", return_value=AsyncMock()) as ping:
         yield ping
-
-
-@pytest.fixture
-def patch_fetch_rows_for_table():
-    with patch.object(MySqlDataSource, "fetch_rows_for_table") as mock_to_patch:
-        yield mock_to_patch
 
 
 @pytest.fixture
@@ -211,6 +213,17 @@ async def mock_connection(mock_cursor):
     return mock_conn
 
 
+def mock_cursor_fetchmany(rows_per_batch=None):
+    if rows_per_batch is None:
+        rows_per_batch = []
+
+    mock_cursor = MagicMock(spec=aiomysql.Cursor)
+    mock_cursor.fetchmany.side_effect = AsyncMock(side_effect=[*rows_per_batch, None])
+    mock_cursor.__aenter__.return_value = mock_cursor
+
+    return mock_cursor
+
+
 @pytest.mark.asyncio
 async def test_close_when_source_setup_correctly_does_not_raise_errors():
     source = await setup_mysql_source()
@@ -243,19 +256,27 @@ async def test_client_get_tables(patch_connection_pool):
         assert result == expected_result
 
 
+@pytest.mark.parametrize(
+    "column_tuples, expected_column_names",
+    [
+        ([], []),
+        ([("id",)], [f"{TABLE_ONE}_id"]),
+        (
+            [("group",), ("class",), ("name",)],
+            [
+                f"{TABLE_ONE}_group",
+                f"{TABLE_ONE}_class",
+                f"{TABLE_ONE}_name",
+            ],
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_client_get_column_names(patch_connection_pool):
-    table = "table"
-    column_1 = "column_1"
-    column_2 = "column_2"
-
-    description_response = [
-        (column_1,),
-        (column_2,),
-    ]
-
+async def test_client_get_column_names(
+    patch_connection_pool, column_tuples, expected_column_names
+):
     mock_cursor = MagicMock(spec=aiomysql.Cursor)
-    mock_cursor.description = description_response
+    mock_cursor.fetchall = AsyncMock(return_value=column_tuples)
     mock_cursor.__aenter__.return_value = mock_cursor
 
     patch_connection_pool.acquire.return_value = await mock_connection(mock_cursor)
@@ -263,10 +284,8 @@ async def test_client_get_column_names(patch_connection_pool):
     client = await setup_mysql_client()
 
     async with client:
-        result = await client.get_column_names(table)
-        expected_result = [f"{table}_{column_1}", f"{table}_{column_2}"]
-
-        assert result == expected_result
+        result = await client.get_column_names(TABLE_ONE)
+        assert result == expected_column_names
 
 
 @pytest.mark.asyncio
@@ -288,11 +307,7 @@ async def test_client_get_last_update_time(patch_connection_pool):
 @pytest.mark.asyncio
 async def test_client_yield_rows_for_table(patch_connection_pool):
     rows_per_batch = [[DOC_ONE], [DOC_TWO], [DOC_THREE]]
-
-    mock_cursor = MagicMock(spec=aiomysql.Cursor)
-    mock_cursor.fetchmany.side_effect = AsyncMock(side_effect=[*rows_per_batch, None])
-    mock_cursor.__aenter__.return_value = mock_cursor
-
+    mock_cursor = mock_cursor_fetchmany(rows_per_batch)
     patch_connection_pool.acquire.return_value = await mock_connection(mock_cursor)
 
     client = await setup_mysql_client()
@@ -305,6 +320,28 @@ async def test_client_yield_rows_for_table(patch_connection_pool):
             yielded_docs.append(doc)
 
         # 3 batches with rows, 4th batch empty
+        num_batches = len(rows_per_batch) / client.fetch_size + 1
+
+        assert len(yielded_docs) == len(rows_per_batch)
+        assert mock_cursor.fetchmany.call_count == num_batches
+
+
+@pytest.mark.asyncio
+async def test_client_yield_rows_for_query(patch_connection_pool):
+    rows_per_batch = [[DOC_ONE]]
+    mock_cursor = mock_cursor_fetchmany(rows_per_batch)
+    patch_connection_pool.acquire.return_value = await mock_connection(mock_cursor)
+
+    client = await setup_mysql_client()
+    client.fetch_size = 1
+
+    async with client:
+        yielded_docs = []
+
+        async for doc in client.yield_rows_for_query("SELECT * FROM db.table"):
+            yielded_docs.append(doc)
+
+        # 1 batch with rows, 2nd batch empty
         num_batches = len(rows_per_batch) / client.fetch_size + 1
 
         assert len(yielded_docs) == len(rows_per_batch)
@@ -359,9 +396,14 @@ async def test_fetch_documents(patch_connection_pool):
         f"table_name_{column}": "table1",
     }
 
+    client = MagicMock()
+    client.get_primary_key_column_names = AsyncMock(side_effect=[primary_key_col])
+    client.get_last_update_time = AsyncMock(return_value=last_update_time)
+    client.get_column_names = AsyncMock(return_value=[column])
+    client.yield_rows_for_query = AsyncIterator([document])
+
     source = await setup_mysql_source(DATABASE)
-    source._get_primary_key_columns = AsyncMock(return_value=[primary_key_col])
-    source._connect = AsyncIterator([[[last_update_time]], [column], document])
+    source.mysql_client = wrap_mock_client_in_context_manager(client)
 
     query = "select * from table"
 
@@ -388,7 +430,7 @@ async def test_get_docs(patch_connection_pool):
     source = await setup_mysql_source(DATABASE)
 
     source.get_tables_to_fetch = AsyncMock(return_value=["table"])
-    source.fetch_rows_from_tables = AsyncIterator([{"a": 1, "b": 2}])
+    source.fetch_documents = AsyncIterator([{"a": 1, "b": 2}])
 
     async for doc, _ in source.get_docs():
         assert doc == {"a": 1, "b": 2}
@@ -407,14 +449,17 @@ async def setup_mysql_client():
     return client
 
 
-async def setup_mysql_source(database=""):
+async def setup_mysql_source(database="", client=None):
+    if client is None:
+        client = MagicMock()
+
     source = create_source(MySqlDataSource)
     source.configuration.set_field(
         name="database", label="Database", value=database, type="str"
     )
 
     source.database = database
-    source.mysql_client = MagicMock()
+    source.mysql_client = client
 
     return source
 
@@ -467,12 +512,10 @@ def setup_available_docs(advanced_snippet):
     ],
 )
 @pytest.mark.asyncio
-async def test_get_docs_with_advanced_rules(
-    filtering, expected_docs, patch_fetch_rows_for_table
-):
+async def test_get_docs_with_advanced_rules(filtering, expected_docs):
     source = await setup_mysql_source(DATABASE)
     docs_in_db = setup_available_docs(filtering.get_advanced_rules())
-    patch_fetch_rows_for_table.return_value = AsyncIterator(docs_in_db)
+    source.fetch_documents = AsyncIterator(docs_in_db)
 
     yielded_docs = set()
     async for doc, _ in source.get_docs(filtering):
@@ -554,11 +597,7 @@ async def test_advanced_rules_tables_validation(
     client = MagicMock()
     client.get_all_table_names = AsyncMock(side_effect=[datasource.keys()])
 
-    context_manager = MagicMock()
-    context_manager.__aenter__.return_value = client
-    context_manager.__aexit__.return_value = None
-
-    source.mysql_client = MagicMock(return_value=context_manager)
+    source.mysql_client = wrap_mock_client_in_context_manager(client)
 
     validation_result = await MySQLAdvancedRulesValidator(source).validate(
         advanced_rules
@@ -576,11 +615,7 @@ async def test_get_tables_when_wildcard_configured_then_fetch_all_tables(tables)
     client = MagicMock()
     client.get_all_table_names = AsyncMock(return_value="table")
 
-    context_manager = MagicMock()
-    context_manager.__aenter__.return_value = client
-    context_manager.__aexit__.return_value = None
-
-    source.mysql_client = MagicMock(return_value=context_manager)
+    source.mysql_client = wrap_mock_client_in_context_manager(client)
 
     await source.get_tables_to_fetch()
 
@@ -680,33 +715,6 @@ async def test_validate_tables_accessible_when_not_accessible_then_error_raised(
 )
 def test_parse_tables_string_to_list(tables_string, expected_tables_list):
     assert parse_tables_string_to_list_of_tables(tables_string) == expected_tables_list
-
-
-@pytest.mark.parametrize(
-    "primary_key_tuples, expected_primary_key_columns",
-    [
-        ([], []),
-        ([("id",)], [f"{TABLE_ONE}_id"]),
-        (
-            [("group",), ("class",), ("name",)],
-            [
-                f"{TABLE_ONE}_group",
-                f"{TABLE_ONE}_class",
-                f"{TABLE_ONE}_name",
-            ],
-        ),
-    ],
-)
-@pytest.mark.asyncio
-async def test_get_primary_key_columns(
-    primary_key_tuples, expected_primary_key_columns
-):
-    source = create_source(MySqlDataSource)
-    source._connect = AsyncIterator([primary_key_tuples])
-
-    primary_key_columns = await source._get_primary_key_columns(TABLE_ONE)
-
-    assert primary_key_columns == expected_primary_key_columns
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4266

This PR adapts the `fetch_documents` method to use the new `MySQLClient`. Therefore every interaction with the remote database server happens through the new client. To not clutter this PR's diff a separate PR will be used to remove all old methods and tests.

Two new methods are introduced acting as wrappers for already existing methods:

- `get_primary_key_column_names`
- `yield_rows_for_query `

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~