### PR TITLE
Bump elasticsearch package to 8.8.0

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,5 +1,5 @@
 aiohttp==3.8.3
-elasticsearch[async]==8.7.0
+elasticsearch[async]==8.8.0
 elastic-transport==8.4.0
 pyyaml==6.0
 envyaml==1.10.211231


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4255

Bumping version of elasticsearch to 8.8.0