### PR TITLE
Fix regex for main labelling for backportrc

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -8,7 +8,7 @@
   "fork": false,
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
-    "^v8.9.0$": "main",
+    "^v8.9.0(.0)?$": "main",
     "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
   },
   "upstream": "elastic/connectors-python"


### PR DESCRIPTION
Maybe it'll fix our autobackports?

It constantly fails saying that it's unable to backport to the branch that's currently main.

Most likely it's broken cause our `main` is automatically labelled with additional `.0` in the end, for example see label for this PR.

We should account for both `v8.9.0` and `v.8.9.0.0` as main, thus I've updated regex to allow optional `.0` in the end.