### PR TITLE
Make mongodb instance password-protected and use this password

### DIFF
--- a/connectors/sources/tests/fixtures/mongodb/connector.json
+++ b/connectors/sources/tests/fixtures/mongodb/connector.json
@@ -43,14 +43,14 @@
                 "label": "Username",
                 "order": 5,
                 "type": "str",
-                "value": ""
+                "value": "admin"
             },
             "password": {
                 "label": "Password",
                 "order": 6,
                 "sensitive": true,
                 "type": "str",
-                "value": ""
+                "value": "justtesting"
             }
         },
         "filtering": [

--- a/connectors/sources/tests/fixtures/mongodb/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/mongodb/docker-compose.yml
@@ -34,6 +34,10 @@ services:
     ports:
       - 27021:27017
     restart: always
+    environment:
+      # provide your credentials here
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=justtesting
   kibana:
     image: docker.elastic.co/kibana/kibana:${VERSION}
     ports:

--- a/connectors/sources/tests/fixtures/mongodb/fixture.py
+++ b/connectors/sources/tests/fixtures/mongodb/fixture.py
@@ -9,7 +9,7 @@ _SIZES = {"small": 750, "medium": 1500, "large": 3000}
 NUMBER_OF_RECORDS_TO_DELETE = 50
 
 fake = Faker()
-client = MongoClient("mongodb://127.0.0.1:27021")
+client = MongoClient("mongodb://admin:justtesting@127.0.0.1:27021")
 
 
 def setup():


### PR DESCRIPTION
Small problem to fix Nightly QA + `NAME=mongodb make ftest`.

Our MongoDB instance is not password-proteched, but connector recently started requiring username/password. This change updates our functional tests to setup a MongoDB instance with a password + change functional test setup to respect this password.