### PR TITLE
[DLS] Guard access control sync jobs execution with DLS feature flag

### DIFF
--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -57,14 +57,15 @@ class JobExecutionService(BaseService):
                 )
                 return
 
-        if (
-            sync_job.job_type == JobType.ACCESS_CONTROL
-            and connector.last_access_control_sync_status == JobStatus.IN_PROGRESS
-        ):
-            logger.debug(
-                f"Connector {connector.id} is still syncing access control, skip the job {sync_job.id}..."
-            )
-            return
+        if connector.features.document_level_security_enabled():
+            if (
+                sync_job.job_type == JobType.ACCESS_CONTROL
+                and connector.last_access_control_sync_status == JobStatus.IN_PROGRESS
+            ):
+                logger.debug(
+                    f"Connector {connector.id} is still syncing access control, skip the job {sync_job.id}..."
+                )
+                return
 
         sync_job_runner = SyncJobRunner(
             source_klass=source_klass,

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4714

This PR guards the current checks for access control sync execution and the new checks implemented in https://github.com/elastic/connectors-python/pull/1013 with the DLS feature flag. The test will be adapted to check for the access control task execution, when the actual access control sync execution is implemented.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)