### PR TITLE
Use SIGINT to terminate the process from monitor

### DIFF
--- a/connectors/sources/tests/fixtures/fixture.py
+++ b/connectors/sources/tests/fixtures/fixture.py
@@ -88,7 +88,7 @@ def _monitor_service(pid):
         print(f"Failed to monitor the sync job. Something bad happened: {e}")
     finally:
         # the process should always be killed, no matter the monitor succeeds, times out or raises errors.
-        os.kill(pid, signal.SIGTERM)
+        os.kill(pid, signal.SIGINT)
         es_client.close()
 
 


### PR DESCRIPTION
Minor change to ftest flow - instead of terminating service with SIGTERM, we give it a chance to gracefully stop with SIGINT.

Why?

Perf8 needs time to compile reports and SIGTERM sometimes prevents it from doing so - if amount of data is reasonably large Perf8 will take several minutes to compile the report. This change potentially makes it so that we'll wait until Perf8 report will be completed.