### PR TITLE
Fix Sharepoint e2e test

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -50,7 +50,7 @@ steps:
       - "perf8-report-*/**/*"
   - label: "🔨 Sharepoint"
     command:
-      - ".buildkite/run_nigthly.sh sharepoint"
+      - ".buildkite/run_nigthly.sh sharepoint extra_small"
     artifact_paths:
       - "perf8-report-*/**/*"
   - label: "🔨 Microsoft SQL"

--- a/.buildkite/run_nigthly.sh
+++ b/.buildkite/run_nigthly.sh
@@ -11,4 +11,6 @@ make install
 export PIP=$ROOT/bin/pip
 
 $PIP install py-spy
-PERF8=yes NAME=$1 DATA_SIZE=small make ftest
+DATA_SIZE="${2:-small}"
+
+PERF8=yes NAME=$1 DATA_SIZE=$DATA_SIZE make ftest

--- a/connectors/sources/tests/fixtures/sharepoint/fixture.py
+++ b/connectors/sources/tests/fixtures/sharepoint/fixture.py
@@ -51,7 +51,6 @@ for k, v in FILE_SIZES_DISTRIBUTION.items():
 
 # Generate data for different sizes
 for k in FILE_SIZES_DISTRIBUTION.keys():
-    print(f"Generating '{k}' size data")
     GENERATED_DATA[k] = "".join(
         [random.choice(string.ascii_letters) for _ in range(SIZES[k])]
     )


### PR DESCRIPTION
This will fix the broken nightly build of Sharepoint connector. 

Also, DATA_SIZE becomes configurable via command argument

### Links:
* [Broken build](https://buildkite.com/elastic/connectors-python-nightly/builds/638#018823cf-eac2-4c4f-9cb0-2dcdef6d2e09)

#### Error with STDOUT logs:
```
+ NUM_DOCS='Generating '\''small'\'' size data
750'
+ /opt/buildkite-agent/builds/bk-agent-elastic-gcp-1684228024617818935/elastic/connectors-python-nightly/connectors/tests/../../bin/python /opt/buildkite-agent/builds/bk-agent-elastic-gcp-1684228024617818935/elastic/connectors-python-nightly/connectors/tests/../../scripts/verify.py --index-name search-sharepoint --service-type sharepoint --size Generating ''\''small'\''' size data 750
[FMWK][09:31:09][INFO] Fetcher <create: 131 |update: 0 |delete: 0>
usage: verify
       [-h]
       [--config-file CONFIG_FILE]
       [--service-type SERVICE_TYPE]
       [--index-name INDEX_NAME]
       [--size SIZE]
verify: error: argument --size: invalid int value: 'Generating'
```

#### Buildkite artifact size error:
```
2023-05-16 09:32:45 ERROR  Error uploading artifact "perf8-report-sharepoint/memreport": File size (9822457856 bytes) exceeds the maximum supported by Buildkite's default artifact storage (5Gb). Alternative artifact storage options may support larger files.
2023-05-16 09:32:46 FATAL  Failed to upload artifacts: uploading artifacts: errors uploading artifacts: [File size (9822457856 bytes) exceeds the maximum supported by Buildkite's default artifact storage (5Gb). Alternative artifact storage options may support larger files.]
🚨 Error: exit status 1
```


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
