### PR TITLE
added a max duration

### DIFF
--- a/connectors/sources/tests/fixtures/fixture.py
+++ b/connectors/sources/tests/fixtures/fixture.py
@@ -136,6 +136,8 @@ def main(args=None):
                     print("1500")
                 case _:
                     print("3000")
+        if args.action == "description":
+            print(f'Running an e2e test for {args.name} with a {DATA_SIZE} corpus.')
         else:
             print(
                 f"Fixture {args.name} does not have an {args.action} action, skipping"

--- a/connectors/sources/tests/fixtures/fixture.py
+++ b/connectors/sources/tests/fixtures/fixture.py
@@ -138,7 +138,9 @@ def main(args=None):
                 case _:
                     print("3000")
         elif args.action == "description":
-            print(f'Running an e2e test for {args.name} with a {os.environ.get("DATA_SIZE", "medium")} corpus.')
+            print(
+                f'Running an e2e test for {args.name} with a {os.environ.get("DATA_SIZE", "medium")} corpus.'
+            )
         else:
             print(
                 f"Fixture {args.name} does not have an {args.action} action, skipping"

--- a/connectors/sources/tests/fixtures/fixture.py
+++ b/connectors/sources/tests/fixtures/fixture.py
@@ -66,7 +66,7 @@ def _set_sync_now_flag():
 
 def _monitor_service(pid):
     es_client = _es_client()
-    timeout = 10 * 60  # 10 minutes timeout
+    timeout = 20 * 60  # 20 minutes timeout
     try:
         # we should have something like connectorIndex.search()[0].last_synced
         # once we have ConnectorIndex and Connector class ready

--- a/connectors/sources/tests/fixtures/fixture.py
+++ b/connectors/sources/tests/fixtures/fixture.py
@@ -137,7 +137,7 @@ def main(args=None):
                     print("1500")
                 case _:
                     print("3000")
-        if args.action == "description":
+        elif args.action == "description":
             print(f'Running an e2e test for {args.name} with a {os.environ.get("DATA_SIZE", "medium")} corpus.')
         else:
             print(

--- a/connectors/sources/tests/fixtures/fixture.py
+++ b/connectors/sources/tests/fixtures/fixture.py
@@ -33,6 +33,7 @@ def _parser():
             "sync",
             "monitor",
             "get_num_docs",
+            "description",
         ],
     )
 
@@ -137,7 +138,7 @@ def main(args=None):
                 case _:
                     print("3000")
         if args.action == "description":
-            print(f'Running an e2e test for {args.name} with a {DATA_SIZE} corpus.')
+            print(f'Running an e2e test for {args.name} with a {os.environ.get("DATA_SIZE", "medium")} corpus.')
         else:
             print(
                 f"Fixture {args.name} does not have an {args.action} action, skipping"

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -45,7 +45,7 @@ $ROOT_DIR/bin/fake-kibana --index-name search-$NAME --service-type $NAME --conne
 $PYTHON fixture.py --name $NAME --action load
 $PYTHON fixture.py --name $NAME --action sync
 
-DESCRIPTION=`$PYTHON fixture.py --name $NAME --action description)`
+DESCRIPTION=`$PYTHON fixture.py --name $NAME --action description`
 
 if [[ $PERF8 == "yes" ]]
 then

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -35,6 +35,7 @@ if [ -f "$NAME/.env" ]; then
   export $(grep -v '^#' $NAME/.env | xargs)
 fi
 
+NUM_DOCS=`$PYTHON fixture.py --name $NAME --action get_num_docs`
 
 if [ -f "$NAME/requirements.txt" ]; then
 $PYTHON -m pip install -r $NAME/requirements.txt
@@ -45,15 +46,14 @@ $ROOT_DIR/bin/fake-kibana --index-name search-$NAME --service-type $NAME --conne
 $PYTHON fixture.py --name $NAME --action load
 $PYTHON fixture.py --name $NAME --action sync
 
-DESCRIPTION=`$PYTHON fixture.py --name $NAME --action description`
-
 if [[ $PERF8 == "yes" ]]
 then
+    $PYTHON fixture.py --name $NAME --action description > description.txt
     if [[ $PLATFORM == "darwin" ]]
     then
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description "$DESCRIPTION" -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description -c $ELASTIC_INGEST --debug & PID=$!
     else
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description "$DESCRIPTION" -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description -c $ELASTIC_INGEST --debug & PID=$!
     fi
 else
     $ELASTIC_INGEST --debug & PID=$!
@@ -69,7 +69,7 @@ $ELASTIC_INGEST --debug & PID_2=$!
 
 $PYTHON fixture.py --name $NAME --action monitor --pid $PID_2
 
-NUM_DOCS=`$PYTHON fixture.py --name $NAME --action get_num_docs`
+
 $PYTHON $ROOT_DIR/scripts/verify.py --index-name search-$NAME --service-type $NAME --size $NUM_DOCS
 $PYTHON fixture.py --name $NAME --action stop_stack
 $PYTHON fixture.py --name $NAME --action teardown
@@ -85,6 +85,8 @@ if [[ $PERF8 == "yes" ]]; then
         sleep 0.5
     done
     set -e
+
+    rm -f description.txt
 
     # reading the status to know if we need to fail
     STATUS=$(<$ROOT_DIR/perf8-report-$NAME/status)

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR="$SCRIPT_DIR/../.."
 PLATFORM='unknown'
 MAX_RSS="200M"
+MAX_DURATION=600
 
 export REFRESH_RATE="${REFRESH_RATE:-5}"
 export DATA_SIZE="${DATA_SIZE:-medium}"
@@ -48,9 +49,9 @@ if [[ $PERF8 == "yes" ]]
 then
     if [[ $PLATFORM == "darwin" ]]
     then
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION -c $ELASTIC_INGEST --debug & PID=$!
     else
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION -c $ELASTIC_INGEST --debug & PID=$!
     fi
 else
     $ELASTIC_INGEST --debug & PID=$!

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -50,9 +50,9 @@ then
     $PYTHON fixture.py --name $NAME --action description > description.txt
     if [[ $PLATFORM == "darwin" ]]
     then
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --debug & PID=$!
     else
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --debug & PID=$!
     fi
 else
     $ELASTIC_INGEST --debug & PID=$!

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -35,7 +35,6 @@ if [ -f "$NAME/.env" ]; then
   export $(grep -v '^#' $NAME/.env | xargs)
 fi
 
-NUM_DOCS=`$PYTHON fixture.py --name $NAME --action get_num_docs`
 
 if [ -f "$NAME/requirements.txt" ]; then
 $PYTHON -m pip install -r $NAME/requirements.txt
@@ -70,6 +69,7 @@ $ELASTIC_INGEST --debug & PID_2=$!
 $PYTHON fixture.py --name $NAME --action monitor --pid $PID_2
 
 
+NUM_DOCS=`$PYTHON fixture.py --name $NAME --action get_num_docs`
 $PYTHON $ROOT_DIR/scripts/verify.py --index-name search-$NAME --service-type $NAME --size $NUM_DOCS
 $PYTHON fixture.py --name $NAME --action stop_stack
 $PYTHON fixture.py --name $NAME --action teardown

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -53,7 +53,7 @@ then
     then
       $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description $DESCRIPTION -c $ELASTIC_INGEST --debug & PID=$!
     else
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION -c $ELASTIC_INGEST --description $DESCRIPTION --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description $DESCRIPTION -c $ELASTIC_INGEST --debug & PID=$!
     fi
 else
     $ELASTIC_INGEST --debug & PID=$!

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -45,13 +45,15 @@ $ROOT_DIR/bin/fake-kibana --index-name search-$NAME --service-type $NAME --conne
 $PYTHON fixture.py --name $NAME --action load
 $PYTHON fixture.py --name $NAME --action sync
 
+DESCRIPTION=`$PYTHON fixture.py --name $NAME --action description)`
+
 if [[ $PERF8 == "yes" ]]
 then
     if [[ $PLATFORM == "darwin" ]]
     then
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description $DESCRIPTION -c $ELASTIC_INGEST --debug & PID=$!
     else
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION -c $ELASTIC_INGEST --description $DESCRIPTION --debug & PID=$!
     fi
 else
     $ELASTIC_INGEST --debug & PID=$!

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -51,9 +51,9 @@ if [[ $PERF8 == "yes" ]]
 then
     if [[ $PLATFORM == "darwin" ]]
     then
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description $DESCRIPTION -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description "$DESCRIPTION" -c $ELASTIC_INGEST --debug & PID=$!
     else
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description $DESCRIPTION -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description "$DESCRIPTION" -c $ELASTIC_INGEST --debug & PID=$!
     fi
 else
     $ELASTIC_INGEST --debug & PID=$!


### PR DESCRIPTION
added a max duration for BK

By default we allow a maximum time of 10 minutes per e2e test. If it goes beyond that limit we fail.
Each connector test can tweak that value in the `.env` variable 
