### PR TITLE
[DLS] Rename "scheduling.permissions" to "scheduling.access_control"

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -507,8 +507,8 @@ class Connector(ESDocument):
         return self.get("scheduling", default={})
 
     @property
-    def permissions_scheduling(self):
-        return self.scheduling.get("permissions", {})
+    def access_control_scheduling(self):
+        return self.scheduling.get("access_control", {})
 
     @property
     def configuration(self):

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -326,7 +326,7 @@ async def test_connector_properties():
             "configuration": {},
             "language": "en",
             "scheduling": {
-                "permissions": {
+                "access_control": {
                     "enabled": True,
                     "interval": "* * * * *"
                 }
@@ -355,8 +355,8 @@ async def test_connector_properties():
     assert connector.language == "en"
     assert connector.last_sync_status == JobStatus.COMPLETED
     assert connector.last_access_control_sync_status == JobStatus.PENDING
-    assert connector.permissions_scheduling["enabled"]
-    assert connector.permissions_scheduling["interval"] == "* * * * *"
+    assert connector.access_control_scheduling["enabled"]
+    assert connector.access_control_scheduling["interval"] == "* * * * *"
     assert connector.sync_cursor == SYNC_CURSOR
     assert isinstance(connector.last_seen, datetime)
     assert isinstance(connector.filtering, Filtering)


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4662

This PR changes the "scheduling.permissions" field to "scheduling.access_control"

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)