### PR TITLE
[Microsoft SQL]Use NamedTemporaryFile for temporary SSL certificate file

### DIFF
--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -116,7 +116,7 @@ class GenericBaseDataSource(BaseDataSource):
         self.dialect = ""
         self.connection = None
         self.queries = None
-        self.certfile = None
+        self.certfile = ""
         self.tables_to_skip = {}
 
     @classmethod

--- a/connectors/sources/tests/test_generic_database.py
+++ b/connectors/sources/tests/test_generic_database.py
@@ -19,7 +19,6 @@ from connectors.sources.generic_database import (
     configured_tables,
     is_wildcard,
 )
-from connectors.sources.mssql import MSSQLDataSource
 from connectors.sources.postgresql import PostgreSQLDataSource
 from connectors.sources.tests.support import create_source
 from connectors.tests.commons import AsyncIterator
@@ -171,8 +170,7 @@ async def test_validate_config_ssl():
 
 @pytest.mark.asyncio
 async def test_close():
-    """Test close method"""
-    source = create_source(MSSQLDataSource)
+    source = create_source(GenericBaseDataSource)
 
     await source.close()
 

--- a/connectors/sources/tests/test_mssql.py
+++ b/connectors/sources/tests/test_mssql.py
@@ -55,7 +55,7 @@ async def test_create_engine(mock_create_url, mock_create_engine):
     mock_create_engine.assert_called_with(
         MSSQL_CONNECTION_STRING,
         connect_args={
-            "cafile": "/tmp/ssl_certificate_mssql_2023-01-24T04:07:19+00:00.pem",
+            "cafile": source.certfile,
             "validate_host": False,
         },
     )
@@ -97,3 +97,10 @@ async def test_get_docs_mssql():
 
     # Assert
     assert actual_response == expected_response
+
+
+@pytest.mark.asyncio
+async def test_close():
+    source = create_source(MSSQLDataSource)
+    source.create_pem_file()
+    await source.close()


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/764

Use NamedTemporaryFile for creating temporary SSL Certificate file for MS-SQL.
<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
