### PR TITLE
[DLS] Add "get_permissions" to BaseDataSource

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -467,6 +467,13 @@ class BaseDataSource:
         """
         pass
 
+    async def get_permissions(self):
+        """Returns an asynchronous iterator on the permission documents present in the backend.
+
+        Each document is a dictionary containing permission data indexed into a corresponding permissions index.
+        """
+        raise NotImplementedError
+
     async def get_docs(self, filtering=None):
         """Returns an iterator on all documents present in the backend
 

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -472,7 +472,7 @@ class BaseDataSource:
 
         Each document is a dictionary containing permission data indexed into a corresponding permissions index.
         """
-        return []
+        raise NotImplementedError
 
     async def get_docs(self, filtering=None):
         """Returns an iterator on all documents present in the backend

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -472,7 +472,7 @@ class BaseDataSource:
 
         Each document is a dictionary containing permission data indexed into a corresponding permissions index.
         """
-        raise NotImplementedError
+        return []
 
     async def get_docs(self, filtering=None):
         """Returns an iterator on all documents present in the backend

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -773,6 +773,9 @@ async def test_base_class():
     with pytest.raises(NotImplementedError):
         await ds.get_docs()
 
+    with pytest.raises(NotImplementedError):
+        await ds.get_permissions()
+
     # default rule validators for every data source (order matters)
     assert BaseDataSource.basic_rules_validators() == [
         BasicRuleAgainstSchemaValidator,

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -773,6 +773,9 @@ async def test_base_class():
     with pytest.raises(NotImplementedError):
         await ds.get_docs()
 
+    with pytest.raises(NotImplementedError):
+        await ds.get_permissions()
+
     # default rule validators for every data source (order matters)
     assert BaseDataSource.basic_rules_validators() == [
         BasicRuleAgainstSchemaValidator,
@@ -782,8 +785,6 @@ async def test_base_class():
 
     # should be empty as advanced rules are specific to a data source
     assert not len(DataSource(configuration=configuration).advanced_rules_validators())
-
-    assert not len(await ds.get_permissions())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -773,9 +773,6 @@ async def test_base_class():
     with pytest.raises(NotImplementedError):
         await ds.get_docs()
 
-    with pytest.raises(NotImplementedError):
-        await ds.get_permissions()
-
     # default rule validators for every data source (order matters)
     assert BaseDataSource.basic_rules_validators() == [
         BasicRuleAgainstSchemaValidator,
@@ -785,6 +782,8 @@ async def test_base_class():
 
     # should be empty as advanced rules are specific to a data source
     assert not len(DataSource(configuration=configuration).advanced_rules_validators())
+
+    assert not len(await ds.get_permissions())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4551

This PR adds the `get_permissions` method to the `BaseDataSource`, which should be implemented by connectors supporting DLS.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~