### PR TITLE
Correctly copy over log_level from Enterprise Search config file

### DIFF
--- a/connectors/config.py
+++ b/connectors/config.py
@@ -38,10 +38,13 @@ def _ent_search_config(configuration):
             continue
 
         connector_field = config_mappings[es_field]
+        es_field_value = ent_search_config[es_field]
 
-        _update_config_field(
-            configuration, connector_field, ent_search_config[es_field]
-        )
+        if es_field == "log_level":
+            # Enterprise Search uses Ruby and is in lower case always, so hacking it here for now
+            es_field_value = es_field_value.upper()
+
+        _update_config_field(configuration, connector_field, es_field_value)
 
         logger.debug(f"Overridden {connector_field}")
 

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -27,6 +27,18 @@ config_mappings = {
     "log_level": "service.log_level",
 }
 
+# Enterprise Search uses Ruby and is in lower case always, so hacking it here for now
+# Ruby-supported log levels: 'debug', 'info', 'warn', 'error', 'fatal', 'unknown'
+# Python-supported log levels: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'NOTSET'
+log_level_mappings = {
+    "debug": "DEBUG",
+    "info": "INFO",
+    "warn": "WARNING",
+    "error": "ERROR",
+    "fatal": "CRITICAL",
+    "unknown": "NOTSET",
+}
+
 
 def _ent_search_config(configuration):
     if "ENT_SEARCH_CONFIG_PATH" not in os.environ:
@@ -41,8 +53,11 @@ def _ent_search_config(configuration):
         es_field_value = ent_search_config[es_field]
 
         if es_field == "log_level":
-            # Enterprise Search uses Ruby and is in lower case always, so hacking it here for now
-            es_field_value = es_field_value.upper()
+            if es_field_value not in log_level_mappings:
+                raise ValueError(
+                    f"Unexpected log level: {es_field_value}. Allowed values: {', '.join(log_level_mappings.keys())}"
+                )
+            es_field_value = log_level_mappings[es_field_value]
 
         _update_config_field(configuration, connector_field, es_field_value)
 

--- a/connectors/tests/entsearch_invalid_log_level.yml
+++ b/connectors/tests/entsearch_invalid_log_level.yml
@@ -1,3 +1,4 @@
+
 elasticsearch:
   host: http://nowhere.com:9200
   user: elastic
@@ -6,4 +7,4 @@ elasticsearch:
     X-Elastic-Auth: SomeYeahValue
     X-Something: 1
 
-log_level: debug
+log_level: WHAT

--- a/connectors/tests/test_config.py
+++ b/connectors/tests/test_config.py
@@ -14,6 +14,9 @@ from connectors.config import _update_config_field, load_config
 
 CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.yml")
 ES_CONFIG_FILE = os.path.join(os.path.dirname(__file__), "entsearch.yml")
+ES_CONFIG_INVALID_LOG_LEVEL_FILE = os.path.join(
+    os.path.dirname(__file__), "entsearch_invalid_log_level.yml"
+)
 
 
 def test_bad_config_file():
@@ -31,6 +34,16 @@ def test_config_with_ent_search(set_env):
         config = load_config(CONFIG_FILE)
         assert config["elasticsearch"]["headers"]["X-Elastic-Auth"] == "SomeYeahValue"
         assert config["service"]["log_level"] == "DEBUG"
+
+
+def test_config_with_invalid_log_level(set_env):
+    with mock.patch.dict(
+        os.environ, {"ENT_SEARCH_CONFIG_PATH": ES_CONFIG_INVALID_LOG_LEVEL_FILE}
+    ):
+        with pytest.raises(ValueError) as e:
+            _ = load_config(CONFIG_FILE)
+
+        assert e.match("Unexpected log level.*")
 
 
 def test_update_config_when_nested_field_does_not_exist():


### PR DESCRIPTION
Funny problem in Cloud - when user changes `log_level` setting, it has to be lowercase.

However, Connector Service expects upper case log_level and is unable to start. Thus, adding this little hack for now to unblock 8.8 deployment - if we're updating log_level for deployment from Enterprise Search, then upper case it.

We need to follow up on this with a more complex value remapping from Enterprise Search config.