### PR TITLE
add premium connectors

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -584,6 +584,15 @@ class BaseDataSource:
         """Returns the sync cursor of the current sync"""
         return self._sync_cursor
 
+    @staticmethod
+    def is_premium():
+        """Returns True if this DataSource is a Premium (paid license gated) connector.
+        Otherwise, returns False.
+
+        NOTE modifying license key logic violates the Elastic License 2.0 that this code is licensed under
+        """
+        return False
+
 
 @cache
 def get_source_klass(fqn):

--- a/tests/fake_sources.py
+++ b/tests/fake_sources.py
@@ -13,9 +13,10 @@ from connectors.filtering.validation import (
     FilteringValidationResult,
     FilteringValidationState,
 )
+from connectors.source import BaseDataSource
 
 
-class FakeSource:
+class FakeSource(BaseDataSource):
     """Fakey"""
 
     name = "Fakey"
@@ -155,3 +156,9 @@ class LargeFakeSource(FakeSource):
         for i in range(1001):
             doc_id = str(i + 1)
             yield {"_id": doc_id, "data": "big" * 4 * 1024}, partial(self._dl, doc_id)
+
+class PremiumFale(FakeSource):
+    service_type = "premium_fake"
+    @classmethod
+    def is_premium():
+        True

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -206,6 +206,42 @@ async def test_job_execution_with_connector_not_found(
 
 
 @pytest.mark.asyncio
+async def test_job_execution_with_premium_connector(
+        connector_index_mock,
+        sync_job_index_mock,
+        concurrent_tasks_mock,
+        sync_job_runner_mock,
+        set_env,
+):
+    connector = mock_connector()
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
+    connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
+    sync_job = mock_sync_job(service_type="premium_fake")
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
+    await create_and_run_service()
+
+    concurrent_tasks_mock.put.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_job_execution_with_premium_connector_with_insufficient_license(
+        connector_index_mock,
+        sync_job_index_mock,
+        concurrent_tasks_mock,
+        sync_job_runner_mock,
+        set_env,
+):
+    connector = mock_connector()
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
+    connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
+    connector_index_mock.has_active_license_enabled = AsyncMock(return_value=(False, License.BASIC))
+    sync_job = mock_sync_job(service_type="premium_fake")
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
+    await create_and_run_service()
+
+    concurrent_tasks_mock.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_job_execution_with_connector_still_syncing(
     connector_index_mock,
     sync_job_index_mock,


### PR DESCRIPTION
Part of https://github.com/elastic/enterprise-search-team/issues/4733

Introduces the concept of "premium" connectors, and won't run syncs for premium connectors if your license level isn't sufficient.

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes (separate issue)


## Related Pull Requests


- https://github.com/elastic/connectors-python/pull/1013

