### PR TITLE
[MySQL] Make doc id generation more stable using sorted table names/pk columns

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -188,6 +188,22 @@ class MySQLClient:
 
             return [f"{table}_{column[0]}" for column in cursor.description]
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -314,14 +314,20 @@ def row2doc(row, column_names, primary_key_columns, table, timestamp):
 
 
 def generate_id(tables, row, primary_key_columns):
-    keys_value = ""
-    for key in primary_key_columns:
-        keys_value += f"{row.get(key)}_" if row.get(key) else ""
+    """Generates an id using table names as prefix in sorted order and primary key values.
+
+    Example:
+        tables: table1, table2
+        primary key values: 1, 42
+        table1_table2_1_42
+    """
+
+    if not isinstance(tables, list):
+        tables = [tables]
 
     return (
-        f"{'_'.join(tables)}_{keys_value}"
-        if isinstance(tables, list)
-        else f"{tables}_{keys_value}"
+        f"{'_'.join(sorted(tables))}_"
+        f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
 

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -578,9 +578,9 @@ class MySqlDataSource(BaseDataSource):
         primary_key_columns = [
             await client.get_primary_key_column_names(table) for table in tables
         ]
-        primary_key_columns = sorted([
-            column for columns in primary_key_columns for column in columns
-        ])
+        primary_key_columns = sorted(
+            [column for columns in primary_key_columns for column in columns]
+        )
 
         if not primary_key_columns:
             logger.warning(

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -578,9 +578,9 @@ class MySqlDataSource(BaseDataSource):
         primary_key_columns = [
             await client.get_primary_key_column_names(table) for table in tables
         ]
-        primary_key_columns = [
+        primary_key_columns = sorted([
             column for columns in primary_key_columns for column in columns
-        ]
+        ])
 
         if not primary_key_columns:
             logger.warning(

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -99,6 +99,12 @@ def patch_ping():
 
 
 @pytest.fixture
+def patch_row2doc():
+    with patch("connectors.sources.mysql.row2doc", return_value=MagicMock()) as row2doc:
+        yield row2doc
+
+
+@pytest.fixture
 def patch_default_wait_multiplier():
     with patch("connectors.sources.mysql.RETRY_INTERVAL", 0):
         yield
@@ -438,6 +444,54 @@ async def test_fetch_documents(patch_connection_pool):
         document_list.append(document)
 
     assert document in document_list
+
+
+@pytest.mark.asyncio
+async def test_fetch_documents_when_used_custom_query_then_sort_pk_cols(
+    patch_connection_pool, patch_row2doc
+):
+    last_update_time = "2023-01-18 17:18:56"
+    primary_key_col = ["cd", "ab"]
+    column = "column"
+
+    document = {
+        "Table": "table_name",
+        "_id": "table_name_",
+        "_timestamp": last_update_time,
+        f"table_name_{column}": "table1",
+    }
+
+    patch_row2doc.return_value = document
+
+    client = MagicMock()
+    client.get_primary_key_column_names = AsyncMock(side_effect=[primary_key_col])
+    client.get_last_update_time = AsyncMock(return_value=last_update_time)
+    client.get_column_names_for_query = AsyncMock(return_value=[column])
+    client.yield_rows_for_query = AsyncIterator([document])
+
+    source = await setup_mysql_source(DATABASE)
+    source.mysql_client = wrap_mock_client_in_context_manager(client)
+
+    document_list = []
+    async for document in source.fetch_documents(
+        tables=[TABLE_ONE], query="SELECT * FROM *"
+    ):
+        document_list.append(document)
+
+    assert document in document_list
+    assert patch_row2doc.call_args.kwargs == {
+        "row": {
+            "Table": "table_name",
+            "_id": "table_name_",
+            "_timestamp": "2023-01-18 17:18:56",
+            "table_name_column": "table1",
+        },
+        "column_names": ["column"],
+        # primary key columns are now sorted
+        "primary_key_columns": ["ab", "cd"],
+        "table": ["table1"],
+        "timestamp": "2023-01-18 17:18:56",
+    }
 
 
 @pytest.mark.asyncio

--- a/connectors/sources/tests/test_mysql.py
+++ b/connectors/sources/tests/test_mysql.py
@@ -804,15 +804,32 @@ def test_parse_tables_string_to_list(tables_string, expected_tables_list):
 
 
 @pytest.mark.parametrize(
-    "row, primary_key_columns, expected_id",
+    "tables, row, primary_key_columns, expected_id",
     [
-        ({"key_1": 1, "key_2": 2}, ["key_1"], f"{TABLE_ONE}_1_"),
-        ({"key_1": 1, "key_2": 2}, ["key_1", "key_2"], f"{TABLE_ONE}_1_2_"),
-        ({"key_1": 1, "key_2": 2}, ["key_1", "key_3"], f"{TABLE_ONE}_1_"),
+        (TABLE_ONE, {"key_1": 1, "key_2": 2}, ["key_1"], f"{TABLE_ONE}_1"),
+        ([TABLE_ONE], {"key_1": 1, "key_2": 2}, ["key_1"], f"{TABLE_ONE}_1"),
+        (
+            [TABLE_ONE, TABLE_TWO],
+            {"key_1": 1, "key_2": 2},
+            ["key_1", "key_2"],
+            f"{TABLE_ONE}_{TABLE_TWO}_1_2",
+        ),
+        (
+            [TABLE_THREE, TABLE_ONE, TABLE_TWO],
+            {"key_1": 1, "key_2": 2},
+            ["key_1", "key_3"],
+            f"{TABLE_ONE}_{TABLE_TWO}_{TABLE_THREE}_1",
+        ),
+        (
+            [TABLE_ONE, TABLE_TWO, TABLE_THREE],
+            {"key_1": 1, "key_2": 2},
+            ["key_1", "key_3"],
+            f"{TABLE_ONE}_{TABLE_TWO}_{TABLE_THREE}_1",
+        ),
     ],
 )
-def test_generate_id(row, primary_key_columns, expected_id):
-    row_id = generate_id(TABLE_ONE, row, primary_key_columns)
+def test_generate_id(tables, row, primary_key_columns, expected_id):
+    row_id = generate_id(tables, row, primary_key_columns)
 
     assert row_id == expected_id
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4240

This PR changes the id generation to always use a sorted versions of the tables/primary key columns for the ids to make ids more stable (tables could have an unsorted order in the advanced rules and impact the order of primary key columns).

We've decided with product to take the query not into account, which leads to the following expected behavior: If you've two queries using the same tables and the result sets overlap, the query executed later "wins" and overrides the documents ingested previously, if the ids match. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~