### PR TITLE
[DLS] Add "last_permissions_sync_status" to kibana and fixtures

### DIFF
--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -149,6 +149,7 @@ async def prepare(service_type, index_name, config, connector_definition=None):
             "language": "en",
             # Last sync
             "last_sync_status": None,
+            "last_permissions_sync_status": None,
             "last_sync_error": None,
             "last_sync_scheduled_at": None,
             "last_permissions_sync_scheduled_at": None,

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/fixtures/connector.json
+++ b/tests/fixtures/connector.json
@@ -9,6 +9,7 @@
         "status": "configured",
         "language": "en",
         "last_sync_status": null,
+        "last_permissions_sync_status": null,
         "last_sync_error": null,
         "last_synced": null,
         "last_seen": null,

--- a/tests/sources/fixtures/mongodb/connector.json
+++ b/tests/sources/fixtures/mongodb/connector.json
@@ -9,6 +9,7 @@
         "status": "configured",
         "language": "en",
         "last_sync_status": null,
+        "last_permissions_sync_status": null,
         "last_sync_error": null,
         "last_synced": null,
         "last_seen": null,

--- a/tests/sources/fixtures/mysql/connector.json
+++ b/tests/sources/fixtures/mysql/connector.json
@@ -9,6 +9,7 @@
         "status": "configured",
         "language": "en",
         "last_sync_status": "canceled",
+        "last_permissions_sync_status": null,
         "last_sync_error": null,
         "last_synced": null,
         "last_seen": null,


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4646

This PR adds `last_permissions_sync_status` to the Kibana fake and the fixtures.

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)