### PR TITLE
Round indexed_document_volume

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -537,8 +537,9 @@ class ElasticServer(ESClient):
                     "bulk_operations": dict(self._bulker.ops),
                     "indexed_document_count": self._bulker.indexed_document_count,
                     # return indexed_document_volume in number of MiB
-                    "indexed_document_volume": self._bulker.indexed_document_volume
-                    // (1024 * 1024),
+                    "indexed_document_volume": round(
+                        self._bulker.indexed_document_volume / (1024 * 1024)
+                    ),
                     "deleted_document_count": self._bulker.deleted_document_count,
                 }
             )


### PR DESCRIPTION
Round the indexed document volume instead of floor. E.g. 1.8 MB should be rounded to 2 MB instead of 1 MB.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)