### PR TITLE
Add sync_cursor to Sync Job

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -229,6 +229,10 @@ class SyncJob(ESDocument):
         return Pipeline(self.get("connector", "pipeline"))
 
     @property
+    def sync_cursor(self):
+        return self.get("connector", "sync_cursor")
+
+    @property
     def terminated(self):
         return self.status in (JobStatus.ERROR, JobStatus.COMPLETED, JobStatus.CANCELED)
 
@@ -260,12 +264,13 @@ class SyncJob(ESDocument):
                 f"Filtering in state {validation_result.state}, errors: {validation_result.errors}."
             )
 
-    async def claim(self):
+    async def claim(self, sync_cursor=None):
         doc = {
             "status": JobStatus.IN_PROGRESS.value,
             "started_at": iso_utc(),
             "last_seen": iso_utc(),
             "worker_hostname": socket.gethostname(),
+            "connector.sync_cursor": sync_cursor,
         }
         await self.index.update(doc_id=self.id, doc=doc)
 

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -321,6 +321,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
         run_ml_inference: boolean;
       };
       service_type: string;   -> Service type of the connector
+      sync_cursor: object;    -> The sync cursor used to start the job
     }
   ];
   created_at: date; -> The date/time when the job is created
@@ -408,7 +409,8 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
             "run_ml_inference" : { "type" : "boolean" }
           }
         },
-        "service_type" : { "type" : "keyword" }
+        "service_type" : { "type" : "keyword" },
+        "sync_cursor" : { "type" : "object" }
       }
     },
     "created_at" : { "type" : "date" },

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -188,6 +188,8 @@ ADVANCED_AND_BASIC_RULES_NON_EMPTY = {
     "rules": RULES,
 }
 
+SYNC_CURSOR = {"foo": "bar"}
+
 
 def test_utc():
     # All dates are in ISO 8601 UTC so we can serialize them
@@ -316,7 +318,6 @@ async def test_all_connectors(mock_responses):
 
 @pytest.mark.asyncio
 async def test_connector_properties():
-    sync_cursor = {"foo": "bar"}
     connector_src = {
         "_id": "test",
         "_source": {
@@ -336,7 +337,7 @@ async def test_connector_properties():
             "pipeline": {},
             "last_sync_scheduled_at": iso_utc(),
             "last_permissions_sync_scheduled_at": iso_utc(),
-            "sync_cursor": sync_cursor,
+            "sync_cursor": SYNC_CURSOR,
         },
     }
 
@@ -354,7 +355,7 @@ async def test_connector_properties():
     assert connector.last_sync_status == JobStatus.COMPLETED
     assert connector.permissions_scheduling["enabled"]
     assert connector.permissions_scheduling["interval"] == "* * * * *"
-    assert connector.sync_cursor == sync_cursor
+    assert connector.sync_cursor == SYNC_CURSOR
     assert isinstance(connector.last_seen, datetime)
     assert isinstance(connector.filtering, Filtering)
     assert isinstance(connector.pipeline, Pipeline)
@@ -567,6 +568,7 @@ async def test_sync_job_properties():
                 "language": "en",
                 "filtering": {},
                 "pipeline": {},
+                "sync_cursor": SYNC_CURSOR,
             },
         },
     }
@@ -582,6 +584,7 @@ async def test_sync_job_properties():
     assert sync_job.configuration.is_empty()
     assert sync_job.index_name == "search-some-index"
     assert sync_job.language == "en"
+    assert sync_job.sync_cursor == SYNC_CURSOR
     assert sync_job.indexed_document_count == 10
     assert sync_job.indexed_document_volume == 20
     assert sync_job.deleted_document_count == 30
@@ -639,10 +642,11 @@ async def test_sync_job_claim():
         "started_at": ANY,
         "last_seen": ANY,
         "worker_hostname": ANY,
+        "connector.sync_cursor": SYNC_CURSOR,
     }
 
     sync_job = SyncJob(elastic_index=index, doc_source=source)
-    await sync_job.claim()
+    await sync_job.claim(sync_cursor=SYNC_CURSOR)
 
     index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4665

This PR:
1. adds `sync_cursor` property to `SyncJob` class
2. adds `sync_cursor` parameter to the `claim` method of `SyncJob` class
3. adds `sync_cursor` to connector protocol

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)