### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -32,7 +32,7 @@ spec:
 apiVersion: "backstage.io/v1alpha1"
 kind: "Resource"
 metadata:
-  name: "connectors-python"
+  name: "connectors-python-main-pipeline"
   description: "Lints and tests Python Connectors"
   links:
     - title: "connectors-python Main Pipeline"


### PR DESCRIPTION
My change broke CI: https://buildkite.com/elastic/terrazzo/builds/10542#0187e1d1-4a5d-43a9-a761-df533b017f06

>  There is already a Construct with name ‘connectors-python’ in Construct

Seems like I need to provide unique name for each entry in `catalog-info.yaml`.