### PR TITLE
[8.7] Remove types from "native" which aren't native in this version

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -29,15 +29,6 @@ service:
 native_service_types:
   - mongodb
   - mysql
-  - network_drive
-  - s3
-  - google_cloud_storage
-  - azure_blob_storage
-  - postgresql
-  - oracle
-  - dir
-  - mssql
-
 
 # Connector client settings
 #connector_id: 'changeme'


### PR DESCRIPTION
Reported by @ppf2 in [this slack thread](https://elastic.slack.com/archives/C01795T48LQ/p1681503868161219?thread_ts=1681155985.696539&cid=C01795T48LQ).

In 8.7, the only native connectors are MongoDB and MySQL. See: https://www.elastic.co/guide/en/enterprise-search/8.7/native-connectors.html

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
