### PR TITLE
Add last_incremental_sync_scheduled_at to Connector

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -539,6 +539,10 @@ class Connector(ESDocument):
         return self._property_as_datetime("last_sync_scheduled_at")
 
     @property
+    def last_incremental_sync_scheduled_at(self):
+        return self._property_as_datetime("last_incremental_sync_scheduled_at")
+
+    @property
     def last_permissions_sync_scheduled_at(self):
         return self._property_as_datetime("last_permissions_sync_scheduled_at")
 
@@ -569,21 +573,22 @@ class Connector(ESDocument):
             if_primary_term=self._primary_term,
         )
 
-    async def update_last_sync_scheduled_at(self, new_ts):
+    async def _update_datetime(self, field, new_ts):
         await self.index.update(
             doc_id=self.id,
-            doc={"last_sync_scheduled_at": new_ts.isoformat()},
+            doc={field: new_ts.isoformat()},
             if_seq_no=self._seq_no,
             if_primary_term=self._primary_term,
         )
 
+    async def update_last_sync_scheduled_at(self, new_ts):
+        await self._update_datetime("last_sync_scheduled_at", new_ts)
+
+    async def update_last_incremental_sync_scheduled_at(self, new_ts):
+        await self._update_datetime("last_incremental_sync_scheduled_at", new_ts)
+
     async def update_last_permissions_sync_scheduled_at(self, new_ts):
-        await self.index.update(
-            doc_id=self.id,
-            doc={"last_permissions_sync_scheduled_at": new_ts.isoformat()},
-            if_seq_no=self._seq_no,
-            if_primary_term=self._primary_term,
-        )
+        await self._update_datetime("last_permissions_sync_scheduled_at", new_ts)
 
     async def sync_starts(self):
         doc = {

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -115,13 +115,14 @@ This is our main communication index, used to communicate the connector's config
   is_native: boolean;   -> Whether this is a native connector
   language: string;     -> the language used for the analyzer
   last_deleted_document_count: number;    -> How many documents were deleted in the last job
+  last_incremental_sync_scheduled_at: date; -> Date/time when the last incremental sync job is scheduled (UTC)
   last_indexed_document_count: number;    -> How many documents were indexed in the last job  
   last_seen: date;      -> Connector writes check-in date-time regularly (UTC)
   last_sync_error: string;   -> Optional last job error message
   last_sync_status: string;  -> Status of the last content sync job, or null if no job has been executed
   last_permissions_sync_status: string:  -> Status of the last permissions sync job, or null if no job has been executed
   last_synced: date;    -> Date/time of last job (UTC)
-  last_sync_scheduled_at: date;    -> Date/time when the last job is scheduled (UTC)
+  last_sync_scheduled_at: date;    -> Date/time when the last full sync job is scheduled (UTC)
   last_permissions_sync_scheduled_at: date;    -> Date/time when the last permissions sync job is scheduled (UTC)
   name: string; -> the name to use for the connector
   pipeline: {
@@ -249,6 +250,7 @@ This is our main communication index, used to communicate the connector's config
     "is_native" : { "type" : "boolean" },
     "language" : { "type" : "keyword" },
     "last_deleted_document_count" : { "type" : "long" },
+    "last_incremental_sync_scheduled_at" : { "type" : "date" },
     "last_indexed_document_count" : { "type" : "long" },
     "last_seen" : { "type" : "date" },
     "last_sync_error" : { "type" : "keyword" },

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1099,6 +1099,31 @@ async def test_connector_update_last_sync_scheduled_at():
 
 
 @pytest.mark.asyncio
+async def test_connector_update_last_incremental_sync_scheduled_at():
+    doc_id = "1"
+    seq_no = 1
+    primary_term = 2
+    new_ts = datetime.utcnow() + timedelta(seconds=20)
+    connector_doc = {
+        "_id": doc_id,
+        "_seq_no": seq_no,
+        "_primary_term": primary_term,
+        "_source": {},
+    }
+    index = Mock()
+    index.update = AsyncMock()
+    connector = Connector(elastic_index=index, doc_source=connector_doc)
+    await connector.update_last_incremental_sync_scheduled_at(new_ts)
+
+    index.update.assert_awaited_once_with(
+        doc_id=doc_id,
+        doc={"last_incremental_sync_scheduled_at": new_ts.isoformat()},
+        if_seq_no=seq_no,
+        if_primary_term=primary_term,
+    )
+
+
+@pytest.mark.asyncio
 async def test_connector_update_last_permissions_sync_scheduled_at():
     doc_id = "2"
     seq_no = 2


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4645

## Checklists

This PR:
1. adds property `last_incremental_sync_scheduled_at` to  class `Connector`
2. adds the mutating method of `last_incremental_sync_scheduled_at` to class `Connector`
3. adds `last_incremental_sync_scheduled_at` to connector protocol 

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)