### PR TITLE
Fix problem with incorrect mappings created for content indices

### DIFF
--- a/connectors/byoei.py
+++ b/connectors/byoei.py
@@ -499,6 +499,8 @@ class ElasticServer(ESClient):
                 )
                 await self.client.indices.put_mapping(
                     index=index,
+                    dynamic=mappings.get("dynamic", False),
+                    dynamic_templates=mappings.get("dynamic_templates", []),
                     properties=mappings.get("properties", {}),
                     expand_wildcards=expand_wildcards,
                 )


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4465

When framework attempts to create a search index mappings, it does not actually provide "dynamic" and "dynamic_templates" settings to the `put_mappings` call. This PR changes it and actually starts providing these options.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
