### PR TITLE
Add sync_cursor to ftest connector.json

### DIFF
--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -216,6 +216,7 @@ async def prepare(service_type, index_name, config, connector_definition=None):
                 "reduce_whitespace": True,
                 "run_ml_inference": True,
             },
+            "sync_cursor": None,
             "sync_now": False,
             "is_native": True,
         }

--- a/tests/fixtures/connector.json
+++ b/tests/fixtures/connector.json
@@ -2,6 +2,7 @@
         "name": "mongodb",
         "service_type": "mongodb",
         "index_name": "search-mongodb",
+        "sync_cursor": null,
         "sync_now": true,
         "is_native": true,
         "api_key_id": null,

--- a/tests/sources/fixtures/mongodb/connector.json
+++ b/tests/sources/fixtures/mongodb/connector.json
@@ -2,6 +2,7 @@
         "name": "mongodb",
         "service_type": "mongodb",
         "index_name": "search-mongodb",
+        "sync_cursor": null,
         "sync_now": true,
         "is_native": true,
         "api_key_id": null,

--- a/tests/sources/fixtures/mysql/connector.json
+++ b/tests/sources/fixtures/mysql/connector.json
@@ -2,6 +2,7 @@
         "name": "mysql",
         "index_name": "search-mysql",
         "service_type": "mysql",
+        "sync_cursor": null,
         "sync_now": true,
         "is_native": true,
         "api_key_id": null,


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4626

Add `sync_cursor` to `connector.json` of ftest.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)