### PR TITLE
[DLS] Add last_access_control_sync_status property to Connector

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -527,8 +527,8 @@ class Connector(ESDocument):
         return JobStatus(self.get("last_sync_status"))
 
     @property
-    def last_permissions_sync_status(self):
-        return JobStatus(self.get("last_permissions_sync_status"))
+    def last_access_control_sync_status(self):
+        return JobStatus(self.get("last_access_control_sync_status"))
 
     def _property_as_datetime(self, key):
         value = self.get(key)

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -526,6 +526,10 @@ class Connector(ESDocument):
     def last_sync_status(self):
         return JobStatus(self.get("last_sync_status"))
 
+    @property
+    def last_permissions_sync_status(self):
+        return JobStatus(self.get("last_permissions_sync_status"))
+
     def _property_as_datetime(self, key):
         value = self.get(key)
         if value is not None:

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -333,6 +333,7 @@ async def test_connector_properties():
             "status": "created",
             "last_seen": iso_utc(),
             "last_sync_status": "completed",
+            "last_permissions_sync_status": "pending",
             "pipeline": {},
             "last_sync_scheduled_at": iso_utc(),
             "last_permissions_sync_scheduled_at": iso_utc(),
@@ -352,6 +353,7 @@ async def test_connector_properties():
     assert connector.index_name == "search-some-index"
     assert connector.language == "en"
     assert connector.last_sync_status == JobStatus.COMPLETED
+    assert connector.last_permissions_sync_status == JobStatus.PENDING
     assert connector.permissions_scheduling["enabled"]
     assert connector.permissions_scheduling["interval"] == "* * * * *"
     assert connector.sync_cursor == sync_cursor

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -333,7 +333,7 @@ async def test_connector_properties():
             "status": "created",
             "last_seen": iso_utc(),
             "last_sync_status": "completed",
-            "last_permissions_sync_status": "pending",
+            "last_access_control_sync_status": "pending",
             "pipeline": {},
             "last_sync_scheduled_at": iso_utc(),
             "last_permissions_sync_scheduled_at": iso_utc(),
@@ -353,7 +353,7 @@ async def test_connector_properties():
     assert connector.index_name == "search-some-index"
     assert connector.language == "en"
     assert connector.last_sync_status == JobStatus.COMPLETED
-    assert connector.last_permissions_sync_status == JobStatus.PENDING
+    assert connector.last_access_control_sync_status == JobStatus.PENDING
     assert connector.permissions_scheduling["enabled"]
     assert connector.permissions_scheduling["interval"] == "* * * * *"
     assert connector.sync_cursor == sync_cursor


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4652

This PR adds the `last_permissions_sync_status` property to the `Connector` class we'll need for at most one permissions sync per connector semantics.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~