### PR TITLE
[8.7] Move get_existing_ids to Fetcher (#807)

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -232,9 +232,9 @@ class Fetcher:
     This class runs a coroutine that puts docs in `queue`, given a document generator.
 
     Arguments:
+    - client: an instance of `connectors.es.ESClient`
     - queue: an `asyncio.Queue` to put docs in
     - index: the target Elasticsearch index
-    - existing_ids: a list of existing Elasticsearch document ids found in the index
     - filter_: an instance of `Filter` to apply on the fetched document -- default: `None`
     - sync_rules_enabled: if `True`, we apply rules -- default: `False`
     - display_every -- display a log every `display_every` doc -- default: `DEFAULT_DISPLAY_EVERY`
@@ -243,9 +243,9 @@ class Fetcher:
 
     def __init__(
         self,
+        client,
         queue,
         index,
-        existing_ids,
         filter_=None,
         sync_rules_enabled=False,
         display_every=DEFAULT_DISPLAY_EVERY,
@@ -253,12 +253,12 @@ class Fetcher:
     ):
         if filter_ is None:
             filter_ = Filter()
+        self.client = client
         self.queue = queue
         self.bulk_time = 0
         self.bulking = False
         self.index = index
         self.loop = asyncio.get_event_loop()
-        self.existing_ids = existing_ids
         self.sync_runs = False
         self.total_downloads = 0
         self.total_docs_updated = 0
@@ -279,6 +279,32 @@ class Fetcher:
             f"update: {self.total_docs_updated} |"
             f"delete: {self.total_docs_deleted}>"
         )
+
+    async def _get_existing_ids(self):
+        """Returns an iterator on the `id` and `_timestamp` fields of all documents in an index.
+
+
+        WARNING
+
+        This function will load all ids in memory -- on very large indices,
+        depending on the id length, it can be quite large.
+
+        300,000 ids will be around 50MiB
+        """
+        logger.debug(f"Scanning existing index {self.index}")
+        try:
+            await self.client.indices.get(index=self.index)
+        except ElasticNotFoundError:
+            return
+
+        async for doc in async_scan(
+            client=self.client,
+            index=self.index,
+            _source=["id", TIMESTAMP_FIELD],
+        ):
+            doc_id = doc["_source"].get("id", doc["_id"])
+            ts = doc["_source"].get(TIMESTAMP_FIELD)
+            yield doc_id, ts
 
     async def _deferred_index(self, lazy_download, doc_id, doc, operation):
         data = await lazy_download(doit=True, timestamp=doc[TIMESTAMP_FIELD])
@@ -313,6 +339,16 @@ class Fetcher:
         """
         logger.info("Starting doc lookups")
         self.sync_runs = True
+
+        start = time.time()
+        existing_ids = {k: v async for (k, v) in self._get_existing_ids()}
+        logger.debug(
+            f"Found {len(existing_ids)} docs in {self.index} (duration "
+            f"{int(time.time() - start)} seconds) "
+        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Size of ids in memory is {get_mb_size(existing_ids)}MiB")
+
         count = 0
         lazy_downloads = ConcurrentTasks(self.concurrent_downloads)
         try:
@@ -329,9 +365,9 @@ class Fetcher:
                 ):
                     continue
 
-                if doc_id in self.existing_ids:
-                    # pop out of self.existing_ids
-                    ts = self.existing_ids.pop(doc_id)
+                if doc_id in existing_ids:
+                    # pop out of existing_ids
+                    ts = existing_ids.pop(doc_id)
 
                     # If the doc has a timestamp, we can use it to see if it has
                     # been modified. This reduces the bulk size a *lot*
@@ -386,8 +422,8 @@ class Fetcher:
         # returned by the backend.
         #
         # Since we popped out every seen doc, existing_ids has now the ids to delete
-        logger.debug(f"Delete {len(self.existing_ids)} docs from Elasticsearch")
-        for doc_id in self.existing_ids.keys():
+        logger.debug(f"Delete {len(existing_ids)} docs from Elasticsearch")
+        for doc_id in existing_ids.keys():
             await self.queue.put(
                 {
                     "_op_type": OP_DELETE,
@@ -466,32 +502,6 @@ class ElasticServer(ESClient):
             return
         else:
             raise IndexMissing(f"Index {index} does not exist!")
-
-    async def get_existing_ids(self, index):
-        """Returns an iterator on the `id` and `_timestamp` fields of all documents in an index.
-
-
-        WARNING
-
-        This function will load all ids in memory -- on very large indices,
-        depending on the id length, it can be quite large.
-
-        300,000 ids will be around 50MiB
-        """
-        logger.debug(f"Scanning existing index {index}")
-        try:
-            await self.client.indices.get(index=index)
-        except ElasticNotFoundError:
-            return
-
-        async for doc in async_scan(
-            client=self.client,
-            index=index,
-            _source=["id", TIMESTAMP_FIELD],
-        ):
-            doc_id = doc["_source"].get("id", doc["_id"])
-            ts = doc["_source"].get(TIMESTAMP_FIELD)
-            yield doc_id, ts
 
     def done(self):
         if self._fetcher_task is not None and not self._fetcher_task.done():
@@ -577,21 +587,13 @@ class ElasticServer(ESClient):
             "concurrent_downloads", DEFAULT_CONCURRENT_DOWNLOADS
         )
 
-        start = time.time()
         stream = MemQueue(maxsize=queue_size, maxmemsize=queue_mem_size * 1024 * 1024)
-        existing_ids = {k: v async for (k, v) in self.get_existing_ids(index)}
-        logger.debug(
-            f"Found {len(existing_ids)} docs in {index} (duration "
-            f"{int(time.time() - start)} seconds) "
-        )
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f"Size of ids in memory is {get_mb_size(existing_ids)}MiB")
 
         # start the fetcher
         self._fetcher = Fetcher(
+            self.client,
             stream,
             index,
-            existing_ids,
             filter_=filter_,
             sync_rules_enabled=sync_rules_enabled,
             display_every=display_every,

--- a/connectors/tests/test_byoei.py
+++ b/connectors/tests/test_byoei.py
@@ -191,8 +191,9 @@ async def test_get_existing_ids(mock_responses):
     set_responses(mock_responses)
 
     es = ElasticServer(config)
+    fetcher = Fetcher(es.client, None, "search-some-index")
     ids = []
-    async for doc_id, ts in es.get_existing_ids("search-some-index"):
+    async for doc_id, ts in fetcher._get_existing_ids():
         ids.append(doc_id)
 
     assert ids == ["1", "2"]
@@ -323,13 +324,11 @@ async def lazy_downloads_mock():
     return lazy_downloads
 
 
-async def setup_fetcher(basic_rule_engine, existing_docs, queue, sync_rules_enabled):
-    existing_ids = {doc["_id"]: doc["_timestamp"] for doc in existing_docs}
-
+async def setup_fetcher(basic_rule_engine, queue, sync_rules_enabled):
     # filtering content doesn't matter as the BasicRuleEngine behavior is mocked
     filter_mock = Mock()
     filter_mock.get_active_filter = Mock(return_value={})
-    fetcher = Fetcher(queue, INDEX, existing_ids, filter_=filter_mock)
+    fetcher = Fetcher(None, queue, INDEX, filter_=filter_mock)
     fetcher.basic_rule_engine = basic_rule_engine if sync_rules_enabled else None
     return fetcher
 
@@ -518,8 +517,10 @@ async def setup_fetcher(basic_rule_engine, existing_docs, queue, sync_rules_enab
         ),
     ],
 )
+@mock.patch("connectors.byoei.Fetcher._get_existing_ids")
 @pytest.mark.asyncio
 async def test_get_docs(
+    get_existing_ids,
     existing_docs,
     docs_from_source,
     doc_should_ingest,
@@ -532,6 +533,10 @@ async def test_get_docs(
 ):
     lazy_downloads = await lazy_downloads_mock()
 
+    get_existing_ids.return_value = AsyncIterator(
+        [(doc["_id"], doc["_timestamp"]) for doc in existing_docs]
+    )
+
     with mock.patch("connectors.utils.ConcurrentTasks", return_value=lazy_downloads):
         queue = await queue_mock()
         basic_rule_engine = await basic_rule_engine_mock(doc_should_ingest)
@@ -541,7 +546,7 @@ async def test_get_docs(
         doc_generator = AsyncIterator([deepcopy(doc) for doc in docs_from_source])
 
         fetcher = await setup_fetcher(
-            basic_rule_engine, existing_docs, queue, sync_rules_enabled
+            basic_rule_engine, queue, sync_rules_enabled
         )
 
         await fetcher.get_docs(doc_generator)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Move get_existing_ids to Fetcher (#807)](https://github.com/elastic/connectors-python/pull/807)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)