### PR TITLE
[DLS] At most one access control sync per connector guard

### DIFF
--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -57,6 +57,15 @@ class JobExecutionService(BaseService):
                 )
                 return
 
+        if (
+            sync_job.job_type == JobType.ACCESS_CONTROL
+            and connector.last_access_control_sync_status == JobStatus.IN_PROGRESS
+        ):
+            logger.debug(
+                f"Connector {connector.id} is still syncing ('{sync_job.job_type.value}'), skip the job {sync_job.id}..."
+            )
+            return
+
         sync_job_runner = SyncJobRunner(
             source_klass=source_klass,
             sync_job=sync_job,

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -53,7 +53,7 @@ class JobExecutionService(BaseService):
         ):
             if connector.last_sync_status == JobStatus.IN_PROGRESS:
                 logger.debug(
-                    f"Connector {connector.id} is still syncing, skip the job {sync_job.id}..."
+                    f"Connector {connector.id} is still syncing content, skip the job {sync_job.id}..."
                 )
                 return
 
@@ -62,7 +62,7 @@ class JobExecutionService(BaseService):
             and connector.last_access_control_sync_status == JobStatus.IN_PROGRESS
         ):
             logger.debug(
-                f"Connector {connector.id} is still syncing ('{sync_job.job_type.value}'), skip the job {sync_job.id}..."
+                f"Connector {connector.id} is still syncing access control, skip the job {sync_job.id}..."
             )
             return
 

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -106,19 +106,23 @@ def sync_job_runner_mock():
         yield sync_job_runner_mock
 
 
-def mock_connector(last_sync_status=JobStatus.COMPLETED):
+def mock_connector(job_type=JobType.FULL, last_sync_status=JobStatus.COMPLETED):
     connector = Mock()
     connector.id = "1"
-    connector.last_sync_status = last_sync_status
+
+    if job_type in [JobType.FULL, JobType.INCREMENTAL]:
+        connector.last_sync_status = last_sync_status
+    else:
+        connector.last_access_control_sync_status = last_sync_status
 
     return connector
 
 
-def mock_sync_job(service_type="fake"):
+def mock_sync_job(service_type="fake", job_type=JobType.FULL):
     sync_job = Mock()
     sync_job.service_type = service_type
     sync_job.connector_id = "1"
-    sync_job.job_type = JobType.FULL
+    sync_job.job_type = job_type
 
     return sync_job
 
@@ -210,6 +214,24 @@ async def test_job_execution_with_connector_still_syncing(
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
     sync_job = mock_sync_job()
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
+    await create_and_run_service()
+
+    concurrent_tasks_mock.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_access_control_job_execution_with_connector_still_syncing(
+    connector_index_mock,
+    sync_job_index_mock,
+    concurrent_tasks_mock,
+    sync_job_runner_mock,
+    set_env,
+):
+    connector = mock_connector(job_type=JobType.ACCESS_CONTROL, last_sync_status=JobStatus.IN_PROGRESS)
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
+    connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
+    sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
     await create_and_run_service()
 

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -106,14 +106,13 @@ def sync_job_runner_mock():
         yield sync_job_runner_mock
 
 
-def mock_connector(job_type=JobType.FULL, last_sync_status=JobStatus.COMPLETED):
+def mock_connector(job_type=JobType.FULL, last_sync_status=JobStatus.COMPLETED, last_access_control_sync_status=JobStatus.COMPLETED):
     connector = Mock()
     connector.id = "1"
+    connector.job_type=job_type
 
-    if job_type in [JobType.FULL, JobType.INCREMENTAL]:
-        connector.last_sync_status = last_sync_status
-    else:
-        connector.last_access_control_sync_status = last_sync_status
+    connector.last_sync_status = last_sync_status
+    connector.last_access_control_sync_status = last_access_control_sync_status
 
     return connector
 
@@ -228,7 +227,7 @@ async def test_access_control_job_execution_with_connector_still_syncing(
     sync_job_runner_mock,
     set_env,
 ):
-    connector = mock_connector(job_type=JobType.ACCESS_CONTROL, last_sync_status=JobStatus.IN_PROGRESS)
+    connector = mock_connector(job_type=JobType.ACCESS_CONTROL, last_access_control_sync_status=JobStatus.IN_PROGRESS)
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
     sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4591

This PR adds a guard to check whether a connector has an access control sync already running, so we don't schedule two access control syncs at the same time for one connector.

The assertion will be adapted to use the separate access control syncs task pool in a separate PR addressing the task pool separation.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)