### PR TITLE
[DLS] Add "last_permissions_sync_status" to connector protocol docs

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -118,7 +118,8 @@ This is our main communication index, used to communicate the connector's config
   last_indexed_document_count: number;    -> How many documents were indexed in the last job  
   last_seen: date;      -> Connector writes check-in date-time regularly (UTC)
   last_sync_error: string;   -> Optional last job error message
-  last_sync_status: string;  -> Status of the last job, or null if no job has been executed
+  last_sync_status: string;  -> Status of the last content sync job, or null if no job has been executed
+  last_permissions_sync_status: string:  -> Status of the last permissions sync job, or null if no job has been executed
   last_synced: date;    -> Date/time of last job (UTC)
   last_sync_scheduled_at: date;    -> Date/time when the last job is scheduled (UTC)
   last_permissions_sync_scheduled_at: date;    -> Date/time when the last permissions sync job is scheduled (UTC)
@@ -253,6 +254,7 @@ This is our main communication index, used to communicate the connector's config
     "last_sync_error" : { "type" : "keyword" },
     "last_sync_scheduled_at" : { "type" : "date" },
     "last_sync_status" : { "type" : "keyword" },
+    "last_permissions_sync_status" : { "type" : "keyword" },
     "last_synced" : { "type" : "date" },
     "name" : { "type" : "keyword" },
     "pipeline" : {


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4646 

This PR adds the new `last_permissions_sync_status` to the connector protocol docs.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)