### PR TITLE
[8.8] Add malformed configuration error to document (#909)

### DIFF
--- a/connectors/byoc.py
+++ b/connectors/byoc.py
@@ -31,6 +31,29 @@ from connectors.utils import (
     next_run,
 )
 
+__all__ = [
+    "CONNECTORS_INDEX",
+    "JOBS_INDEX",
+    "ConnectorIndex",
+    "Filter",
+    "SyncJobIndex",
+    "DataSourceError",
+    "JobStatus",
+    "Pipeline",
+    "JobTriggerMethod",
+    "ServiceTypeNotConfiguredError",
+    "ServiceTypeNotSupportedError",
+    "Status",
+    "IDLE_JOBS_THRESHOLD",
+    "JOB_NOT_FOUND_ERROR",
+    "Connector",
+    "Features",
+    "Filtering",
+    "Sort",
+    "SyncJob",
+]
+
+
 CONNECTORS_INDEX = ".elastic-connectors"
 JOBS_INDEX = ".elastic-connectors-sync-jobs"
 
@@ -85,10 +108,6 @@ class ServiceTypeNotConfiguredError(Exception):
 
 
 class DataSourceError(Exception):
-    pass
-
-
-class MalformedConfigurationError(Exception):
     pass
 
 
@@ -684,8 +703,7 @@ class Connector(ESDocument):
         return result["count"]
 
     async def validate_configuration_formatting(self, fqn, service_type):
-        """Wrapper function for validating configuration fields
-        and field properties.
+        """Wrapper function for validating configuration field properties.
 
         Args:
             fqn (string): the source fqn for a service, from config file
@@ -700,31 +718,9 @@ class Connector(ESDocument):
         default_config = source_klass.get_simple_configuration()
         current_config = self.configuration.to_dict()
 
-        self.validate_configuration_fields(service_type, default_config, current_config)
         await self.add_missing_configuration_field_properties(
             service_type, default_config, current_config
         )
-
-    def validate_configuration_fields(
-        self, service_type, default_config, current_config
-    ):
-        """Checks if any fields in a configuration are missing.
-        If a field is missing, raises an error.
-        Ignores additional non-standard fields.
-
-        Args:
-            service_type (string): service type of the connector
-            default_config (dict): the default configuration for the connector
-            current_config (dict): the currently existing configuration for the connector
-        """
-        missing_fields = list(set(default_config.keys()) - set(current_config.keys()))
-
-        if len(missing_fields) > 0:
-            raise MalformedConfigurationError(
-                f'Connector for {service_type}(id: "{self.id}") has missing configuration fields: {", ".join(missing_fields)}'
-            )
-
-        return
 
     async def add_missing_configuration_field_properties(
         self, service_type, default_config, current_config

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -431,6 +431,28 @@ class BaseDataSource:
         """
         self.configuration.check_valid()
 
+    def validate_config_fields(self):
+        """ "Checks if any fields in a configuration are missing.
+        If a field is missing, raises an error.
+        Ignores additional non-standard fields.
+
+        Args:
+            default_config (dict): the default configuration for the connector
+            current_config (dict): the currently existing configuration for the connector
+        """
+
+        default_config = self.get_simple_configuration()
+        current_config = self.configuration.to_dict()
+
+        missing_fields = list(set(default_config.keys()) - set(current_config.keys()))
+
+        if len(missing_fields) > 0:
+            raise MalformedConfigurationError(
+                f'Connector has missing configuration fields: {", ".join(missing_fields)}'
+            )
+
+        return
+
     async def ping(self):
         """When called, pings the backend
 
@@ -541,4 +563,8 @@ class ConfigurableFieldValueError(Exception):
 
 
 class ConfigurableFieldDependencyError(Exception):
+    pass
+
+
+class MalformedConfigurationError(Exception):
     pass

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -105,6 +105,7 @@ class SyncJobRunner:
                 return
 
             logger.debug(f"Validating configuration for {self.data_provider}")
+            self.data_provider.validate_config_fields()
             await self.data_provider.validate_config()
 
             logger.debug(

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -817,34 +817,6 @@ async def test_connector_prepare_with_prepared_connector():
 
 
 @pytest.mark.asyncio
-async def test_connector_prepare_with_connector_missing_field_raises_error():
-    doc_id = "1"
-    seq_no = 1
-    primary_term = 2
-    connector_doc = {
-        "_id": doc_id,
-        "_seq_no": seq_no,
-        "_primary_term": primary_term,
-        "_source": {
-            "service_type": "banana",
-            "configuration": {"two": "value"},
-        },
-    }
-    config = {
-        "connector_id": doc_id,
-        "service_type": "banana",
-        "sources": {"banana": "connectors.tests.test_byoc:Banana"},
-    }
-    index = Mock()
-    index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
-    index.update = AsyncMock()
-    connector = Connector(elastic_index=index, doc_source=connector_doc)
-    with pytest.raises(MalformedConfigurationError):
-        await connector.prepare(config)
-        index.update.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_connector_prepare_with_connector_missing_field_properties_creates_them():
     doc_id = "1"
     seq_no = 1

--- a/connectors/tests/test_byoc.py
+++ b/connectors/tests/test_byoc.py
@@ -23,7 +23,6 @@ from connectors.byoc import (
     Filtering,
     JobStatus,
     JobTriggerMethod,
-    MalformedConfigurationError,
     Pipeline,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,

--- a/connectors/tests/test_source.py
+++ b/connectors/tests/test_source.py
@@ -21,6 +21,7 @@ from connectors.source import (
     ConfigurableFieldValueError,
     DataSourceConfiguration,
     Field,
+    MalformedConfigurationError,
     ValidationTypes,
     get_source_klass,
     get_source_klasses,
@@ -831,3 +832,48 @@ async def test_serialize(raw_doc, expected_doc):
 
         for serialized_doc_key, expected_doc_key in zip(serialized_doc, expected_doc):
             assert serialized_doc[serialized_doc_key] == expected_doc[expected_doc_key]
+
+
+@pytest.mark.asyncio
+async def test_validate_config_fields_when_valid_no_errors_raised():
+    configuration = {
+        "host": {
+            "value": "127.0.0.1",
+            "type": "str",
+        },
+        "port": {
+            "value": 3306,
+            "type": "int",
+        },
+        "direct": {
+            "value": True,
+            "type": "bool",
+        },
+        "user": {
+            "value": "root",
+            "type": "str",
+        },
+    }
+    ds = DataSource(configuration=DataSourceConfiguration(configuration))
+    ds.validate_config_fields()
+
+
+@pytest.mark.asyncio
+async def test_validate_config_fields_when_invalid_raises_error():
+    configuration = {
+        "host": {
+            "value": "127.0.0.1",
+            "type": "str",
+        },
+        "port": {
+            "value": 3306,
+            "type": "int",
+        },
+        "direct": {
+            "value": True,
+            "type": "bool",
+        },
+    }
+    ds = DataSource(configuration=DataSourceConfiguration(configuration))
+    with pytest.raises(MalformedConfigurationError):
+        ds.validate_config_fields()

--- a/connectors/tests/test_sync_job_runner.py
+++ b/connectors/tests/test_sync_job_runner.py
@@ -61,6 +61,7 @@ def create_runner(
     data_provider = Mock()
     data_provider.tweak_bulk_options = Mock()
     data_provider.changed = AsyncMock(return_value=source_changed)
+    data_provider.validate_config_fields = Mock()
     data_provider.validate_config = AsyncMock(side_effect=validate_config_exception)
     data_provider.ping = AsyncMock()
     if not source_available:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Add malformed configuration error to document (#909)](https://github.com/elastic/connectors-python/pull/909)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)