### PR TITLE
Add incremental sync support to BaseDataSource

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -339,6 +339,7 @@ class BaseDataSource:
 
     name = None
     service_type = None
+    support_incremental_sync = False
 
     def __init__(self, configuration):
         if not isinstance(configuration, DataSourceConfiguration):
@@ -399,11 +400,6 @@ class BaseDataSource:
         """
 
         return hash_id(_id)
-
-    @classmethod
-    def support_incremental_sync(cls):
-        """Indicates whether the data source supports incremental sync"""
-        return False
 
     async def validate_filtering(self, filtering):
         """Execute all basic rule and advanced rule validators."""

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -348,6 +348,8 @@ class BaseDataSource:
 
         self.configuration = configuration
         self.configuration.set_defaults(self.get_default_configuration())
+        # A dictionary, the structure of which is connector dependent, to indicate a point where the sync is at
+        self._sync_cursor = None
 
     def __str__(self):
         return f"Datasource `{self.__class__.name}`"
@@ -397,6 +399,11 @@ class BaseDataSource:
         """
 
         return hash_id(_id)
+
+    @classmethod
+    def support_incremental_sync(cls):
+        """Indicates whether the data source supports incremental sync"""
+        return False
 
     async def validate_filtering(self, filtering):
         """Execute all basic rule and advanced rule validators."""
@@ -501,6 +508,34 @@ class BaseDataSource:
         """
         raise NotImplementedError
 
+    async def get_docs_incrementally(self, sync_cursor, filtering=None):
+        """Returns an iterator on all documents changed since the sync_cursor
+
+        Each document is a tuple with:
+        - a mapping with the data to index
+        - a coroutine to download extra data (attachments)
+        - an operation, can be one of index, update or delete
+
+        The mapping should have least an `id` field
+        and optionally a `timestamp` field in ISO 8601 UTC
+
+        The coroutine is called if the document needs to be synced
+        and has attachments. It needs to return a mapping to index.
+
+        It has two arguments: doit and timestamp
+        If doit is False, it should return None immediately.
+        If timestamp is provided, it should be used in the mapping.
+
+        Example:
+
+           async def get_file(doit=True, timestamp=None):
+               if not doit:
+                   return
+               return {'TEXT': 'DATA', 'timestamp': timestamp,
+                       'id': 'doc-id'}
+        """
+        raise NotImplementedError
+
     def tweak_bulk_options(self, options):
         """Receives the bulk options every time a sync happens, so they can be
         tweaked if needed.
@@ -548,6 +583,10 @@ class BaseDataSource:
             doc[key] = _serialize(value)
 
         return doc
+
+    def sync_cursor(self):
+        """Returns the sync cursor of the current sync"""
+        return self._sync_cursor
 
 
 @cache

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -765,6 +765,8 @@ async def test_base_class():
     }
     assert ds.get_simple_configuration() == expected
 
+    assert not ds.support_incremental_sync()
+
     with pytest.raises(NotImplementedError):
         await ds.ping()
 
@@ -772,6 +774,9 @@ async def test_base_class():
 
     with pytest.raises(NotImplementedError):
         await ds.get_docs()
+
+    with pytest.raises(NotImplementedError):
+        await ds.get_docs_incrementally({})
 
     with pytest.raises(NotImplementedError):
         await ds.get_permissions()

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -765,7 +765,7 @@ async def test_base_class():
     }
     assert ds.get_simple_configuration() == expected
 
-    assert not ds.support_incremental_sync()
+    assert not DataSource.support_incremental_sync
 
     with pytest.raises(NotImplementedError):
         await ds.ping()


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4635

This PR
1. adds a class method `support_incremental_sync` to indicate whether the data source supports incremental syn
2. adds a method `get_docs_incrementally` to run incremental sync
3. adds a method `sync_cursor`

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)