### PR TITLE
Fix mapper issue: mapper [size] cannot be changed from type [long] to [text]

### DIFF
--- a/connectors/sources/sharepoint.py
+++ b/connectors/sources/sharepoint.py
@@ -84,7 +84,6 @@ SCHEMA = {
     },
     LIST_ITEM: {
         "title": "Title",
-        "author_id": "EditorId",
         "creation_time": "Created",
         "_timestamp": "Modified",
     },
@@ -855,7 +854,7 @@ class SharepointDataSource(BaseDataSource):
         document.update(
             {
                 "_id": item["GUID"],
-                "size": item.get("File", {}).get("Length", 0),
+                "size": item.get("File", {}).get("Length", "0"),
                 "url": urljoin(
                     self.sharepoint_client.host_url,
                     item[item_type]["ServerRelativeUrl"],
@@ -882,13 +881,13 @@ class SharepointDataSource(BaseDataSource):
         Returns:
             dictionary: Modified document with the help of adapter schema.
         """
-        document = {"type": LIST_ITEM}
+        document = {"type": LIST_ITEM, "author_id": str(item["EditorId"])}
 
         document.update(
             {
                 "_id": item["_id"] if "_id" in item.keys() else item["GUID"],
-                "file_name": item.get("file_name"),
-                "size": item.get("Length", 0),
+                "file_name": item.get("file_name", ""),
+                "size": item.get("Length", "0"),
                 "url": item["url"],
             }
         )

--- a/tests/sources/test_sharepoint.py
+++ b/tests/sources/test_sharepoint.py
@@ -193,7 +193,7 @@ def test_prepare_list_items_doc():
         "type": "list_item",
         "_id": 1,
         "file_name": "filename",
-        "size": 0,
+        "size": "0",
         "title": "dummy",
         "author_id": "123",
         "creation_time": "2023-01-30T12:48:31Z",


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/939###
This PR includes:
1. Converting all elastic field values to string type
## Checklists

#### Pre-Review Checklist
- [ ] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [ ] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
