### PR TITLE
Update SSL cert label for MSSQL

### DIFF
--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -96,7 +96,7 @@ class MSSQLDataSource(GenericBaseDataSource):
                 },
                 "ssl_ca": {
                     "depends_on": [{"field": "ssl_enabled", "value": True}],
-                    "label": "Certificate data",
+                    "label": "SSL certificate",
                     "order": 11,
                     "type": "str",
                     "value": "",


### PR DESCRIPTION
Updating label for SSL certificate for MSSQL connector - it's called "SSL certificate" in PostgreSQL and in Frontend.