### PR TITLE
Execute the oldest sync job first

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -62,6 +62,11 @@ class JobTriggerMethod(Enum):
     UNSET = None
 
 
+class Sort(Enum):
+    ASC = "asc"
+    DESC = "desc"
+
+
 class ServiceTypeNotSupportedError(Exception):
     pass
 
@@ -710,7 +715,7 @@ class SyncJobIndex(ESIndex):
                 ]
             }
         }
-        sort = [{"created_at": "asc"}]
+        sort = [{"created_at": Sort.ASC.value}]
         async for job in self.get_all_docs(query=query, sort=sort):
             yield job
 

--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -710,7 +710,8 @@ class SyncJobIndex(ESIndex):
                 ]
             }
         }
-        async for job in self.get_all_docs(query=query):
+        sort = [{"created_at": "asc"}]
+        async for job in self.get_all_docs(query=query, sort=sort):
             yield job
 
     async def orphaned_jobs(self, connector_ids):

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -83,12 +83,13 @@ class ESIndex(ESClient):
             script=script,
         )
 
-    async def get_all_docs(self, query=None, page_size=DEFAULT_PAGE_SIZE):
+    async def get_all_docs(self, query=None, sort=None, page_size=DEFAULT_PAGE_SIZE):
         """
         Lookup for elasticsearch documents using {query}
 
         Args:
             query (dict): Represents an Elasticsearch query
+            sort (list): A list of fields to sort the result
             page_size (int): Number of documents per query
         Returns:
             Iterator
@@ -106,6 +107,7 @@ class ESIndex(ESClient):
                 resp = await self.client.search(
                     index=self.index_name,
                     query=query,
+                    sort=sort,
                     from_=offset,
                     size=page_size,
                     expand_wildcards="hidden",

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -26,6 +26,7 @@ from connectors.byoc import (
     Pipeline,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
+    Sort,
     Status,
     SyncJob,
     SyncJobIndex,
@@ -1465,7 +1466,7 @@ async def test_pending_jobs(get_all_docs, set_env):
             ]
         }
     }
-    expected_sort = [{"created_at": "asc"}]
+    expected_sort = [{"created_at": Sort.ASC.value}]
 
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
     jobs = [

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -1465,13 +1465,14 @@ async def test_pending_jobs(get_all_docs, set_env):
             ]
         }
     }
+    expected_sort = [{"created_at": "asc"}]
 
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
     jobs = [
         job async for job in sync_job_index.pending_jobs(connector_ids=connector_ids)
     ]
 
-    get_all_docs.assert_called_with(query=expected_query)
+    get_all_docs.assert_called_with(query=expected_query, sort=expected_sort)
     assert len(jobs) == 1
     assert jobs[0] == job
 

--- a/connectors/tests/test_es_index.py
+++ b/connectors/tests/test_es_index.py
@@ -36,6 +36,8 @@ async def test_es_index_create_object_error(mock_responses):
         async for doc_ in index.get_all_docs():
             pass
 
+    await index.close()
+
 
 class FakeDocument:
     pass


### PR DESCRIPTION
This PR adds `sort` to `pending_jobs` of `SyncJobIndex` class, so that the oldest sync job is executed first.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)