### PR TITLE
[Documentation] Rectify default value of data source in Confluence

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -38,7 +38,7 @@ The following configuration fields need to be provided for setting up the connec
 
 ##### `data_source`
 
-Dropdown to determine the Confluence platform type: `Confluence Cloud` or `Confluence Server`. Default value is `Confluence Cloud`.
+Dropdown to determine the Confluence platform type: `Confluence Cloud` or `Confluence Server`. Default value is `Confluence Server`.
 
 ##### `username`
 


### PR DESCRIPTION
<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

Default value of data source is `Confluence Server`. Reference: https://github.com/elastic/connectors-python/blob/3c318299f6bb0d86e165f819d1d19e5424b6c7f3/connectors/sources/confluence.py#L219

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- ~~[x] Contributed any configuration settings changes to the configuration reference~~

