### PR TITLE
Report indexed_document_volume in MiB

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -536,9 +536,8 @@ class ElasticServer(ESClient):
                 {
                     "bulk_operations": dict(self._bulker.ops),
                     "indexed_document_count": self._bulker.indexed_document_count,
-                    "indexed_document_volume": round(
-                        self._bulker.indexed_document_volume
-                    ),
+                    # return indexed_document_volume in number of MiB
+                    "indexed_document_volume": self._bulker.indexed_document_volume // (1024 * 1024),
                     "deleted_document_count": self._bulker.deleted_document_count,
                 }
             )

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -302,7 +302,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
   deleted_document_count: number; -> Number of documents deleted in the job
   error: string; -> Optional error message
   indexed_document_count: number; -> Number of documents indexed in the job
-  indexed_document_volume: number; -> The volume (in bytes) of documents indexed in the job
+  indexed_document_volume: number; -> The volume (in MiB) of documents indexed in the job
   last_seen: date; -> Connector writes check-in date-time regularly (UTC)
   metadata: object; -> Connector-specific metadata
   started_at: date; -> The date/time when the job is started


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors-python/issues/735

See [this slack thread](https://elastic.slack.com/archives/C01795T48LQ/p1681748531281409). The field type for `indexed_document_volume` is `integer`, which can only represent about 2GB worth of "bytes". This PR stores MiB instead of bytes in `indexed_document_volume`, so the limit will be increased to ~2PB.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)