### PR TITLE
Don't stop the ConcurrentTasks when one task raises exception

### DIFF
--- a/connectors/tests/test_utils.py
+++ b/connectors/tests/test_utils.py
@@ -237,9 +237,7 @@ async def test_concurrent_runner_fails():
     for i in range(10):
         await runner.put(functools.partial(coroutine, i))
 
-    with pytest.raises(Exception):
-        await runner.join()
-
+    await runner.join()
     assert 5 not in results
 
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -323,7 +323,9 @@ class ConcurrentTasks:
         self.tasks.remove(task)
         self._task_over.set()
         if task.exception():
-            raise task.exception()
+            logger.error(
+                f"Exception found for task {task.get_name()}: {task.exception()}"
+            )
         if result_callback is not None:
             result_callback(task.result())
         # global callback
@@ -352,7 +354,7 @@ class ConcurrentTasks:
 
     async def join(self):
         """Wait for all tasks to finish."""
-        await asyncio.gather(*self.tasks)
+        await asyncio.gather(*self.tasks, return_exceptions=True)
 
     def cancel(self):
         """Cancels all tasks"""


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4517

See the detailed analysis here: https://github.com/elastic/enterprise-search-team/issues/4517#issuecomment-1546108471

This PR makes the changes, so that when an exception is raised from a task in `ConcurrentTasks`, the [join](https://github.com/elastic/connectors-python/blob/ccaa51a7de7b104c381f7ba71581b56bdad89475/connectors/utils.py#L353-L355) will still wait for other tasks to complete.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)