### PR TITLE
[MySQL] Remove old data source methods replaced by new MySQLClient methods

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -188,6 +188,22 @@ class MySQLClient:
 
             return [f"{table}_{column[0]}" for column in cursor.description]
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -371,19 +371,6 @@ async def test_client_ping_negative(patch_logger):
 
 
 @pytest.mark.asyncio
-async def test_connect_with_retry(
-    patch_logger, patch_connection_pool, patch_default_wait_multiplier
-):
-    source = await setup_mysql_source()
-
-    streamer = source._connect(query="select * from database.table", fetch_many=True)
-
-    with pytest.raises(Exception):
-        async for _ in streamer:
-            pass
-
-
-@pytest.mark.asyncio
 async def test_fetch_documents(patch_connection_pool):
     last_update_time = "2023-01-18 17:18:56"
     primary_key_col = "pk"
@@ -412,17 +399,6 @@ async def test_fetch_documents(patch_connection_pool):
         document_list.append(document)
 
     assert document in document_list
-
-
-@pytest.mark.asyncio
-async def test_fetch_rows_from_tables(patch_connection_pool):
-    document = {"_id": 1}
-
-    source = await setup_mysql_source()
-    source.fetch_rows_for_table = AsyncIterator([document])
-
-    async for row in source.fetch_rows_from_tables("table"):
-        assert "_id" in row
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR removes all old methods, which now live inside in the `MySQLClient`class.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~