### PR TITLE
Reset connector error when a new sync job starts

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -552,6 +552,7 @@ class Connector(ESDocument):
             "last_sync_status": JobStatus.IN_PROGRESS.value,
             "last_sync_error": None,
             "status": Status.CONNECTED.value,
+            "error": None,
         }
         await self.index.update(
             doc_id=self.id,

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -394,6 +394,7 @@ async def test_sync_starts():
         "last_sync_status": JobStatus.IN_PROGRESS.value,
         "last_sync_error": None,
         "status": Status.CONNECTED.value,
+        "error": None,
     }
 
     connector = Connector(elastic_index=index, doc_source=connector_doc)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4354

When a new sync job starts, it should also reset the connector error.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)