### PR TITLE
[MySQL] Use CancellableSleeps in MySQLClient

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -188,6 +188,22 @@ class MySQLClient:
 
             return [f"{table}_{column[0]}" for column in cursor.description]
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -232,6 +232,17 @@ async def test_close_when_source_setup_correctly_does_not_raise_errors():
 
 
 @pytest.mark.asyncio
+async def test_client_when_aexit_called_then_cancel_sleeps(patch_connection_pool):
+    client = await setup_mysql_client()
+
+    async with client:
+        client._sleeps.cancel = Mock()
+        pass
+
+    client._sleeps.cancel.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_client_get_tables(patch_connection_pool):
     table_1 = "table_1"
     table_2 = "table_2"


### PR DESCRIPTION
This PR adapts the `MySQLClient` to use the `CancellableSleeps` class to be able to directly cancel sleeps, if needed.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~