### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,7 @@
 apiVersion: "backstage.io/v1alpha1"
 kind: "Component"
 metadata:
-  name: "connectors-python"
+  name: "elastic-connectors-python"
   description: "Ingestion Service hosting connectors that can be used to ingest data into Elasticsearch"
   annotations:
     backstage.io/source-location: "url:https://github.com/elastic/connectors-python/"
@@ -62,7 +62,7 @@ spec:
 apiVersion: "backstage.io/v1alpha1"
 kind: "Resource"
 metadata:
-  name: "connectors-python-nightly"
+  name: "connectors-python-nightly-pipeline"
   description: "Nightly Connector Service Tests"
   links:
     - title: "connectors-python Nightly Buildkite Jobs"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -32,7 +32,7 @@ spec:
 apiVersion: "backstage.io/v1alpha1"
 kind: "Resource"
 metadata:
-  name: "connectors-python-main-pipeline"
+  name: "connectors-python"
   description: "Lints and tests Python Connectors"
   links:
     - title: "connectors-python Main Pipeline"
@@ -62,7 +62,7 @@ spec:
 apiVersion: "backstage.io/v1alpha1"
 kind: "Resource"
 metadata:
-  name: "connectors-python-nightly-pipeline"
+  name: "connectors-python-nightly"
   description: "Nightly Connector Service Tests"
   links:
     - title: "connectors-python Nightly Buildkite Jobs"


### PR DESCRIPTION
Some more renames - seems like the names for Components (maybe Pipelines too?) should be unique across all repos.

We already have our components in CI repo, thus while migrating we need to change names in this repo for now.