### PR TITLE
Add a sample option to CLI to get connector default config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ ftest: bin/pytest bin/elastic-ingest
 run: install
 	bin/elastic-ingest
 
+default-config: install
+	bin/elastic-ingest --action config --service-type $(SERVICE_TYPE)
+
 docker-build:
 	docker build -t docker.elastic.co/enterprise-search/elastic-connectors:$(VERSION)-SNAPSHOT .
 

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -12,6 +12,7 @@ executes the `main` function of this module, which starts the service.
 """
 import asyncio
 import functools
+import json
 import logging
 import os
 import signal
@@ -22,7 +23,7 @@ from connectors.config import load_config
 from connectors.logger import logger, set_logger
 from connectors.preflight_check import PreflightCheck
 from connectors.services import get_services
-from connectors.source import get_source_klasses
+from connectors.source import get_source_klass, get_source_klasses
 from connectors.utils import get_event_loop
 
 __all__ = ["main"]
@@ -36,7 +37,7 @@ def _parser():
         "--action",
         type=str,
         default=["schedule", "execute", "cleanup"],
-        choices=["schedule", "execute", "list", "cleanup"],
+        choices=["schedule", "execute", "list", "default_configuration", "cleanup"],
         nargs="+",
         help="What elastic-ingest should do",
     )
@@ -77,6 +78,13 @@ def _parser():
         action="store_true",
         default=False,
         help="Display the version and exit.",
+    )
+
+    parser.add_argument(
+        "--service-type",
+        type=str,
+        default=None,
+        help="Service type to get default configuration for if action is default_configuration",
     )
 
     parser.add_argument(
@@ -154,6 +162,18 @@ def run(args):
         print("Bye")
         return 0
 
+    if args.action == ["default_configuration"]:
+        service_type = args.service_type
+        print(f"Getting default configuration for service type {service_type}")
+        source_list = config["sources"]
+        if service_type not in source_list:
+            print(f"Could not find a connector for service type {service_type}")
+            return 0
+        source_klass = get_source_klass(source_list[service_type])
+        print(json.dumps(source_klass.get_simple_configuration(), indent=2))
+        print("Bye")
+        return 0
+
     if "list" in args.action:
         print("Cannot use the `list` action with other actions")
         return -1
@@ -182,4 +202,5 @@ def main(args=None):
     if args.version:
         print(__version__)
         return 0
+
     return run(args)

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -37,7 +37,7 @@ def _parser():
         "--action",
         type=str,
         default=["schedule", "execute", "cleanup"],
-        choices=["schedule", "execute", "list", "default_configuration", "cleanup"],
+        choices=["schedule", "execute", "list", "config", "cleanup"],
         nargs="+",
         help="What elastic-ingest should do",
     )
@@ -84,7 +84,7 @@ def _parser():
         "--service-type",
         type=str,
         default=None,
-        help="Service type to get default configuration for if action is default_configuration",
+        help="Service type to get default configuration for if action is config",
     )
 
     parser.add_argument(
@@ -162,13 +162,15 @@ def run(args):
         print("Bye")
         return 0
 
-    if args.action == ["default_configuration"]:
+    if args.action == ["config"]:
         service_type = args.service_type
         print(f"Getting default configuration for service type {service_type}")
+
         source_list = config["sources"]
         if service_type not in source_list:
             print(f"Could not find a connector for service type {service_type}")
-            return 0
+            return -1
+
         source_klass = get_source_klass(source_list[service_type])
         print(json.dumps(source_klass.get_simple_configuration(), indent=2))
         print("Bye")

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -180,6 +180,10 @@ def run(args):
         print("Cannot use the `list` action with other actions")
         return -1
 
+    if "config" in args.action:
+        print("Cannot use the `config` action with other actions")
+        return -1
+
     loop = get_event_loop(args.uvloop)
     coro = _start_service(args.action, config, loop)
 


### PR DESCRIPTION
Introducing an additional option to cli - `config`.

With this option CLI will output the default connector configuration for connector passed in `--service-type` argument.

 It's also possible to use this command with `make default-config SERVICE_TYPE=<service_type>` for convenience.

Example output:

```sh
artemshelkovnikov@Artems-MacBook-Pro-2 connectors-py % make default-config SERVICE_TYPE=mongodb
bin/elastic-ingest --action config --service-type mongodb
[FMWK][12:13:39][INFO] Running connector service version 8.9.0.0
[FMWK][12:13:39][INFO] Loading config from /Users/artemshelkovnikov/git_tree/connectors-py/connectors/../config.yml
Getting default configuration for service type mongodb
{
  "host": {
    "default_value": null,
    "depends_on": [],
    "display": "text",
    "label": "Server hostname",
    "options": [],
    "order": 1,
    "required": true,
    "sensitive": false,
    "tooltip": null,
    "type": "str",
    "ui_restrictions": [],
    "validations": [],
    "value": ""
  },
  "user": {
    "default_value": null,
    "depends_on": [],
    "display": "text",
    "label": "Username",
    "options": [],
    "order": 2,
    "required": false,
    "sensitive": false,
    "tooltip": null,
    "type": "str",
    "ui_restrictions": [],
    "validations": [],
    "value": ""
  },
  "password": {
    "default_value": null,
    "depends_on": [],
    "display": "text",
    "label": "Password",
    "options": [],
    "order": 3,
    "required": false,
    "sensitive": true,
    "tooltip": null,
    "type": "str",
    "ui_restrictions": [],
    "validations": [],
    "value": ""
  },
  "database": {
    "default_value": null,
    "depends_on": [],
    "display": "text",
    "label": "Database",
    "options": [],
    "order": 4,
    "required": true,
    "sensitive": false,
    "tooltip": null,
    "type": "str",
    "ui_restrictions": [],
    "validations": [],
    "value": ""
  },
  "collection": {
    "default_value": null,
    "depends_on": [],
    "display": "text",
    "label": "Collection",
    "options": [],
    "order": 5,
    "required": true,
    "sensitive": false,
    "tooltip": null,
    "type": "str",
    "ui_restrictions": [],
    "validations": [],
    "value": ""
  },
  "direct_connection": {
    "default_value": null,
    "depends_on": [],
    "display": "toggle",
    "label": "Direct connection",
    "options": [],
    "order": 6,
    "required": true,
    "sensitive": false,
    "tooltip": null,
    "type": "bool",
    "ui_restrictions": [],
    "validations": [],
    "value": false
  }
}
Bye
```