### PR TITLE
Add malformed configuration error to document

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -55,7 +55,6 @@ __all__ = [
     "Connector",
     "Features",
     "Filtering",
-    "MalformedConfigurationError",
     "Sort",
     "SyncJob",
 ]
@@ -115,10 +114,6 @@ class ServiceTypeNotConfiguredError(Exception):
 
 
 class DataSourceError(Exception):
-    pass
-
-
-class MalformedConfigurationError(Exception):
     pass
 
 
@@ -714,8 +709,7 @@ class Connector(ESDocument):
         return result["count"]
 
     async def validate_configuration_formatting(self, fqn, service_type):
-        """Wrapper function for validating configuration fields
-        and field properties.
+        """Wrapper function for validating configuration field properties.
 
         Args:
             fqn (string): the source fqn for a service, from config file
@@ -730,46 +724,9 @@ class Connector(ESDocument):
         default_config = source_klass.get_simple_configuration()
         current_config = self.configuration.to_dict()
 
-        await self.validate_configuration_fields(
-            service_type, default_config, current_config
-        )
         await self.add_missing_configuration_field_properties(
             service_type, default_config, current_config
         )
-
-    async def validate_configuration_fields(
-        self, service_type, default_config, current_config
-    ):
-        """Checks if any fields in a configuration are missing.
-        If a field is missing, raises an error.
-        Ignores additional non-standard fields.
-
-        Args:
-            service_type (string): service type of the connector
-            default_config (dict): the default configuration for the connector
-            current_config (dict): the currently existing configuration for the connector
-        """
-        missing_fields = list(set(default_config.keys()) - set(current_config.keys()))
-
-        if len(missing_fields) > 0:
-            doc = {
-                "last_seen": iso_utc(),
-                "status": "error",
-                "error": f'Configuration fields are missing: {", ".join(missing_fields)}.',
-            }
-            await self.index.update(
-                doc_id=self.id,
-                doc=doc,
-                if_seq_no=self._seq_no,
-                if_primary_term=self._primary_term,
-            )
-            await self.reload()
-
-            raise MalformedConfigurationError(
-                f'Connector for {service_type}(id: "{self.id}") has missing configuration fields: {", ".join(missing_fields)}'
-            )
-
-        return
 
     async def add_missing_configuration_field_properties(
         self, service_type, default_config, current_config

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -431,6 +431,28 @@ class BaseDataSource:
         """
         self.configuration.check_valid()
 
+    def validate_config_fields(self):
+        """ "Checks if any fields in a configuration are missing.
+        If a field is missing, raises an error.
+        Ignores additional non-standard fields.
+
+        Args:
+            default_config (dict): the default configuration for the connector
+            current_config (dict): the currently existing configuration for the connector
+        """
+
+        default_config = self.get_simple_configuration()
+        current_config = self.configuration.to_dict()
+
+        missing_fields = list(set(default_config.keys()) - set(current_config.keys()))
+
+        if len(missing_fields) > 0:
+            raise MalformedConfigurationError(
+                f'Connector has missing configuration fields: {", ".join(missing_fields)}'
+            )
+
+        return
+
     async def ping(self):
         """When called, pings the backend
 
@@ -541,4 +563,8 @@ class ConfigurableFieldValueError(Exception):
 
 
 class ConfigurableFieldDependencyError(Exception):
+    pass
+
+
+class MalformedConfigurationError(Exception):
     pass

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -105,6 +105,7 @@ class SyncJobRunner:
                 return
 
             logger.debug(f"Validating configuration for {self.data_provider}")
+            self.data_provider.validate_config_fields()
             await self.data_provider.validate_config()
 
             logger.debug(

--- a/connectors/tests/test_protocol.py
+++ b/connectors/tests/test_protocol.py
@@ -855,7 +855,6 @@ async def test_connector_prepare_with_connector_missing_field_raises_error():
     )
 
 
-
 @pytest.mark.asyncio
 async def test_connector_prepare_with_connector_missing_field_properties_creates_them():
     doc_id = "1"

--- a/connectors/tests/test_protocol.py
+++ b/connectors/tests/test_protocol.py
@@ -30,7 +30,6 @@ from connectors.protocol import (
     Filtering,
     JobStatus,
     JobTriggerMethod,
-    MalformedConfigurationError,
     Pipeline,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
@@ -815,44 +814,6 @@ async def test_connector_prepare_with_prepared_connector():
     connector = Connector(elastic_index=index, doc_source=connector_doc)
     await connector.prepare(config)
     index.update.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_connector_prepare_with_connector_missing_field_raises_error():
-    doc_id = "1"
-    seq_no = 1
-    primary_term = 2
-    connector_doc = {
-        "_id": doc_id,
-        "_seq_no": seq_no,
-        "_primary_term": primary_term,
-        "_source": {
-            "service_type": "banana",
-            "configuration": {"two": "value"},
-        },
-    }
-    config = {
-        "connector_id": doc_id,
-        "service_type": "banana",
-        "sources": {"banana": "connectors.tests.test_protocol:Banana"},
-    }
-    index = Mock()
-    index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
-    index.update = AsyncMock()
-    connector = Connector(elastic_index=index, doc_source=connector_doc)
-    with pytest.raises(MalformedConfigurationError):
-        await connector.prepare(config)
-
-    index.update.assert_called_once_with(
-        doc_id=doc_id,
-        doc={
-            "last_seen": ANY,
-            "status": "error",
-            "error": "Configuration fields are missing: one.",
-        },
-        if_seq_no=seq_no,
-        if_primary_term=primary_term,
-    )
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_protocol.py
+++ b/connectors/tests/test_protocol.py
@@ -842,17 +842,17 @@ async def test_connector_prepare_with_connector_missing_field_raises_error():
     connector = Connector(elastic_index=index, doc_source=connector_doc)
     with pytest.raises(MalformedConfigurationError):
         await connector.prepare(config)
-        index.update.assert_called_once_with(
-            doc_id=doc_id,
-            doc={
-                "last_seen": ANY,
-                "status": "error",
-                "error": "Configuration fields are missing: one.",
-            },
-            if_seq_no=seq_no,
-            if_primary_term=primary_term,
-        )
-        index.update.assert_not_awaited()
+
+    index.update.assert_called_once_with(
+        doc_id=doc_id,
+        doc={
+            "last_seen": ANY,
+            "status": "error",
+            "error": "Configuration fields are missing: one.",
+        },
+        if_seq_no=seq_no,
+        if_primary_term=primary_term,
+    )
 
 
 

--- a/connectors/tests/test_protocol.py
+++ b/connectors/tests/test_protocol.py
@@ -842,7 +842,18 @@ async def test_connector_prepare_with_connector_missing_field_raises_error():
     connector = Connector(elastic_index=index, doc_source=connector_doc)
     with pytest.raises(MalformedConfigurationError):
         await connector.prepare(config)
+        index.update.assert_called_once_with(
+            doc_id=doc_id,
+            doc={
+                "last_seen": ANY,
+                "status": "error",
+                "error": "Configuration fields are missing: one.",
+            },
+            if_seq_no=seq_no,
+            if_primary_term=primary_term,
+        )
         index.update.assert_not_awaited()
+
 
 
 @pytest.mark.asyncio

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -21,6 +21,7 @@ from connectors.source import (
     ConfigurableFieldValueError,
     DataSourceConfiguration,
     Field,
+    MalformedConfigurationError,
     ValidationTypes,
     get_source_klass,
     get_source_klasses,
@@ -831,3 +832,48 @@ async def test_serialize(raw_doc, expected_doc):
 
         for serialized_doc_key, expected_doc_key in zip(serialized_doc, expected_doc):
             assert serialized_doc[serialized_doc_key] == expected_doc[expected_doc_key]
+
+
+@pytest.mark.asyncio
+async def test_validate_config_fields_when_valid_no_errors_raised():
+    configuration = {
+        "host": {
+            "value": "127.0.0.1",
+            "type": "str",
+        },
+        "port": {
+            "value": 3306,
+            "type": "int",
+        },
+        "direct": {
+            "value": True,
+            "type": "bool",
+        },
+        "user": {
+            "value": "root",
+            "type": "str",
+        },
+    }
+    ds = DataSource(configuration=DataSourceConfiguration(configuration))
+    ds.validate_config_fields()
+
+
+@pytest.mark.asyncio
+async def test_validate_config_fields_when_invalid_raises_error():
+    configuration = {
+        "host": {
+            "value": "127.0.0.1",
+            "type": "str",
+        },
+        "port": {
+            "value": 3306,
+            "type": "int",
+        },
+        "direct": {
+            "value": True,
+            "type": "bool",
+        },
+    }
+    ds = DataSource(configuration=DataSourceConfiguration(configuration))
+    with pytest.raises(MalformedConfigurationError):
+        ds.validate_config_fields()

--- a/connectors/tests/test_sync_job_runner.py
+++ b/connectors/tests/test_sync_job_runner.py
@@ -61,6 +61,7 @@ def create_runner(
     data_provider = Mock()
     data_provider.tweak_bulk_options = Mock()
     data_provider.changed = AsyncMock(return_value=source_changed)
+    data_provider.validate_config_fields = Mock()
     data_provider.validate_config = AsyncMock(side_effect=validate_config_exception)
     data_provider.ping = AsyncMock()
     if not source_available:


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4219

When configuration is missing fields, we raise an error. That information doesn't make it to Kibana, because it is never added to the `error` document field.

This PR adds the missing error information to the document.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference