### PR TITLE
[8.7] Make connectors respect cloud log level (#809)

### DIFF
--- a/connectors/tests/config.yml
+++ b/connectors/tests/config.yml
@@ -15,6 +15,7 @@ service:
   max_errors: 20
   max_errors_span: 600
   max_concurrent_syncs: 10
+  log_level: INFO
 
 connector_id: '1'
 

--- a/connectors/tests/entsearch.yml
+++ b/connectors/tests/entsearch.yml
@@ -5,3 +5,5 @@ elasticsearch:
   headers:
     X-Elastic-Auth: SomeYeahValue
     X-Something: 1
+
+log_level: DEBUG

--- a/connectors/tests/test_config.py
+++ b/connectors/tests/test_config.py
@@ -10,7 +10,7 @@ from unittest import mock
 import pytest
 from envyaml import EnvYAML
 
-from connectors.config import load_config
+from connectors.config import _update_config_field, load_config
 
 CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.yml")
 ES_CONFIG_FILE = os.path.join(os.path.dirname(__file__), "entsearch.yml")
@@ -30,3 +30,36 @@ def test_config_with_ent_search(set_env):
     with mock.patch.dict(os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG_FILE}):
         config = load_config(CONFIG_FILE)
         assert config["elasticsearch"]["headers"]["X-Elastic-Auth"] == "SomeYeahValue"
+        assert config["service"]["log_level"] == "DEBUG"
+
+
+def test_update_config_when_nested_field_does_not_exist():
+    config = {}
+
+    _update_config_field(config, "test.nested.property", 50)
+
+    assert config["test"]["nested"]["property"] == 50
+
+
+def test_update_config_when_nested_field_exists():
+    config = {"test": {"nested": {"property": 25}}}
+
+    _update_config_field(config, "test.nested.property", 50)
+
+    assert config["test"]["nested"]["property"] == 50
+
+
+def test_update_config_when_root_field_does_not_exist():
+    config = {}
+
+    _update_config_field(config, "test", 50)
+
+    assert config["test"] == 50
+
+
+def test_update_config_when_root_field_does_exists():
+    config = {"test": 10}
+
+    _update_config_field(config, "test", 50)
+
+    assert config["test"] == 50


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Make connectors respect cloud log level (#809)](https://github.com/elastic/connectors-python/pull/809)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)