### PR TITLE
[Sharepoint] Add server relative url for list and its items

### DIFF
--- a/connectors/sources/sharepoint.py
+++ b/connectors/sources/sharepoint.py
@@ -590,6 +590,7 @@ class SharepointClient:
                         attachment_file.get("ServerRelativeUrl"),
                     )
                     result["file_name"] = attachment_file.get("FileName")
+                    result["server_relative_url"] = attachment_file["ServerRelativeUrl"]
 
                     if (
                         os.path.splitext(attachment_file["FileName"])[-1]
@@ -815,6 +816,7 @@ class SharepointDataSource(BaseDataSource):
         document["url"] = urljoin(
             self.sharepoint_client.host_url, item["RootFolder"]["ServerRelativeUrl"]
         )
+        document["server_relative_url"] = item["RootFolder"]["ServerRelativeUrl"]
 
         self.map_document_with_schema(
             document=document, item=item, document_type=document_type
@@ -858,6 +860,7 @@ class SharepointDataSource(BaseDataSource):
                     self.sharepoint_client.host_url,
                     item[item_type]["ServerRelativeUrl"],
                 ),
+                "server_relative_url": item[item_type]["ServerRelativeUrl"],
                 "type": item_type,
             }
         )
@@ -889,6 +892,9 @@ class SharepointDataSource(BaseDataSource):
                 "url": item["url"],
             }
         )
+        server_url = item.get("server_relative_url")
+        if server_url:
+            document["server_relative_url"] = server_url
 
         self.map_document_with_schema(
             document=document, item=item, document_type=LIST_ITEM

--- a/tests/sources/test_sharepoint.py
+++ b/tests/sources/test_sharepoint.py
@@ -165,6 +165,7 @@ def test_prepare_drive_items_doc():
         "creation_time": "2023-01-30T12:48:31Z",
         "_timestamp": "2023-01-30T12:48:31Z",
         "url": f"{HOST_URL}/site",
+        "server_relative_url": "/site",
     }
 
     # Execute
@@ -186,6 +187,7 @@ def test_prepare_list_items_doc():
         "FileRef": "/site",
         "url": f"{HOST_URL}/site",
         "file_name": "filename",
+        "server_relative_url": "/site",
     }
     expected_response = {
         "type": "list_item",
@@ -197,6 +199,7 @@ def test_prepare_list_items_doc():
         "creation_time": "2023-01-30T12:48:31Z",
         "_timestamp": "2023-01-30T12:48:31Z",
         "url": f"{HOST_URL}/site",
+        "server_relative_url": "/site",
     }
 
     # Execute
@@ -313,6 +316,7 @@ async def test_get_list_items():
             "_id": "1",
             "url": "http://127.0.0.1:8491/sites/collection1/ctest/Lists/ctestlist/Attachments/1/v4.txt",
             "file_name": "s3 queries.txt",
+            "server_relative_url": "/sites/collection1/ctest/Lists/ctestlist/Attachments/1/v4.txt",
         },
         {
             "AttachmentFiles": {},


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/941###
This PR includes:
1. Add  `server_relative_url` for list and its items as a document field in elastic search.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

