### PR TITLE
[8.8] Update SSL cert label for MSSQL (#857)

### DIFF
--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -96,7 +96,7 @@ class MSSQLDataSource(GenericBaseDataSource):
                 },
                 "ssl_ca": {
                     "depends_on": [{"field": "ssl_enabled", "value": True}],
-                    "label": "Certificate data",
+                    "label": "SSL certificate",
                     "order": 11,
                     "type": "str",
                     "value": "",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Update SSL cert label for MSSQL (#857)](https://github.com/elastic/connectors-python/pull/857)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)