### PR TITLE
Allow to create job with job type

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -869,7 +869,7 @@ class SyncJobIndex(ESIndex):
             doc_source=doc_source,
         )
 
-    async def create(self, connector, trigger_method, job_type=JobType.FULL):
+    async def create(self, connector, trigger_method, job_type):
         filtering = connector.filtering.get_active_filter().transform_filtering()
         job_def = {
             "connector": {

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -869,7 +869,7 @@ class SyncJobIndex(ESIndex):
             doc_source=doc_source,
         )
 
-    async def create(self, connector, trigger_method):
+    async def create(self, connector, trigger_method, job_type=JobType.FULL):
         filtering = connector.filtering.get_active_filter().transform_filtering()
         job_def = {
             "connector": {
@@ -882,6 +882,7 @@ class SyncJobIndex(ESIndex):
                 "configuration": connector.configuration.to_dict(),
             },
             "trigger_method": trigger_method.value,
+            "job_type": job_type.value,
             "status": JobStatus.PENDING.value,
             "indexed_document_count": 0,
             "indexed_document_volume": 0,

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -24,6 +24,7 @@ from connectors.protocol import (
     Status,
     SyncJobIndex,
 )
+from connectors.protocol.connectors import JobType
 from connectors.services.base import BaseService
 from connectors.source import get_source_klass
 
@@ -163,7 +164,9 @@ class JobSchedulingService(BaseService):
         if await _should_schedule_on_demand_sync():
             logger.info(f"Creating an on demand sync for connector {connector.id}...")
             await self.sync_job_index.create(
-                connector=connector, trigger_method=JobTriggerMethod.ON_DEMAND
+                connector=connector,
+                trigger_method=JobTriggerMethod.ON_DEMAND,
+                job_type=JobType.FULL,
             )
 
     async def _scheduled_sync(self, connector):
@@ -209,5 +212,7 @@ class JobSchedulingService(BaseService):
         if await _should_schedule_scheduled_sync():
             logger.info(f"Creating a scheduled sync for connector {connector.id}...")
             await self.sync_job_index.create(
-                connector=connector, trigger_method=JobTriggerMethod.SCHEDULED
+                connector=connector,
+                trigger_method=JobTriggerMethod.SCHEDULED,
+                job_type=JobType.FULL,
             )

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1670,6 +1670,7 @@ async def test_create_job(index_method, trigger_method, set_env):
     expected_index_doc = {
         "connector": ANY,
         "trigger_method": trigger_method.value,
+        "job_type": JobType.INCREMENTAL.value,
         "status": JobStatus.PENDING.value,
         "indexed_document_count": 0,
         "indexed_document_volume": 0,
@@ -1679,7 +1680,7 @@ async def test_create_job(index_method, trigger_method, set_env):
     }
 
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
-    await sync_job_index.create(connector=connector, trigger_method=trigger_method)
+    await sync_job_index.create(connector=connector, trigger_method=trigger_method, job_type=JobType.INCREMENTAL)
 
     index_method.assert_called_with(expected_index_doc)
 

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -20,6 +20,7 @@ from connectors.protocol import (
     ServiceTypeNotSupportedError,
     Status,
 )
+from connectors.protocol.connectors import JobType
 from connectors.services.job_scheduling import JobSchedulingService
 from connectors.source import DataSourceConfiguration
 from tests.commons import AsyncIterator
@@ -145,7 +146,7 @@ async def test_connector_sync_now(
     connector.reset_sync_now_flag.assert_awaited()
     connector.update_last_sync_scheduled_at.assert_not_awaited()
     sync_job_index_mock.create.assert_awaited_once_with(
-        connector=connector, trigger_method=JobTriggerMethod.ON_DEMAND
+        connector=connector, trigger_method=JobTriggerMethod.ON_DEMAND, job_type=JobType.FULL,
     )
 
 
@@ -193,7 +194,7 @@ async def test_connector_ready_to_sync(
     connector.reset_sync_now_flag.assert_not_awaited()
     connector.update_last_sync_scheduled_at.assert_awaited()
     sync_job_index_mock.create.assert_awaited_once_with(
-        connector=connector, trigger_method=JobTriggerMethod.SCHEDULED
+        connector=connector, trigger_method=JobTriggerMethod.SCHEDULED, job_type=JobType.FULL,
     )
 
 
@@ -256,10 +257,10 @@ async def test_connector_both_on_demand_and_scheduled(
     connector.reset_sync_now_flag.assert_awaited()
     connector.update_last_sync_scheduled_at.assert_awaited()
     sync_job_index_mock.create.assert_any_await(
-        connector=connector, trigger_method=JobTriggerMethod.ON_DEMAND
+        connector=connector, trigger_method=JobTriggerMethod.ON_DEMAND, job_type=JobType.FULL,
     )
     sync_job_index_mock.create.assert_any_await(
-        connector=connector, trigger_method=JobTriggerMethod.SCHEDULED
+        connector=connector, trigger_method=JobTriggerMethod.SCHEDULED, job_type=JobType.FULL,
     )
     assert sync_job_index_mock.create.await_count == 2
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4627

Allows to create a sync job with job type, defaulted to `full`

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)