### PR TITLE
Use custom docker images for our CI

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,0 +1,12 @@
+## Here we define our Buildkite pipelines
+
+We use our own custom image. The image definition can be found here: https://github.com/elastic/ci-agent-images/pull/132
+The image is built weekly, see the cron definition: https://github.com/elastic/ci/pull/1813/files
+
+The image and cron job were built following instruction from several sources:
+
+- https://docs.elastic.dev/ci/agent-images-for-buildkite
+- https://github.com/elastic/ci/blob/main/vm-images/README.md
+- https://github.com/elastic/ci-agent-images/README.md
+
+In case something is unclear, don't hesitate to contact #buildkite Slack channel.

--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,6 +1,7 @@
 ## Here we define our Buildkite pipelines
 
 We use our own custom image. The image definition can be found here: https://github.com/elastic/ci-agent-images/pull/132
+
 The image is built weekly, see the cron definition: https://github.com/elastic/ci/pull/1813/files
 
 The image and cron job were built following instruction from several sources:

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,7 +1,7 @@
 agents:
-  provider: "gcp"
-  machineType: "n1-standard-8"
-  useVault: true
+  image: docker.elastic.co/ci-agent-images/enterprise-search/connectors-python:1.0.0
+  ephemeralStorage: 50G
+  memory: 4G
 
 steps:
   - label: "🏗️ Docker images"

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,5 +1,5 @@
 agents:
-  image: family/enterprise-search-ubuntu-2204-connectors-py
+  image: enterprise-search-ubuntu-2204-connectors-py
 
 steps:
   - label: "🏗️ Docker images"

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,4 +1,7 @@
 agents:
+  provider: "gcp"
+  machineType: "n1-standard-8"
+  useVault: true
   image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,5 +1,5 @@
 agents:
-  image: enterprise-search-ubuntu-2204-connectors-py
+  image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:
   - label: "🏗️ Docker images"

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,7 +1,5 @@
 agents:
-  image: docker.elastic.co/ci-agent-images/enterprise-search/connectors-python:1.0.0
-  ephemeralStorage: 50G
-  memory: 4G
+  image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:
   - label: "🏗️ Docker images"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   provider: "gcp"
   machineType: "n1-standard-8"
-  useVault: true
+  useVault: false
   image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: enterprise-search-ubuntu-2204-connectors-py
+  image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:
   - command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,5 @@
 agents:
-  image: docker.elastic.co/ci-agent-images/enterprise-search/connectors-python:1.0.0
-  ephemeralStorage: 50G
-  memory: 4G
+  image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:
   - command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,7 @@
 agents:
+  provider: "gcp"
+  machineType: "n1-standard-8"
+  useVault: true
   image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: family/enterprise-search-ubuntu-2204-connectors-py
+  image: enterprise-search-ubuntu-2204-connectors-py
 
 steps:
   - command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
-  provider: "gcp"
-  machineType: "n1-standard-8"
-  useVault: false
+  image: docker.elastic.co/ci-agent-images/enterprise-search/connectors-python:1.0.0
+  ephemeralStorage: 50G
+  memory: 4G
 
 steps:
   - command:

--- a/.buildkite/run_dockerized_test.sh
+++ b/.buildkite/run_dockerized_test.sh
@@ -3,29 +3,6 @@
 # TODO: convert all this install in a docker image we can just use
 set -exuo pipefail
 
-sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install ca-certificates curl gnupg lsb-release -y
-sudo mkdir -p /etc/apt/keyrings
-
-echo "Installing Docker & Docker Compose"
-ARCH=`dpkg --print-architecture`
-RELEASE=`lsb_release -cs`
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-echo "deb [arch=$ARCH signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $RELEASE stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
-sudo systemctl start docker
-
-# installs Python 3.10
-echo "Installing Python 3.10"
-sudo apt-get remove python3-pip python3-setuptools -y
-sudo DEBIAN_FRONTEND=noninteractive apt install software-properties-common -y
-sudo add-apt-repository ppa:deadsnakes/ppa -y
-sudo TZ=UTC DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends python3.10 python3.10-dev python3.10-venv -y
-
-
-curl -sS https://bootstrap.pypa.io/get-pip.py | sudo python3.10
-
 echo "Starting test task"
 BASEDIR=$(realpath $(dirname $0))
 ROOT=$(realpath $BASEDIR/../)

--- a/.buildkite/run_nigthly.sh
+++ b/.buildkite/run_nigthly.sh
@@ -1,30 +1,6 @@
 #!/bin/bash
 set -exuo pipefail
 
-# TODO: convert all this install in a docker image we can just use
-sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install ca-certificates curl gnupg lsb-release -y
-sudo mkdir -p /etc/apt/keyrings
-
-echo "Installing Docker & Docker Compose"
-ARCH=`dpkg --print-architecture`
-RELEASE=`lsb_release -cs`
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-echo "deb [arch=$ARCH signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $RELEASE stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
-sudo systemctl start docker
-
-# installs Python 3.10
-echo "Installing Python 3.10"
-sudo apt-get remove python3-pip python3-setuptools -y
-sudo DEBIAN_FRONTEND=noninteractive apt install software-properties-common -y
-sudo add-apt-repository ppa:deadsnakes/ppa -y
-sudo TZ=UTC DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends python3.10 python3.10-dev python3.10-venv -y
-
-
-curl -sS https://bootstrap.pypa.io/get-pip.py | sudo python3.10
-
 echo "Starting test task"
 BASEDIR=$(realpath $(dirname $0))
 ROOT=$(realpath $BASEDIR/../)


### PR DESCRIPTION
## Follow-up for https://github.com/elastic/ci-agent-images/pull/132

We'll have our own docker image to run our pipelines against. This PR makes use of this image and cleans up scripts that run tests.

Example before:

https://buildkite.com/elastic/connectors-python/builds/4574#01879df5-c172-4e72-8b53-dd43513f35ff

![image](https://user-images.githubusercontent.com/12238374/233329251-43dc1f68-e2f4-40cc-9f9a-db5c2cdb0f68.png)

Example after:

https://buildkite.com/elastic/connectors-python/builds/4583#01879e0c-2445-4e4b-a921-0eb8dc12e4e3

![image](https://user-images.githubusercontent.com/12238374/233329378-61033899-63ae-442e-b10e-29a478967bd7.png)
