### PR TITLE
Update the code to fix issue while indexing subsite and large size files

### DIFF
--- a/connectors/sources/tests/test_sharepoint.py
+++ b/connectors/sources/tests/test_sharepoint.py
@@ -223,7 +223,7 @@ def test_prepare_list_items_doc():
         "type": "list_item",
         "_id": 1,
         "file_name": "filename",
-        "size": None,
+        "size": 0,
         "title": "dummy",
         "author_id": "123",
         "creation_time": "2023-01-30T12:48:31Z",
@@ -590,8 +590,9 @@ async def test_get_content():
         "id": 1,
         "server_relative_url": "/url",
         "_timestamp": "2022-06-20T10:37:44Z",
-        "Length": "11",
+        "size": "11",
         "type": "sites",
+        "file_name": "dummy.pdf",
     }
     EXPECTED_CONTENT = {
         "_id": 1,
@@ -622,10 +623,11 @@ async def test_get_content_when_size_is_bigger():
     document = {
         "id": 1,
         "_timestamp": "2022-06-20T10:37:44Z",
-        "Length": "1048576011",
+        "size": "1048576011",
         "title": "dummy",
         "type": "sites",
         "server_relative_url": "/sites",
+        "file_name": "dummy.pdf",
     }
 
     source = create_source(SharepointDataSource)
@@ -645,8 +647,9 @@ async def test_get_content_when_doit_is_none():
     document = {
         "id": 1,
         "_timestamp": "2022-06-20T10:37:44Z",
-        "length": "11",
+        "size": "11",
         "type": "sites",
+        "file_name": "dummy.pdf",
     }
     source = create_source(SharepointDataSource)
     # Execute


### PR DESCRIPTION
#### This PR includes: ####

- Fix keyerror issue  for `server_relative_url` while fetching data for nested sites in `get_docs`
- Fix `filename` keyerror issue in logger message while indexing more than 10MB size file for drive items


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)



