### PR TITLE
[Docs] MySQL sync rules examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ If you are looking for the implementation in Ruby, See [connectors-ruby](https:/
 - [Connector Protocol](https://github.com/elastic/connectors-python/blob/main/docs/CONNECTOR_PROTOCOL.md)
 - [Configuration](docs/CONFIG.md)
 - [Contribution guide](docs/CONTRIBUTING.md)
+
+### Advanced sync rules
+
+- [MySQL](docs/sync-rules/MYSQL.md)

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/docs/sync-rules/MYSQL.md
+++ b/docs/sync-rules/MYSQL.md
@@ -1,0 +1,88 @@
+### Setting up the MySQL connector
+
+See the [Developer guide](../../docs/DEVELOPING.md) for setting up connectors.
+
+### MySQL Docker setup
+
+#### Run MySQL container
+```shell
+docker run --name mysql_container -p 3306:3306 -e MYSQL_ROOT_PASSWORD=changeme -e MYSQL_USER=elastic -e MYSQL_PASSWORD=changeme -d mysql:latest
+```
+
+#### Grant privileges to user
+
+```shell
+docker exec -it mysql_container mysql -u root -p
+```
+
+```mysql
+GRANT ALL PRIVILEGES ON sample_db.* TO 'elastic'@'%';
+FLUSH PRIVILEGES;
+```
+
+### Example data
+```mysql
+CREATE DATABASE sample_db;
+USE sample_db;
+
+CREATE TABLE person (
+    person_id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255),
+    age INT
+);
+
+CREATE TABLE address (
+    address_id INT AUTO_INCREMENT PRIMARY KEY,
+    address VARCHAR(255)
+);
+
+INSERT INTO person (name, age) VALUES ('Alice', 30);
+INSERT INTO person (name, age) VALUES ('Bob', 25);
+INSERT INTO person (name, age) VALUES ('Carol', 35);
+
+INSERT INTO address (address) VALUES ('123 Elm St');
+INSERT INTO address (address) VALUES ('456 Oak St');
+INSERT INTO address (address) VALUES ('789 Pine St');
+```
+
+### Example advanced sync rules
+
+#### Two LIMIT queries
+
+```json
+[
+  {
+    "tables": [
+      "person"
+    ],
+    "query": "SELECT * FROM sample_db.person LIMIT 1;"
+  },
+  {
+    "tables": [
+      "address"
+    ],
+    "query": "SELECT * FROM sample_db.address LIMIT 1;"
+  }
+]
+```
+
+#### One WHERE query
+
+```json
+[
+  {
+    "tables": ["person"],
+    "query": "SELECT * FROM sample_db.person WHERE sample_db.person.age > 25;"
+  }
+]
+```
+
+#### One JOIN query
+```json
+[
+  {
+    "tables": ["person", "tables"],
+    "query": "SELECT * FROM sample_db.person INNER JOIN sample_db.address ON sample_db.person.person_id = sample_db.address.address_id;"
+  }
+]
+```


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4470

This PR adds a new directory under `docs` to provide simple examples for connectors, which have implemented sync rules. These examples target developers trying out and/or modifying the advanced rules implementation.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
~- [ ] Covered the changes with automated tests~
~- [ ] Tested the changes locally~
~- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)~
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~