### PR TITLE
Add MongoDB to nightly runs

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -67,3 +67,8 @@ steps:
       - ".buildkite/run_nigthly.sh confluence"
     artifact_paths:
       - "perf8-report-*/**/*"
+  - label: "🔨 MongoDB"
+    command:
+      - ".buildkite/run_nigthly.sh mongodb"
+    artifact_paths:
+      - "perf8-report-*/**/*"


### PR DESCRIPTION
Minor thing - we have a functional test for MongoDB, but it's not included into nightlies. This PR makes sure we run a functional test for MongoDB during Nightly QA.