### PR TITLE
[8.8] add xlsb, xlsm in tika supported filetypes (#894)

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -54,6 +54,8 @@ TIKA_SUPPORTED_FILETYPES = [
     ".pdf",
     ".doc",
     ".aspx",
+    ".xlsb",
+    ".xlsm",
 ]
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [add xlsb, xlsm in tika supported filetypes (#894)](https://github.com/elastic/connectors-python/pull/894)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)