### PR TITLE
Revert "Use unsigned_long for field indexed_document_volume"

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -384,7 +384,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
     "deleted_document_count" : { "type" : "integer" },
     "error" : { "type" : "keyword" },
     "indexed_document_count" : { "type" : "integer" },
-    "indexed_document_volume" : { "type" : "unsigned_long" },
+    "indexed_document_volume" : { "type" : "integer" },
     "last_seen" : { "type" : "date" },
     "metadata" : { "type" : "object" },
     "started_at" : { "type" : "date" },


### PR DESCRIPTION
Reverts elastic/connectors-python#781

See: https://github.com/elastic/connectors-python/issues/735#issuecomment-1513725750