### PR TITLE
[Sharepoint] Make all documents IDs size 36 bytes

### DIFF
--- a/connectors/sources/tests/fixtures/sharepoint/fixture.py
+++ b/connectors/sources/tests/fixtures/sharepoint/fixture.py
@@ -19,11 +19,12 @@ _SIZES = {"small": 1000000, "medium": 2000000, "large": 6000000}
 FILE_SIZE = _SIZES[DATA_SIZE]
 LARGE_DATA = "".join([random.choice(string.ascii_letters) for _ in range(FILE_SIZE)])
 DOC_ID_SIZE = 36
-DOC_ID_FILLING_CHAR = '0' # used to fill in missing symbols for IDs
+DOC_ID_FILLING_CHAR = "0"  # used to fill in missing symbols for IDs
+
 
 def adjust_document_id_size(id):
     """
-      This methods make sure that all the documemts ids are min 36 bytes like in Sharepoint
+    This methods make sure that all the documemts ids are min 36 bytes like in Sharepoint
     """
 
     bytesize = len(id)
@@ -31,7 +32,7 @@ def adjust_document_id_size(id):
     if bytesize >= DOC_ID_SIZE:
         return id
 
-    addition = "".join(['0' for _ in range(DOC_ID_SIZE-bytesize-1)])
+    addition = "".join(["0" for _ in range(DOC_ID_SIZE - bytesize - 1)])
     return f"{id}-{addition}"
 
 
@@ -108,7 +109,9 @@ def get_lists(parent_site_url, site):
                 {
                     "BaseType": 1,
                     "Created": "2023-01-30T10:02:39Z",
-                    "Id": adjust_document_id_size(f"document-library-{site}-{lists_count}"),
+                    "Id": adjust_document_id_size(
+                        f"document-library-{site}-{lists_count}"
+                    ),
                     "LastItemModifiedDate": "2023-01-30T10:02:40Z",
                     "ParentWebUrl": f"/{parent_site_url}",
                     "Title": f"{site}-List2",
@@ -167,7 +170,9 @@ def get_list_and_items(parent_site_url, list_id):
                 {
                     "Attachments": False,
                     "Created": "2023-01-30T10:02:39Z",
-                    "GUID": adjust_document_id_size(f"list-item-{parent_site_url}-{list_id}"),
+                    "GUID": adjust_document_id_size(
+                        f"list-item-{parent_site_url}-{list_id}"
+                    ),
                     "FileRef": parent_site_url,
                     "Modified": "2023-01-30T10:02:40Z",
                     "EditorId": "aabb-112c",
@@ -199,7 +204,9 @@ def get_list_and_items(parent_site_url, list_id):
                         "TimeLastModified": "2023-02-13T10:24:36Z",
                     },
                     "Modified": "2023-02-13T10:24:36Z",
-                    "GUID": adjust_document_id_size(f"drive-folder-{parent_site_url}-{list_id}"),
+                    "GUID": adjust_document_id_size(
+                        f"drive-folder-{parent_site_url}-{list_id}"
+                    ),
                 },
                 {
                     "File": {
@@ -212,7 +219,9 @@ def get_list_and_items(parent_site_url, list_id):
                         "UniqueId": "6f885b24-af40-44e0-bd53-82e76e634cf6",
                     },
                     "Modified": "2023-01-30T10:02:39Z",
-                    "GUID": adjust_document_id_size(f"drive-file-{parent_site_url}-{list_id}"),
+                    "GUID": adjust_document_id_size(
+                        f"drive-file-{parent_site_url}-{list_id}"
+                    ),
                 },
             ]
         }

--- a/connectors/sources/tests/fixtures/sharepoint/fixture.py
+++ b/connectors/sources/tests/fixtures/sharepoint/fixture.py
@@ -13,11 +13,25 @@ import string
 from flask import Flask, request
 
 app = Flask(__name__)
-start_lists, end_lists = 0, 450
+start_lists, end_lists = 0, 4500
 DATA_SIZE = os.environ.get("DATA_SIZE", "small").lower()
 _SIZES = {"small": 1000000, "medium": 2000000, "large": 6000000}
 FILE_SIZE = _SIZES[DATA_SIZE]
 LARGE_DATA = "".join([random.choice(string.ascii_letters) for _ in range(FILE_SIZE)])
+DOC_ID_SIZE = 36
+
+def adjust_document_id_size(id):
+    """
+      This methods make sure that all the documemts ids are min 36 bytes like in Sharepoint
+    """
+
+    bytesize = len(id)
+
+    if bytesize >= DOC_ID_SIZE:
+        return id
+
+    addition = "".join([random.choice(string.ascii_letters) for _ in range(DOC_ID_SIZE-bytesize)])
+    return f"{id}{addition}"
 
 
 @app.route("/sites/<string:site_collections>/_api/web/webs", methods=["GET"])
@@ -37,7 +51,7 @@ def get_sites(site_collections):
         sites["value"].append(
             {
                 "Created": "2023-01-30T10:02:39",
-                "Id": "sites-0",
+                "Id": adjust_document_id_size("sites-0"),
                 "LastItemModifiedDate": "2023-02-16T06:48:30Z",
                 "ServerRelativeUrl": "/sites/site1",
                 "Title": "site1",
@@ -49,7 +63,7 @@ def get_sites(site_collections):
             "value": [
                 {
                     "Created": "2023-01-30T10:02:39",
-                    "Id": "ping-1aaabbb",
+                    "Id": adjust_document_id_size("ping-1aaabbb"),
                     "LastItemModifiedDate": "2023-02-16T06:48:30Z",
                     "ServerRelativeUrl": "/sites/collection1/site1",
                     "Title": "site1",
@@ -78,7 +92,7 @@ def get_lists(parent_site_url, site):
                 {
                     "BaseType": 0,
                     "Created": "2023-01-30T10:02:39Z",
-                    "Id": f"lists-{site}-{lists_count}",
+                    "Id": adjust_document_id_size(f"lists-{site}-{lists_count}"),
                     "LastItemModifiedDate": "2023-01-30T10:02:40Z",
                     "ParentWebUrl": f"/{parent_site_url}",
                     "Title": "List1",
@@ -93,7 +107,7 @@ def get_lists(parent_site_url, site):
                 {
                     "BaseType": 1,
                     "Created": "2023-01-30T10:02:39Z",
-                    "Id": f"document-library-{site}-{lists_count}",
+                    "Id": adjust_document_id_size(f"document-library-{site}-{lists_count}"),
                     "LastItemModifiedDate": "2023-01-30T10:02:40Z",
                     "ParentWebUrl": f"/{parent_site_url}",
                     "Title": f"{site}-List2",
@@ -138,7 +152,7 @@ def get_list_and_items(parent_site_url, list_id):
                         }
                     ],
                     "Created": "2023-01-30T10:02:39Z",
-                    "GUID": f"list-item-att-{parent_site_url}-{list_id}",
+                    "GUID": adjust_document_id_size(f"list-item-att-{parent_site_url}-{list_id}"),
                     "FileRef": parent_site_url,
                     "Modified": "2023-01-30T10:02:40Z",
                     "EditorId": "aabb-112c",
@@ -152,23 +166,23 @@ def get_list_and_items(parent_site_url, list_id):
                 {
                     "Attachments": False,
                     "Created": "2023-01-30T10:02:39Z",
-                    "GUID": f"list-item-{parent_site_url}-{list_id}",
+                    "GUID": adjust_document_id_size(f"list-item-{parent_site_url}-{list_id}"),
                     "FileRef": parent_site_url,
                     "Modified": "2023-01-30T10:02:40Z",
                     "EditorId": "aabb-112c",
                     "Title": f"list-item-{list_id}",
-                    "Id": f"list-id1-{list_id}",
+                    "Id": adjust_document_id_size(f"list-id1-{list_id}"),
                     "ContentTypeId": f"123-{list_id}",
                 },
                 {
                     "Attachments": False,
                     "Created": "2023-01-30T10:02:39Z",
-                    "GUID": f"list-item-{list_id}",
+                    "GUID": adjust_document_id_size(f"list-item-{list_id}"),
                     "FileRef": parent_site_url,
                     "Modified": "2023-01-30T10:02:40Z",
                     "EditorId": "aabb-112c",
                     "Title": f"list-item-{list_id}",
-                    "Id": f"list-id2-{list_id}",
+                    "Id": adjust_document_id_size(f"list-id2-{list_id}"),
                     "ContentTypeId": f"456-{list_id}",
                 },
             ]
@@ -184,7 +198,7 @@ def get_list_and_items(parent_site_url, list_id):
                         "TimeLastModified": "2023-02-13T10:24:36Z",
                     },
                     "Modified": "2023-02-13T10:24:36Z",
-                    "GUID": f"drive-folder-{parent_site_url}-{list_id}",
+                    "GUID": adjust_document_id_size(f"drive-folder-{parent_site_url}-{list_id}"),
                 },
                 {
                     "File": {
@@ -197,7 +211,7 @@ def get_list_and_items(parent_site_url, list_id):
                         "UniqueId": "6f885b24-af40-44e0-bd53-82e76e634cf6",
                     },
                     "Modified": "2023-01-30T10:02:39Z",
-                    "GUID": f"drive-file-{parent_site_url}-{list_id}",
+                    "GUID": adjust_document_id_size(f"drive-file-{parent_site_url}-{list_id}"),
                 },
             ]
         }
@@ -223,7 +237,7 @@ def get_attachment_data(parent_site_url, file_relative_url):
         "ServerRelativeUrl": f"{parent_site_url}/dummy",
         "TimeCreated": "2023-01-30T10:02:40Z",
         "TimeLastModified": "2023-01-30T10:02:40Z",
-        "UniqueId": f"attachment-{parent_site_url}",
+        "UniqueId": adjust_document_id_size(f"attachment-{parent_site_url}"),
     }
 
 

--- a/connectors/sources/tests/fixtures/sharepoint/fixture.py
+++ b/connectors/sources/tests/fixtures/sharepoint/fixture.py
@@ -13,7 +13,7 @@ import string
 from flask import Flask, request
 
 app = Flask(__name__)
-start_lists, end_lists = 0, 100
+start_lists, end_lists = 0, 450
 DATA_SIZE = os.environ.get("DATA_SIZE", "small").lower()
 _SIZES = {"small": 1000000, "medium": 2000000, "large": 6000000}
 FILE_SIZE = _SIZES[DATA_SIZE]

--- a/connectors/sources/tests/fixtures/sharepoint/fixture.py
+++ b/connectors/sources/tests/fixtures/sharepoint/fixture.py
@@ -30,7 +30,7 @@ def adjust_document_id_size(id):
     if bytesize >= DOC_ID_SIZE:
         return id
 
-    addition = "".join([random.choice(string.ascii_letters) for _ in range(DOC_ID_SIZE-bytesize)])
+    addition = "".join(['0' for _ in range(DOC_ID_SIZE-bytesize)])
     return f"{id}{addition}"
 
 

--- a/connectors/sources/tests/fixtures/sharepoint/fixture.py
+++ b/connectors/sources/tests/fixtures/sharepoint/fixture.py
@@ -13,12 +13,13 @@ import string
 from flask import Flask, request
 
 app = Flask(__name__)
-start_lists, end_lists = 0, 4500
+start_lists, end_lists = 0, 100
 DATA_SIZE = os.environ.get("DATA_SIZE", "small").lower()
 _SIZES = {"small": 1000000, "medium": 2000000, "large": 6000000}
 FILE_SIZE = _SIZES[DATA_SIZE]
 LARGE_DATA = "".join([random.choice(string.ascii_letters) for _ in range(FILE_SIZE)])
 DOC_ID_SIZE = 36
+DOC_ID_FILLING_CHAR = '0' # used to fill in missing symbols for IDs
 
 def adjust_document_id_size(id):
     """
@@ -30,8 +31,8 @@ def adjust_document_id_size(id):
     if bytesize >= DOC_ID_SIZE:
         return id
 
-    addition = "".join(['0' for _ in range(DOC_ID_SIZE-bytesize)])
-    return f"{id}{addition}"
+    addition = "".join(['0' for _ in range(DOC_ID_SIZE-bytesize-1)])
+    return f"{id}-{addition}"
 
 
 @app.route("/sites/<string:site_collections>/_api/web/webs", methods=["GET"])
@@ -122,7 +123,7 @@ def get_lists(parent_site_url, site):
             ]
         )
     # Removing the data for the second sync
-    end_lists -= 50
+    # end_lists -= 50
     return lists
 
 
@@ -152,7 +153,7 @@ def get_list_and_items(parent_site_url, list_id):
                         }
                     ],
                     "Created": "2023-01-30T10:02:39Z",
-                    "GUID": adjust_document_id_size(f"list-item-att-{parent_site_url}-{list_id}"),
+                    "GUID": f"list-item-att-{parent_site_url}-{list_id}",
                     "FileRef": parent_site_url,
                     "Modified": "2023-01-30T10:02:40Z",
                     "EditorId": "aabb-112c",
@@ -237,7 +238,7 @@ def get_attachment_data(parent_site_url, file_relative_url):
         "ServerRelativeUrl": f"{parent_site_url}/dummy",
         "TimeCreated": "2023-01-30T10:02:40Z",
         "TimeLastModified": "2023-01-30T10:02:40Z",
-        "UniqueId": adjust_document_id_size(f"attachment-{parent_site_url}"),
+        "UniqueId": f"attachment-{parent_site_url}",
     }
 
 


### PR DESCRIPTION
To be able to measure data volume more precisely we need to store documents' IDs as 36 bytes strings (Sharepoint format)

## Related links
* https://github.com/elastic/enterprise-search-team/issues/4332
