### PR TITLE
Add xlsb, xlsm in tika supported filetypes

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -54,6 +54,8 @@ TIKA_SUPPORTED_FILETYPES = [
     ".pdf",
     ".doc",
     ".aspx",
+    ".xlsb",
+    ".xlsm",
 ]
 
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/892

Add XLSM and XLSB filetypes to the list `TIKA_SUPPORTED_FILETYPES` in utils.py

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes [ ] New external service dependencies added.

