### PR TITLE
Increase nightly ES limits to 2GB to avoid memory errors

### DIFF
--- a/connectors/sources/tests/fixtures/azure_blob_storage/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/azure_blob_storage/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/confluence/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/confluence/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/dir/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/dir/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/google_cloud_storage/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/google_cloud_storage/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/jira/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/jira/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/mongodb/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/mongodb/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/mssql/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/mssql/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/mysql/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/mysql/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/network_drive/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/network_drive/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/oracle/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/oracle/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/postgresql/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/postgresql/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/s3/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/s3/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true

--- a/connectors/sources/tests/fixtures/sharepoint/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/sharepoint/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
       - ELASTIC_PASSWORD=changeme
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true


### PR DESCRIPTION
Our functional tests seem to fail from time to time with an error:

```
Failed to monitor the sync job. Something bad happened: ApiError(429, 'circuit_breaking_exception', '[parent] Data too large, data for [<http_request>] would be [520278848/496.1mb], which is larger than the limit of [510027366/486.3mb], real usage: [520278848/496.1mb], new bytes reserved: [0/0b], usages [eql_sequence=0/0b, fielddata=0/0b, request=0/0b, inflight_requests=0/0b, model_inference=0/0b]')
```

Looking at the documentation of Elasticsearch this error happens because our Elasticsearch instance is overloaded with data that's being ingested - it's stored in-memory. 

This PR increases the amount of RAM used by Elasticsearch to 2GB, hopefully that should be sufficient.