### PR TITLE
Use unsigned_long for field indexed_document_volume

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -384,7 +384,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
     "deleted_document_count" : { "type" : "integer" },
     "error" : { "type" : "keyword" },
     "indexed_document_count" : { "type" : "integer" },
-    "indexed_document_volume" : { "type" : "integer" },
+    "indexed_document_volume" : { "type" : "unsigned_long" },
     "last_seen" : { "type" : "date" },
     "metadata" : { "type" : "object" },
     "started_at" : { "type" : "date" },


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors-python/issues/735

The field `indexed_document_volume` (in bytes) in `.elastic-connectors-sync-jobs` is of type `integer`, which can hold a maximum value of `2^31-1`, which is equivalent to 2-ish GB. This PR changes it to `unsigned_long`, which can hold a maximum value of `2^64-1`, which is equivalent to 18-ish Exa Bytes (1 Exa Byte = 1000 PB).

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)