### PR TITLE
[8.7] Fix linters for now (#848)

### DIFF
--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -488,7 +488,7 @@ class GenericBaseDataSource(BaseDataSource):
             raise NotImplementedError
         return (
             map(
-                lambda table: table[0],
+                lambda table: table[0],  # type: ignore
                 await anext(
                     self.execute_query(
                         query=self.queries.all_tables(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Fix linters for now (#848)](https://github.com/elastic/connectors-python/pull/848)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)