### PR TITLE
Use vault in nightly tests

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,7 +1,7 @@
 agents:
   provider: "gcp"
   machineType: "n1-standard-8"
-  useVault: false
+  useVault: true
   image: family/enterprise-search-ubuntu-2204-connectors-py
 
 steps:


### PR DESCRIPTION
I've set `useVault: false` for Nightly pipeline but it's actually needed to build Docker images, see https://buildkite.com/elastic/connectors-python-nightly/builds/587#0187dbb5-92de-4791-9115-4d0db6c1b1e1

This PR returns `useVault: true` for Nightlies