### PR TITLE
[Sharepoint] Use correct throttling headers 

### DIFF
--- a/tests/sources/fixtures/sharepoint/fixture.py
+++ b/tests/sources/fixtures/sharepoint/fixture.py
@@ -11,7 +11,7 @@ import random
 import string
 
 from flask import Flask, request
-from flask_limiter import Limiter
+from flask_limiter import Limiter, HEADERS
 from flask_limiter.util import get_remote_address
 
 app = Flask(__name__)
@@ -29,6 +29,10 @@ if THROTTLING:
         ],  # Sharepoint 50k+ licences limits
         retry_after="delta_seconds",
         headers_enabled=True,
+        header_name_mapping={
+                 HEADERS.LIMIT : "RateLimit-Limit",
+                 HEADERS.RESET : "RateLimit-Reset",
+                 HEADERS.REMAINING: "RateLimit-Remaining"},
     )
 
 # Number of Sharepoint subsites

--- a/tests/sources/fixtures/sharepoint/fixture.py
+++ b/tests/sources/fixtures/sharepoint/fixture.py
@@ -11,7 +11,7 @@ import random
 import string
 
 from flask import Flask, request
-from flask_limiter import Limiter, HEADERS
+from flask_limiter import HEADERS, Limiter
 from flask_limiter.util import get_remote_address
 
 app = Flask(__name__)

--- a/tests/sources/fixtures/sharepoint/fixture.py
+++ b/tests/sources/fixtures/sharepoint/fixture.py
@@ -30,9 +30,10 @@ if THROTTLING:
         retry_after="delta_seconds",
         headers_enabled=True,
         header_name_mapping={
-                 HEADERS.LIMIT : "RateLimit-Limit",
-                 HEADERS.RESET : "RateLimit-Reset",
-                 HEADERS.REMAINING: "RateLimit-Remaining"},
+            HEADERS.LIMIT: "RateLimit-Limit",
+            HEADERS.RESET: "RateLimit-Reset",
+            HEADERS.REMAINING: "RateLimit-Remaining",
+        },
     )
 
 # Number of Sharepoint subsites


### PR DESCRIPTION
Flask limiter use slightly different names for the HTTP throttling headers. This PR will align them with Sharepoint server

## Checklists

#### Pre-Review Checklist
- [x] This PR has a meaningful title
- [x] This PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
