### PR TITLE
Make user and password optional for MongoDb

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -134,13 +134,20 @@ class MongoDataSource(BaseDataSource):
                 "type": "str",
                 "value": "",
             },
-            "user": {"label": "Username", "order": 5, "type": "str", "value": ""},
+            "user": {
+                "label": "Username",
+                "order": 5,
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
             "password": {
                 "label": "Password",
                 "order": 6,
                 "sensitive": True,
                 "type": "str",
                 "value": "",
+                "required": False,
             },
         }
 


### PR DESCRIPTION
Small fix for a small bug - all configurable fields are required by default, but MongoDB connector can operate on MongoDB instance without auth, so this PR is making `user` and `password` fields optional