### PR TITLE
Import from connectors.protocol

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -30,8 +30,7 @@ from elasticsearch.helpers import async_scan
 from connectors.es import ESClient
 from connectors.filtering.basic_rule import BasicRuleEngine, parse
 from connectors.logger import logger, tracer
-from connectors.protocol import Filter
-from connectors.protocol.connectors import JobType
+from connectors.protocol import Filter, JobType
 from connectors.utils import (
     DEFAULT_CHUNK_MEM_SIZE,
     DEFAULT_CHUNK_SIZE,

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -5,8 +5,13 @@
 #
 from connectors.es.index import DocumentNotFoundError
 from connectors.logger import logger
-from connectors.protocol import ConnectorIndex, DataSourceError, JobStatus, SyncJobIndex
-from connectors.protocol.connectors import JobType
+from connectors.protocol import (
+    ConnectorIndex,
+    DataSourceError,
+    JobStatus,
+    JobType,
+    SyncJobIndex,
+)
 from connectors.services.base import BaseService
 from connectors.source import get_source_klass
 from connectors.sync_job_runner import SyncJobRunner

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -13,8 +13,7 @@ from connectors.es.client import with_concurrency_control
 from connectors.es.index import DocumentNotFoundError
 from connectors.es.sink import OP_INDEX, SyncOrchestrator, UnsupportedJobType
 from connectors.logger import logger
-from connectors.protocol import JobStatus
-from connectors.protocol.connectors import JobType
+from connectors.protocol import JobStatus, JobType
 from connectors.utils import truncate_id
 
 UTF_8 = "utf-8"

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -30,6 +30,7 @@ from connectors.protocol import (
     Filtering,
     JobStatus,
     JobTriggerMethod,
+    JobType,
     Pipeline,
     ServiceTypeNotConfiguredError,
     ServiceTypeNotSupportedError,
@@ -38,7 +39,6 @@ from connectors.protocol import (
     SyncJob,
     SyncJobIndex,
 )
-from connectors.protocol.connectors import JobType
 from connectors.source import BaseDataSource
 from connectors.utils import iso_utc
 from tests.commons import AsyncIterator

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -11,8 +11,7 @@ import pytest
 
 from connectors.config import load_config
 from connectors.es.index import DocumentNotFoundError
-from connectors.protocol import JobStatus
-from connectors.protocol.connectors import JobType
+from connectors.protocol import JobStatus, JobType
 from connectors.services.job_execution import JobExecutionService
 from tests.commons import AsyncIterator
 

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -20,8 +20,7 @@ from connectors.es.sink import (
     Sink,
     SyncOrchestrator,
 )
-from connectors.protocol import Pipeline
-from connectors.protocol.connectors import JobType
+from connectors.protocol import JobType, Pipeline
 from tests.commons import AsyncIterator
 
 INDEX = "some-index"

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -11,8 +11,7 @@ from elasticsearch import ConflictError
 
 from connectors.es.index import DocumentNotFoundError
 from connectors.filtering.validation import InvalidFilteringError
-from connectors.protocol import Filter, JobStatus, Pipeline
-from connectors.protocol.connectors import JobType
+from connectors.protocol import Filter, JobStatus, JobType, Pipeline
 from connectors.sync_job_runner import SyncJobRunner, SyncJobStartError
 from tests.commons import AsyncIterator
 


### PR DESCRIPTION
`JobType` should be imported from `connectors.protocol`, instead of `connectors.protocol.connectors`

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)