### PR TITLE
Add sync_cursor to connector protocol doc

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -135,6 +135,7 @@ This is our main communication index, used to communicate the connector's config
   };
   service_type: string; -> Service type of the connector
   status: string;       -> Connector status Enum, see below
+  sync_cursor: object;  -> Cursor object of the last sync job, used to run incremental sync
   sync_now: boolean;    -> Flag to signal user wants to initiate a job
 }
 ```
@@ -270,6 +271,7 @@ This is our main communication index, used to communicate the connector's config
     },
     "service_type" : { "type" : "keyword" },
     "status" : { "type" : "keyword" },
+    "sync_cursor" : { "type" : "object" },
     "sync_now" : { "type" : "boolean" }
   }
 }


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4626

Update the connector protocol to include `sync_cursor` in `.elastic-connectors` index

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)