### PR TITLE
Align mysql and mongodb with native connectors

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -114,40 +114,40 @@ class MongoDataSource(BaseDataSource):
     @classmethod
     def get_default_configuration(cls):
         return {
-            "collection": {
-                "label": "Collection",
-                "order": 1,
-                "type": "str",
-                "value": "",
-            },
-            "database": {"label": "Database", "order": 2, "type": "str", "value": ""},
-            "direct_connection": {
-                "display": "toggle",
-                "label": "Direct connection",
-                "order": 3,
-                "type": "bool",
-                "value": False,
-            },
             "host": {
-                "label": "Server Hostname",
-                "order": 4,
+                "label": "Server hostname",
+                "order": 1,
                 "type": "str",
                 "value": "",
             },
             "user": {
                 "label": "Username",
-                "order": 5,
+                "order": 2,
                 "type": "str",
                 "value": "",
                 "required": False,
             },
             "password": {
                 "label": "Password",
-                "order": 6,
+                "order": 3,
                 "sensitive": True,
                 "type": "str",
                 "value": "",
                 "required": False,
+            },
+            "database": {"label": "Database", "order": 4, "type": "str", "value": ""},
+            "collection": {
+                "label": "Collection",
+                "order": 5,
+                "type": "str",
+                "value": "",
+            },
+            "direct_connection": {
+                "display": "toggle",
+                "label": "Direct connection",
+                "order": 6,
+                "type": "bool",
+                "value": False,
             },
         }
 

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -391,7 +391,7 @@ class MySqlDataSource(BaseDataSource):
             },
             "ssl_enabled": {
                 "display": "toggle",
-                "label": "Enable SSL verification",
+                "label": "Enable SSL",
                 "order": 7,
                 "type": "bool",
                 "value": DEFAULT_SSL_ENABLED,

--- a/connectors/sources/tests/fixtures/mongodb/connector.json
+++ b/connectors/sources/tests/fixtures/mongodb/connector.json
@@ -14,35 +14,16 @@
         "created_at": null,
         "updated_at": null,
         "configuration": {
-            "collection": {
-                "label": "Collection",
-                "order": 1,
-                "type": "str",
-                "value": "sample_collection"
-            },
-            "database": {
-                "label": "Database",
-                "order": 2,
-                "type": "str",
-                "value": "sample_database"
-            },
-            "direct_connection": {
-                "display": "toggle",
-                "label": "Direct connection?",
-                "order": 3,
-                "type": "bool",
-                "value": true
-            },
             "host": {
                 "label": "Server Hostname",
-                "order": 4,
+                "order": 1,
                 "type": "str",
                 "value": "mongodb://127.0.0.1:27021"
             },
             "user": {
                 "default_value": "",
                 "label": "Username",
-                "order": 5,
+                "order": 2,
                 "type": "str",
                 "value": "admin",
                 "required": false
@@ -50,12 +31,31 @@
             "password": {
                 "default_value": "",
                 "label": "Password",
-                "order": 6,
+                "order": 3,
                 "sensitive": true,
                 "type": "str",
                 "value": "justtesting",
                 "required": false
-            }
+            },
+            "database": {
+                "label": "Database",
+                "order": 4,
+                "type": "str",
+                "value": "sample_database"
+            },
+            "collection": {
+                "label": "Collection",
+                "order": 5,
+                "type": "str",
+                "value": "sample_collection"
+            },
+            "direct_connection": {
+                "display": "toggle",
+                "label": "Direct connection",
+                "order": 6,
+                "type": "bool",
+                "value": true
+            },
         },
         "filtering": [
                 {

--- a/connectors/sources/tests/fixtures/mysql/connector.json
+++ b/connectors/sources/tests/fixtures/mysql/connector.json
@@ -55,7 +55,7 @@
                 },
                 "ssl_enabled": {
                         "display": "toggle",
-                        "label": "Enable SSL verification",
+                        "label": "Enable SSL",
                         "order": 7,
                         "type": "bool",
                         "value": false
@@ -70,7 +70,7 @@
                 "fetch_size": {
                         "default_value": 50,
                         "display": "numeric",
-                        "label": "Number of rows fetched per request",
+                        "label": "Rows fetched per request",
                         "order": 9,
                         "required": false,
                         "type": "int",
@@ -80,7 +80,7 @@
                 "retry_count": {
                         "default_value": 3,
                         "display": "numeric",
-                        "label": "Maximum retries per request",
+                        "label": "Retries per request",
                         "order": 10,
                         "required": false,
                         "type": "int",


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4265

MongoDB and MySQL native connectors and custom connectors are misaligned in their configurable fields.
This PR changes the default fields so that they will be the same as their native counterparts.
See Kibana PR: https://github.com/elastic/kibana/pull/155606

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
