### PR TITLE
Align aioboto3 version with x86

### DIFF
--- a/requirements/aarch64.txt
+++ b/requirements/aarch64.txt
@@ -2,6 +2,6 @@
 -r framework.txt
 
 aiomysql==0.0.22
-aioboto3==9.0.0
+aioboto3==10.1.0
 motor==2.5.1
 smbprotocol==1.9.0


### PR DESCRIPTION
Fixes this test on M1: 

```
self = s3.ServiceResource()

    def close(self):
>       return self.meta.client.close()
ERROR       AttributeError: 'S3' object has no attribute 'close'

lib/python3.10/site-packages/aioboto3/resources/base.py:17: AttributeError
ERROR    asyncio:base_events.py:1758 Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x12af3a170>
```