### PR TITLE
Move last_sync_status to Job Execution Service

### DIFF
--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -6,6 +6,8 @@
 import asyncio
 import time
 
+import elasticsearch
+
 from connectors.byoc import JobStatus
 from connectors.byoei import ElasticServer
 from connectors.es import Mappings
@@ -21,6 +23,10 @@ ES_ID_SIZE_LIMIT = 512
 
 
 class SyncJobRunningError(Exception):
+    pass
+
+
+class SyncJobStartError(Exception):
     pass
 
 
@@ -84,12 +90,7 @@ class SyncJobRunner:
             raise SyncJobRunningError(f"Sync job {self.job_id} is already running.")
         self.running = True
 
-        if not await self.sync_starts():
-            logger.debug(
-                f"Failed to start sync for connector {self.connector_id}, the sync is executed by another connector service."
-            )
-            return
-
+        await self.sync_starts()
         await self.sync_job.claim()
         self._start_time = time.time()
 
@@ -215,16 +216,23 @@ class SyncJobRunner:
     @with_concurrency_control()
     async def sync_starts(self):
         if not await self.reload_connector():
-            return False
+            raise SyncJobStartError(f"Couldn't reload connector {self.connector_id}")
 
         if self.connector.last_sync_status == JobStatus.IN_PROGRESS:
             logger.debug(
-                f"Connector {self.connector_id} is syncing, skip the job {self.job_id}..."
+                f"A sync job is started for connector {self.connector_id} by another connector instance, skipping..."
             )
-            return False
+            raise SyncJobStartError(
+                f"A sync job is started for connector {self.connector_id} by another connector instance"
+            )
 
-        await self.connector.sync_starts()
-        return True
+        try:
+            await self.connector.sync_starts()
+        except Exception as e:
+            if isinstance(e, elasticsearch.ConflictError):
+                raise
+            else:
+                raise SyncJobStartError(f"Unexpected error happened: {e}")
 
     async def prepare_docs(self):
         logger.debug(f"Using pipeline {self.sync_job.pipeline}")

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -228,11 +228,10 @@ class SyncJobRunner:
 
         try:
             await self.connector.sync_starts()
+        except elasticsearch.ConflictError:
+            raise
         except Exception as e:
-            if isinstance(e, elasticsearch.ConflictError):
-                raise
-            else:
-                raise SyncJobStartError(f"Unexpected error happened: {e}")
+            raise SyncJobStartError from e
 
     async def prepare_docs(self):
         logger.debug(f"Using pipeline {self.sync_job.pipeline}")

--- a/connectors/tests/test_sync_job_runner.py
+++ b/connectors/tests/test_sync_job_runner.py
@@ -12,7 +12,7 @@ from elasticsearch import ConflictError
 from connectors.byoc import Filter, JobStatus, Pipeline
 from connectors.es.index import DocumentNotFoundError
 from connectors.filtering.validation import InvalidFilteringError
-from connectors.sync_job_runner import SyncJobRunner
+from connectors.sync_job_runner import SyncJobRunner, SyncJobStartError
 from connectors.tests.commons import AsyncIterator
 
 total_document_count = 100
@@ -125,7 +125,9 @@ async def test_connector_sync_starts_fail():
         meta=None,
         body={},
     )
-    await sync_job_runner.execute()
+
+    with pytest.raises(SyncJobStartError):
+        await sync_job_runner.execute()
 
     assert sync_job_runner.elastic_server is None
     sync_job_runner.connector.sync_starts.assert_awaited()


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4159

1. Add the `connector.last_sync_status` check to Job Execution Service, so if the connector is still syncing, don't create a `SyncJobRunner` instance for the sync job.
2. Raise `SyncJobStartError` if a `SyncJobRunner` instance fails to start a sync

Context is here: https://github.com/elastic/connectors-python/pull/768#discussion_r1165566262

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)