### PR TITLE
Fix misformatted mongodb connector.json

### DIFF
--- a/connectors/sources/tests/fixtures/mongodb/connector.json
+++ b/connectors/sources/tests/fixtures/mongodb/connector.json
@@ -55,7 +55,7 @@
                 "order": 6,
                 "type": "bool",
                 "value": true
-            },
+            }
         },
         "filtering": [
                 {


### PR DESCRIPTION
Small mistake in MongoDB connector.json - somehow there's a dangling comma!