### PR TITLE
Add extraction config to all connectors

### DIFF
--- a/.buildkite/publish_docker.sh
+++ b/.buildkite/publish_docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -exuo pipefail
+
+# !!! WARNING DO NOT add -x to avoid leaking vault passwords
+set -euo pipefail
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install ca-certificates curl gnupg lsb-release -y
@@ -24,7 +26,8 @@ cd $ROOT
 echo "Building the image"
 make docker-build
 
-printenv
+
+# !!! WARNING be cautious about the following lines, to avoid leaking the secrets in the CI logs
 
 VAULT_ADDR=${VAULT_ADDR:-https://vault-ci-prod.elastic.dev}
 VAULT_USER="docker-swiftypeadmin"

--- a/config.yml
+++ b/config.yml
@@ -26,6 +26,12 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 native_service_types:
   - mongodb
   - mysql
@@ -43,8 +49,8 @@ native_service_types:
 
 
 # Connector client settings
-#connector_id: 'changeme'
-#service_type: 'changeme'
+connector_id: "69TqlYgBMxS6DnFjzBDB"
+service_type: 'sharepoint_online'
 
 sources:
   mongodb: connectors.sources.mongo:MongoDataSource

--- a/config.yml
+++ b/config.yml
@@ -49,8 +49,8 @@ native_service_types:
 
 
 # Connector client settings
-connector_id: "69TqlYgBMxS6DnFjzBDB"
-service_type: 'sharepoint_online'
+#connector_id: 'changeme'
+#service_type: 'changeme'
 
 sources:
   mongodb: connectors.sources.mongo:MongoDataSource

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -71,7 +71,7 @@ class JobExecutionService(BaseService):
             source_klass=source_klass,
             sync_job=sync_job,
             connector=connector,
-            es_config=self.es_config,
+            config=self.config,
         )
         await self.syncs.put(sync_job_runner.execute)
 

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -94,7 +94,9 @@ class JobSchedulingService(BaseService):
         source_klass = get_source_klass(self.source_list[connector.service_type])
         if connector.features.sync_rules_enabled():
             await connector.validate_filtering(
-                validator=source_klass(connector.configuration)
+                validator=source_klass(
+                    connector.configuration, self.config["extraction_service"]
+                )
             )
 
         await self._on_demand_sync(connector)

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -95,7 +95,8 @@ class JobSchedulingService(BaseService):
         if connector.features.sync_rules_enabled():
             await connector.validate_filtering(
                 validator=source_klass(
-                    connector.configuration, self.config["extraction_service"]
+                    connector.configuration,
+                    extraction_config=self.config["extraction_service"],
                 )
             )
 

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -341,7 +341,7 @@ class BaseDataSource:
     service_type = None
     support_incremental_sync = False
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         if not isinstance(configuration, DataSourceConfiguration):
             raise TypeError(
                 f"Configuration expected type is {DataSourceConfiguration.__name__}, actual: {type(configuration).__name__}."
@@ -349,6 +349,7 @@ class BaseDataSource:
 
         self.configuration = configuration
         self.configuration.set_defaults(self.get_default_configuration())
+        self.extraction_config = extraction_config
         # A dictionary, the structure of which is connector dependent, to indicate a point where the sync is at
         self._sync_cursor = None
 
@@ -504,34 +505,6 @@ class BaseDataSource:
         """
         raise NotImplementedError
 
-    async def get_docs_incrementally(self, sync_cursor, filtering=None):
-        """Returns an iterator on all documents changed since the sync_cursor
-
-        Each document is a tuple with:
-        - a mapping with the data to index
-        - a coroutine to download extra data (attachments)
-        - an operation, can be one of index, update or delete
-
-        The mapping should have least an `id` field
-        and optionally a `timestamp` field in ISO 8601 UTC
-
-        The coroutine is called if the document needs to be synced
-        and has attachments. It needs to return a mapping to index.
-
-        It has two arguments: doit and timestamp
-        If doit is False, it should return None immediately.
-        If timestamp is provided, it should be used in the mapping.
-
-        Example:
-
-           async def get_file(doit=True, timestamp=None):
-               if not doit:
-                   return
-               return {'TEXT': 'DATA', 'timestamp': timestamp,
-                       'id': 'doc-id'}
-        """
-        raise NotImplementedError
-
     def tweak_bulk_options(self, options):
         """Receives the bulk options every time a sync happens, so they can be
         tweaked if needed.
@@ -579,10 +552,6 @@ class BaseDataSource:
             doc[key] = _serialize(value)
 
         return doc
-
-    def sync_cursor(self):
-        """Returns the sync cursor of the current sync"""
-        return self._sync_cursor
 
 
 @cache

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -505,6 +505,28 @@ class BaseDataSource:
         """
         raise NotImplementedError
 
+    async def get_docs_incrementally(self, sync_cursor, filtering=None):
+        """Returns an iterator on all documents changed since the sync_cursor
+        Each document is a tuple with:
+        - a mapping with the data to index
+        - a coroutine to download extra data (attachments)
+        - an operation, can be one of index, update or delete
+        The mapping should have least an `id` field
+        and optionally a `timestamp` field in ISO 8601 UTC
+        The coroutine is called if the document needs to be synced
+        and has attachments. It needs to return a mapping to index.
+        It has two arguments: doit and timestamp
+        If doit is False, it should return None immediately.
+        If timestamp is provided, it should be used in the mapping.
+        Example:
+           async def get_file(doit=True, timestamp=None):
+               if not doit:
+                   return
+               return {'TEXT': 'DATA', 'timestamp': timestamp,
+                       'id': 'doc-id'}
+        """
+        raise NotImplementedError
+
     def tweak_bulk_options(self, options):
         """Receives the bulk options every time a sync happens, so they can be
         tweaked if needed.
@@ -552,6 +574,10 @@ class BaseDataSource:
             doc[key] = _serialize(value)
 
         return doc
+
+    def sync_cursor(self):
+        """Returns the sync cursor of the current sync"""
+        return self._sync_cursor
 
 
 @cache

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -341,7 +341,7 @@ class BaseDataSource:
     service_type = None
     support_incremental_sync = False
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         if not isinstance(configuration, DataSourceConfiguration):
             raise TypeError(
                 f"Configuration expected type is {DataSourceConfiguration.__name__}, actual: {type(configuration).__name__}."
@@ -507,18 +507,24 @@ class BaseDataSource:
 
     async def get_docs_incrementally(self, sync_cursor, filtering=None):
         """Returns an iterator on all documents changed since the sync_cursor
+
         Each document is a tuple with:
         - a mapping with the data to index
         - a coroutine to download extra data (attachments)
         - an operation, can be one of index, update or delete
+
         The mapping should have least an `id` field
         and optionally a `timestamp` field in ISO 8601 UTC
+
         The coroutine is called if the document needs to be synced
         and has attachments. It needs to return a mapping to index.
+
         It has two arguments: doit and timestamp
         If doit is False, it should return None immediately.
         If timestamp is provided, it should be used in the mapping.
+
         Example:
+
            async def get_file(doit=True, timestamp=None):
                if not doit:
                    return

--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -36,7 +36,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
     name = "Azure Blob Storage"
     service_type = "azure_blob_storage"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Set up the connection to the azure base client
 
         Args:

--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -36,13 +36,15 @@ class AzureBlobStorageDataSource(BaseDataSource):
     name = "Azure Blob Storage"
     service_type = "azure_blob_storage"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Set up the connection to the azure base client
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.connection_string = None
         self.retry_count = self.configuration["retry_count"]
         self.concurrent_downloads = self.configuration["concurrent_downloads"]

--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -41,6 +41,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -189,7 +189,7 @@ class ConfluenceDataSource(BaseDataSource):
     name = "Confluence"
     service_type = "confluence"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Setup the connection to Confluence
 
         Args:

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -194,6 +194,7 @@ class ConfluenceDataSource(BaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -189,13 +189,15 @@ class ConfluenceDataSource(BaseDataSource):
     name = "Confluence"
     service_type = "confluence"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Setup the connection to Confluence
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.spaces = self.configuration["spaces"]
         self.concurrent_downloads = self.configuration["concurrent_downloads"]
         self.confluence_client = ConfluenceClient(configuration)

--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -25,7 +25,7 @@ class DirectoryDataSource(BaseDataSource):
     name = "System Directory"
     service_type = "dir"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         super().__init__(
             configuration=configuration, extraction_config=extraction_config
         )

--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -25,8 +25,10 @@ class DirectoryDataSource(BaseDataSource):
     name = "System Directory"
     service_type = "dir"
 
-    def __init__(self, configuration):
-        super().__init__(configuration=configuration)
+    def __init__(self, configuration, extraction_config):
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.directory = os.path.abspath(self.configuration["directory"])
         self.pattern = self.configuration["pattern"]
 

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -98,6 +98,7 @@ class GenericBaseDataSource(BaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -93,13 +93,15 @@ class Queries(ABC):
 class GenericBaseDataSource(BaseDataSource):
     """Class contains common functionalities for Generic Database connector"""
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Setup connection to the database-server configured by user
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
 
         # Connector configurations
         self.retry_count = self.configuration["retry_count"]

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -93,7 +93,7 @@ class Queries(ABC):
 class GenericBaseDataSource(BaseDataSource):
     """Class contains common functionalities for Generic Database connector"""
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Setup connection to the database-server configured by user
 
         Args:

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -157,13 +157,15 @@ class GoogleCloudStorageDataSource(BaseDataSource):
     name = "Google Cloud Storage"
     service_type = "google_cloud_storage"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Set up the connection to the Google Cloud Storage Client.
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
 
     @classmethod
     def get_default_configuration(cls):

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -157,7 +157,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
     name = "Google Cloud Storage"
     service_type = "google_cloud_storage"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Set up the connection to the Google Cloud Storage Client.
 
         Args:

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -162,6 +162,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -197,13 +197,15 @@ class JiraDataSource(BaseDataSource):
     name = "Jira"
     service_type = "jira"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Setup the connection to the Jira
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.concurrent_downloads = self.configuration["concurrent_downloads"]
         self.jira_client = JiraClient(configuration=configuration)
 

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -197,7 +197,7 @@ class JiraDataSource(BaseDataSource):
     name = "Jira"
     service_type = "jira"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Setup the connection to the Jira
 
         Args:

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -202,6 +202,7 @@ class JiraDataSource(BaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -90,8 +90,10 @@ class MongoDataSource(BaseDataSource):
     name = "MongoDB"
     service_type = "mongodb"
 
-    def __init__(self, configuration):
-        super().__init__(configuration=configuration)
+    def __init__(self, configuration, extraction_config):
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
 
         client_params = {}
 

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -90,7 +90,7 @@ class MongoDataSource(BaseDataSource):
     name = "MongoDB"
     service_type = "mongodb"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         super().__init__(
             configuration=configuration, extraction_config=extraction_config
         )

--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -56,7 +56,7 @@ class MSSQLDataSource(GenericBaseDataSource):
     name = "Microsoft SQL Server"
     service_type = "mssql"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Setup connection to the Microsoft SQL database-server configured by user
 
         Args:

--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -56,13 +56,15 @@ class MSSQLDataSource(GenericBaseDataSource):
     name = "Microsoft SQL Server"
     service_type = "mssql"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Setup connection to the Microsoft SQL database-server configured by user
 
         Args:
             configuration (DataSourceConfiguration): Instance of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.ssl_enabled = self.configuration["ssl_enabled"]
         self.ssl_ca = self.configuration["ssl_ca"]
         self.validate_host = self.configuration["validate_host"]

--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -61,6 +61,7 @@ class MSSQLDataSource(GenericBaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Instance of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -337,8 +337,10 @@ class MySqlDataSource(BaseDataSource):
     name = "MySQL"
     service_type = "mysql"
 
-    def __init__(self, configuration):
-        super().__init__(configuration=configuration)
+    def __init__(self, configuration, extraction_config):
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self._sleeps = CancellableSleeps()
         self.retry_count = self.configuration["retry_count"]
         self.ssl_enabled = self.configuration["ssl_enabled"]

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -337,7 +337,7 @@ class MySqlDataSource(BaseDataSource):
     name = "MySQL"
     service_type = "mysql"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         super().__init__(
             configuration=configuration, extraction_config=extraction_config
         )

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -27,7 +27,7 @@ class NASDataSource(BaseDataSource):
     name = "Network Drive"
     service_type = "network_drive"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Set up the connection to the Network Drive
 
         Args:

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -32,6 +32,7 @@ class NASDataSource(BaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -27,13 +27,15 @@ class NASDataSource(BaseDataSource):
     name = "Network Drive"
     service_type = "network_drive"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Set up the connection to the Network Drive
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.username = self.configuration["username"]
         self.password = self.configuration["password"]
         self.server_ip = self.configuration["server_ip"]

--- a/connectors/sources/oracle.py
+++ b/connectors/sources/oracle.py
@@ -58,6 +58,7 @@ class OracleDataSource(GenericBaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Instance of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/oracle.py
+++ b/connectors/sources/oracle.py
@@ -53,7 +53,7 @@ class OracleDataSource(GenericBaseDataSource):
     name = "Oracle Database"
     service_type = "oracle"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Setup connection to the Oracle database-server configured by user
 
         Args:

--- a/connectors/sources/oracle.py
+++ b/connectors/sources/oracle.py
@@ -53,13 +53,15 @@ class OracleDataSource(GenericBaseDataSource):
     name = "Oracle Database"
     service_type = "oracle"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Setup connection to the Oracle database-server configured by user
 
         Args:
             configuration (DataSourceConfiguration): Instance of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.is_async = False
         self.oracle_home = self.configuration["oracle_home"]
         self.wallet_config = self.configuration["wallet_configuration_path"]

--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -60,6 +60,7 @@ class PostgreSQLDataSource(GenericBaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Instance of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -55,7 +55,7 @@ class PostgreSQLDataSource(GenericBaseDataSource):
     name = "PostgreSQL"
     service_type = "postgresql"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Setup connection to the PostgreSQL database-server configured by user
 
         Args:

--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -55,13 +55,15 @@ class PostgreSQLDataSource(GenericBaseDataSource):
     name = "PostgreSQL"
     service_type = "postgresql"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Setup connection to the PostgreSQL database-server configured by user
 
         Args:
             configuration (DataSourceConfiguration): Instance of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.ssl_enabled = self.configuration["ssl_enabled"]
         self.ssl_ca = self.configuration["ssl_ca"]
         self.connection_string = f"postgresql+asyncpg://{self.user}:{quote(self.password)}@{self.host}:{self.port}/{self.database}"

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -233,6 +233,7 @@ class S3DataSource(BaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -228,7 +228,7 @@ class S3DataSource(BaseDataSource):
     name = "Amazon S3"
     service_type = "s3"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Set up the connection to the Amazon S3.
 
         Args:

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -228,13 +228,15 @@ class S3DataSource(BaseDataSource):
     name = "Amazon S3"
     service_type = "s3"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Set up the connection to the Amazon S3.
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.s3_client = S3Client(configuration=configuration)
 
     async def ping(self):

--- a/connectors/sources/sharepoint.py
+++ b/connectors/sources/sharepoint.py
@@ -681,7 +681,7 @@ class SharepointDataSource(BaseDataSource):
     name = "SharePoint"
     service_type = "sharepoint"
 
-    def __init__(self, configuration, extraction_config):
+    def __init__(self, configuration, extraction_config=None):
         """Setup the connection to the SharePoint
 
         Args:

--- a/connectors/sources/sharepoint.py
+++ b/connectors/sources/sharepoint.py
@@ -681,13 +681,15 @@ class SharepointDataSource(BaseDataSource):
     name = "SharePoint"
     service_type = "sharepoint"
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config):
         """Setup the connection to the SharePoint
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
         """
-        super().__init__(configuration=configuration)
+        super().__init__(
+            configuration=configuration, extraction_config=extraction_config
+        )
         self.sharepoint_client = SharepointClient(configuration=configuration)
 
     @classmethod

--- a/connectors/sources/sharepoint.py
+++ b/connectors/sources/sharepoint.py
@@ -686,6 +686,7 @@ class SharepointDataSource(BaseDataSource):
 
         Args:
             configuration (DataSourceConfiguration): Object of DataSourceConfiguration class.
+            extraction_config (dict): Configuration settings for `extraction_service` in config.yaml.
         """
         super().__init__(
             configuration=configuration, extraction_config=extraction_config

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -72,13 +72,14 @@ class SyncJobRunner:
         source_klass,
         sync_job,
         connector,
-        es_config,
+        config,
     ):
         self.source_klass = source_klass
         self.data_provider = None
         self.sync_job = sync_job
         self.connector = connector
-        self.es_config = es_config
+        self.es_config = config["elasticsearch"]
+        self.extraction_config = config["extraction_service"]
         self.elastic_server = None
         self.job_reporting_task = None
         self.bulk_options = self.es_config.get("bulk", {})
@@ -97,7 +98,9 @@ class SyncJobRunner:
         self._start_time = time.time()
 
         try:
-            self.data_provider = self.source_klass(self.sync_job.configuration)
+            self.data_provider = self.source_klass(
+                self.sync_job.configuration, self.extraction_config
+            )
             if not await self.data_provider.changed():
                 logger.debug(
                     f"No change in {self.sync_job.service_type} data provider, skipping..."

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -99,7 +99,7 @@ class SyncJobRunner:
 
         try:
             self.data_provider = self.source_klass(
-                self.sync_job.configuration, self.extraction_config
+                self.sync_job.configuration, extraction_config=self.extraction_config
             )
             if not await self.data_provider.changed():
                 logger.debug(

--- a/tests/fake_sources.py
+++ b/tests/fake_sources.py
@@ -22,7 +22,7 @@ class FakeSource:
     service_type = "fake"
     support_incremental_sync = False
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, extraction_config=None):
         self.configuration = configuration
         if configuration.has_field("raise"):
             raise Exception("I break on init")

--- a/tests/fixtures/config.yml
+++ b/tests/fixtures/config.yml
@@ -17,6 +17,12 @@ service:
   max_concurrent_syncs: 10
   log_level: INFO
 
+extraction_service:
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: '1'
 
 sources:

--- a/tests/fixtures/config_2.yml
+++ b/tests/fixtures/config_2.yml
@@ -14,6 +14,12 @@ service:
   max_errors: 20
   max_errors_span: 600
 
+extraction_service:
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'blah'
 
 sources:

--- a/tests/fixtures/config_https.yml
+++ b/tests/fixtures/config_https.yml
@@ -15,6 +15,12 @@ service:
   max_errors: 20
   max_errors_span: 600
 
+extraction_service:
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: '1'
 
 sources:

--- a/tests/fixtures/config_mem.yml
+++ b/tests/fixtures/config_mem.yml
@@ -16,6 +16,12 @@ service:
   max_errors_span: 600
   trace_mem: true
 
+extraction_service:
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: '1'
 
 sources:

--- a/tests/fixtures/memconfig.yml
+++ b/tests/fixtures/memconfig.yml
@@ -17,6 +17,12 @@ service:
   max_errors: 20
   max_errors_span: 600
 
+extraction_service:
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: '1'
 
 sources:

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -74,13 +74,16 @@ def create_runner(
 
     sync_job = mock_sync_job()
     connector = mock_connector()
-    es_config = {}
+    config = {
+        "elasticsearch": {},
+        "extraction_service": {},
+    }
 
     return SyncJobRunner(
         source_klass=source_klass,
         sync_job=sync_job,
         connector=connector,
-        es_config=es_config,
+        config=config,
     )
 
 


### PR DESCRIPTION
## Related https://github.com/elastic/enterprise-search-team/issues/4574

With upcoming content extraction on edge changes for sharepoint online, it will be necessary for the config.yaml data under `extraction_services` to be accessible from within connectors. This PR adds that config to all connectors, so that we can easily merge in the sharepoint online changes once they're ready.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
