### PR TITLE
[DLS] Add "permissions" job_type to SyncJob class

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -94,6 +94,11 @@ class JobStatus(Enum):
     UNSET = None
 
 
+class JobType(Enum):
+    PERMISSIONS = "permissions"
+    UNSET = None
+
+
 class JobTriggerMethod(Enum):
     ON_DEMAND = "on_demand"
     SCHEDULED = "scheduled"
@@ -240,6 +245,10 @@ class SyncJob(ESDocument):
     @property
     def total_document_count(self):
         return self.get("total_document_count", default=0)
+
+    @property
+    def job_type(self):
+        return JobType(self.get("job_type"))
 
     async def validate_filtering(self, validator):
         validation_result = await validator.validate_filtering(self.filtering)

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -38,6 +38,7 @@ from connectors.protocol import (
     SyncJob,
     SyncJobIndex,
 )
+from connectors.protocol.connectors import JobType
 from connectors.source import BaseDataSource
 from connectors.utils import iso_utc
 from tests.commons import AsyncIterator
@@ -549,6 +550,7 @@ async def test_sync_job_properties():
         "_id": "test",
         "_source": {
             "status": "error",
+            "job_type": "permissions",
             "error": "something wrong",
             "indexed_document_count": 10,
             "indexed_document_volume": 20,
@@ -581,8 +583,12 @@ async def test_sync_job_properties():
     assert sync_job.indexed_document_volume == 20
     assert sync_job.deleted_document_count == 30
     assert sync_job.total_document_count == 100
+
     assert isinstance(sync_job.filtering, Filter)
     assert isinstance(sync_job.pipeline, Pipeline)
+
+    assert sync_job.job_type == JobType.PERMISSIONS
+    assert isinstance(sync_job.job_type, JobType)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4590

This PR adds a new enum `JobType` used by DLS and incremental syncs. There's no default value provided as we should raise/log an error, if we encounter a job without a job type IMO.

The corresponding protocol change will be handled by a different PR in Enterprise Search.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~