### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,6 +1,7 @@
 ################################################################################
 ###################### catalog-info for connectors-python ######################
 # Declare a Backstage Component for connectors-python
+# When doing changes validate them using https://backstage.elastic.dev/entity-validation
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
 apiVersion: "backstage.io/v1alpha1"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,22 +1,29 @@
+# Declare a Backstage Component for cloud-on-k8s-operator
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: connectors-python
-
+  description: Ingestion Service hosting connectors that can be used to ingest data into Elasticsearch.
+  annotations:
+    github.com/project-slug: elastic/connectors-python
+    buildkite.com/project-slug: elastic/connectors-python
 spec:
   type: service
+  lifecycle: experimental
   owner: group:ingestion-team
   system: buildkite
-  lifecycle: production
-
 ---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: buildkite.elastic.dev/v1
 kind: Pipeline
 metadata:
   description: Connectors Service in Python Nightly Tests
   name: connectors-python-nightly
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/connectors-python-nightly
 spec:
   pipeline_file: .buildkite/nightly.yml
   provider_settings:
@@ -39,13 +46,16 @@ spec:
     everyone:
       access_level: READ_ONLY
     ingestion-team: {}
-
 ---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: buildkite.elastic.dev/v1
 kind: Pipeline
 metadata:
   description: Connectors Service in Python
-  name: connectors-python-pr
+  name: connectors-python
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/connectors-python
 spec:
   pipeline_file: .buildkite/pipeline.yml
   branch_configuration: main

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,9 +13,9 @@ metadata:
     github.com/project-slug: "elastic/connectors-python"
     github.com/team-slug: "elastic/ingestion-team"
     buildkite.com/project-slug: "elastic/connectors-python"
-tags:
-  - "python"
-  - "buildkite"
+  tags:
+    - "python"
+    - "buildkite"
 spec:
   type: "service"
   lifecycle: "production"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,66 +1,103 @@
-# Declare a Backstage Component for cloud-on-k8s-operator
+################################################################################
+###################### catalog-info for connectors-python ######################
+# Declare a Backstage Component for connectors-python
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
-apiVersion: backstage.io/v1alpha1
-kind: Component
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
 metadata:
-  name: connectors-python
-  description: Ingestion Service hosting connectors that can be used to ingest data into Elasticsearch.
+  name: "connectors-python"
+  description: "Ingestion Service hosting connectors that can be used to ingest data into Elasticsearch"
   annotations:
-    github.com/project-slug: elastic/connectors-python
-    buildkite.com/project-slug: elastic/connectors-python
+    backstage.io/source-location: "url:https://github.com/elastic/connectors-python/"
+    github.com/project-slug: "elastic/connectors-python"
+    github.com/team-slug: "elastic/ingestion-team"
+    buildkite.com/project-slug: "elastic/connectors-python"
+tags:
+  - "python"
+  - "buildkite"
 spec:
-  type: service
-  lifecycle: experimental
-  owner: group:ingestion-team
-  system: buildkite
----
+  type: "service"
+  lifecycle: "production"
+  owner: "group:ingestion-team"
+
+###############################################################################
+############################# buildkite pipelines #############################
+# Declare our Buildkite pipelines
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
-apiVersion: buildkite.elastic.dev/v1
-kind: Pipeline
-metadata:
-  description: Connectors Service in Python Nightly Tests
-  name: connectors-python-nightly
-  links:
-    - title: Pipeline
-      url: https://buildkite.com/elastic/connectors-python-nightly
-spec:
-  pipeline_file: .buildkite/nightly.yml
-  provider_settings:
-    trigger_mode: none
-  repository: elastic/connectors-python
-  schedules:
-    Daily 8_7:
-      branch: '8.7'
-      cronline: '@daily'
-      message: Runs daily `8.7` e2e test
-    Daily 8_8:
-      branch: '8.8'
-      cronline: '@daily'
-      message: Runs daily `8.8` e2e test
-    Daily main:
-      branch: main
-      cronline: '@daily'
-      message: Runs daily `main` e2e test
-  teams:
-    everyone:
-      access_level: READ_ONLY
-    ingestion-team: {}
+
+# Declare the main pipeline that's used for PRs and commits
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
-apiVersion: buildkite.elastic.dev/v1
-kind: Pipeline
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
 metadata:
-  description: Connectors Service in Python
-  name: connectors-python
+  name: "connectors-python"
+  description: "Lints and tests Python Connectors"
   links:
-    - title: Pipeline
-      url: https://buildkite.com/elastic/connectors-python
+    - title: "connectors-python Main Pipeline"
+      url: "https://buildkite.com/elastic/connectors-python"
 spec:
-  pipeline_file: .buildkite/pipeline.yml
-  branch_configuration: main
-  repository: elastic/connectors-python
-  teams:
-    everyone:
-      access_level: READ_ONLY
-    ingestion-team: {}
+  type: "buildkite-pipeline"
+  owner: "group:ingestion-team"
+  system: "buildkite"
+  implementation:
+    apiVersion: "buildkite.elastic.dev/v1"
+    kind: "Pipeline"
+    metadata:
+      name: "Connectors Python"
+      description: "Your Connector Service to ingest data into Elasticsearch"
+    spec:
+      branch_configuration: "main"
+      pipeline_file: ".buildkite/pipeline.yml"
+      repository: "elastic/connectors-python"
+      teams:
+        everyone:
+          access_level: "READ_ONLY"
+        ingestion-team: {}
+
+############################# Nightly Test Suites #############################
+# Declare daily/nightly tests pipeline
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "connectors-python-nightly"
+  description: "Nightly Connector Service Tests"
+  links:
+    - title: "connectors-python Nightly Buildkite Jobs"
+      url: "https://buildkite.com/elastic/connectors-python"
+spec:
+  type: "buildkite-pipeline"
+  owner: "group:ingestion-team"
+  system: "buildkite"
+  implementation:
+    apiVersion: "buildkite.elastic.dev/v1"
+    kind: "Pipeline"
+    metadata:
+      name: "connectors-python-nightly"
+      description: "Connectors Service in Python Nightly Tests"
+      links:
+        - title: "Connector Service Nightly Pipeline"
+          url: "https://buildkite.com/elastic/connectors-python-nightly"
+    spec:
+      pipeline_file: ".buildkite/nightly.yml"
+      provider_settings:
+        trigger_mode: "none"
+      repository: "elastic/connectors-python"
+      schedules:
+        Daily 8_7:
+          branch: '8.7'
+          cronline: '@daily'
+          message: "Runs daily `8.7` e2e test"
+        Daily 8_8:
+          branch: '8.8'
+          cronline: '@daily'
+          message: "Runs daily `8.8` e2e test"
+        Daily main:
+          branch: main
+          cronline: '@daily'
+          message: "Runs daily `main` e2e test"
+      teams:
+        everyone:
+          access_level: "READ_ONLY"
+        ingestion-team: {}


### PR DESCRIPTION
Just minor changes to make it nicer.

I copied its format from CI repo, but it's actually not right. Actual schema can be validated with https://backstage.elastic.dev/entity-validation, and that's what I did - changed the schema and validated it with the mentioned tool.