### PR TITLE
Use default_value for value when applicable

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -246,11 +246,7 @@ class DataSourceConfiguration:
     def __getitem__(self, key):
         if key not in self._config and key in self._defaults:
             return self._defaults[key]
-
-        if self._config[key].required:
-            return self._config[key].value
-
-        return self._config[key].value or self._config[key].default_value
+        return self._config[key].value
 
     def get(self, key, default=None):
         if key not in self._config:

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -54,27 +54,29 @@ class Field:
     def __init__(
         self,
         name,
-        label=None,
-        value="",
-        type="str",
-        required=True,
+        default_value=None,
         depends_on=None,
+        label=None,
+        required=True,
+        type="str",
         validations=None,
+        value=None,
     ):
-        if label is None:
-            label = name
         if depends_on is None:
             depends_on = []
+        if label is None:
+            label = name
         if validations is None:
             validations = []
 
-        self.name = name
-        self.label = label
-        self._type = type
-        self.value = self._convert(value, type)
-        self.required = required
+        self.default_value = self._convert(default_value, type)
         self.depends_on = depends_on
+        self.label = label
+        self.name = name
+        self.required = required
+        self._type = type
         self.validations = validations
+        self._value = self._convert(value, type)
 
     @property
     def type(self):
@@ -84,6 +86,24 @@ class Field:
     def type(self, value):
         self._type = value
         self.value = self._convert(self.value, self._type)
+
+    @property
+    def value(self):
+        """Returns either the `value` or `default_value` of a Field.
+        The `default_value` will only be returned if the Field is not required
+        and the `value` is empty.
+        """
+        if self.required:
+            return self._value
+
+        if self.is_value_empty():
+            return self.default_value
+
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value
 
     def _convert(self, value, type_):
         if not isinstance(value, str):
@@ -101,7 +121,10 @@ class Field:
         return value
 
     def is_value_empty(self):
-        value = self.value
+        """Checks if the `value` field is empty or not.
+        This always checks `value` and never `default_value`.
+        """
+        value = self._value
 
         match value:
             case str():
@@ -118,6 +141,8 @@ class Field:
 
     def validate(self):
         """Used to validate the `value` of a Field using its `validations`.
+        If `value` is empty and the field is not required,
+        the validation is run on the `default_value` instead.
 
         Returns a list of errors as strings.
         If the list is empty, then the Field `value` is valid.
@@ -201,12 +226,13 @@ class DataSourceConfiguration:
                 if isinstance(value, dict):
                     self.set_field(
                         key,
-                        value.get("label"),
-                        value.get("value", ""),
-                        value.get("type", "str"),
-                        value.get("required", True),
+                        value.get("default_value", None),
                         value.get("depends_on", []),
+                        value.get("label"),
+                        value.get("required", True),
+                        value.get("type", "str"),
                         value.get("validations", []),
+                        value.get("value", None),
                     )
                 else:
                     self.set_field(key, label=key.capitalize(), value=str(value))
@@ -220,7 +246,11 @@ class DataSourceConfiguration:
     def __getitem__(self, key):
         if key not in self._config and key in self._defaults:
             return self._defaults[key]
-        return self._config[key].value
+
+        if self._config[key].required:
+            return self._config[key].value
+
+        return self._config[key].value or self._config[key].default_value
 
     def get(self, key, default=None):
         if key not in self._config:
@@ -233,15 +263,16 @@ class DataSourceConfiguration:
     def set_field(
         self,
         name,
-        label=None,
-        value="",
-        type="str",
-        required=True,
+        default_value=None,
         depends_on=None,
+        label=None,
+        required=True,
+        type="str",
         validations=None,
+        value=None,
     ):
         self._config[name] = Field(
-            name, label, value, type, required, depends_on, validations
+            name, default_value, depends_on, label, required, type, validations, value
         )
 
     def get_field(self, name):

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -130,7 +130,7 @@ def test_default():
         ("bool", False, True, None, True),
     ],
 )
-def test_value_when_str_returns_correct_value(
+def test_value_returns_correct_value(
     type, required, default_value, value, expected_value
 ):
     assert (

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -28,19 +28,37 @@ from connectors.source import (
 
 CONFIG = {
     "host": {
-        "value": "mongodb://127.0.0.1:27021",
         "label": "MongoDB Host",
         "type": "str",
+        "value": "mongodb://127.0.0.1:27021",
     },
     "database": {
-        "value": "sample_airbnb",
         "label": "MongoDB Database",
         "type": "str",
+        "value": "sample_airbnb",
     },
     "collection": {
-        "value": "listingsAndReviews",
         "label": "MongoDB Collection",
         "type": "str",
+        "value": "listingsAndReviews",
+    },
+    "connector_nickname": {
+        "default_value": "MongoDB Connector",
+        "label": "Connector Nickname",
+        "type": "str",
+        "value": "",
+    },
+    "retry_count": {
+        "default_value": 3,
+        "label": "Retry Count",
+        "type": "int",
+        "value": None,
+    },
+    "tables": {
+        "default_value": ["*"],
+        "label": "List of Tables",
+        "type": "list",
+        "value": [""],
     },
 }
 
@@ -75,6 +93,56 @@ def test_default():
     c = DataSourceConfiguration(CONFIG)
     assert c.get("database") == "sample_airbnb"
     assert c.get("dd", 1) == 1
+
+
+@pytest.mark.parametrize(
+    "type, required, default_value, value, expected_value",
+    [
+        # these include examples that would not normally validate
+        # that is because `.value` does care about validation, it only returns a value
+        # strings
+        ("str", True, "default", "input", "input"),
+        ("str", True, "default", None, None),
+        ("str", True, "default", "", ""),
+        ("str", False, "default", "input", "input"),
+        ("str", False, "default", None, "default"),
+        ("str", False, "default", "", "default"),
+        # integers
+        ("int", True, 3, 1, 1),
+        ("int", True, 3, None, None),
+        ("int", False, 3, 1, 1),
+        ("int", False, 3, None, 3),
+        # lists
+        ("list", True, ["1", "2"], ["3", "4"], ["3", "4"]),
+        ("list", True, ["1", "2"], [], []),
+        ("list", True, ["1", "2"], [""], [""]),
+        ("list", True, ["1", "2"], [None], [None]),
+        ("list", True, ["1", "2"], None, None),
+        ("list", False, ["1", "2"], ["3", "4"], ["3", "4"]),
+        ("list", False, ["1", "2"], [], ["1", "2"]),
+        ("list", False, ["1", "2"], [""], ["1", "2"]),
+        ("list", False, ["1", "2"], [None], ["1", "2"]),
+        ("list", False, ["1", "2"], None, ["1", "2"]),
+        # booleans
+        ("bool", True, True, False, False),
+        ("bool", True, True, None, None),
+        ("bool", False, True, False, False),
+        ("bool", False, True, None, True),
+    ],
+)
+def test_value_when_str_returns_correct_value(
+    type, required, default_value, value, expected_value
+):
+    assert (
+        Field(
+            "name",
+            type=type,
+            required=required,
+            default_value=default_value,
+            value=value,
+        ).value
+        == expected_value
+    )
 
 
 class MyConnector:


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4198

This change allows `Field` to return a `default_value` when its `value` is requested.
This will only happen if `required: False` and `value` is empty.

If this is approved, I will make a followup PR to set the `value` for all non-required configuration fields to `None` and add an appropriate `default_value`.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
