### PR TITLE
[Confluence] Update E2E test for space as configurable field 

### DIFF
--- a/connectors/sources/tests/fixtures/confluence/fixture.py
+++ b/connectors/sources/tests/fixtures/confluence/fixture.py
@@ -24,7 +24,7 @@ class ConfluenceAPI:
         self.space_start_at = 0
         self.space_page_limit = 100
         self.total_spaces = 4000
-        self.total_content = 100
+        self.total_content = 50
         self.attachment_start_at = 1
         self.attachment_end_at = 6
 
@@ -98,11 +98,12 @@ class ConfluenceAPI:
         content = {
             "results": [],
             "start": 0,
-            "limit": 100,
-            "size": 100,
+            "limit": 50,
+            "size": 50,
             "_links": {"next": None},
         }
-        document_type = args.get("type", "page")
+        confluence_query = args.get("cql")
+        document_type = confluence_query.split("type=")[1]
         for content_count in range(self.total_content):
             content["results"].append(
                 {


### PR DESCRIPTION
<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

This PR aims to add the following changes in e2e:
- With the endpoint change for `content` API, the maximum allowed limit for results is now changed from 100 to 50 in [PR for space as a configurable field](https://github.com/elastic/connectors-python/pull/752/files#diff-c334a0be5ca7d084a2bfca1f24b2d07c40b96f20e359b31b24b3e71056853327R40). The present PR adds relevant change in e2e for the same.
- The API query for `content` was updated from `type=page` to `cql=type=page` or `cql=type=blogpost` in the [PR for space as a configurable field](https://github.com/elastic/connectors-python/pull/752/files#diff-c334a0be5ca7d084a2bfca1f24b2d07c40b96f20e359b31b24b3e71056853327R40) due to which relevant changes needs to be added in e2e for fetching `type` from `args`. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
