### PR TITLE
Return connectors-python back

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -45,7 +45,7 @@ spec:
     apiVersion: "buildkite.elastic.dev/v1"
     kind: "Pipeline"
     metadata:
-      name: "Connectors Python"
+      name: "connectors-python"
       description: "Your Connector Service to ingest data into Elasticsearch"
     spec:
       branch_configuration: "main"


### PR DESCRIPTION
When investigating a problem with CI I renamed "connectors-python" to "Connectors Python" and it makes it look weird in CI:

![image](https://user-images.githubusercontent.com/12238374/236033166-06a30339-a78b-45d0-998c-410d9e725a60.png)

Thus, returning back the name of "connectors-python".