### PR TITLE
useVault: false for pipelines - we don't use Vault

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,7 +1,7 @@
 agents:
   provider: "gcp"
   machineType: "n1-standard-8"
-  useVault: true
+  useVault: false
   image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   provider: "gcp"
   machineType: "n1-standard-2"
-  useVault: true
+  useVault: false
   image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:


### PR DESCRIPTION
There was a bug that added 15 seconds to each CI job that is ran in Buildkite. Our pipelines for Buildkite semi-randomly had this option set to true due to it providing no visible side-effects while improving our run-times.

It was fixed with https://github.com/elastic/vault-buildkite-plugin/pull/26 and it's safe to do `useVault: false` for now - we don't have secrets that we use.