### PR TITLE
[MySQL] Fallback on iso_utc, if last_update_time is not present

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -188,6 +188,22 @@ class MySQLClient:
 
             return [f"{table}_{column[0]}" for column in cursor.description]
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -21,7 +21,13 @@ from connectors.sources.generic_database import (
     configured_tables,
     is_wildcard,
 )
-from connectors.utils import CancellableSleeps, RetryStrategy, retryable, ssl_context, iso_utc
+from connectors.utils import (
+    CancellableSleeps,
+    RetryStrategy,
+    iso_utc,
+    retryable,
+    ssl_context,
+)
 
 SPLIT_BY_COMMA_OUTSIDE_BACKTICKS_PATTERN = re.compile(r"`(?:[^`]|``)+`|\w+")
 

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -21,7 +21,7 @@ from connectors.sources.generic_database import (
     configured_tables,
     is_wildcard,
 )
-from connectors.utils import CancellableSleeps, RetryStrategy, retryable, ssl_context
+from connectors.utils import CancellableSleeps, RetryStrategy, retryable, ssl_context, iso_utc
 
 SPLIT_BY_COMMA_OUTSIDE_BACKTICKS_PATTERN = re.compile(r"`(?:[^`]|``)+`|\w+")
 
@@ -557,7 +557,7 @@ class MySqlDataSource(BaseDataSource):
             row.update(
                 {
                     "_id": self._generate_id(table, row, primary_key_columns),
-                    "_timestamp": last_update_time,
+                    "_timestamp": last_update_time or iso_utc(),
                     "Table": table,
                 }
             )


### PR DESCRIPTION
Align the behavior between the MySQL connector and the connectors inheriting from the GenericDatabaseConnector by falling back to `iso_utc()`, if the `last_update_time` is not present in a row returned from a MySQL table.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~