### PR TITLE
[8.7] Report indexed_document_volume in MiB (#796)

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -530,9 +530,9 @@ class ElasticServer(ESClient):
                 {
                     "bulk_operations": dict(self._bulker.ops),
                     "indexed_document_count": self._bulker.indexed_document_count,
-                    "indexed_document_volume": round(
-                        self._bulker.indexed_document_volume
-                    ),
+                    # return indexed_document_volume in number of MiB
+                    "indexed_document_volume": self._bulker.indexed_document_volume
+                    // (1024 * 1024),
                     "deleted_document_count": self._bulker.deleted_document_count,
                 }
             )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Report indexed_document_volume in MiB (#796)](https://github.com/elastic/connectors-python/pull/796)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)