### PR TITLE
[DLS] Add "last_permissions_sync_scheduled_at" property to connector class

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -510,7 +510,9 @@ class Connector(ESDocument):
     def _property_as_datetime(self, key):
         last_sync_scheduled_at = self.get(key)
         if last_sync_scheduled_at is not None:
-            last_sync_scheduled_at = datetime.fromisoformat(last_sync_scheduled_at)
+            last_sync_scheduled_at = datetime.fromisoformat(
+                last_sync_scheduled_at
+            )  # pyright: ignore
         return last_sync_scheduled_at
 
     @property

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -510,9 +510,7 @@ class Connector(ESDocument):
     def _property_as_datetime(self, key):
         value = self.get(key)
         if value is not None:
-            value = datetime.fromisoformat(
-                value  # pyright: ignore
-            )
+            value = datetime.fromisoformat(value)  # pyright: ignore
         return value
 
     @property

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -511,8 +511,8 @@ class Connector(ESDocument):
         last_sync_scheduled_at = self.get(key)
         if last_sync_scheduled_at is not None:
             last_sync_scheduled_at = datetime.fromisoformat(
-                last_sync_scheduled_at
-            )  # pyright: ignore
+                last_sync_scheduled_at  # pyright: ignore
+            )
         return last_sync_scheduled_at
 
     @property

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -508,12 +508,12 @@ class Connector(ESDocument):
         return JobStatus(self.get("last_sync_status"))
 
     def _property_as_datetime(self, key):
-        last_sync_scheduled_at = self.get(key)
-        if last_sync_scheduled_at is not None:
-            last_sync_scheduled_at = datetime.fromisoformat(
-                last_sync_scheduled_at  # pyright: ignore
+        value = self.get(key)
+        if value is not None:
+            value = datetime.fromisoformat(
+                value  # pyright: ignore
             )
-        return last_sync_scheduled_at
+        return value
 
     @property
     def last_sync_scheduled_at(self):

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -507,14 +507,19 @@ class Connector(ESDocument):
     def last_sync_status(self):
         return JobStatus(self.get("last_sync_status"))
 
+    def _property_as_datetime(self, key):
+        last_sync_scheduled_at = self.get(key)
+        if last_sync_scheduled_at is not None:
+            last_sync_scheduled_at = datetime.fromisoformat(last_sync_scheduled_at)
+        return last_sync_scheduled_at
+
     @property
     def last_sync_scheduled_at(self):
-        last_sync_scheduled_at = self.get("last_sync_scheduled_at")
-        if last_sync_scheduled_at is not None:
-            last_sync_scheduled_at = datetime.fromisoformat(
-                last_sync_scheduled_at  # pyright: ignore
-            )
-        return last_sync_scheduled_at
+        return self._property_as_datetime("last_sync_scheduled_at")
+
+    @property
+    def last_permissions_sync_scheduled_at(self):
+        return self._property_as_datetime("last_permissions_sync_scheduled_at")
 
     async def heartbeat(self, interval):
         if (

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -328,6 +328,7 @@ async def test_connector_properties():
             "last_sync_status": "completed",
             "pipeline": {},
             "last_sync_scheduled_at": iso_utc(),
+            "last_permissions_sync_scheduled_at": iso_utc()
         },
     }
 
@@ -348,6 +349,7 @@ async def test_connector_properties():
     assert isinstance(connector.pipeline, Pipeline)
     assert isinstance(connector.features, Features)
     assert isinstance(connector.last_sync_scheduled_at, datetime)
+    assert isinstance(connector.last_permissions_sync_scheduled_at, datetime)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4568

This PR adds the `last_permissions_sync_scheduled_at` property to the connectors class. The property will be added to protocol with another PR.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~