### PR TITLE
[Sharepoint] Fix DATA_SIZE variable

### DIFF
--- a/connectors/sources/tests/fixtures/sharepoint/docker-compose.yml
+++ b/connectors/sources/tests/fixtures/sharepoint/docker-compose.yml
@@ -81,6 +81,8 @@ services:
     volumes:
       - .:/python-flask
     restart: always
+    environment:
+      - DATA_SIZE=${DATA_SIZE}
 
 volumes:
   esdata:


### PR DESCRIPTION
`DATA_SIZE` wasn't passed correctly to `docker compose` from `ftest.sh`

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

Links:
* [Fix Sharepoint e2e test](https://github.com/elastic/connectors-python/pull/922)
