### PR TITLE
Increase FTEST RSS thresholds for 8.7

### DIFF
--- a/connectors/sources/tests/fixtures/google_cloud_storage/.env
+++ b/connectors/sources/tests/fixtures/google_cloud_storage/.env
@@ -1,2 +1,2 @@
 STORAGE_EMULATOR_HOST="http://localhost:4443"
-MAX_RSS="290M"
+MAX_RSS="325M"

--- a/connectors/sources/tests/fixtures/mssql/.env
+++ b/connectors/sources/tests/fixtures/mssql/.env
@@ -1,1 +1,1 @@
-MAX_RSS="230M"
+MAX_RSS="265M"

--- a/connectors/sources/tests/fixtures/mysql/.env
+++ b/connectors/sources/tests/fixtures/mysql/.env
@@ -1,1 +1,1 @@
-MAX_RSS="240M"
+MAX_RSS="275M"

--- a/connectors/sources/tests/fixtures/oracle/.env
+++ b/connectors/sources/tests/fixtures/oracle/.env
@@ -1,1 +1,1 @@
-MAX_RSS="240M"
+MAX_RSS="275M"

--- a/connectors/sources/tests/fixtures/postgresql/.env
+++ b/connectors/sources/tests/fixtures/postgresql/.env
@@ -1,1 +1,1 @@
-MAX_RSS="410M"
+MAX_RSS="445M"

--- a/connectors/tests/ftest.sh
+++ b/connectors/tests/ftest.sh
@@ -8,7 +8,7 @@ PERF8=$2
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR="$SCRIPT_DIR/../.."
 PLATFORM='unknown'
-MAX_RSS="200M"
+MAX_RSS="235M"
 
 export REFRESH_RATE="${REFRESH_RATE:-5}"
 export DATA_SIZE="${DATA_SIZE:-medium}"


### PR DESCRIPTION
Increasing RSS thresholds by ~35MB for each connector affected.

Seems like we've improved our memory footprints between 8.7 and 8.8 and RSS limits that work for 8.8 don't work for 8.7.

This. PR just increase thresholds so that our nightlies work well.