### PR TITLE
Attempt to use non-native default and ftest configs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,26 +27,8 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-native_service_types:
-  - mongodb
-  - mysql
-  - network_drive
-  - s3
-  - google_cloud_storage
-  - azure_blob_storage
-  - postgresql
-  - oracle
-  - confluence
-  - dir
-  - sharepoint
-  - mssql
-  - jira
-  - sharepoint_online
-
-
-# Connector client settings
-#connector_id: 'changeme'
-#service_type: 'changeme'
+connector_id: 'changeme'
+service_type: 'changeme'
 
 sources:
   mongodb: connectors.sources.mongo:MongoDataSource

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -297,7 +297,9 @@ async def prepare(service_type, index_name, config, connector_definition=None):
         }
 
         logger.info(f"Prepare {CONNECTORS_INDEX}")
-        await upsert_index(es, CONNECTORS_INDEX, docs=[doc], doc_ids=[config["connector_id"]])
+        await upsert_index(
+            es, CONNECTORS_INDEX, docs=[doc], doc_ids=[config["connector_id"]]
+        )
 
         logger.info(f"Prepare {JOBS_INDEX}")
         await upsert_index(es, JOBS_INDEX, docs=[], mappings=JOB_INDEX_MAPPINGS)
@@ -315,7 +317,9 @@ async def prepare(service_type, index_name, config, connector_definition=None):
         await es.close()
 
 
-async def upsert_index(es, index, docs=None, doc_ids=None, mappings=None, settings=None):
+async def upsert_index(
+    es, index, docs=None, doc_ids=None, mappings=None, settings=None
+):
     """Override the index with new mappings and settings.
 
     If the index with such name exists, it's deleted and then created again

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -354,10 +354,8 @@ async def upsert_index(
     # TODO: bulk
 
     if doc_ids is None:
-        doc_id = 1
-        for doc in docs:
+        for doc_id, doc in enumerate(docs):
             await es.client.index(index=index, id=doc_id, document=doc)
-            doc_id += 1
     else:
         for doc, doc_id in zip(docs, doc_ids, strict=True):
             await es.client.index(index=index, id=doc_id, document=doc)

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -359,7 +359,7 @@ async def upsert_index(
             await es.client.index(index=index, id=doc_id, document=doc)
             doc_id += 1
     else:
-        for doc, doc_id in zip(docs, doc_ids):
+        for doc, doc_id in zip(docs, doc_ids, strict=True):
             await es.client.index(index=index, id=doc_id, document=doc)
 
 

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -281,7 +281,7 @@ async def prepare(service_type, index_name, config, connector_definition=None):
             # Scheduling intervals
             "scheduling": {
                 "full": {
-                    "enabled": False,
+                    "enabled": True,
                     "interval": "1 * * * * *",
                 },
             },  # quartz syntax

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -354,7 +354,7 @@ async def upsert_index(
     # TODO: bulk
 
     if doc_ids is None:
-        for doc_id, doc in enumerate(docs):
+        for doc_id, doc in enumerate(docs, start=1):
             await es.client.index(index=index, id=doc_id, document=doc)
     else:
         for doc, doc_id in zip(docs, doc_ids, strict=True):

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -293,7 +293,7 @@ async def prepare(service_type, index_name, config, connector_definition=None):
             },
             "sync_cursor": None,
             "sync_now": False,
-            "is_native": True,
+            "is_native": False,
         }
 
         logger.info(f"Prepare {CONNECTORS_INDEX}")

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -182,7 +182,7 @@ class JobExecutionService(BaseService):
 
                     if len(supported_connector_ids) == 0:
                         logger.info(
-                            f"There's no supported connectors found with native service types [{', '.join(native_service_types)}] and connector ids [{', '.join(connector_ids)}]"
+                            f"There's no supported connectors found with native service types [{', '.join(native_service_types)}] or connector ids [{', '.join(connector_ids)}]"
                         )
                     else:
                         async for sync_job in self.sync_job_index.pending_jobs(

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -10,6 +10,6 @@ pytest-randomly>=3.12.0
 git+https://github.com/elastic/perf8#egg=perf8
 freezegun>=0.3.4
 pytest-fail-slow>=0.3.0
-pyright>=1.1.295
+pyright>=1.1.312
 requests>=2.31.0
 retry>=0.9.2

--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -50,7 +50,7 @@ fi
 $PYTHON fixture.py --name $NAME --action setup
 $PYTHON fixture.py --name $NAME --action start_stack
 $PYTHON fixture.py --name $NAME --action check_stack
-$ROOT_DIR/bin/fake-kibana --index-name $INDEX_NAME --service-type $SERVICE_TYPE --connector-definition $NAME/connector.json --debug
+$ROOT_DIR/bin/fake-kibana --index-name $INDEX_NAME --service-type $SERVICE_TYPE --config-file $NAME/config.yml --connector-definition $NAME/connector.json --debug
 $PYTHON fixture.py --name $NAME --action load
 $PYTHON fixture.py --name $NAME --action sync
 

--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -73,7 +73,7 @@ $PYTHON fixture.py --name $NAME --action monitor --pid $PID
 $PYTHON fixture.py --name $NAME --action remove
 $PYTHON fixture.py --name $NAME --action sync
 
-$ELASTIC_INGEST --debug & PID_2=$!
+$ELASTIC_INGEST  --config-file $NAME/config.yml  --debug & PID_2=$!
 
 $PYTHON fixture.py --name $NAME --action monitor --pid $PID_2
 

--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -52,26 +52,24 @@ $PYTHON fixture.py --name $NAME --action start_stack
 $PYTHON fixture.py --name $NAME --action check_stack
 $ROOT_DIR/bin/fake-kibana --index-name $INDEX_NAME --service-type $SERVICE_TYPE --config-file $NAME/config.yml --connector-definition $NAME/connector.json --debug
 $PYTHON fixture.py --name $NAME --action load
-$PYTHON fixture.py --name $NAME --action sync
 
 if [[ $PERF8 == "yes" ]]
 then
     $PYTHON fixture.py --name $NAME --action description > description.txt
     if [[ $PLATFORM == "darwin" ]]
     then
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
     else
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
     fi
 else
-    $ELASTIC_INGEST --debug & PID=$!
+    $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
 fi
 
 
 $PYTHON fixture.py --name $NAME --action monitor --pid $PID
 
 $PYTHON fixture.py --name $NAME --action remove
-$PYTHON fixture.py --name $NAME --action sync
 
 $ELASTIC_INGEST  --config-file $NAME/config.yml  --debug & PID_2=$!
 

--- a/tests/sources/fixtures/README.md
+++ b/tests/sources/fixtures/README.md
@@ -26,7 +26,7 @@ This file may contain four functions (all optional):
 - load -- loads data in the backend
 - remove -- removes random data in the backend
 - setup -- called before the docker is started
-- teardown -- called after the docker has been teared down
+- teardown -- called after the docker has been torn down
 
 requirements.txt
 ================

--- a/tests/sources/fixtures/README.md
+++ b/tests/sources/fixtures/README.md
@@ -6,10 +6,17 @@ Each fixture needs to implement the following:
 - create a directory here that matches the service type
 - add in it the following files:
 
+  - config.yml
   - fixture.py
   - requirements.txt
   - docker-compose.yml
 
+config.yml
+==========
+
+The config file necessary to run the connector for the ftest.
+Specifically, this must set the `connector_id` and `service_type` for the connector.
+Other configuration changes are optional.
 
 fixture.py
 ==========

--- a/tests/sources/fixtures/azure_blob_storage/config.yml
+++ b/tests/sources/fixtures/azure_blob_storage/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'abs'
+service_type: 'azure_blob_storage'
+
+sources:
+  azure_blob_storage: connectors.sources.azure_blob_storage:AzureBlobStorageDataSource

--- a/tests/sources/fixtures/confluence/config.yml
+++ b/tests/sources/fixtures/confluence/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'confluence'
+service_type: 'confluence'
+
+sources:
+  confluence: connectors.sources.confluence:ConfluenceDataSource

--- a/tests/sources/fixtures/dir/config.yml
+++ b/tests/sources/fixtures/dir/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'dir'
+service_type: 'dir'
+
+sources:
+  dir: connectors.sources.directory:DirectoryDataSource

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -73,6 +73,7 @@ def _es_client():
     }
     return Elasticsearch(**options)
 
+
 def _monitor_service(pid):
     es_client = _es_client()
     timeout = 20 * 60  # 20 minutes timeout

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -53,7 +53,6 @@ def _parser():
             "stop_stack",
             "setup",
             "teardown",
-            "sync",
             "monitor",
             "get_num_docs",
             "description",
@@ -73,20 +72,6 @@ def _es_client():
         "basic_auth": ("elastic", "changeme"),
     }
     return Elasticsearch(**options)
-
-
-def _set_sync_now_flag():
-    es_client = _es_client()
-    try:
-        response = es_client.search(index=CONNECTORS_INDEX, size=1)
-        connector_id = response["hits"]["hits"][0]["_id"]
-        doc = {"sync_now": True}
-        es_client.update(index=CONNECTORS_INDEX, id=connector_id, doc=doc)
-    except Exception as e:
-        print(f"Failed to set sync_now flag. Something bad happened: {e}")
-    finally:
-        es_client.close()
-
 
 def _monitor_service(pid):
     es_client = _es_client()
@@ -140,10 +125,6 @@ def main(args=None):
             os.system("docker compose up -d")
         else:
             os.system("docker compose down --volumes")
-        return
-
-    if args.action == "sync":
-        _set_sync_now_flag()
         return
 
     if args.action == "monitor":

--- a/tests/sources/fixtures/google_cloud_storage/config.yml
+++ b/tests/sources/fixtures/google_cloud_storage/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'gcs'
+service_type: 'google_cloud_storage'
+
+sources:
+  google_cloud_storage: connectors.sources.google_cloud_storage:GoogleCloudStorageDataSource

--- a/tests/sources/fixtures/jira/config.yml
+++ b/tests/sources/fixtures/jira/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'jira'
+service_type: 'jira'
+
+sources:
+  jira: connectors.sources.jira:JiraDataSource

--- a/tests/sources/fixtures/mongodb/config.yml
+++ b/tests/sources/fixtures/mongodb/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'mongo'
+service_type: 'mongodb'
+
+sources:
+  mongodb: connectors.sources.mongo:MongoDataSource

--- a/tests/sources/fixtures/mongodb/connector.json
+++ b/tests/sources/fixtures/mongodb/connector.json
@@ -4,7 +4,7 @@
         "index_name": "search-mongodb",
         "sync_cursor": null,
         "sync_now": true,
-        "is_native": true,
+        "is_native": false,
         "api_key_id": null,
         "status": "configured",
         "language": "en",

--- a/tests/sources/fixtures/mongodb_serverless/config.yml
+++ b/tests/sources/fixtures/mongodb_serverless/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'mongo_serverless'
+service_type: 'mongodb'
+
+sources:
+  mongodb: connectors.sources.mongo:MongoDataSource

--- a/tests/sources/fixtures/mongodb_serverless/connector.json
+++ b/tests/sources/fixtures/mongodb_serverless/connector.json
@@ -3,7 +3,7 @@
   "service_type": "mongodb",
   "index_name": "search-mongodb",
   "sync_cursor": null,
-  "sync_now": true,
+  "sync_now": false,
   "is_native": false,
   "api_key_id": null,
   "status": "configured",

--- a/tests/sources/fixtures/mongodb_serverless/connector.json
+++ b/tests/sources/fixtures/mongodb_serverless/connector.json
@@ -4,7 +4,7 @@
   "index_name": "search-mongodb",
   "sync_cursor": null,
   "sync_now": true,
-  "is_native": true,
+  "is_native": false,
   "api_key_id": null,
   "status": "configured",
   "language": "en",

--- a/tests/sources/fixtures/mongodb_serverless/connector.json
+++ b/tests/sources/fixtures/mongodb_serverless/connector.json
@@ -1,119 +1,125 @@
 {
-        "name": "mongodb",
-        "service_type": "mongodb",
-        "index_name": "search-mongodb",
-        "sync_cursor": null,
-        "sync_now": true,
-        "is_native": true,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_sync_status": null,
-        "last_permissions_sync_status": null,
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-            "host": {
-                "label": "Server Hostname",
-                "order": 1,
-                "type": "str",
-                "value": "mongodb://127.0.0.1:27021"
-            },
-            "user": {
-                "default_value": "",
-                "label": "Username",
-                "order": 2,
-                "type": "str",
-                "value": "admin",
-                "required": false
-            },
-            "password": {
-                "default_value": "",
-                "label": "Password",
-                "order": 3,
-                "sensitive": true,
-                "type": "str",
-                "value": "justtesting",
-                "required": false
-            },
-            "database": {
-                "label": "Database",
-                "order": 4,
-                "type": "str",
-                "value": "sample_database"
-            },
-            "collection": {
-                "label": "Collection",
-                "order": 5,
-                "type": "str",
-                "value": "sample_collection"
-            },
-            "direct_connection": {
-                "display": "toggle",
-                "label": "Direct connection",
-                "order": 6,
-                "type": "bool",
-                "value": true
-            }
+  "name": "mongodb",
+  "service_type": "mongodb",
+  "index_name": "search-mongodb",
+  "sync_cursor": null,
+  "sync_now": true,
+  "is_native": true,
+  "api_key_id": null,
+  "status": "configured",
+  "language": "en",
+  "last_sync_status": null,
+  "last_permissions_sync_status": null,
+  "last_sync_error": null,
+  "last_synced": null,
+  "last_seen": null,
+  "created_at": null,
+  "updated_at": null,
+  "configuration": {
+    "host": {
+      "label": "Server Hostname",
+      "order": 1,
+      "type": "str",
+      "value": "mongodb://127.0.0.1:27021"
+    },
+    "user": {
+      "default_value": "",
+      "label": "Username",
+      "order": 2,
+      "type": "str",
+      "value": "admin",
+      "required": false
+    },
+    "password": {
+      "default_value": "",
+      "label": "Password",
+      "order": 3,
+      "sensitive": true,
+      "type": "str",
+      "value": "justtesting",
+      "required": false
+    },
+    "database": {
+      "label": "Database",
+      "order": 4,
+      "type": "str",
+      "value": "sample_database"
+    },
+    "collection": {
+      "label": "Collection",
+      "order": 5,
+      "type": "str",
+      "value": "sample_collection"
+    },
+    "direct_connection": {
+      "display": "toggle",
+      "label": "Direct connection",
+      "order": 6,
+      "type": "bool",
+      "value": true
+    }
+  },
+  "filtering": [
+    {
+      "domain": "DEFAULT",
+      "draft": {
+        "advanced_snippet": {
+          "updated_at": "2023-01-31T16:41:27.341Z",
+          "created_at": "2023-01-31T16:38:49.244Z",
+          "value": {}
         },
-        "filtering": [
-                {
-                        "domain": "DEFAULT",
-                        "draft": {
-                        "advanced_snippet": {
-                          "updated_at": "2023-01-31T16:41:27.341Z",
-                          "created_at": "2023-01-31T16:38:49.244Z",
-                          "value": {}
-                        },
-                        "rules": [
-                          {
-                              "field": "_",
-                              "updated_at": "2023-01-31T16:41:27.341Z",
-                              "created_at": "2023-01-31T16:38:49.244Z",
-                              "rule": "regex",
-                              "id": "DEFAULT",
-                              "value": ".*",
-                              "order": 1,
-                              "policy": "include"
-                          }
-                        ],
-                        "validation": {"state": "valid", "errors": []}
-                  },
-                  "active": {
-                        "advanced_snippet": {
-                          "updated_at": "2023-01-31T16:41:27.341Z",
-                          "created_at": "2023-01-31T16:38:49.244Z",
-                          "value": {}
-                        },
-                        "rules": [
-                          {
-                              "field": "_",
-                              "updated_at": "2023-01-31T16:41:27.341Z",
-                              "created_at": "2023-01-31T16:38:49.244Z",
-                              "rule": "regex",
-                              "id": "DEFAULT",
-                              "value": ".*",
-                              "order": 1,
-                              "policy": "include"
-                          }
-                        ],
-                        "validation": {"state": "valid", "errors": []}
-                        }
-                }
-        ],
-        "scheduling": {
-          "full": {
-            "enabled": True,
-            "interval": "1 * * * * *"
+        "rules": [
+          {
+            "field": "_",
+            "updated_at": "2023-01-31T16:41:27.341Z",
+            "created_at": "2023-01-31T16:38:49.244Z",
+            "rule": "regex",
+            "id": "DEFAULT",
+            "value": ".*",
+            "order": 1,
+            "policy": "include"
           }
-        },
-        "pipeline": {
-          "extract_binary_content": true,
-          "name": "ent-search-generic-ingestion",
-          "reduce_whitespace": true,
-          "run_ml_inference": true
+        ],
+        "validation": {
+          "state": "valid",
+          "errors": []
         }
+      },
+      "active": {
+        "advanced_snippet": {
+          "updated_at": "2023-01-31T16:41:27.341Z",
+          "created_at": "2023-01-31T16:38:49.244Z",
+          "value": {}
+        },
+        "rules": [
+          {
+            "field": "_",
+            "updated_at": "2023-01-31T16:41:27.341Z",
+            "created_at": "2023-01-31T16:38:49.244Z",
+            "rule": "regex",
+            "id": "DEFAULT",
+            "value": ".*",
+            "order": 1,
+            "policy": "include"
+          }
+        ],
+        "validation": {
+          "state": "valid",
+          "errors": []
+        }
+      }
+    }
+  ],
+  "scheduling": {
+    "full": {
+      "enabled": true,
+      "interval": "1 * * * * *"
+    }
+  },
+  "pipeline": {
+    "extract_binary_content": true,
+    "name": "ent-search-generic-ingestion",
+    "reduce_whitespace": true,
+    "run_ml_inference": true
+  }
 }

--- a/tests/sources/fixtures/mongodb_serverless/connector.json
+++ b/tests/sources/fixtures/mongodb_serverless/connector.json
@@ -104,11 +104,16 @@
                         }
                 }
         ],
-        "scheduling": {"enabled": true, "interval": "1 * * * * *"},
+        "scheduling": {
+          "full": {
+            "enabled": True,
+            "interval": "1 * * * * *"
+          }
+        },
         "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+          "extract_binary_content": true,
+          "name": "ent-search-generic-ingestion",
+          "reduce_whitespace": true,
+          "run_ml_inference": true
         }
 }

--- a/tests/sources/fixtures/mssql/config.yml
+++ b/tests/sources/fixtures/mssql/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'mssql'
+service_type: 'mssql'
+
+sources:
+  mssql: connectors.sources.mssql:MSSQLDataSource

--- a/tests/sources/fixtures/mssql/fixture.py
+++ b/tests/sources/fixtures/mssql/fixture.py
@@ -73,7 +73,7 @@ def load():
     database.autocommit = False
 
     for table in range(NUM_TABLES):
-        print(f"Adding data in {table}...")
+        print(f"Adding data from table #{table}...")
         sql_query = f"CREATE TABLE customers_{table} (name VARCHAR(255), age int, description TEXT, PRIMARY KEY (name))"
         cursor.execute(sql_query)
         for i in range(10):

--- a/tests/sources/fixtures/mysql/config.yml
+++ b/tests/sources/fixtures/mysql/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'mysql'
+service_type: 'mysql'
+
+sources:
+  mysql: connectors.sources.mysql:MySqlDataSource

--- a/tests/sources/fixtures/mysql/connector.json
+++ b/tests/sources/fixtures/mysql/connector.json
@@ -4,7 +4,7 @@
         "service_type": "mysql",
         "sync_cursor": null,
         "sync_now": true,
-        "is_native": true,
+        "is_native": false,
         "api_key_id": null,
         "status": "configured",
         "language": "en",

--- a/tests/sources/fixtures/mysql/fixture.py
+++ b/tests/sources/fixtures/mysql/fixture.py
@@ -42,7 +42,7 @@ def load():
     cursor.execute(f"CREATE DATABASE {DATABASE_NAME}")
     cursor.execute(f"USE {DATABASE_NAME}")
     for table in range(NUM_TABLES):
-        print(f"Adding data in {table}...")
+        print(f"Adding data from table #{table}...")
         sql_query = f"CREATE TABLE IF NOT EXISTS customers_{table} (name VARCHAR(255), age int, description LONGTEXT, PRIMARY KEY (name))"
         cursor.execute(sql_query)
         for i in range(10):

--- a/tests/sources/fixtures/network_drive/config.yml
+++ b/tests/sources/fixtures/network_drive/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'network_drive'
+service_type: 'network_drive'
+
+sources:
+  network_drive: connectors.sources.network_drive:NASDataSource

--- a/tests/sources/fixtures/oracle/config.yml
+++ b/tests/sources/fixtures/oracle/config.yml
@@ -1,0 +1,34 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'oracle'
+service_type: 'oracle'
+
+sources:
+  oracle: connectors.sources.oracle:OracleDataSource
+

--- a/tests/sources/fixtures/oracle/fixture.py
+++ b/tests/sources/fixtures/oracle/fixture.py
@@ -79,7 +79,7 @@ def load():
         )
         cursor = connection.cursor()
         for table in range(NUM_TABLES):
-            print(f"Adding data in {table}...")
+            print(f"Adding data from table #{table}...")
             sql_query = f"CREATE TABLE customers_{table} (id int, name VARCHAR(255), age int, description long, PRIMARY KEY (id))"
             cursor.execute(sql_query)
             for i in range(10):

--- a/tests/sources/fixtures/postgresql/config.yml
+++ b/tests/sources/fixtures/postgresql/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'postgres'
+service_type: 'postgresql'
+
+sources:
+  postgresql: connectors.sources.postgresql:PostgreSQLDataSource

--- a/tests/sources/fixtures/postgresql/fixture.py
+++ b/tests/sources/fixtures/postgresql/fixture.py
@@ -57,7 +57,7 @@ def load():
         """N tables of 10001 rows each. each row is ~ 1024*20 bytes"""
         connect = await asyncpg.connect(CONNECTION_STRING)
         for table in range(NUM_TABLES):
-            print(f"Adding data in {table}...")
+            print(f"Adding data from table #{table}...")
             sql_query = f"CREATE TABLE IF NOT EXISTS customers_{table} (name VARCHAR(255), age int, description TEXT, PRIMARY KEY (name))"
             await connect.execute(sql_query)
             for i in range(10):

--- a/tests/sources/fixtures/s3/config.yml
+++ b/tests/sources/fixtures/s3/config.yml
@@ -1,0 +1,33 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 's3'
+service_type: 's3'
+
+sources:
+  s3: connectors.sources.s3:S3DataSource

--- a/tests/sources/fixtures/sharepoint/config.yml
+++ b/tests/sources/fixtures/sharepoint/config.yml
@@ -1,0 +1,34 @@
+elasticsearch:
+  host: http://localhost:9200
+  username: elastic
+  password: changeme
+  ssl: true
+  bulk:
+    queue_max_size: 1024
+    queue_max_mem_size: 25
+    display_every: 100
+    chunk_size: 1000
+    max_concurrency: 5
+    chunk_max_mem_size: 5
+    concurrent_downloads: 10
+  request_timeout: 120
+  max_wait_duration: 120
+  initial_backoff_duration: 1
+  backoff_multiplier: 2
+  log_level: info
+
+service:
+  idling: 30
+  heartbeat: 300
+  max_errors: 20
+  max_errors_span: 600
+  max_concurrent_syncs: 1
+  job_cleanup_interval: 300
+  log_level: INFO
+
+connector_id: 'sharepoint'
+service_type: 'sharepoint'
+
+sources:
+  sharepoint: connectors.sources.sharepoint:SharepointDataSource
+


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4731

- Removes "native" as the default way to start connectors
- enables ftests to run on their on config files, and with pre-determined connector ids (non-native)
- removes `sync_now` usage from ftests
- cleans up some testing logging

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes (separate issue)
- [ ] Contributed any configuration settings changes to the configuration reference

## Release Note

Cloned/forked connectors from connectors-python no longer run in "native" mode. Native mode is available exclusively on Elastic Cloud deployments.
