### PR TITLE
Fix linters for now

### DIFF
--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -470,7 +470,7 @@ class GenericBaseDataSource(BaseDataSource):
             raise NotImplementedError
         return (
             map(
-                lambda table: table[0],
+                lambda table: table[0],  # type: ignore
                 await anext(
                     self.execute_query(
                         query=self.queries.all_tables(


### PR DESCRIPTION
Linting stage fails due to newer version of static analyser reporting an error:

```
artemshelkovnikov@Artems-MacBook-Pro-2 connectors-py % make lint
bin/isort --check . --sp .isort.cfg
Skipped 6 files
bin/black --check connectors
All done! ✨ 🍰 ✨
91 files would be left unchanged.
bin/black --check setup.py
All done! ✨ 🍰 ✨
1 file would be left unchanged.
bin/flake8 connectors
bin/flake8 setup.py
bin/black --check scripts
All done! ✨ 🍰 ✨
1 file would be left unchanged.
bin/flake8 scripts
bin/pyright connectors
/Users/artemshelkovnikov/git_tree/connectors-py/connectors/sources/generic_database.py
  /Users/artemshelkovnikov/git_tree/connectors-py/connectors/sources/generic_database.py:473:31 - error: "__getitem__" method not defined on type "object*" (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations
make: *** [lint] Error 1
```

Looking at the code it looks like it can be ignored, though code of course is not perfect.