### PR TITLE
Update sync_cursor for a completed sync job

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -625,7 +625,7 @@ class Connector(ESDocument):
         }
         await self.index.update(doc_id=self.id, doc=doc)
 
-    async def sync_done(self, job):
+    async def sync_done(self, job, sync_cursor=None):
         job_status = JobStatus.ERROR if job is None else job.status
         job_error = JOB_NOT_FOUND_ERROR if job is None else job.error
         if job_error is None and job_status == JobStatus.ERROR:
@@ -641,6 +641,10 @@ class Connector(ESDocument):
             "status": connector_status.value,
             "error": job_error,
         }
+
+        # only update sync cursor after a successful sync job
+        if job_status == JobStatus.COMPLETED:
+            doc["sync_cursor"] = sync_cursor
 
         if job is not None and job.terminated:
             doc["last_indexed_document_count"] = job.indexed_document_count

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -625,7 +625,7 @@ class Connector(ESDocument):
         }
         await self.index.update(doc_id=self.id, doc=doc)
 
-    async def sync_done(self, job, sync_cursor=None):
+    async def sync_done(self, job, cursor=None):
         job_status = JobStatus.ERROR if job is None else job.status
         job_error = JOB_NOT_FOUND_ERROR if job is None else job.error
         if job_error is None and job_status == JobStatus.ERROR:
@@ -644,7 +644,7 @@ class Connector(ESDocument):
 
         # only update sync cursor after a successful sync job
         if job_status == JobStatus.COMPLETED:
-            doc["sync_cursor"] = sync_cursor
+            doc["sync_cursor"] = cursor
 
         if job is not None and job.terminated:
             doc["last_indexed_document_count"] = job.indexed_document_count

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -453,9 +453,6 @@ def mock_job(
     return job
 
 
-sync_cursor = {"foo": "bar"}
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "job, expected_doc_source_update",
@@ -512,7 +509,7 @@ sync_cursor = {"foo": "bar"}
                 "last_sync_error": None,
                 "status": Status.CONNECTED.value,
                 "error": None,
-                "sync_cursor": sync_cursor,
+                "sync_cursor": SYNC_CURSOR,
                 "last_indexed_document_count": 0,
                 "last_deleted_document_count": 0,
             },
@@ -525,7 +522,7 @@ async def test_sync_done(job, expected_doc_source_update):
     index.update = AsyncMock(return_value=1)
 
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    await connector.sync_done(job=job, cursor=sync_cursor)
+    await connector.sync_done(job=job, cursor=SYNC_CURSOR)
     index.update.assert_called_with(doc_id=connector.id, doc=expected_doc_source_update)
 
 

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1819,4 +1819,3 @@ def test_pipeline_properties(key, value, default_value):
 )
 def test_get_advanced_rules(filtering, expected_advanced_rules):
     assert Filter(filtering).get_advanced_rules() == expected_advanced_rules
-    

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -234,7 +234,7 @@ mongo = {
     ],
 )
 async def test_supported_connectors(
-    native_service_types, connector_ids, expected_connector_count, mock_responses
+        native_service_types, connector_ids, expected_connector_count, mock_responses
 ):
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     native_connectors_query = {
@@ -372,9 +372,9 @@ async def test_connector_properties():
     [
         (60, None, True),
         (
-            60,
-            iso_utc(),
-            False,
+                60,
+                iso_utc(),
+                False,
         ),
         (60, iso_utc(datetime.now(timezone.utc) - timedelta(seconds=70)), True),
     ],
@@ -440,9 +440,9 @@ async def test_connector_error():
 
 
 def mock_job(
-    status=JobStatus.COMPLETED,
-    error=None,
-    terminated=True,
+        status=JobStatus.COMPLETED,
+        error=None,
+        terminated=True,
 ):
     job = Mock()
     job.status = status
@@ -453,65 +453,69 @@ def mock_job(
     return job
 
 
+sync_cursor = {"foo": "bar"}
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "job, expected_doc_source_update",
     [
         (
-            None,
-            {
-                "last_sync_status": JobStatus.ERROR.value,
-                "last_synced": ANY,
-                "last_sync_error": JOB_NOT_FOUND_ERROR,
-                "status": Status.ERROR.value,
-                "error": JOB_NOT_FOUND_ERROR,
-            },
+                None,
+                {
+                    "last_sync_status": JobStatus.ERROR.value,
+                    "last_synced": ANY,
+                    "last_sync_error": JOB_NOT_FOUND_ERROR,
+                    "status": Status.ERROR.value,
+                    "error": JOB_NOT_FOUND_ERROR,
+                },
         ),
         (
-            mock_job(status=JobStatus.ERROR, error="something wrong"),
-            {
-                "last_sync_status": JobStatus.ERROR.value,
-                "last_synced": ANY,
-                "last_sync_error": "something wrong",
-                "status": Status.ERROR.value,
-                "error": "something wrong",
-                "last_indexed_document_count": 0,
-                "last_deleted_document_count": 0,
-            },
+                mock_job(status=JobStatus.ERROR, error="something wrong"),
+                {
+                    "last_sync_status": JobStatus.ERROR.value,
+                    "last_synced": ANY,
+                    "last_sync_error": "something wrong",
+                    "status": Status.ERROR.value,
+                    "error": "something wrong",
+                    "last_indexed_document_count": 0,
+                    "last_deleted_document_count": 0,
+                },
         ),
         (
-            mock_job(status=JobStatus.CANCELED),
-            {
-                "last_sync_status": JobStatus.CANCELED.value,
-                "last_synced": ANY,
-                "last_sync_error": None,
-                "status": Status.CONNECTED.value,
-                "error": None,
-                "last_indexed_document_count": 0,
-                "last_deleted_document_count": 0,
-            },
+                mock_job(status=JobStatus.CANCELED),
+                {
+                    "last_sync_status": JobStatus.CANCELED.value,
+                    "last_synced": ANY,
+                    "last_sync_error": None,
+                    "status": Status.CONNECTED.value,
+                    "error": None,
+                    "last_indexed_document_count": 0,
+                    "last_deleted_document_count": 0,
+                },
         ),
         (
-            mock_job(status=JobStatus.SUSPENDED, terminated=False),
-            {
-                "last_sync_status": JobStatus.SUSPENDED.value,
-                "last_synced": ANY,
-                "last_sync_error": None,
-                "status": Status.CONNECTED.value,
-                "error": None,
-            },
+                mock_job(status=JobStatus.SUSPENDED, terminated=False),
+                {
+                    "last_sync_status": JobStatus.SUSPENDED.value,
+                    "last_synced": ANY,
+                    "last_sync_error": None,
+                    "status": Status.CONNECTED.value,
+                    "error": None,
+                },
         ),
         (
-            mock_job(),
-            {
-                "last_sync_status": JobStatus.COMPLETED.value,
-                "last_synced": ANY,
-                "last_sync_error": None,
-                "status": Status.CONNECTED.value,
-                "error": None,
-                "last_indexed_document_count": 0,
-                "last_deleted_document_count": 0,
-            },
+                mock_job(),
+                {
+                    "last_sync_status": JobStatus.COMPLETED.value,
+                    "last_synced": ANY,
+                    "last_sync_error": None,
+                    "status": Status.CONNECTED.value,
+                    "error": None,
+                    "sync_cursor": sync_cursor,
+                    "last_indexed_document_count": 0,
+                    "last_deleted_document_count": 0,
+                },
         ),
     ],
 )
@@ -521,7 +525,7 @@ async def test_sync_done(job, expected_doc_source_update):
     index.update = AsyncMock(return_value=1)
 
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    await connector.sync_done(job=job)
+    await connector.sync_done(job=job, sync_cursor=sync_cursor)
     index.update.assert_called_with(doc_id=connector.id, doc=expected_doc_source_update)
 
 
@@ -604,19 +608,19 @@ async def test_sync_job_properties():
     "validation_result_state, validation_result_errors, should_raise_exception",
     [
         (
-            FilteringValidationState.VALID,
-            [],
-            False,
+                FilteringValidationState.VALID,
+                [],
+                False,
         ),
         (
-            FilteringValidationState.INVALID,
-            ["something wrong"],
-            True,
+                FilteringValidationState.INVALID,
+                ["something wrong"],
+                True,
         ),
     ],
 )
 async def test_sync_job_validate_filtering(
-    validation_result_state, validation_result_errors, should_raise_exception
+        validation_result_state, validation_result_errors, should_raise_exception
 ):
     source = {"_id": "1"}
     index = Mock()
@@ -665,11 +669,11 @@ async def test_sync_job_update_metadata():
     }
     connector_metadata = {"foo": "bar"}
     expected_doc_source_update = (
-        {
-            "last_seen": ANY,
-        }
-        | ingestion_stats
-        | {"metadata": connector_metadata}
+            {
+                "last_seen": ANY,
+            }
+            | ingestion_stats
+            | {"metadata": connector_metadata}
     )
 
     sync_job = SyncJob(elastic_index=index, doc_source=source)
@@ -1186,7 +1190,7 @@ async def test_connector_validate_filtering_invalid():
             {
                 "domain": DEFAULT_DOMAIN,
                 "draft": DRAFT_FILTERING_DEFAULT_DOMAIN
-                | {"validation": validation_result.to_dict()},
+                         | {"validation": validation_result.to_dict()},
                 "active": ACTIVE_FILTERING_DEFAULT_DOMAIN,
             },
             FILTERING_OTHER_DOMAIN,
@@ -1219,9 +1223,9 @@ async def test_connector_validate_filtering_valid():
             {
                 "domain": DEFAULT_DOMAIN,
                 "draft": DRAFT_FILTERING_DEFAULT_DOMAIN
-                | {"validation": validation_result.to_dict()},
+                         | {"validation": validation_result.to_dict()},
                 "active": DRAFT_FILTERING_DEFAULT_DOMAIN
-                | {"validation": validation_result.to_dict()},
+                          | {"validation": validation_result.to_dict()},
             },
             FILTERING_OTHER_DOMAIN,
         ]
@@ -1252,9 +1256,9 @@ async def test_connector_validate_filtering_with_race_condition():
             {
                 "domain": DEFAULT_DOMAIN,
                 "draft": DRAFT_FILTERING_DEFAULT_DOMAIN
-                | {"validation": validation_result.to_dict()},
+                         | {"validation": validation_result.to_dict()},
                 "active": DRAFT_FILTERING_DEFAULT_DOMAIN
-                | {"validation": validation_result.to_dict()},
+                          | {"validation": validation_result.to_dict()},
             },
             FILTERING_OTHER_DOMAIN,
         ]
@@ -1280,16 +1284,16 @@ async def test_connector_validate_filtering_with_race_condition():
     "filtering_json, filter_state, domain, expected_filter",
     [
         (
-            FILTERING,
-            ACTIVE_FILTER_STATE,
-            Filtering.DEFAULT_DOMAIN,
-            ACTIVE_FILTERING_DEFAULT_DOMAIN,
+                FILTERING,
+                ACTIVE_FILTER_STATE,
+                Filtering.DEFAULT_DOMAIN,
+                ACTIVE_FILTERING_DEFAULT_DOMAIN,
         ),
         (
-            FILTERING,
-            DRAFT_FILTER_STATE,
-            Filtering.DEFAULT_DOMAIN,
-            DRAFT_FILTERING_DEFAULT_DOMAIN,
+                FILTERING,
+                DRAFT_FILTER_STATE,
+                Filtering.DEFAULT_DOMAIN,
+                DRAFT_FILTERING_DEFAULT_DOMAIN,
         ),
         (FILTERING, ACTIVE_FILTER_STATE, OTHER_DOMAIN_ONE, EMPTY_FILTER),
         (FILTERING, ACTIVE_FILTER_STATE, OTHER_DOMAIN_TWO, EMPTY_FILTER),
@@ -1344,12 +1348,12 @@ def test_get_draft_filter(domain, expected_filter):
     "filtering, expected_transformed_filtering",
     [
         (
-            {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
-            {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
+                {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
+                {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
         ),
         (
-            {"advanced_snippet": {"value": {}}, "rules": []},
-            {"advanced_snippet": {"value": {}}, "rules": []},
+                {"advanced_snippet": {"value": {}}, "rules": []},
+                {"advanced_snippet": {"value": {}}, "rules": []},
         ),
         ({"advanced_snippet": {}, "rules": []}, {"advanced_snippet": {}, "rules": []}),
         ({}, {"advanced_snippet": {}, "rules": []}),
@@ -1358,8 +1362,8 @@ def test_get_draft_filter(domain, expected_filter):
 )
 def test_transform_filtering(filtering, expected_transformed_filtering):
     assert (
-        Filter(filter_=filtering).transform_filtering()
-        == expected_transformed_filtering
+            Filter(filter_=filtering).transform_filtering()
+            == expected_transformed_filtering
     )
 
 
@@ -1367,129 +1371,129 @@ def test_transform_filtering(filtering, expected_transformed_filtering):
     "features_json, feature_enabled",
     [
         (
-            {
-                "sync_rules": {
-                    "basic": {"enabled": True},
-                    "advanced": {"enabled": True},
-                }
-            },
-            {
-                Features.BASIC_RULES_NEW: True,
-                Features.ADVANCED_RULES_NEW: True,
-                Features.BASIC_RULES_OLD: False,
-                Features.ADVANCED_RULES_OLD: False,
-            },
-        ),
-        (
-            {
-                "sync_rules": {
-                    "basic": {"enabled": True},
-                    "advanced": {"enabled": False},
-                }
-            },
-            {
-                Features.BASIC_RULES_NEW: True,
-                Features.ADVANCED_RULES_NEW: False,
-                Features.BASIC_RULES_OLD: False,
-                Features.ADVANCED_RULES_OLD: False,
-            },
-        ),
-        (
-            {
-                "sync_rules": {
-                    "basic": {"enabled": False},
-                    "advanced": {"enabled": False},
-                }
-            },
-            {
-                Features.BASIC_RULES_NEW: False,
-                Features.ADVANCED_RULES_NEW: False,
-                Features.BASIC_RULES_OLD: False,
-                Features.ADVANCED_RULES_OLD: False,
-            },
-        ),
-        (
-            {"filtering_advanced_config": True, "filtering_rules": True},
-            {
-                Features.BASIC_RULES_NEW: False,
-                Features.ADVANCED_RULES_NEW: False,
-                Features.BASIC_RULES_OLD: True,
-                Features.ADVANCED_RULES_OLD: True,
-            },
-        ),
-        (
-            {"filtering_advanced_config": False, "filtering_rules": False},
-            {
-                Features.BASIC_RULES_NEW: False,
-                Features.ADVANCED_RULES_NEW: False,
-                Features.BASIC_RULES_OLD: False,
-                Features.ADVANCED_RULES_OLD: False,
-            },
-        ),
-        (
-            {"filtering_advanced_config": True, "filtering_rules": False},
-            {
-                Features.BASIC_RULES_NEW: False,
-                Features.ADVANCED_RULES_NEW: False,
-                Features.BASIC_RULES_OLD: False,
-                Features.ADVANCED_RULES_OLD: True,
-            },
-        ),
-        (
-            {
-                "sync_rules": {
-                    "basic": {"enabled": True},
-                    "advanced": {"enabled": True},
+                {
+                    "sync_rules": {
+                        "basic": {"enabled": True},
+                        "advanced": {"enabled": True},
+                    }
                 },
-                "filtering_advanced_config": True,
-                "filtering_rules": True,
-            },
-            {
-                Features.BASIC_RULES_NEW: True,
-                Features.ADVANCED_RULES_NEW: True,
-                Features.BASIC_RULES_OLD: True,
-                Features.ADVANCED_RULES_OLD: True,
-            },
+                {
+                    Features.BASIC_RULES_NEW: True,
+                    Features.ADVANCED_RULES_NEW: True,
+                    Features.BASIC_RULES_OLD: False,
+                    Features.ADVANCED_RULES_OLD: False,
+                },
         ),
         (
-            None,
-            {
-                Features.BASIC_RULES_NEW: False,
-                Features.ADVANCED_RULES_NEW: False,
-                Features.BASIC_RULES_OLD: False,
-                Features.ADVANCED_RULES_OLD: False,
-                Features.DOCUMENT_LEVEL_SECURITY: False
-            },
+                {
+                    "sync_rules": {
+                        "basic": {"enabled": True},
+                        "advanced": {"enabled": False},
+                    }
+                },
+                {
+                    Features.BASIC_RULES_NEW: True,
+                    Features.ADVANCED_RULES_NEW: False,
+                    Features.BASIC_RULES_OLD: False,
+                    Features.ADVANCED_RULES_OLD: False,
+                },
         ),
         (
-            {},
-            {
-                Features.BASIC_RULES_NEW: False,
-                Features.ADVANCED_RULES_NEW: False,
-                Features.BASIC_RULES_OLD: False,
-                Features.ADVANCED_RULES_OLD: False,
-                Features.DOCUMENT_LEVEL_SECURITY: False
-            },
+                {
+                    "sync_rules": {
+                        "basic": {"enabled": False},
+                        "advanced": {"enabled": False},
+                    }
+                },
+                {
+                    Features.BASIC_RULES_NEW: False,
+                    Features.ADVANCED_RULES_NEW: False,
+                    Features.BASIC_RULES_OLD: False,
+                    Features.ADVANCED_RULES_OLD: False,
+                },
         ),
         (
-            {
-                "document_level_security": {
-                    "enabled": True
+                {"filtering_advanced_config": True, "filtering_rules": True},
+                {
+                    Features.BASIC_RULES_NEW: False,
+                    Features.ADVANCED_RULES_NEW: False,
+                    Features.BASIC_RULES_OLD: True,
+                    Features.ADVANCED_RULES_OLD: True,
+                },
+        ),
+        (
+                {"filtering_advanced_config": False, "filtering_rules": False},
+                {
+                    Features.BASIC_RULES_NEW: False,
+                    Features.ADVANCED_RULES_NEW: False,
+                    Features.BASIC_RULES_OLD: False,
+                    Features.ADVANCED_RULES_OLD: False,
+                },
+        ),
+        (
+                {"filtering_advanced_config": True, "filtering_rules": False},
+                {
+                    Features.BASIC_RULES_NEW: False,
+                    Features.ADVANCED_RULES_NEW: False,
+                    Features.BASIC_RULES_OLD: False,
+                    Features.ADVANCED_RULES_OLD: True,
+                },
+        ),
+        (
+                {
+                    "sync_rules": {
+                        "basic": {"enabled": True},
+                        "advanced": {"enabled": True},
+                    },
+                    "filtering_advanced_config": True,
+                    "filtering_rules": True,
+                },
+                {
+                    Features.BASIC_RULES_NEW: True,
+                    Features.ADVANCED_RULES_NEW: True,
+                    Features.BASIC_RULES_OLD: True,
+                    Features.ADVANCED_RULES_OLD: True,
+                },
+        ),
+        (
+                None,
+                {
+                    Features.BASIC_RULES_NEW: False,
+                    Features.ADVANCED_RULES_NEW: False,
+                    Features.BASIC_RULES_OLD: False,
+                    Features.ADVANCED_RULES_OLD: False,
+                    Features.DOCUMENT_LEVEL_SECURITY: False
+                },
+        ),
+        (
+                {},
+                {
+                    Features.BASIC_RULES_NEW: False,
+                    Features.ADVANCED_RULES_NEW: False,
+                    Features.BASIC_RULES_OLD: False,
+                    Features.ADVANCED_RULES_OLD: False,
+                    Features.DOCUMENT_LEVEL_SECURITY: False
+                },
+        ),
+        (
+                {
+                    "document_level_security": {
+                        "enabled": True
+                    }
+                },
+                {
+                    Features.DOCUMENT_LEVEL_SECURITY: True
                 }
-            },
-            {
-                Features.DOCUMENT_LEVEL_SECURITY: True
-            }
         ),
         (
-            {
-                "document_level_security": {
-                    "enabled": False
+                {
+                    "document_level_security": {
+                        "enabled": False
+                    }
+                },
+                {
+                    Features.DOCUMENT_LEVEL_SECURITY: False
                 }
-            },
-            {
-                Features.DOCUMENT_LEVEL_SECURITY: False
-            }
         )
     ],
 )
@@ -1508,59 +1512,59 @@ def test_feature_enabled(features_json, feature_enabled):
     "features_json, sync_rules_enabled",
     [
         (
-            {
-                "sync_rules": {
-                    "basic": {"enabled": True},
-                    "advanced": {"enabled": False},
+                {
+                    "sync_rules": {
+                        "basic": {"enabled": True},
+                        "advanced": {"enabled": False},
+                    },
+                    "filtering_advanced_config": False,
+                    "filtering_rules": False,
                 },
-                "filtering_advanced_config": False,
-                "filtering_rules": False,
-            },
-            True,
+                True,
         ),
         (
-            {
-                "sync_rules": {
-                    "basic": {"enabled": False},
-                    "advanced": {"enabled": True},
+                {
+                    "sync_rules": {
+                        "basic": {"enabled": False},
+                        "advanced": {"enabled": True},
+                    },
+                    "filtering_advanced_config": False,
+                    "filtering_rules": False,
                 },
-                "filtering_advanced_config": False,
-                "filtering_rules": False,
-            },
-            True,
+                True,
         ),
         (
-            {
-                "sync_rules": {
-                    "basic": {"enabled": False},
-                    "advanced": {"enabled": False},
+                {
+                    "sync_rules": {
+                        "basic": {"enabled": False},
+                        "advanced": {"enabled": False},
+                    },
+                    "filtering_advanced_config": True,
+                    "filtering_rules": False,
                 },
-                "filtering_advanced_config": True,
-                "filtering_rules": False,
-            },
-            True,
+                True,
         ),
         (
-            {
-                "sync_rules": {
-                    "basic": {"enabled": False},
-                    "advanced": {"enabled": False},
+                {
+                    "sync_rules": {
+                        "basic": {"enabled": False},
+                        "advanced": {"enabled": False},
+                    },
+                    "filtering_advanced_config": False,
+                    "filtering_rules": True,
                 },
-                "filtering_advanced_config": False,
-                "filtering_rules": True,
-            },
-            True,
+                True,
         ),
         (
-            {
-                "sync_rules": {
-                    "basic": {"enabled": False},
-                    "advanced": {"enabled": False},
+                {
+                    "sync_rules": {
+                        "basic": {"enabled": False},
+                        "advanced": {"enabled": False},
+                    },
+                    "filtering_advanced_config": False,
+                    "filtering_rules": False,
                 },
-                "filtering_advanced_config": False,
-                "filtering_rules": False,
-            },
-            False,
+                False,
         ),
         ({"other_feature": True}, False),
         (None, False),
@@ -1615,18 +1619,18 @@ def test_incremental_sync_enabled(features_json, incremental_sync_enabled):
         # extract True
         ({"a": {"b": {"c": True}}}, ["a", "b", "c"], False, True),
         (
-            {"a": {"b": {"c": True}}},
-            # "d" doesn't exist -> fall back to False
-            ["a", "b", "c", "d"],
-            False,
-            False,
+                {"a": {"b": {"c": True}}},
+                # "d" doesn't exist -> fall back to False
+                ["a", "b", "c", "d"],
+                False,
+                False,
         ),
         (
-            {"a": {"b": {"c": True}}},
-            # "wrong_key" doesn't exist -> fall back to False
-            ["wrong_key", "b", "c"],
-            False,
-            False,
+                {"a": {"b": {"c": True}}},
+                # "wrong_key" doesn't exist -> fall back to False
+                ["wrong_key", "b", "c"],
+                False,
+                False,
         ),
         # fallback to True
         (None, ["a", "b", "c"], True, True),
@@ -1781,11 +1785,11 @@ def test_advanced_rules_present(filtering, should_advanced_rules_be_present):
     ],
 )
 def test_has_validation_state(
-    filtering, validation_state, has_expected_validation_state
+        filtering, validation_state, has_expected_validation_state
 ):
     assert (
-        Filter(filtering).has_validation_state(validation_state)
-        == has_expected_validation_state
+            Filter(filtering).has_validation_state(validation_state)
+            == has_expected_validation_state
     )
 
 

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -525,7 +525,7 @@ async def test_sync_done(job, expected_doc_source_update):
     index.update = AsyncMock(return_value=1)
 
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    await connector.sync_done(job=job, sync_cursor=sync_cursor)
+    await connector.sync_done(job=job, cursor=sync_cursor)
     index.update.assert_called_with(doc_id=connector.id, doc=expected_doc_source_update)
 
 

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1819,3 +1819,4 @@ def test_pipeline_properties(key, value, default_value):
 )
 def test_get_advanced_rules(filtering, expected_advanced_rules):
     assert Filter(filtering).get_advanced_rules() == expected_advanced_rules
+    

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -234,7 +234,7 @@ mongo = {
     ],
 )
 async def test_supported_connectors(
-        native_service_types, connector_ids, expected_connector_count, mock_responses
+    native_service_types, connector_ids, expected_connector_count, mock_responses
 ):
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     native_connectors_query = {
@@ -372,9 +372,9 @@ async def test_connector_properties():
     [
         (60, None, True),
         (
-                60,
-                iso_utc(),
-                False,
+            60,
+            iso_utc(),
+            False,
         ),
         (60, iso_utc(datetime.now(timezone.utc) - timedelta(seconds=70)), True),
     ],
@@ -440,9 +440,9 @@ async def test_connector_error():
 
 
 def mock_job(
-        status=JobStatus.COMPLETED,
-        error=None,
-        terminated=True,
+    status=JobStatus.COMPLETED,
+    error=None,
+    terminated=True,
 ):
     job = Mock()
     job.status = status
@@ -461,61 +461,61 @@ sync_cursor = {"foo": "bar"}
     "job, expected_doc_source_update",
     [
         (
-                None,
-                {
-                    "last_sync_status": JobStatus.ERROR.value,
-                    "last_synced": ANY,
-                    "last_sync_error": JOB_NOT_FOUND_ERROR,
-                    "status": Status.ERROR.value,
-                    "error": JOB_NOT_FOUND_ERROR,
-                },
+            None,
+            {
+                "last_sync_status": JobStatus.ERROR.value,
+                "last_synced": ANY,
+                "last_sync_error": JOB_NOT_FOUND_ERROR,
+                "status": Status.ERROR.value,
+                "error": JOB_NOT_FOUND_ERROR,
+            },
         ),
         (
-                mock_job(status=JobStatus.ERROR, error="something wrong"),
-                {
-                    "last_sync_status": JobStatus.ERROR.value,
-                    "last_synced": ANY,
-                    "last_sync_error": "something wrong",
-                    "status": Status.ERROR.value,
-                    "error": "something wrong",
-                    "last_indexed_document_count": 0,
-                    "last_deleted_document_count": 0,
-                },
+            mock_job(status=JobStatus.ERROR, error="something wrong"),
+            {
+                "last_sync_status": JobStatus.ERROR.value,
+                "last_synced": ANY,
+                "last_sync_error": "something wrong",
+                "status": Status.ERROR.value,
+                "error": "something wrong",
+                "last_indexed_document_count": 0,
+                "last_deleted_document_count": 0,
+            },
         ),
         (
-                mock_job(status=JobStatus.CANCELED),
-                {
-                    "last_sync_status": JobStatus.CANCELED.value,
-                    "last_synced": ANY,
-                    "last_sync_error": None,
-                    "status": Status.CONNECTED.value,
-                    "error": None,
-                    "last_indexed_document_count": 0,
-                    "last_deleted_document_count": 0,
-                },
+            mock_job(status=JobStatus.CANCELED),
+            {
+                "last_sync_status": JobStatus.CANCELED.value,
+                "last_synced": ANY,
+                "last_sync_error": None,
+                "status": Status.CONNECTED.value,
+                "error": None,
+                "last_indexed_document_count": 0,
+                "last_deleted_document_count": 0,
+            },
         ),
         (
-                mock_job(status=JobStatus.SUSPENDED, terminated=False),
-                {
-                    "last_sync_status": JobStatus.SUSPENDED.value,
-                    "last_synced": ANY,
-                    "last_sync_error": None,
-                    "status": Status.CONNECTED.value,
-                    "error": None,
-                },
+            mock_job(status=JobStatus.SUSPENDED, terminated=False),
+            {
+                "last_sync_status": JobStatus.SUSPENDED.value,
+                "last_synced": ANY,
+                "last_sync_error": None,
+                "status": Status.CONNECTED.value,
+                "error": None,
+            },
         ),
         (
-                mock_job(),
-                {
-                    "last_sync_status": JobStatus.COMPLETED.value,
-                    "last_synced": ANY,
-                    "last_sync_error": None,
-                    "status": Status.CONNECTED.value,
-                    "error": None,
-                    "sync_cursor": sync_cursor,
-                    "last_indexed_document_count": 0,
-                    "last_deleted_document_count": 0,
-                },
+            mock_job(),
+            {
+                "last_sync_status": JobStatus.COMPLETED.value,
+                "last_synced": ANY,
+                "last_sync_error": None,
+                "status": Status.CONNECTED.value,
+                "error": None,
+                "sync_cursor": sync_cursor,
+                "last_indexed_document_count": 0,
+                "last_deleted_document_count": 0,
+            },
         ),
     ],
 )
@@ -608,19 +608,19 @@ async def test_sync_job_properties():
     "validation_result_state, validation_result_errors, should_raise_exception",
     [
         (
-                FilteringValidationState.VALID,
-                [],
-                False,
+            FilteringValidationState.VALID,
+            [],
+            False,
         ),
         (
-                FilteringValidationState.INVALID,
-                ["something wrong"],
-                True,
+            FilteringValidationState.INVALID,
+            ["something wrong"],
+            True,
         ),
     ],
 )
 async def test_sync_job_validate_filtering(
-        validation_result_state, validation_result_errors, should_raise_exception
+    validation_result_state, validation_result_errors, should_raise_exception
 ):
     source = {"_id": "1"}
     index = Mock()
@@ -669,11 +669,11 @@ async def test_sync_job_update_metadata():
     }
     connector_metadata = {"foo": "bar"}
     expected_doc_source_update = (
-            {
-                "last_seen": ANY,
-            }
-            | ingestion_stats
-            | {"metadata": connector_metadata}
+        {
+            "last_seen": ANY,
+        }
+        | ingestion_stats
+        | {"metadata": connector_metadata}
     )
 
     sync_job = SyncJob(elastic_index=index, doc_source=source)
@@ -1190,7 +1190,7 @@ async def test_connector_validate_filtering_invalid():
             {
                 "domain": DEFAULT_DOMAIN,
                 "draft": DRAFT_FILTERING_DEFAULT_DOMAIN
-                         | {"validation": validation_result.to_dict()},
+                | {"validation": validation_result.to_dict()},
                 "active": ACTIVE_FILTERING_DEFAULT_DOMAIN,
             },
             FILTERING_OTHER_DOMAIN,
@@ -1223,9 +1223,9 @@ async def test_connector_validate_filtering_valid():
             {
                 "domain": DEFAULT_DOMAIN,
                 "draft": DRAFT_FILTERING_DEFAULT_DOMAIN
-                         | {"validation": validation_result.to_dict()},
+                | {"validation": validation_result.to_dict()},
                 "active": DRAFT_FILTERING_DEFAULT_DOMAIN
-                          | {"validation": validation_result.to_dict()},
+                | {"validation": validation_result.to_dict()},
             },
             FILTERING_OTHER_DOMAIN,
         ]
@@ -1256,9 +1256,9 @@ async def test_connector_validate_filtering_with_race_condition():
             {
                 "domain": DEFAULT_DOMAIN,
                 "draft": DRAFT_FILTERING_DEFAULT_DOMAIN
-                         | {"validation": validation_result.to_dict()},
+                | {"validation": validation_result.to_dict()},
                 "active": DRAFT_FILTERING_DEFAULT_DOMAIN
-                          | {"validation": validation_result.to_dict()},
+                | {"validation": validation_result.to_dict()},
             },
             FILTERING_OTHER_DOMAIN,
         ]
@@ -1284,16 +1284,16 @@ async def test_connector_validate_filtering_with_race_condition():
     "filtering_json, filter_state, domain, expected_filter",
     [
         (
-                FILTERING,
-                ACTIVE_FILTER_STATE,
-                Filtering.DEFAULT_DOMAIN,
-                ACTIVE_FILTERING_DEFAULT_DOMAIN,
+            FILTERING,
+            ACTIVE_FILTER_STATE,
+            Filtering.DEFAULT_DOMAIN,
+            ACTIVE_FILTERING_DEFAULT_DOMAIN,
         ),
         (
-                FILTERING,
-                DRAFT_FILTER_STATE,
-                Filtering.DEFAULT_DOMAIN,
-                DRAFT_FILTERING_DEFAULT_DOMAIN,
+            FILTERING,
+            DRAFT_FILTER_STATE,
+            Filtering.DEFAULT_DOMAIN,
+            DRAFT_FILTERING_DEFAULT_DOMAIN,
         ),
         (FILTERING, ACTIVE_FILTER_STATE, OTHER_DOMAIN_ONE, EMPTY_FILTER),
         (FILTERING, ACTIVE_FILTER_STATE, OTHER_DOMAIN_TWO, EMPTY_FILTER),
@@ -1348,12 +1348,12 @@ def test_get_draft_filter(domain, expected_filter):
     "filtering, expected_transformed_filtering",
     [
         (
-                {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
-                {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
+            {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
+            {"advanced_snippet": {"value": {"query": {}}}, "rules": []},
         ),
         (
-                {"advanced_snippet": {"value": {}}, "rules": []},
-                {"advanced_snippet": {"value": {}}, "rules": []},
+            {"advanced_snippet": {"value": {}}, "rules": []},
+            {"advanced_snippet": {"value": {}}, "rules": []},
         ),
         ({"advanced_snippet": {}, "rules": []}, {"advanced_snippet": {}, "rules": []}),
         ({}, {"advanced_snippet": {}, "rules": []}),
@@ -1362,8 +1362,8 @@ def test_get_draft_filter(domain, expected_filter):
 )
 def test_transform_filtering(filtering, expected_transformed_filtering):
     assert (
-            Filter(filter_=filtering).transform_filtering()
-            == expected_transformed_filtering
+        Filter(filter_=filtering).transform_filtering()
+        == expected_transformed_filtering
     )
 
 
@@ -1371,129 +1371,129 @@ def test_transform_filtering(filtering, expected_transformed_filtering):
     "features_json, feature_enabled",
     [
         (
-                {
-                    "sync_rules": {
-                        "basic": {"enabled": True},
-                        "advanced": {"enabled": True},
-                    }
-                },
-                {
-                    Features.BASIC_RULES_NEW: True,
-                    Features.ADVANCED_RULES_NEW: True,
-                    Features.BASIC_RULES_OLD: False,
-                    Features.ADVANCED_RULES_OLD: False,
-                },
-        ),
-        (
-                {
-                    "sync_rules": {
-                        "basic": {"enabled": True},
-                        "advanced": {"enabled": False},
-                    }
-                },
-                {
-                    Features.BASIC_RULES_NEW: True,
-                    Features.ADVANCED_RULES_NEW: False,
-                    Features.BASIC_RULES_OLD: False,
-                    Features.ADVANCED_RULES_OLD: False,
-                },
-        ),
-        (
-                {
-                    "sync_rules": {
-                        "basic": {"enabled": False},
-                        "advanced": {"enabled": False},
-                    }
-                },
-                {
-                    Features.BASIC_RULES_NEW: False,
-                    Features.ADVANCED_RULES_NEW: False,
-                    Features.BASIC_RULES_OLD: False,
-                    Features.ADVANCED_RULES_OLD: False,
-                },
-        ),
-        (
-                {"filtering_advanced_config": True, "filtering_rules": True},
-                {
-                    Features.BASIC_RULES_NEW: False,
-                    Features.ADVANCED_RULES_NEW: False,
-                    Features.BASIC_RULES_OLD: True,
-                    Features.ADVANCED_RULES_OLD: True,
-                },
-        ),
-        (
-                {"filtering_advanced_config": False, "filtering_rules": False},
-                {
-                    Features.BASIC_RULES_NEW: False,
-                    Features.ADVANCED_RULES_NEW: False,
-                    Features.BASIC_RULES_OLD: False,
-                    Features.ADVANCED_RULES_OLD: False,
-                },
-        ),
-        (
-                {"filtering_advanced_config": True, "filtering_rules": False},
-                {
-                    Features.BASIC_RULES_NEW: False,
-                    Features.ADVANCED_RULES_NEW: False,
-                    Features.BASIC_RULES_OLD: False,
-                    Features.ADVANCED_RULES_OLD: True,
-                },
-        ),
-        (
-                {
-                    "sync_rules": {
-                        "basic": {"enabled": True},
-                        "advanced": {"enabled": True},
-                    },
-                    "filtering_advanced_config": True,
-                    "filtering_rules": True,
-                },
-                {
-                    Features.BASIC_RULES_NEW: True,
-                    Features.ADVANCED_RULES_NEW: True,
-                    Features.BASIC_RULES_OLD: True,
-                    Features.ADVANCED_RULES_OLD: True,
-                },
-        ),
-        (
-                None,
-                {
-                    Features.BASIC_RULES_NEW: False,
-                    Features.ADVANCED_RULES_NEW: False,
-                    Features.BASIC_RULES_OLD: False,
-                    Features.ADVANCED_RULES_OLD: False,
-                    Features.DOCUMENT_LEVEL_SECURITY: False
-                },
-        ),
-        (
-                {},
-                {
-                    Features.BASIC_RULES_NEW: False,
-                    Features.ADVANCED_RULES_NEW: False,
-                    Features.BASIC_RULES_OLD: False,
-                    Features.ADVANCED_RULES_OLD: False,
-                    Features.DOCUMENT_LEVEL_SECURITY: False
-                },
-        ),
-        (
-                {
-                    "document_level_security": {
-                        "enabled": True
-                    }
-                },
-                {
-                    Features.DOCUMENT_LEVEL_SECURITY: True
+            {
+                "sync_rules": {
+                    "basic": {"enabled": True},
+                    "advanced": {"enabled": True},
                 }
+            },
+            {
+                Features.BASIC_RULES_NEW: True,
+                Features.ADVANCED_RULES_NEW: True,
+                Features.BASIC_RULES_OLD: False,
+                Features.ADVANCED_RULES_OLD: False,
+            },
         ),
         (
-                {
-                    "document_level_security": {
-                        "enabled": False
-                    }
-                },
-                {
-                    Features.DOCUMENT_LEVEL_SECURITY: False
+            {
+                "sync_rules": {
+                    "basic": {"enabled": True},
+                    "advanced": {"enabled": False},
                 }
+            },
+            {
+                Features.BASIC_RULES_NEW: True,
+                Features.ADVANCED_RULES_NEW: False,
+                Features.BASIC_RULES_OLD: False,
+                Features.ADVANCED_RULES_OLD: False,
+            },
+        ),
+        (
+            {
+                "sync_rules": {
+                    "basic": {"enabled": False},
+                    "advanced": {"enabled": False},
+                }
+            },
+            {
+                Features.BASIC_RULES_NEW: False,
+                Features.ADVANCED_RULES_NEW: False,
+                Features.BASIC_RULES_OLD: False,
+                Features.ADVANCED_RULES_OLD: False,
+            },
+        ),
+        (
+            {"filtering_advanced_config": True, "filtering_rules": True},
+            {
+                Features.BASIC_RULES_NEW: False,
+                Features.ADVANCED_RULES_NEW: False,
+                Features.BASIC_RULES_OLD: True,
+                Features.ADVANCED_RULES_OLD: True,
+            },
+        ),
+        (
+            {"filtering_advanced_config": False, "filtering_rules": False},
+            {
+                Features.BASIC_RULES_NEW: False,
+                Features.ADVANCED_RULES_NEW: False,
+                Features.BASIC_RULES_OLD: False,
+                Features.ADVANCED_RULES_OLD: False,
+            },
+        ),
+        (
+            {"filtering_advanced_config": True, "filtering_rules": False},
+            {
+                Features.BASIC_RULES_NEW: False,
+                Features.ADVANCED_RULES_NEW: False,
+                Features.BASIC_RULES_OLD: False,
+                Features.ADVANCED_RULES_OLD: True,
+            },
+        ),
+        (
+            {
+                "sync_rules": {
+                    "basic": {"enabled": True},
+                    "advanced": {"enabled": True},
+                },
+                "filtering_advanced_config": True,
+                "filtering_rules": True,
+            },
+            {
+                Features.BASIC_RULES_NEW: True,
+                Features.ADVANCED_RULES_NEW: True,
+                Features.BASIC_RULES_OLD: True,
+                Features.ADVANCED_RULES_OLD: True,
+            },
+        ),
+        (
+            None,
+            {
+                Features.BASIC_RULES_NEW: False,
+                Features.ADVANCED_RULES_NEW: False,
+                Features.BASIC_RULES_OLD: False,
+                Features.ADVANCED_RULES_OLD: False,
+                Features.DOCUMENT_LEVEL_SECURITY: False
+            },
+        ),
+        (
+            {},
+            {
+                Features.BASIC_RULES_NEW: False,
+                Features.ADVANCED_RULES_NEW: False,
+                Features.BASIC_RULES_OLD: False,
+                Features.ADVANCED_RULES_OLD: False,
+                Features.DOCUMENT_LEVEL_SECURITY: False
+            },
+        ),
+        (
+            {
+                "document_level_security": {
+                    "enabled": True
+                }
+            },
+            {
+                Features.DOCUMENT_LEVEL_SECURITY: True
+            }
+        ),
+        (
+            {
+                "document_level_security": {
+                    "enabled": False
+                }
+            },
+            {
+                Features.DOCUMENT_LEVEL_SECURITY: False
+            }
         )
     ],
 )
@@ -1512,59 +1512,59 @@ def test_feature_enabled(features_json, feature_enabled):
     "features_json, sync_rules_enabled",
     [
         (
-                {
-                    "sync_rules": {
-                        "basic": {"enabled": True},
-                        "advanced": {"enabled": False},
-                    },
-                    "filtering_advanced_config": False,
-                    "filtering_rules": False,
+            {
+                "sync_rules": {
+                    "basic": {"enabled": True},
+                    "advanced": {"enabled": False},
                 },
-                True,
+                "filtering_advanced_config": False,
+                "filtering_rules": False,
+            },
+            True,
         ),
         (
-                {
-                    "sync_rules": {
-                        "basic": {"enabled": False},
-                        "advanced": {"enabled": True},
-                    },
-                    "filtering_advanced_config": False,
-                    "filtering_rules": False,
+            {
+                "sync_rules": {
+                    "basic": {"enabled": False},
+                    "advanced": {"enabled": True},
                 },
-                True,
+                "filtering_advanced_config": False,
+                "filtering_rules": False,
+            },
+            True,
         ),
         (
-                {
-                    "sync_rules": {
-                        "basic": {"enabled": False},
-                        "advanced": {"enabled": False},
-                    },
-                    "filtering_advanced_config": True,
-                    "filtering_rules": False,
+            {
+                "sync_rules": {
+                    "basic": {"enabled": False},
+                    "advanced": {"enabled": False},
                 },
-                True,
+                "filtering_advanced_config": True,
+                "filtering_rules": False,
+            },
+            True,
         ),
         (
-                {
-                    "sync_rules": {
-                        "basic": {"enabled": False},
-                        "advanced": {"enabled": False},
-                    },
-                    "filtering_advanced_config": False,
-                    "filtering_rules": True,
+            {
+                "sync_rules": {
+                    "basic": {"enabled": False},
+                    "advanced": {"enabled": False},
                 },
-                True,
+                "filtering_advanced_config": False,
+                "filtering_rules": True,
+            },
+            True,
         ),
         (
-                {
-                    "sync_rules": {
-                        "basic": {"enabled": False},
-                        "advanced": {"enabled": False},
-                    },
-                    "filtering_advanced_config": False,
-                    "filtering_rules": False,
+            {
+                "sync_rules": {
+                    "basic": {"enabled": False},
+                    "advanced": {"enabled": False},
                 },
-                False,
+                "filtering_advanced_config": False,
+                "filtering_rules": False,
+            },
+            False,
         ),
         ({"other_feature": True}, False),
         (None, False),
@@ -1619,18 +1619,18 @@ def test_incremental_sync_enabled(features_json, incremental_sync_enabled):
         # extract True
         ({"a": {"b": {"c": True}}}, ["a", "b", "c"], False, True),
         (
-                {"a": {"b": {"c": True}}},
-                # "d" doesn't exist -> fall back to False
-                ["a", "b", "c", "d"],
-                False,
-                False,
+            {"a": {"b": {"c": True}}},
+            # "d" doesn't exist -> fall back to False
+            ["a", "b", "c", "d"],
+            False,
+            False,
         ),
         (
-                {"a": {"b": {"c": True}}},
-                # "wrong_key" doesn't exist -> fall back to False
-                ["wrong_key", "b", "c"],
-                False,
-                False,
+            {"a": {"b": {"c": True}}},
+            # "wrong_key" doesn't exist -> fall back to False
+            ["wrong_key", "b", "c"],
+            False,
+            False,
         ),
         # fallback to True
         (None, ["a", "b", "c"], True, True),
@@ -1785,11 +1785,11 @@ def test_advanced_rules_present(filtering, should_advanced_rules_be_present):
     ],
 )
 def test_has_validation_state(
-        filtering, validation_state, has_expected_validation_state
+    filtering, validation_state, has_expected_validation_state
 ):
     assert (
-            Filter(filtering).has_validation_state(validation_state)
-            == has_expected_validation_state
+        Filter(filtering).has_validation_state(validation_state)
+        == has_expected_validation_state
     )
 
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4626

Adds mutating of `sync_cursor` to the `sync_done` method of the `Connector` class, so that the `sync_cursor` will only be updated after a completed sync job.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)