### PR TITLE
Sort column names by ORDINAL_POSITION

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -68,7 +68,7 @@ class MySQLQueries(Queries):
         return f"SELECT UPDATE_TIME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{self.database}' AND TABLE_NAME = '{table}'"
 
     def columns(self, table):
-        return f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{self.database}' AND TABLE_NAME = '{table}'"
+        return f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{self.database}' AND TABLE_NAME = '{table}' ORDER BY ORDINAL_POSITION"
 
     def ping(self):
         pass


### PR DESCRIPTION
Found a small issue with MySQL connector that was found during functional tests:

When data is received from MySQL, rows are taken and zipped with column names. These column names are taken from the `columns` method in the PR, but the problem is:

```
SELECT * from customers;

| name  | description | age |
| artem | lalala      | 123 | 

SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'customerinfo' AND TABLE_NAME = 'customers';

| COLUMN_NAME |
| age         |
| description |
| name        |
```

Sorting is different! As a result, the record for the data above will look like this:

```json
{
  "age": "artem",
  "description": "lalala",
  "name": "123"
}
```

This PR fixes it by also sorting column names by ORDINAL_POSITION - without it they seem to be sorted alphabetically.