### PR TITLE
Jira advanced sync rules

### DIFF
--- a/connectors/sources/atlassian.py
+++ b/connectors/sources/atlassian.py
@@ -1,0 +1,62 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+import fastjsonschema
+from fastjsonschema import JsonSchemaValueException
+
+from connectors.filtering.validation import (
+    AdvancedRulesValidator,
+    SyncRuleValidationResult,
+)
+from connectors.utils import RetryStrategy, retryable
+
+RETRIES = 3
+RETRY_INTERVAL = 2
+
+
+class AtlassianAdvancedRulesValidator(AdvancedRulesValidator):
+    QUERY_OBJECT_SCHEMA_DEFINITION = {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "minLength": 1},
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    }
+
+    SCHEMA_DEFINITION = {"type": "array", "items": QUERY_OBJECT_SCHEMA_DEFINITION}
+
+    SCHEMA = fastjsonschema.compile(definition=SCHEMA_DEFINITION)
+
+    def __init__(self, source):
+        self.source = source
+
+    async def validate(self, advanced_rules):
+        if len(advanced_rules) == 0:
+            return SyncRuleValidationResult.valid_result(
+                SyncRuleValidationResult.ADVANCED_RULES
+            )
+
+        return await self._remote_validation(advanced_rules)
+
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def _remote_validation(self, advanced_rules):
+        try:
+            AtlassianAdvancedRulesValidator.SCHEMA(advanced_rules)
+        except JsonSchemaValueException as e:
+            return SyncRuleValidationResult(
+                rule_id=SyncRuleValidationResult.ADVANCED_RULES,
+                is_valid=False,
+                validation_message=e.message,
+            )
+
+        return SyncRuleValidationResult.valid_result(
+            SyncRuleValidationResult.ADVANCED_RULES
+        )

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -21,6 +21,7 @@ from aiohttp.client_exceptions import ServerDisconnectedError
 
 from connectors.logger import logger
 from connectors.source import BaseDataSource
+from connectors.sources.atlassian import AtlassianAdvancedRulesValidator
 from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     CancellableSleeps,
@@ -310,6 +311,9 @@ class JiraDataSource(BaseDataSource):
             },
         }
 
+    def advanced_rules_validators(self):
+        return [AtlassianAdvancedRulesValidator(self)]
+
     def tweak_bulk_options(self, options):
         """Tweak bulk options as per concurrent downloads support by jira
 
@@ -492,15 +496,20 @@ class JiraDataSource(BaseDataSource):
         except Exception as exception:
             logger.warning(f"Skipping data for type: {ISSUE_DATA}. Error: {exception}")
 
-    async def _get_issues(self):
+    async def _get_issues(self, query=""):
         """Get issues with the help of REST APIs
 
         Yields:
             Dictionary: Jira issue to get indexed
             issue (dict): Issue response to fetch the attachments
         """
-        query = f"project in ({','.join(self.jira_client.projects)})"
-        jql = "" if self.jira_client.projects == ["*"] else query
+
+        jql = query or (
+            ""
+            if self.jira_client.projects == ["*"]
+            else f"project in ({','.join(self.jira_client.projects)})"
+        )
+
         async for response in self.jira_client.paginated_api_call(
             url_name=ISSUES, jql=jql
         ):
@@ -558,11 +567,21 @@ class JiraDataSource(BaseDataSource):
         Yields:
             dictionary: dictionary containing meta-data of the files.
         """
-        await self._verify_projects()
+        if filtering and filtering.has_advanced_rules():
+            advanced_rules = filtering.get_advanced_rules()
 
-        await self.fetchers.put(self._get_projects)
-        await self.fetchers.put(self._get_issues)
-        self.tasks += 2
+            for rule in advanced_rules:
+                await self.fetchers.put(
+                    partial(self._get_issues, rule.get("query", ""))
+                )
+                self.tasks += 1
+
+        else:
+            await self._verify_projects()
+
+            await self.fetchers.put(self._get_projects)
+            await self.fetchers.put(self._get_issues)
+            self.tasks += 2
 
         async for item in self._consumer():
             yield item

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -496,18 +496,18 @@ class JiraDataSource(BaseDataSource):
         except Exception as exception:
             logger.warning(f"Skipping data for type: {ISSUE_DATA}. Error: {exception}")
 
-    async def _get_issues(self, query=""):
+    async def _get_issues(self, custom_query=""):
         """Get issues with the help of REST APIs
 
         Yields:
             Dictionary: Jira issue to get indexed
             issue (dict): Issue response to fetch the attachments
         """
+        wildcard_query = ""
+        projects_query = f"project in ({','.join(self.jira_client.projects)})"
 
-        jql = query or (
-            ""
-            if self.jira_client.projects == ["*"]
-            else f"project in ({','.join(self.jira_client.projects)})"
+        jql = custom_query or (
+            wildcard_query if self.jira_client.projects == ["*"] else projects_query
         )
 
         async for response in self.jira_client.paginated_api_call(

--- a/tests/sources/test_atlassian.py
+++ b/tests/sources/test_atlassian.py
@@ -1,0 +1,92 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+from unittest.mock import ANY
+
+import pytest
+
+from connectors.filtering.validation import (
+    AdvancedRulesValidator,
+    SyncRuleValidationResult,
+)
+from connectors.sources.atlassian import AtlassianAdvancedRulesValidator
+
+
+@pytest.mark.parametrize(
+    "advanced_rules, expected_validation_result",
+    [
+        (
+            # valid: empty array should be valid
+            [],
+            SyncRuleValidationResult.valid_result(
+                SyncRuleValidationResult.ADVANCED_RULES
+            ),
+        ),
+        (
+            # valid: empty object should also be valid -> default value in Kibana
+            {},
+            SyncRuleValidationResult.valid_result(
+                SyncRuleValidationResult.ADVANCED_RULES
+            ),
+        ),
+        (
+            # valid: one custom query
+            [{"query": "type=A"}],
+            SyncRuleValidationResult.valid_result(
+                SyncRuleValidationResult.ADVANCED_RULES
+            ),
+        ),
+        (
+            # valid: two custom queries
+            [{"query": "type=A"}, {"query": "type=B"}],
+            SyncRuleValidationResult.valid_result(
+                SyncRuleValidationResult.ADVANCED_RULES
+            ),
+        ),
+        (
+            # invalid: query empty
+            [{"query": "type=A"}, {"query": ""}],
+            SyncRuleValidationResult(
+                SyncRuleValidationResult.ADVANCED_RULES,
+                is_valid=False,
+                validation_message=ANY,
+            ),
+        ),
+        (
+            # invalid: unallowed key
+            [{"query": "type=A"}, {"queries": "type=B"}],
+            SyncRuleValidationResult(
+                SyncRuleValidationResult.ADVANCED_RULES,
+                is_valid=False,
+                validation_message=ANY,
+            ),
+        ),
+        (
+            # invalid: list of strings -> wrong type
+            {"query": ["type=A"]},
+            SyncRuleValidationResult(
+                SyncRuleValidationResult.ADVANCED_RULES,
+                is_valid=False,
+                validation_message=ANY,
+            ),
+        ),
+        (
+            # invalid: array of arrays -> wrong type
+            {"query": ["type=A", ""]},
+            SyncRuleValidationResult(
+                SyncRuleValidationResult.ADVANCED_RULES,
+                is_valid=False,
+                validation_message=ANY,
+            ),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_advanced_rules_validation(advanced_rules, expected_validation_result):
+    validation_result = await AtlassianAdvancedRulesValidator(
+        AdvancedRulesValidator
+    ).validate(advanced_rules)
+
+    assert validation_result == expected_validation_result

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -474,7 +474,6 @@ async def test_verify_projects():
 
 @pytest.mark.asyncio
 async def test_verify_projects_with_unavailable_project_keys():
-    """Test _verify_projects method with unavailable project keys"""
     source = create_source(JiraDataSource)
     source.jira_client.projects = ["TP", "AP"]
 

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -14,11 +14,14 @@ import pytest
 from aiohttp import StreamReader
 from freezegun import freeze_time
 
+from connectors.byoc import Filter
 from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.jira import JiraClient, JiraDataSource
+from connectors.sources.tests.support import create_source
+from connectors.tests.commons import AsyncIterator
 from connectors.utils import ssl_context
-from tests.commons import AsyncIterator
-from tests.sources.support import create_source
+
+ADVANCED_SNIPPET = "advanced_snippet"
 
 HOST_URL = "http://127.0.0.1:8080"
 MOCK_MYSELF = {
@@ -81,6 +84,51 @@ EXPECTED_ISSUE = {
             }
         ],
     },
+}
+
+MOCK_ISSUE_TYPE_BUG = {
+    "id": "1234",
+    "key": "TP-2",
+    "fields": {
+        "project": {"name": "test_project"},
+        "updated": "2023-02-01T01:02:20",
+        "issuetype": {"name": "Bug"},
+        "attachment": [
+            {
+                "id": 10001,
+                "filename": "test_file.txt",
+                "created": "2023-02-01T01:02:20",
+                "size": 200,
+            }
+        ],
+    },
+}
+EXPECTED_ISSUE_TYPE_BUG = {
+    "_id": "test_project-TP-2",
+    "_timestamp": "2023-02-01T01:02:20",
+    "Type": "Bug",
+    "Issue": {
+        "project": {"name": "test_project"},
+        "updated": "2023-02-01T01:02:20",
+        "issuetype": {"name": "Bug"},
+        "attachment": [
+            {
+                "id": 10001,
+                "filename": "test_file.txt",
+                "created": "2023-02-01T01:02:20",
+                "size": 200,
+            }
+        ],
+    },
+}
+
+EXPECTED_ATTACHMENT_TYPE_BUG = {
+    "_id": "TP-2-10001",
+    "title": "test_file.txt",
+    "Type": "Attachment",
+    "issue": "TP-2",
+    "_timestamp": "2023-02-01T01:02:20",
+    "size": 200,
 }
 
 MOCK_ATTACHMENT = [
@@ -160,6 +208,14 @@ def side_effect_function(url, ssl):
         return get_json_mock(mock_response=MOCK_MYSELF)
     elif url == f"{HOST_URL}/rest/api/2/project?expand=description,lead,url":
         return get_json_mock(mock_response=MOCK_PROJECT)
+    elif url == f"{HOST_URL}/rest/api/2/search?jql=type=bug&maxResults=100&startAt=0":
+        mocked_issue_data_bug = {"issues": [MOCK_ISSUE_TYPE_BUG], "total": 1}
+        return get_json_mock(mock_response=mocked_issue_data_bug)
+    elif url == f"{HOST_URL}/rest/api/2/issue/TP-2":
+        return get_json_mock(mock_response=MOCK_ISSUE_TYPE_BUG)
+    elif url == f"{HOST_URL}/rest/api/2/search?jql=type=task&maxResults=100&startAt=0":
+        mocked_issue_data_task = {"issues": [MOCK_ISSUE], "total": 1}
+        return get_json_mock(mock_response=mocked_issue_data_task)
 
 
 @pytest.mark.asyncio
@@ -418,7 +474,7 @@ async def test_verify_projects():
 
 @pytest.mark.asyncio
 async def test_verify_projects_with_unavailable_project_keys():
-    """Test _verify_projects method with unavaiable project keys"""
+    """Test _verify_projects method with unavailable project keys"""
     source = create_source(JiraDataSource)
     source.jira_client.projects = ["TP", "AP"]
 
@@ -563,3 +619,39 @@ async def test_get_docs():
     ):
         async for item, _ in source.get_docs():
             assert item in EXPECTED_RESPONSES
+
+
+@pytest.mark.parametrize(
+    "filtering, expected_docs",
+    [
+        (
+            Filter(
+                {
+                    ADVANCED_SNIPPET: {
+                        "value": [{"query": "type=task"}, {"query": "type=bug"}]
+                    }
+                }
+            ),
+            [
+                EXPECTED_ISSUE,
+                EXPECTED_ATTACHMENT,
+                EXPECTED_ISSUE_TYPE_BUG,
+                EXPECTED_ATTACHMENT_TYPE_BUG,
+            ],
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_docs_with_advanced_rules(filtering, expected_docs):
+    source = create_source(JiraDataSource)
+
+    source.get_content = Mock(return_value=EXPECTED_ATTACHMENT_TYPE_BUG)
+
+    yielded_docs = []
+    with mock.patch.object(
+        source.jira_client._get_session(), "get", side_effect=side_effect_function
+    ):
+        async for item, _ in source.get_docs(filtering):
+            yielded_docs.append(item)
+
+    assert yielded_docs == expected_docs

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -14,12 +14,12 @@ import pytest
 from aiohttp import StreamReader
 from freezegun import freeze_time
 
-from connectors.byoc import Filter
+from connectors.protocol import Filter
 from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.jira import JiraClient, JiraDataSource
-from connectors.sources.tests.support import create_source
-from connectors.tests.commons import AsyncIterator
 from connectors.utils import ssl_context
+from tests.commons import AsyncIterator
+from tests.sources.support import create_source
 
 ADVANCED_SNIPPET = "advanced_snippet"
 


### PR DESCRIPTION
## Closes #945 

This PR introduces advanced filtering rules for JIRA by custom JQL queries to filter out issues based on that. Also included `atlassian.py` which can be helpful to implement filtering rules for Atlassian connectors [`Jira` & `Confluence` for now]

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference