### PR TITLE
Add extraction service

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,6 +27,12 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 native_service_types:
   - mongodb
   - mysql

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -320,6 +320,7 @@ class Extractor:
             self.total_downloads += 1
             data.pop("_id", None)
             data.pop(TIMESTAMP_FIELD, None)
+            data.pop("_tempfile_suffix", None)
             doc.update(data)
 
         await self.queue.put(

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -23,7 +23,13 @@ from connectors.filtering.validation import (
 )
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.utils import CacheWithTimeout, convert_to_b64, html_to_text, url_encode
+from connectors.utils import (
+    CacheWithTimeout,
+    ExtractionService,
+    convert_to_b64,
+    html_to_text,
+    url_encode,
+)
 
 if "OVERRIDE_URL" in os.environ:
     logger.warning("x" * 50)
@@ -546,6 +552,7 @@ class SharepointOnlineDataSource(BaseDataSource):
         super().__init__(configuration=configuration)
 
         self._client = None
+        self.extraction_service = ExtractionService()
 
     @property
     def client(self):

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -765,7 +765,8 @@ class SharepointOnlineDataSource(BaseDataSource):
                                         "lastModifiedDateTime"
                                     ]
                                     attachment_download_func = partial(
-                                        self.get_attachment_content, list_item_attachment
+                                        self.get_attachment_content,
+                                        list_item_attachment,
                                     )
                                     yield list_item_attachment, attachment_download_func
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -723,7 +723,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                                         drive_item.get("name", "")
                                     )[-1]
                                     download_func = partial(
-                                        self.get_content, drive_item
+                                        self.get_drive_item_content, drive_item
                                     )
 
                             yield drive_item, download_func
@@ -765,7 +765,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                                         "lastModifiedDateTime"
                                     ]
                                     attachment_download_func = partial(
-                                        self.get_attachment, list_item_attachment
+                                        self.get_attachment_content, list_item_attachment
                                     )
                                     yield list_item_attachment, attachment_download_func
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -662,112 +662,125 @@ class SharepointOnlineDataSource(BaseDataSource):
             advanced_rules = filtering.get_advanced_rules()
             max_data_age = advanced_rules["maxDataAge"]
 
-        async for site_collection in self.client.site_collections():
-            site_collection["_id"] = site_collection["webUrl"]
-            site_collection["object_type"] = "site_collection"
-            yield site_collection, None
+        try:
+            self.extraction_service._begin_session()
 
-            async for site in self.client.sites(
-                site_collection["siteCollection"]["hostname"],
-                self.configuration["site_collections"],
-            ):  # TODO: simplify and eliminate root call
-                site["_id"] = site["id"]
-                site["object_type"] = "site"
+            async for site_collection in self.client.site_collections():
+                site_collection["_id"] = site_collection["webUrl"]
+                site_collection["object_type"] = "site_collection"
+                yield site_collection, None
 
-                yield site, None
+                async for site in self.client.sites(
+                    site_collection["siteCollection"]["hostname"],
+                    self.configuration["site_collections"],
+                ):  # TODO: simplify and eliminate root call
+                    site["_id"] = site["id"]
+                    site["object_type"] = "site"
 
-                async for site_drive in self.client.site_drives(site["id"]):
-                    site_drive["_id"] = site_drive["id"]
-                    site_drive["object_type"] = "site_drive"
-                    yield site_drive, None
+                    yield site, None
 
-                    async for drive_item in self.client.drive_items(site_drive["id"]):
-                        drive_item["_id"] = drive_item["id"]
-                        drive_item["object_type"] = "drive_item"
-                        drive_item["_timestamp"] = drive_item["lastModifiedDateTime"]
-                        drive_item["_tempfile_suffix"] = os.path.splitext(
-                            drive_item.get("name", "")
-                        )[-1]
+                    async for site_drive in self.client.site_drives(site["id"]):
+                        site_drive["_id"] = site_drive["id"]
+                        site_drive["object_type"] = "site_drive"
+                        yield site_drive, None
 
-                        download_func = None
+                        async for drive_item in self.client.drive_items(
+                            site_drive["id"]
+                        ):
+                            drive_item["_id"] = drive_item["id"]
+                            drive_item["object_type"] = "drive_item"
+                            drive_item["_timestamp"] = drive_item[
+                                "lastModifiedDateTime"
+                            ]
 
-                        if "@microsoft.graph.downloadUrl" in drive_item:
-                            modified_date = datetime.strptime(
-                                drive_item["lastModifiedDateTime"], "%Y-%m-%dT%H:%M:%SZ"
-                            )
-                            if (
-                                max_data_age
-                                and modified_date
-                                < datetime.utcnow() - timedelta(seconds=max_data_age)
-                            ):
-                                logger.warning(
-                                    f"Not downloading file {drive_item['name']}: last modified on {drive_item['lastModifiedDateTime']}"
+                            download_func = None
+
+                            if "@microsoft.graph.downloadUrl" in drive_item:
+                                modified_date = datetime.strptime(
+                                    drive_item["lastModifiedDateTime"],
+                                    "%Y-%m-%dT%H:%M:%SZ",
                                 )
-                            elif drive_item["size"] > MAX_DOCUMENT_SIZE:
-                                logger.warning(
-                                    f"Not downloading file {drive_item['name']} of size {drive_item['size']}"
+                                if (
+                                    max_data_age
+                                    and modified_date
+                                    < datetime.utcnow()
+                                    - timedelta(seconds=max_data_age)
+                                ):
+                                    logger.warning(
+                                        f"Not downloading file {drive_item['name']}: last modified on {drive_item['lastModifiedDateTime']}"
+                                    )
+                                elif drive_item["size"] > MAX_DOCUMENT_SIZE:
+                                    logger.warning(
+                                        f"Not downloading file {drive_item['name']} of size {drive_item['size']}"
+                                    )
+                                else:
+                                    drive_item["_tempfile_suffix"] = os.path.splitext(
+                                        drive_item.get("name", "")
+                                    )[-1]
+                                    download_func = partial(
+                                        self.get_content, drive_item
+                                    )
+
+                            yield drive_item, download_func
+
+                    async for site_list in self.client.site_lists(site["id"]):
+                        site_list["_id"] = site_list["id"]
+                        site_list["object_type"] = "site_list"
+
+                        yield site_list, None
+
+                        async for list_item in self.client.site_list_items(
+                            site["id"], site_list["id"]
+                        ):
+                            list_item["_id"] = list_item["id"]
+                            list_item["object_type"] = "list_item"
+                            list_item["_tempfile_suffix"] = os.path.splitext(
+                                list_item.get("FileName", "")
+                            )[-1]
+
+                            content_type = list_item["contentType"]["name"]
+
+                            if content_type in [
+                                "Web Template Extensions",
+                                "Client Side Component Manifests",
+                            ]:  # TODO: make it more flexible. For now I ignore them cause they 404 all the time
+                                continue
+
+                            if "Attachments" in list_item["fields"]:
+                                async for list_item_attachment in self.client.site_list_item_attachments(
+                                    site["webUrl"], site_list["name"], list_item["id"]
+                                ):
+                                    list_item_attachment["_id"] = list_item_attachment[
+                                        "odata.id"
+                                    ]
+                                    list_item_attachment[
+                                        "object_type"
+                                    ] = "list_item_attachment"
+                                    list_item_attachment["_timestamp"] = list_item[
+                                        "lastModifiedDateTime"
+                                    ]
+                                    attachment_download_func = partial(
+                                        self.get_attachment, list_item_attachment
+                                    )
+                                    yield list_item_attachment, attachment_download_func
+
+                            download_func = None
+
+                            yield list_item, download_func
+
+                    async for site_page in self.client.site_pages(site["webUrl"]):
+                        site_page["_id"] = site_page["GUID"]
+                        site_page["object_type"] = "site_page"
+
+                        for html_field in ["LayoutWebpartsContent", "CanvasContent1"]:
+                            if html_field in site_page:
+                                site_page[html_field] = html_to_text(
+                                    site_page[html_field]
                                 )
-                            else:
-                                download_func = partial(
-                                    self.get_drive_item_content, drive_item
-                                )
 
-                        yield drive_item, download_func
-
-                async for site_list in self.client.site_lists(site["id"]):
-                    site_list["_id"] = site_list["id"]
-                    site_list["object_type"] = "site_list"
-
-                    yield site_list, None
-
-                    async for list_item in self.client.site_list_items(
-                        site["id"], site_list["id"]
-                    ):
-                        list_item["_id"] = list_item["id"]
-                        list_item["object_type"] = "list_item"
-                        list_item["_tempfile_suffix"] = os.path.splitext(
-                            list_item.get("FileName", "")
-                        )[-1]
-
-                        content_type = list_item["contentType"]["name"]
-
-                        if content_type in [
-                            "Web Template Extensions",
-                            "Client Side Component Manifests",
-                        ]:  # TODO: make it more flexible. For now I ignore them cause they 404 all the time
-                            continue
-
-                        if "Attachments" in list_item["fields"]:
-                            async for list_item_attachment in self.client.site_list_item_attachments(
-                                site["webUrl"], site_list["name"], list_item["id"]
-                            ):
-                                list_item_attachment["_id"] = list_item_attachment[
-                                    "odata.id"
-                                ]
-                                list_item_attachment[
-                                    "object_type"
-                                ] = "list_item_attachment"
-                                list_item_attachment["_timestamp"] = list_item[
-                                    "lastModifiedDateTime"
-                                ]
-                                attachment_download_func = partial(
-                                    self.get_attachment_content, list_item_attachment
-                                )
-                                yield list_item_attachment, attachment_download_func
-
-                        download_func = None
-
-                        yield list_item, download_func
-
-                async for site_page in self.client.site_pages(site["webUrl"]):
-                    site_page["_id"] = site_page["GUID"]
-                    site_page["object_type"] = "site_page"
-
-                    for html_field in ["LayoutWebpartsContent", "CanvasContent1"]:
-                        if html_field in site_page:
-                            site_page[html_field] = html_to_text(site_page[html_field])
-
-                    yield site_page, None
+                        yield site_page, None
+        finally:
+            self.extraction_service._end_session()
 
     async def get_attachment_content(self, attachment, timestamp=None, doit=False):
         if not doit:

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -786,7 +786,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                         yield site_page, None
         finally:
             if self.extraction_service:
-                self.extraction_service._end_session()
+                await self.extraction_service._end_session()
 
     async def get_attachment_content(self, attachment, timestamp=None, doit=False):
         if not doit:

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -552,7 +552,11 @@ class SharepointOnlineDataSource(BaseDataSource):
         super().__init__(configuration=configuration)
 
         self._client = None
-        self.extraction_service = ExtractionService()
+
+        if self.configuration["use_text_extraction_service"]:
+            self.extraction_service = ExtractionService()
+        else:
+            self.extraction_service = None
 
     @property
     def client(self):
@@ -663,7 +667,8 @@ class SharepointOnlineDataSource(BaseDataSource):
             max_data_age = advanced_rules["maxDataAge"]
 
         try:
-            self.extraction_service._begin_session()
+            if self.extraction_service:
+                self.extraction_service._begin_session()
 
             async for site_collection in self.client.site_collections():
                 site_collection["_id"] = site_collection["webUrl"]
@@ -780,7 +785,8 @@ class SharepointOnlineDataSource(BaseDataSource):
 
                         yield site_page, None
         finally:
-            self.extraction_service._end_session()
+            if self.extraction_service:
+                self.extraction_service._end_session()
 
     async def get_attachment_content(self, attachment, timestamp=None, doit=False):
         if not doit:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -760,14 +760,9 @@ class ExtractionService:
             logger.warn(
                 f"Extraction service could not parse `{filename}'. Status: [{response.status}]."
             )
-        if len(content) > 20971520:
-            logger.info(
-                f"Extraction service returned more than 20MiB for {filename}. Keeping only 20MiB."
-            )
-            content = content[:20971520]
         if content.get("error"):
             logger.warn(
-                f"Extraction service could not parse `{filename}'; {content.get('error')}: {content.get('message')}"
+                f"Extraction service could not parse `{filename}'; {content.get('error', 'unexpected error')}: {content.get('message', 'unknown cause')}"
             )
 
         return content.get("extracted_text", "")

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -724,7 +724,7 @@ class ExtractionService:
         filename = os.path.basename(filepath)
         params = {"local_file_path": filepath}
 
-        async with self.session.post(
+        async with self._begin_session().post(
             f"{self.host}/extract_local_file_text",
             json=params,
         ) as response:
@@ -742,7 +742,7 @@ class ExtractionService:
             file_data = aiohttp.FormData()
             file_data.add_field("file", BytesIO(file.read()), filename=filename)
 
-            async with self.session.post(
+            async with self._begin_session().post(
                 f"{self.host}/extract_text/", data=file_data
             ) as response:
                 return await self.parse_extraction_resp(filename, response)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -729,7 +729,7 @@ class ExtractionService:
         params = {"local_file_path": filepath}
 
         async with self._begin_session().post(
-            f"{self.host}/extract_local_file_text",
+            f"{self.host}/extract_local_file_text/",
             json=params,
         ) as response:
             return await self.parse_extraction_resp(filename, response)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -712,7 +712,9 @@ class ExtractionService:
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                f"{self.host}/extract_local_file_text", headers=self.headers, json=params
+                f"{self.host}/extract_local_file_text",
+                headers=self.headers,
+                json=params,
             ) as response:
                 return await self.parse_extraction_resp(filename, response)
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -18,7 +18,6 @@ import urllib.parse
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 
-import aiofiles
 import aiohttp
 import yaml
 from base64io import Base64IO

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -821,7 +821,7 @@ class TestSharepointOnlineDataSource:
 
     @pytest.mark.asyncio
     async def test_get_attachment_content(self, patch_sharepoint_client):
-        attachment = { "odata.id": "1", "_tempfile_suffix": ".ppt" }
+        attachment = {"odata.id": "1", "_tempfile_suffix": ".ppt"}
         message = b"This is content of attachment"
 
         async def download_func(attachment_id, async_buffer):
@@ -837,14 +837,15 @@ class TestSharepointOnlineDataSource:
 
     @pytest.mark.asyncio
     async def test_get_attachment_with_text_extraction_enabled_adds_body(
-            self, patch_sharepoint_client
+        self, patch_sharepoint_client
     ):
         attachment = {"odata.id": "1", "_tempfile_suffix": ".ppt"}
         message = "This is the text content of drive item"
 
         with patch(
-                "connectors.utils.ExtractionService.extract_text", return_value=message
+            "connectors.utils.ExtractionService.extract_text", return_value=message
         ) as extraction_service_mock:
+
             async def download_func(attachment_id, async_buffer):
                 await async_buffer.write(bytes(message, "utf-8"))
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -821,7 +821,7 @@ class TestSharepointOnlineDataSource:
 
     @pytest.mark.asyncio
     async def test_get_attachment_content(self, patch_sharepoint_client):
-        attachment = {"odata.id": "1"}
+        attachment = { "odata.id": "1", "_tempfile_suffix": ".ppt" }
         message = b"This is content of attachment"
 
         async def download_func(attachment_id, async_buffer):
@@ -841,6 +841,7 @@ class TestSharepointOnlineDataSource:
             "size": 15,
             "lastModifiedDateTime": datetime.now(timezone.utc),
             "parentReference": {"driveId": "drive-1"},
+            "_tempfile_suffix": ".txt",
         }
         message = b"This is content of drive item"
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -8,7 +8,6 @@ import base64
 import re
 from datetime import datetime, timedelta, timezone
 from functools import partial
-from unittest import mock
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import aiohttp

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -8,6 +8,7 @@ import base64
 import re
 from datetime import datetime, timedelta, timezone
 from functools import partial
+from unittest import mock
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -833,6 +834,31 @@ class TestSharepointOnlineDataSource:
         download_result = await source.get_attachment_content(attachment, doit=True)
 
         assert download_result["_attachment"] == base64.b64encode(message).decode()
+        assert "body" not in download_result
+
+    @pytest.mark.asyncio
+    async def test_get_attachment_with_text_extraction_enabled_adds_body(
+            self, patch_sharepoint_client
+    ):
+        attachment = {"odata.id": "1", "_tempfile_suffix": ".ppt"}
+        message = "This is the text content of drive item"
+
+        with patch(
+                "connectors.utils.ExtractionService.extract_text", return_value=message
+        ) as extraction_service_mock:
+            async def download_func(attachment_id, async_buffer):
+                await async_buffer.write(bytes(message, "utf-8"))
+
+            patch_sharepoint_client.download_attachment = download_func
+            source = create_source(
+                SharepointOnlineDataSource, use_text_extraction_service=True
+            )
+
+            download_result = await source.get_attachment_content(attachment, doit=True)
+
+            extraction_service_mock.assert_called_once()
+            assert download_result["body"] == message
+            assert "_attachment" not in download_result
 
     @pytest.mark.asyncio
     async def test_get_drive_item_content(self, patch_sharepoint_client):
@@ -854,3 +880,35 @@ class TestSharepointOnlineDataSource:
         download_result = await source.get_drive_item_content(drive_item, doit=True)
 
         assert download_result["_attachment"] == base64.b64encode(message).decode()
+        assert "body" not in download_result
+
+    @pytest.mark.asyncio
+    async def test_get_content_with_text_extraction_enabled_adds_body(
+        self, patch_sharepoint_client
+    ):
+        drive_item = {
+            "id": "1",
+            "size": 15,
+            "lastModifiedDateTime": datetime.now(timezone.utc),
+            "parentReference": {"driveId": "drive-1"},
+            "_tempfile_suffix": ".txt",
+        }
+        message = "This is the text content of drive item"
+
+        with patch(
+            "connectors.utils.ExtractionService.extract_text", return_value=message
+        ) as extraction_service_mock:
+
+            async def download_func(drive_id, drive_item_id, async_buffer):
+                await async_buffer.write(bytes(message, "utf-8"))
+
+            patch_sharepoint_client.download_drive_item = download_func
+            source = create_source(
+                SharepointOnlineDataSource, use_text_extraction_service=True
+            )
+
+            download_result = await source.get_drive_item_content(drive_item, doit=True)
+
+            extraction_service_mock.assert_called_once()
+            assert download_result["body"] == message
+            assert "_attachment" not in download_result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,8 +16,7 @@ import tempfile
 import time
 import timeit
 from datetime import datetime
-from io import StringIO
-from unittest.mock import MagicMock, Mock, mock_open, patch
+from unittest.mock import Mock, mock_open, patch
 
 import pytest
 import pytest_asyncio
@@ -25,7 +24,7 @@ from aioresponses import aioresponses
 from freezegun import freeze_time
 from pympler import asizeof
 
-from connectors import logger, utils
+from connectors import utils
 from connectors.utils import (
     ConcurrentTasks,
     ExtractionService,
@@ -709,5 +708,5 @@ class TestExtractionService:
                 assert response == ""
 
                 patch_logger.assert_present(
-                    f"Extraction service could not parse `notreal.txt'; oh no!: I'm all messed up..."
+                    "Extraction service could not parse `notreal.txt'; oh no!: I'm all messed up..."
                 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,15 +16,19 @@ import tempfile
 import time
 import timeit
 from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, mock_open, patch
 
+import aiohttp
 import pytest
+import pytest_asyncio
+from aioresponses import aioresponses
 from freezegun import freeze_time
 from pympler import asizeof
 
 from connectors import utils
 from connectors.utils import (
     ConcurrentTasks,
+    ExtractionService,
     InvalidIndexNameError,
     MemQueue,
     RetryStrategy,
@@ -583,3 +587,58 @@ def test_html_to_text_with_weird_html():
     invalid_html = "<div/>just</div> text"
 
     assert html_to_text(invalid_html) == "just\n text"
+
+
+class TestExtractionService:
+    @pytest_asyncio.fixture
+    async def mock_responses(self):
+        with aioresponses() as m:
+            yield m
+
+    @pytest.mark.asyncio
+    async def test_extract_text_without_file_pointer(self, mock_responses):
+        mock_config = {
+            "extraction_service": {
+                "host": "http://localhost:8090",
+                "text_extraction": {"use_file_pointers": False},
+            }
+        }
+
+        filename = "tmp/notreal.txt"
+        url = "http://localhost:8090/extract_text"
+        payload = {"extracted_text": "I've been extracted!"}
+
+        with patch("yaml.safe_load") as mock_safe_load:
+            mock_safe_load.return_value = mock_config
+
+            with patch("builtins.open", mock_open(read_data="data")):
+                mock_responses.post(url, status=200, payload=payload)
+
+                extraction_service = ExtractionService()
+                response = await extraction_service.extract_text(filename)
+
+                assert response == "I've been extracted!"
+
+    @pytest.mark.asyncio
+    async def test_extract_text_with_file_pointer(self, mock_responses):
+        mock_config = {
+            "extraction_service": {
+                "host": "http://localhost:8090",
+                "text_extraction": {"use_file_pointers": True},
+            }
+        }
+        filename = "tmp/notreal.txt"
+        url = "http://localhost:8090/extract_local_file_text"
+        payload = {"extracted_text": "I've been extracted!"}
+
+        with patch("yaml.safe_load") as mock_safe_load:
+            mock_safe_load.return_value = mock_config
+
+            with patch("builtins.open", mock_open(read_data="data")):
+                mock_responses.post(url, status=200, payload=payload)
+
+                extraction_service = ExtractionService()
+                response = await extraction_service.extract_text(filename)
+
+                assert response == "I've been extracted!"
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -603,18 +603,21 @@ class TestExtractionService:
             }
         }
 
-        filename = "tmp/notreal.txt"
-        url = "http://localhost:8090/extract_text"
+        filepath = "tmp/notreal.txt"
+        url = "http://localhost:8090/extract_text/"
         payload = {"extracted_text": "I've been extracted!"}
 
         with patch("yaml.safe_load") as mock_safe_load:
             mock_safe_load.return_value = mock_config
 
-            with patch("builtins.open", mock_open(read_data="data")):
+            with patch("builtins.open", mock_open(read_data=b"data")):
                 mock_responses.post(url, status=200, payload=payload)
 
                 extraction_service = ExtractionService()
-                response = await extraction_service.extract_text(filename)
+                extraction_service._begin_session()
+
+                response = await extraction_service.extract_text(filepath)
+                extraction_service._end_session()
 
                 assert response == "I've been extracted!"
 
@@ -626,8 +629,8 @@ class TestExtractionService:
                 "text_extraction": {"use_file_pointers": True},
             }
         }
-        filename = "tmp/notreal.txt"
-        url = "http://localhost:8090/extract_local_file_text"
+        filepath = "tmp/notreal.txt"
+        url = "http://localhost:8090/extract_local_file_text/"
         payload = {"extracted_text": "I've been extracted!"}
 
         with patch("yaml.safe_load") as mock_safe_load:
@@ -637,6 +640,9 @@ class TestExtractionService:
                 mock_responses.post(url, status=200, payload=payload)
 
                 extraction_service = ExtractionService()
-                response = await extraction_service.extract_text(filename)
+                extraction_service._begin_session()
+
+                response = await extraction_service.extract_text(filepath)
+                extraction_service._end_session()
 
                 assert response == "I've been extracted!"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,8 @@ import tempfile
 import time
 import timeit
 from datetime import datetime
-from unittest.mock import Mock, mock_open, patch
+from io import StringIO
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
 import pytest_asyncio
@@ -24,7 +25,7 @@ from aioresponses import aioresponses
 from freezegun import freeze_time
 from pympler import asizeof
 
-from connectors import utils
+from connectors import logger, utils
 from connectors.utils import (
     ConcurrentTasks,
     ExtractionService,
@@ -643,6 +644,70 @@ class TestExtractionService:
                 extraction_service._begin_session()
 
                 response = await extraction_service.extract_text(filepath)
-                extraction_service._end_session()
+                await extraction_service._end_session()
 
                 assert response == "I've been extracted!"
+
+    @pytest.mark.asyncio
+    async def test_extract_text_when_response_isnt_200_logs_warning(
+        self, mock_responses, patch_logger
+    ):
+        mock_config = {
+            "extraction_service": {
+                "host": "http://localhost:8090",
+                "text_extraction": {"use_file_pointers": True},
+            }
+        }
+        filepath = "tmp/notreal.txt"
+        url = "http://localhost:8090/extract_local_file_text/"
+
+        with patch("yaml.safe_load") as mock_safe_load:
+            mock_safe_load.return_value = mock_config
+
+            with patch("builtins.open", mock_open(read_data="data")):
+                mock_responses.post(url, status=400, payload={})
+
+                extraction_service = ExtractionService()
+                extraction_service._begin_session()
+
+                response = await extraction_service.extract_text(filepath)
+                await extraction_service._end_session()
+                assert response == ""
+
+                patch_logger.assert_present(
+                    "Extraction service could not parse `notreal.txt'. Status: [400]."
+                )
+
+    @pytest.mark.asyncio
+    async def test_extract_text_when_response_is_200_with_error_logs_warning(
+        self, mock_responses, patch_logger
+    ):
+        mock_config = {
+            "extraction_service": {
+                "host": "http://localhost:8090",
+                "text_extraction": {"use_file_pointers": True},
+            }
+        }
+        filepath = "tmp/notreal.txt"
+        url = "http://localhost:8090/extract_local_file_text/"
+
+        with patch("yaml.safe_load") as mock_safe_load:
+            mock_safe_load.return_value = mock_config
+
+            with patch("builtins.open", mock_open(read_data="data")):
+                mock_responses.post(
+                    url,
+                    status=200,
+                    payload={"error": "oh no!", "message": "I'm all messed up..."},
+                )
+
+                extraction_service = ExtractionService()
+                extraction_service._begin_session()
+
+                response = await extraction_service.extract_text(filepath)
+                await extraction_service._end_session()
+                assert response == ""
+
+                patch_logger.assert_present(
+                    f"Extraction service could not parse `notreal.txt'; oh no!: I'm all messed up..."
+                )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,6 @@ import timeit
 from datetime import datetime
 from unittest.mock import Mock, mock_open, patch
 
-import aiohttp
 import pytest
 import pytest_asyncio
 from aioresponses import aioresponses
@@ -641,4 +640,3 @@ class TestExtractionService:
                 response = await extraction_service.extract_text(filename)
 
                 assert response == "I've been extracted!"
-


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4574

Adds extraction service as a standalone service outside of connectors.

The extraction service is only initialised and used if the user has set `use_text_extraction_service: true`.
If enabled, it will send files to the [data-extraction-service](https://github.com/elastic/data-extraction-service), which will return the extracted text or any errors.
This content is added directly to the `body` of the document before indexing. No `_attachment` is added in this case.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

## Related Pull Requests

* https://github.com/elastic/data-extraction-service/pull/11
