### PR TITLE
Fix make lint|autoformat to also work on tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,20 @@ clean:
 lint: bin/python bin/black bin/elastic-ingest
 	bin/isort --check . --sp .isort.cfg
 	bin/black --check connectors
+	bin/black --check tests
 	bin/black --check setup.py
-	bin/ruff connectors
-	bin/ruff setup.py
 	bin/black --check scripts
+	bin/ruff connectors
+	bin/ruff tests
+	bin/ruff setup.py
 	bin/ruff scripts
 	bin/pyright connectors
+	bin/pyright tests
 
 autoformat: bin/python bin/black bin/elastic-ingest
 	bin/isort . --sp .isort.cfg
 	bin/black connectors
+	bin/black tests
 	bin/black setup.py
 	bin/black scripts
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,6 @@ import traceback
 import pytest
 from aioresponses import aioresponses
 
-import connectors
-
 
 class Logger:
     def __init__(self, silent=True):

--- a/tests/es/test_client.py
+++ b/tests/es/test_client.py
@@ -12,10 +12,8 @@ from elasticsearch import ConflictError, ConnectionError
 
 from connectors.es.client import ESClient, License, with_concurrency_control
 
-BASIC_CONFIG = {
-    "username": "elastic",
-    "password": "changeme"
-}
+BASIC_CONFIG = {"username": "elastic", "password": "changeme"}
+
 
 def test_esclient():
     # creating a client with a minimal config should create one with sane
@@ -162,15 +160,29 @@ async def test_with_concurrency_control():
         (License.BASIC, [License.BASIC]),
         (License.GOLD, [License.BASIC, License.GOLD]),
         (License.PLATINUM, [License.BASIC, License.GOLD, License.PLATINUM]),
-        (License.ENTERPRISE, [License.BASIC, License.GOLD, License.PLATINUM, License.ENTERPRISE]),
-        (License.TRIAL, [License.BASIC, License.GOLD, License.PLATINUM, License.ENTERPRISE, License.TRIAL])
-    ]
+        (
+            License.ENTERPRISE,
+            [License.BASIC, License.GOLD, License.PLATINUM, License.ENTERPRISE],
+        ),
+        (
+            License.TRIAL,
+            [
+                License.BASIC,
+                License.GOLD,
+                License.PLATINUM,
+                License.ENTERPRISE,
+                License.TRIAL,
+            ],
+        ),
+    ],
 )
 @pytest.mark.asyncio
 async def test_has_license_enabled(enabled_license, licenses_enabled):
     es_client = ESClient(BASIC_CONFIG)
     es_client.client = AsyncMock()
-    es_client.client.license.get = AsyncMock(return_value={"license": { "type": enabled_license.value}})
+    es_client.client.license.get = AsyncMock(
+        return_value={"license": {"type": enabled_license.value}}
+    )
 
     for license_ in licenses_enabled:
         is_enabled, _ = await es_client.has_active_license_enabled(license_)
@@ -180,18 +192,23 @@ async def test_has_license_enabled(enabled_license, licenses_enabled):
 @pytest.mark.parametrize(
     "enabled_license, licenses_disabled",
     [
-        (License.BASIC, [License.GOLD, License.PLATINUM, License.ENTERPRISE, License.TRIAL]),
+        (
+            License.BASIC,
+            [License.GOLD, License.PLATINUM, License.ENTERPRISE, License.TRIAL],
+        ),
         (License.GOLD, [License.PLATINUM, License.ENTERPRISE, License.TRIAL]),
         (License.PLATINUM, [License.ENTERPRISE, License.TRIAL]),
         (License.ENTERPRISE, [License.TRIAL]),
-        (License.TRIAL, [])
-    ]
+        (License.TRIAL, []),
+    ],
 )
 @pytest.mark.asyncio
 async def test_has_licenses_disabled(enabled_license, licenses_disabled):
     es_client = ESClient(BASIC_CONFIG)
     es_client.client = AsyncMock()
-    es_client.client.license.get = AsyncMock(return_value={"license": {"type": enabled_license.value}})
+    es_client.client.license.get = AsyncMock(
+        return_value={"license": {"type": enabled_license.value}}
+    )
 
     for license_ in licenses_disabled:
         is_enabled, _ = await es_client.has_active_license_enabled(license_)
@@ -202,10 +219,11 @@ async def test_has_licenses_disabled(enabled_license, licenses_disabled):
 async def test_has_license_disabled_with_expired_license():
     es_client = ESClient(BASIC_CONFIG)
     es_client.client = AsyncMock()
-    es_client.client.license.get = AsyncMock(return_value={"license": {"type": License.PLATINUM, "status": "expired"}})
+    es_client.client.license.get = AsyncMock(
+        return_value={"license": {"type": License.PLATINUM, "status": "expired"}}
+    )
 
     is_enabled, license_ = await es_client.has_active_license_enabled(License.PLATINUM)
 
     assert not is_enabled
     assert license_ == License.EXPIRED
-

--- a/tests/es/test_index.py
+++ b/tests/es/test_index.py
@@ -33,7 +33,7 @@ async def test_es_index_create_object_error(mock_responses):
         payload={"hits": {"total": {"value": 1}, "hits": [{"_id": 1}]}},
     )
     with pytest.raises(NotImplementedError) as _:
-        async for doc_ in index.get_all_docs():
+        async for _ in index.get_all_docs():
             pass
 
     await index.close()

--- a/tests/fake_sources.py
+++ b/tests/fake_sources.py
@@ -157,8 +157,10 @@ class LargeFakeSource(FakeSource):
             doc_id = str(i + 1)
             yield {"_id": doc_id, "data": "big" * 4 * 1024}, partial(self._dl, doc_id)
 
+
 class PremiumFake(FakeSource):
     service_type = "premium_fake"
+
     @classmethod
     def is_premium():
-        True
+        return True

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -326,18 +326,9 @@ async def test_connector_properties():
             "configuration": {},
             "language": "en",
             "scheduling": {
-                "access_control": {
-                    "enabled": True,
-                    "interval": "* * * * *"
-                },
-                "full": {
-                    "enabled": True,
-                    "interval": "* * * * *"
-                },
-                "incremental": {
-                    "enabled": True,
-                    "interval": "* * * * *"
-                }
+                "access_control": {"enabled": True, "interval": "* * * * *"},
+                "full": {"enabled": True, "interval": "* * * * *"},
+                "incremental": {"enabled": True, "interval": "* * * * *"},
             },
             "status": "created",
             "last_seen": iso_utc(),
@@ -413,25 +404,34 @@ async def test_heartbeat(interval, last_seen, should_send_heartbeat):
 @pytest.mark.parametrize(
     "job_type, expected_doc_source_update",
     [
-        (JobType.FULL, {
-            "last_sync_status": JobStatus.IN_PROGRESS.value,
-            "last_sync_error": None,
-            "status": Status.CONNECTED.value,
-            "error": None,
-        }),
-        (JobType.INCREMENTAL, {
-            "last_sync_status": JobStatus.IN_PROGRESS.value,
-            "last_sync_error": None,
-            "status": Status.CONNECTED.value,
-            "error": None,
-        }),
-        (JobType.ACCESS_CONTROL, {
-            "last_access_control_sync_status": JobStatus.IN_PROGRESS.value,
-            "last_access_control_sync_error": None,
-            "status": Status.CONNECTED.value,
-            "error": None,
-        })
-    ]
+        (
+            JobType.FULL,
+            {
+                "last_sync_status": JobStatus.IN_PROGRESS.value,
+                "last_sync_error": None,
+                "status": Status.CONNECTED.value,
+                "error": None,
+            },
+        ),
+        (
+            JobType.INCREMENTAL,
+            {
+                "last_sync_status": JobStatus.IN_PROGRESS.value,
+                "last_sync_error": None,
+                "status": Status.CONNECTED.value,
+                "error": None,
+            },
+        ),
+        (
+            JobType.ACCESS_CONTROL,
+            {
+                "last_access_control_sync_status": JobStatus.IN_PROGRESS.value,
+                "last_access_control_sync_error": None,
+                "status": Status.CONNECTED.value,
+                "error": None,
+            },
+        ),
+    ],
 )
 @pytest.mark.asyncio
 async def test_sync_starts(job_type, expected_doc_source_update):
@@ -501,7 +501,9 @@ def mock_job(
             },
         ),
         (
-            mock_job(status=JobStatus.ERROR, job_type=JobType.FULL, error="something wrong"),
+            mock_job(
+                status=JobStatus.ERROR, job_type=JobType.FULL, error="something wrong"
+            ),
             {
                 "last_sync_status": JobStatus.ERROR.value,
                 "last_synced": ANY,
@@ -525,7 +527,9 @@ def mock_job(
             },
         ),
         (
-            mock_job(status=JobStatus.SUSPENDED, job_type=JobType.FULL, terminated=False),
+            mock_job(
+                status=JobStatus.SUSPENDED, job_type=JobType.FULL, terminated=False
+            ),
             {
                 "last_sync_status": JobStatus.SUSPENDED.value,
                 "last_synced": ANY,
@@ -573,7 +577,11 @@ def mock_job(
             },
         ),
         (
-            mock_job(status=JobStatus.ERROR, job_type=JobType.ACCESS_CONTROL, error="something wrong"),
+            mock_job(
+                status=JobStatus.ERROR,
+                job_type=JobType.ACCESS_CONTROL,
+                error="something wrong",
+            ),
             {
                 "last_access_control_sync_status": JobStatus.ERROR.value,
                 "last_synced": ANY,
@@ -585,7 +593,11 @@ def mock_job(
             },
         ),
         (
-            mock_job(status=JobStatus.SUSPENDED, job_type=JobType.ACCESS_CONTROL, terminated=False),
+            mock_job(
+                status=JobStatus.SUSPENDED,
+                job_type=JobType.ACCESS_CONTROL,
+                terminated=False,
+            ),
             {
                 "last_access_control_sync_status": JobStatus.SUSPENDED.value,
                 "last_synced": ANY,
@@ -630,11 +642,13 @@ mock_next_run = iso_utc()
         (False, None, JobType.FULL),
         (True, mock_next_run, JobType.FULL),
         (False, None, JobType.INCREMENTAL),
-        (True, mock_next_run, JobType.INCREMENTAL)
+        (True, mock_next_run, JobType.INCREMENTAL),
     ],
 )
 @patch("connectors.protocol.connectors.next_run")
-async def test_connector_next_sync(next_run, scheduling_enabled, expected_next_sync, job_type):
+async def test_connector_next_sync(
+    next_run, scheduling_enabled, expected_next_sync, job_type
+):
     connector_doc = {
         "_id": "1",
         "_source": {
@@ -649,8 +663,8 @@ async def test_connector_next_sync(next_run, scheduling_enabled, expected_next_s
                 },
                 "incremental": {
                     "enabled": scheduling_enabled,
-                    "interval": "1 * * * * *"
-                }
+                    "interval": "1 * * * * *",
+                },
             },
         },
     }
@@ -1196,10 +1210,12 @@ async def test_connector_reset_sync_now_flag():
         (JobType.FULL, "last_sync_scheduled_at"),
         (JobType.INCREMENTAL, "last_incremental_sync_scheduled_at"),
         (JobType.ACCESS_CONTROL, "last_access_control_sync_scheduled_at"),
-    ]
+    ],
 )
 @pytest.mark.asyncio
-async def test_connector_update_last_sync_scheduled_at_by_job_type(job_type, date_field_to_update):
+async def test_connector_update_last_sync_scheduled_at_by_job_type(
+    job_type, date_field_to_update
+):
     doc_id = "2"
     seq_no = 2
     primary_term = 1
@@ -1527,7 +1543,7 @@ def test_transform_filtering(filtering, expected_transformed_filtering):
                 Features.ADVANCED_RULES_NEW: False,
                 Features.BASIC_RULES_OLD: False,
                 Features.ADVANCED_RULES_OLD: False,
-                Features.DOCUMENT_LEVEL_SECURITY: False
+                Features.DOCUMENT_LEVEL_SECURITY: False,
             },
         ),
         (
@@ -1537,9 +1553,9 @@ def test_transform_filtering(filtering, expected_transformed_filtering):
                 Features.ADVANCED_RULES_NEW: False,
                 Features.BASIC_RULES_OLD: False,
                 Features.ADVANCED_RULES_OLD: False,
-                Features.DOCUMENT_LEVEL_SECURITY: False
+                Features.DOCUMENT_LEVEL_SECURITY: False,
             },
-        )
+        ),
     ],
 )
 def test_feature_enabled(features_json, feature_enabled):
@@ -1642,9 +1658,7 @@ def test_sync_rules_enabled(features_json, sync_rules_enabled):
             False,
         ),
         (
-            {
-                "incremental_sync": {}
-            },
+            {"incremental_sync": {}},
             False,
         ),
         ({"other_feature": True}, False),
@@ -1656,42 +1670,6 @@ def test_incremental_sync_enabled(features_json, incremental_sync_enabled):
     features = Features(features_json)
 
     assert features.incremental_sync_enabled() == incremental_sync_enabled
-
-
-@pytest.mark.parametrize(
-    "features_json, document_level_security_enabled",
-    [
-        (
-            {
-                "document_level_security": {
-                    "enabled": True,
-                },
-            },
-            True,
-        ),
-        (
-            {
-                "document_level_security": {
-                    "enabled": False,
-                },
-            },
-            False,
-        ),
-        (
-            {
-                "document_level_security": {}
-            },
-            False,
-        ),
-        ({"other_feature": True}, False),
-        (None, False),
-        ({}, False),
-    ],
-)
-def test_incremental_sync_enabled(features_json, document_level_security_enabled):
-    features = Features(features_json)
-
-    assert features.document_level_security_enabled() == document_level_security_enabled
 
 
 @pytest.mark.parametrize(
@@ -1752,7 +1730,9 @@ async def test_create_job(index_method, trigger_method, set_env):
     }
 
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
-    await sync_job_index.create(connector=connector, trigger_method=trigger_method, job_type=JobType.INCREMENTAL)
+    await sync_job_index.create(
+        connector=connector, trigger_method=trigger_method, job_type=JobType.INCREMENTAL
+    )
 
     index_method.assert_called_with(expected_index_doc)
 

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -69,7 +69,9 @@ def connector_index_mock():
         connector_index_mock = Mock()
         connector_index_mock.stop_waiting = Mock()
         connector_index_mock.close = AsyncMock()
-        connector_index_mock.has_active_license_enabled = AsyncMock(return_value=(True, None))
+        connector_index_mock.has_active_license_enabled = AsyncMock(
+            return_value=(True, None)
+        )
         connector_index_klass_mock.return_value = connector_index_mock
 
         yield connector_index_mock
@@ -96,6 +98,7 @@ def concurrent_task_mock():
 
     return task_mock
 
+
 @pytest.fixture(autouse=True)
 def concurrent_tasks_mocks():
     with patch(
@@ -103,7 +106,10 @@ def concurrent_tasks_mocks():
     ) as concurrent_tasks_klass_mock:
         concurrent_content_syncs_tasks_mock = concurrent_task_mock()
         concurrent_access_control_syncs_tasks_mock = concurrent_task_mock()
-        concurrent_tasks_klass_mock.side_effect = [concurrent_content_syncs_tasks_mock, concurrent_access_control_syncs_tasks_mock]
+        concurrent_tasks_klass_mock.side_effect = [
+            concurrent_content_syncs_tasks_mock,
+            concurrent_access_control_syncs_tasks_mock,
+        ]
 
         yield concurrent_content_syncs_tasks_mock, concurrent_access_control_syncs_tasks_mock
 
@@ -120,7 +126,12 @@ def sync_job_runner_mock():
         yield sync_job_runner_mock
 
 
-def mock_connector(job_type=JobType.FULL, last_sync_status=JobStatus.COMPLETED, last_access_control_sync_status=JobStatus.COMPLETED, document_level_security_enabled=True):
+def mock_connector(
+    job_type=JobType.FULL,
+    last_sync_status=JobStatus.COMPLETED,
+    last_access_control_sync_status=JobStatus.COMPLETED,
+    document_level_security_enabled=True,
+):
     connector = Mock()
     connector.id = "1"
     connector.job_type = job_type
@@ -129,7 +140,9 @@ def mock_connector(job_type=JobType.FULL, last_sync_status=JobStatus.COMPLETED, 
     connector.last_access_control_sync_status = last_access_control_sync_status
 
     connector.features = Mock()
-    connector.features.document_level_security_enabled = Mock(return_value=document_level_security_enabled)
+    connector.features.document_level_security_enabled = Mock(
+        return_value=document_level_security_enabled
+    )
 
     return connector
 
@@ -188,12 +201,16 @@ async def test_job_execution_content_sync_job_and_access_control_sync_job(
 
     content_sync_job = mock_sync_job()
     access_control_sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
-    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([content_sync_job, access_control_sync_job])
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator(
+        [content_sync_job, access_control_sync_job]
+    )
 
     await create_and_run_service()
 
     content_syncs_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
-    access_control_syncs_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
+    access_control_syncs_tasks_mock.put.assert_awaited_once_with(
+        sync_job_runner_mock.execute
+    )
 
 
 @pytest.mark.asyncio
@@ -234,11 +251,15 @@ async def test_job_execution_access_control_sync_job(
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
 
     access_control_sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
-    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([access_control_sync_job])
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator(
+        [access_control_sync_job]
+    )
 
     await create_and_run_service()
 
-    access_control_syncs_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
+    access_control_syncs_tasks_mock.put.assert_awaited_once_with(
+        sync_job_runner_mock.execute
+    )
     content_syncs_tasks_mock.put.assert_not_awaited()
 
 
@@ -276,7 +297,9 @@ async def test_job_execution_with_connector_not_found(
     connector_index_mock.fetch_by_id = AsyncMock(side_effect=DocumentNotFoundError())
     content_sync_job = mock_sync_job()
     access_control_sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
-    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([content_sync_job, access_control_sync_job])
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator(
+        [content_sync_job, access_control_sync_job]
+    )
     await create_and_run_service()
 
     content_syncs_tasks_mock.put.assert_not_awaited()
@@ -285,11 +308,11 @@ async def test_job_execution_with_connector_not_found(
 
 @pytest.mark.asyncio
 async def test_job_execution_with_premium_connector(
-        connector_index_mock,
-        sync_job_index_mock,
-        concurrent_tasks_mocks,
-        sync_job_runner_mock,
-        set_env,
+    connector_index_mock,
+    sync_job_index_mock,
+    concurrent_tasks_mocks,
+    sync_job_runner_mock,
+    set_env,
 ):
     content_syncs_tasks_mock, access_control_syncs_tasks_mock = concurrent_tasks_mocks
 
@@ -301,28 +324,34 @@ async def test_job_execution_with_premium_connector(
     await create_and_run_service()
 
     content_syncs_tasks_mock.put.assert_not_awaited()
-    access_control_syncs_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
+    access_control_syncs_tasks_mock.put.assert_awaited_once_with(
+        sync_job_runner_mock.execute
+    )
 
 
 @pytest.mark.asyncio
 async def test_job_execution_with_premium_connector_with_insufficient_license(
-        connector_index_mock,
-        sync_job_index_mock,
-        concurrent_tasks_mocks,
-        sync_job_runner_mock,
-        set_env,
+    connector_index_mock,
+    sync_job_index_mock,
+    concurrent_tasks_mocks,
+    sync_job_runner_mock,
+    set_env,
 ):
     content_syncs_tasks_mock, access_control_syncs_tasks_mock = concurrent_tasks_mocks
 
     connector = mock_connector()
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
-    connector_index_mock.has_active_license_enabled = AsyncMock(return_value=(False, License.BASIC))
+    connector_index_mock.has_active_license_enabled = AsyncMock(
+        return_value=(False, License.BASIC)
+    )
 
     access_control_sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
     content_sync_job = mock_sync_job()
 
-    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([content_sync_job, access_control_sync_job])
+    sync_job_index_mock.pending_jobs.return_value = AsyncIterator(
+        [content_sync_job, access_control_sync_job]
+    )
     await create_and_run_service()
 
     # Access control sync job should not be executed (license insufficient)
@@ -363,7 +392,10 @@ async def test_access_control_job_execution_with_connector_still_syncing(
 ):
     content_syncs_tasks_mock, access_control_syncs_tasks_mock = concurrent_tasks_mocks
 
-    connector = mock_connector(job_type=JobType.ACCESS_CONTROL, last_access_control_sync_status=JobStatus.IN_PROGRESS)
+    connector = mock_connector(
+        job_type=JobType.ACCESS_CONTROL,
+        last_access_control_sync_status=JobStatus.IN_PROGRESS,
+    )
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
     sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
@@ -384,10 +416,15 @@ async def test_access_control_job_execution_with_insufficient_license(
 ):
     content_syncs_tasks_mock, access_control_syncs_tasks_mock = concurrent_tasks_mocks
 
-    connector = mock_connector(job_type=JobType.ACCESS_CONTROL, last_access_control_sync_status=JobStatus.COMPLETED)
+    connector = mock_connector(
+        job_type=JobType.ACCESS_CONTROL,
+        last_access_control_sync_status=JobStatus.COMPLETED,
+    )
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
-    connector_index_mock.has_active_license_enabled = AsyncMock(return_value=(False, License.BASIC))
+    connector_index_mock.has_active_license_enabled = AsyncMock(
+        return_value=(False, License.BASIC)
+    )
 
     sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
@@ -407,7 +444,11 @@ async def test_access_control_job_execution_with_dls_feature_flag_disabled(
 ):
     content_syncs_tasks_mock, access_control_syncs_tasks_mock = concurrent_tasks_mocks
 
-    connector = mock_connector(job_type=JobType.ACCESS_CONTROL, last_access_control_sync_status=JobStatus.IN_PROGRESS, document_level_security_enabled=False)
+    connector = mock_connector(
+        job_type=JobType.ACCESS_CONTROL,
+        last_access_control_sync_status=JobStatus.IN_PROGRESS,
+        document_level_security_enabled=False,
+    )
 
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
@@ -431,7 +472,9 @@ async def test_job_execution_with_unknown_job_type(
 ):
     content_syncs_tasks_mock, access_control_syncs_tasks_mock = concurrent_tasks_mocks
 
-    connector = mock_connector(job_type=JobType.UNSET, last_access_control_sync_status=JobStatus.IN_PROGRESS)
+    connector = mock_connector(
+        job_type=JobType.UNSET, last_access_control_sync_status=JobStatus.IN_PROGRESS
+    )
 
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
@@ -448,17 +491,29 @@ async def test_job_execution_with_unknown_job_type(
 def test_load_max_concurrent_content_syncs_from_config():
     max_concurrent_content_syncs = 3
 
-    assert load_max_concurrent_content_syncs({"max_concurrent_content_syncs": max_concurrent_content_syncs}) == max_concurrent_content_syncs
+    assert (
+        load_max_concurrent_content_syncs(
+            {"max_concurrent_content_syncs": max_concurrent_content_syncs}
+        )
+        == max_concurrent_content_syncs
+    )
 
 
 def test_load_max_concurrent_content_syncs_fallback_on_old_config_entry():
     max_concurrent_syncs = 3
 
-    assert load_max_concurrent_content_syncs(
-        {"max_concurrent_syncs": max_concurrent_syncs}) == max_concurrent_syncs
+    assert (
+        load_max_concurrent_content_syncs(
+            {"max_concurrent_syncs": max_concurrent_syncs}
+        )
+        == max_concurrent_syncs
+    )
 
 
-@patch("connectors.services.job_execution.DEFAULT_MAX_CONCURRENT_CONTENT_SYNCS", MAX_FIVE_CONCURRENT_SYNCS)
+@patch(
+    "connectors.services.job_execution.DEFAULT_MAX_CONCURRENT_CONTENT_SYNCS",
+    MAX_FIVE_CONCURRENT_SYNCS,
+)
 def test_load_max_concurrent_content_syncs_fallback_on_default():
     assert load_max_concurrent_content_syncs({}) == MAX_FIVE_CONCURRENT_SYNCS
 
@@ -466,10 +521,17 @@ def test_load_max_concurrent_content_syncs_fallback_on_default():
 def test_load_max_concurrent_access_control_syncs_from_config():
     max_concurrent_access_control_syncs = 3
 
-    assert load_max_concurrent_access_control_syncs({"max_concurrent_access_control_syncs": max_concurrent_access_control_syncs}) == max_concurrent_access_control_syncs
+    assert (
+        load_max_concurrent_access_control_syncs(
+            {"max_concurrent_access_control_syncs": max_concurrent_access_control_syncs}
+        )
+        == max_concurrent_access_control_syncs
+    )
 
 
-@patch("connectors.services.job_execution.DEFAULT_MAX_CONCURRENT_ACCESS_CONTROL_SYNCS", MAX_SIX_CONCURRENT_SYNCS)
+@patch(
+    "connectors.services.job_execution.DEFAULT_MAX_CONCURRENT_ACCESS_CONTROL_SYNCS",
+    MAX_SIX_CONCURRENT_SYNCS,
+)
 def test_load_max_concurrent_access_control_syncs_fallback_on_default():
     assert load_max_concurrent_access_control_syncs({}) == MAX_SIX_CONCURRENT_SYNCS
-

--- a/tests/sources/fixtures/sharepoint_online/fixture.py
+++ b/tests/sources/fixtures/sharepoint_online/fixture.py
@@ -15,329 +15,342 @@ from flask_limiter.util import get_remote_address
 
 app = Flask(__name__)
 
+
 @app.route("/<string:tenant_id>/oauth2/v2.0/token", methods=["POST"])
 def get_graph_token(tenant_id):
-    return {
-        "access_token": f"fake-graph-api-token-{tenant_id}",
-        "expires_in": 3699
-    }
+    return {"access_token": f"fake-graph-api-token-{tenant_id}", "expires_in": 3699}
+
 
 @app.route("/<string:tenant_id>/tokens/OAuth/2", methods=["POST"])
 def get_rest_token(tenant_id):
-    return {
-        "access_token": f"fake-rest-api-token-{tenant_id}",
-        "expires_in": 3699
-    }
+    return {"access_token": f"fake-rest-api-token-{tenant_id}", "expires_in": 3699}
+
 
 @app.route("/common/userrealm/", methods=["GET"])
 def get_tenant():
-    return {"NameSpaceType":"Managed","Login":"cj@something.onmicrosoft.com","DomainName":"something.onmicrosoft.com","FederationBrandName":"Elastic","TenantBrandingInfo":None,"cloud_instance_name":"microsoftonline.com"}
+    return {
+        "NameSpaceType": "Managed",
+        "Login": "cj@something.onmicrosoft.com",
+        "DomainName": "something.onmicrosoft.com",
+        "FederationBrandName": "Elastic",
+        "TenantBrandingInfo": None,
+        "cloud_instance_name": "microsoftonline.com",
+    }
 
 
 @app.route("/sites/", methods=["GET"])
 def get_site_collections():
     return {
-                '@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#sites(siteCollection,webUrl)',
-                'value': [
-                    {
-                        'webUrl': 'https://enterprisesearch.sharepoint.com/',
-                        'siteCollection': {
-                            'hostname': 'enterprisesearch.sharepoint.com',
-                            'root': {}
-                        }
-                    }
-                ]
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites(siteCollection,webUrl)",
+        "value": [
+            {
+                "webUrl": "https://enterprisesearch.sharepoint.com/",
+                "siteCollection": {
+                    "hostname": "enterprisesearch.sharepoint.com",
+                    "root": {},
+                },
             }
+        ],
+    }
+
 
 @app.route("/sites/<string:site_id>/sites", methods=["GET"])
 def get_sites(site_id):
     return {
-        "@odata.context":"https://graph.microsoft.com/v1.0/$metadata#sites",
-        "value":[
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites",
+        "value": [
             {
-                "createdDateTime":"2023-05-31T16:08:46Z",
-                "description":"It's a private one",
-                "id":"enterprisesearch.sharepoint.com,792c7c37-803b-47af-88c2-88d8707aab65,e6ead828-d7a5-4c72-b8e7-0687c6a078e7",
-                "lastModifiedDateTime":"2023-05-31T16:08:48Z",
-                "name":"PrivateSubsite",
-                "webUrl":"http://localhost:10337/sites/ArtemsSiteForTesting",
-                "displayName":"Private Subsite"
+                "createdDateTime": "2023-05-31T16:08:46Z",
+                "description": "It's a private one",
+                "id": "enterprisesearch.sharepoint.com,792c7c37-803b-47af-88c2-88d8707aab65,e6ead828-d7a5-4c72-b8e7-0687c6a078e7",
+                "lastModifiedDateTime": "2023-05-31T16:08:48Z",
+                "name": "PrivateSubsite",
+                "webUrl": "http://localhost:10337/sites/ArtemsSiteForTesting",
+                "displayName": "Private Subsite",
             }
-        ]
+        ],
     }
+
 
 @app.route("/sites/<string:site_id>/drives", methods=["GET"])
 def get_site_drives(site_id):
     return {
-            '@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#drives',
-            'value': [
-                {
-                    'createdDateTime': '2023-05-31T16:08:47Z',
-                    'description': '',
-                    'id': 'b!N3wseTuAr0eIwojYcHqrZSjY6ual13JMuOcGh8ageOexVaqPcFq1R7TWeUCQv6dv',
-                    'lastModifiedDateTime': '2023-05-31T16:08:47Z',
-                    'name': 'Documents',
-                    'webUrl': 'http://localhost:10337/sites/ArtemsSiteForTesting/Shared Documents',
-                    'driveType': 'documentLibrary',
-                    'createdBy': {
-                        'user': {
-                            'email': 'demo@enterprisesearch.onmicrosoft.com', 
-                            'id': 'baa37bda-0dd1-4799-ae22-f3476c2cf58d',
-                            'displayName': 'Enterprise Search'
-                            }
-                        },
-                    'owner': {
-                        'user': {
-                            'email': 'demo@enterprisesearch.onmicrosoft.com',
-                            'id': 'baa37bda-0dd1-4799-ae22-f3476c2cf58d',
-                            'displayName': 'Enterprise Search'
-                            }
-                        }, 
-                    'quota': {
-                        'deleted': 79501, 
-                        'remaining': 27487790614899,
-                        'state': 'normal', 
-                        'total': 27487790694400, 
-                        'used': 0
-                        }
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#drives",
+        "value": [
+            {
+                "createdDateTime": "2023-05-31T16:08:47Z",
+                "description": "",
+                "id": "b!N3wseTuAr0eIwojYcHqrZSjY6ual13JMuOcGh8ageOexVaqPcFq1R7TWeUCQv6dv",
+                "lastModifiedDateTime": "2023-05-31T16:08:47Z",
+                "name": "Documents",
+                "webUrl": "http://localhost:10337/sites/ArtemsSiteForTesting/Shared Documents",
+                "driveType": "documentLibrary",
+                "createdBy": {
+                    "user": {
+                        "email": "demo@enterprisesearch.onmicrosoft.com",
+                        "id": "baa37bda-0dd1-4799-ae22-f3476c2cf58d",
+                        "displayName": "Enterprise Search",
                     }
-                ]
+                },
+                "owner": {
+                    "user": {
+                        "email": "demo@enterprisesearch.onmicrosoft.com",
+                        "id": "baa37bda-0dd1-4799-ae22-f3476c2cf58d",
+                        "displayName": "Enterprise Search",
+                    }
+                },
+                "quota": {
+                    "deleted": 79501,
+                    "remaining": 27487790614899,
+                    "state": "normal",
+                    "total": 27487790694400,
+                    "used": 0,
+                },
             }
+        ],
+    }
+
 
 @app.route("/drives/<string:drive_id>/root", methods=["GET"])
 def get_drive_root(drive_id):
     return {
-            '@odata.context': f"https://graph.microsoft.com/v1.0/$metadata#drives('{drive_id}')/root/$entity", 
-            'createdDateTime': '2023-05-21T05:23:51Z', 
-            'id': '01WDQZWT56Y2GOVW7725BZO354PWSELRRZ', 
-            'lastModifiedDateTime': '2023-05-21T05:23:51Z', 
-            'name': 'root', 
-            'webUrl': 'http://localhost:10337/sites/PrivateSpace/Shared Documents', 
-            'size': 0, 
-            'parentReference': {
-                'driveType': 'documentLibrary', 
-                'driveId': drive_id
-            }, 
-            'fileSystemInfo': {
-                'createdDateTime': '2023-05-21T05:23:51Z', 
-                'lastModifiedDateTime': '2023-05-21T05:23:51Z'
-            }, 
-            'folder': {
-                'childCount': 0
-            }, 
-            'root': {}
-        }
+        "@odata.context": f"https://graph.microsoft.com/v1.0/$metadata#drives('{drive_id}')/root/$entity",
+        "createdDateTime": "2023-05-21T05:23:51Z",
+        "id": "01WDQZWT56Y2GOVW7725BZO354PWSELRRZ",
+        "lastModifiedDateTime": "2023-05-21T05:23:51Z",
+        "name": "root",
+        "webUrl": "http://localhost:10337/sites/PrivateSpace/Shared Documents",
+        "size": 0,
+        "parentReference": {"driveType": "documentLibrary", "driveId": drive_id},
+        "fileSystemInfo": {
+            "createdDateTime": "2023-05-21T05:23:51Z",
+            "lastModifiedDateTime": "2023-05-21T05:23:51Z",
+        },
+        "folder": {"childCount": 0},
+        "root": {},
+    }
 
-@app.route("/drives/<string:drive_id>/items/<string:drive_item_id>/children", methods=["GET"])
+
+@app.route(
+    "/drives/<string:drive_id>/items/<string:drive_item_id>/children", methods=["GET"]
+)
 def get_drive_item_children(drive_id, drive_item_id):
     return {
-            '@odata.context': f"https://graph.microsoft.com/v1.0/$metadata#drives('{drive_id}')/items('{drive_item_id}')/children",
-            'value': []
-        }
+        "@odata.context": f"https://graph.microsoft.com/v1.0/$metadata#drives('{drive_id}')/items('{drive_item_id}')/children",
+        "value": [],
+    }
+
 
 @app.route("/sites/<string:site_id>/lists", methods=["GET"])
 def get_site_lists(site_id):
     return {
-            '@odata.context': "https://graph.microsoft.com/v1.0/$metadata#sites('enterprisesearch.sharepoint.com%2C792c7c37-803b-47af-88c2-88d8707aab65%2Ce6ead828-d7a5-4c72-b8e7-0687c6a078e7')/lists",
-            'value': [
-                {
-                    '@odata.etag': '"8faa55b1-5a70-47b5-b4d6-794090bfa76f,1"',
-                    'createdDateTime': '2023-05-31T16:08:47Z',
-                    'description': '',
-                    'eTag': '"8faa55b1-5a70-47b5-b4d6-794090bfa76f,1"',
-                    'id': '8faa55b1-5a70-47b5-b4d6-794090bfa76f',
-                    'lastModifiedDateTime': '2023-05-31T16:08:48Z',
-                    'name': 'Shared Documents',
-                    'webUrl': 'http://localhost:10337/sites/PrivateSubsite/Shared Documents',
-                    'displayName': 'Documents',
-                    'createdBy': {
-                        'user': {
-                            'email': 'demo@enterprisesearch.onmicrosoft.com',
-                            'id': 'baa37bda-0dd1-4799-ae22-f3476c2cf58d',
-                            'displayName': 'Enterprise Search'
-                        }
-                    }, 
-                    'parentReference': {
-                        'siteId': 'enterprisesearch.sharepoint.com,792c7c37-803b-47af-88c2-88d8707aab65,e6ead828-d7a5-4c72-b8e7-0687c6a078e7'
-                    },
-                    'list': {
-                        'contentTypesEnabled': False,
-                        'hidden': False,
-                        'template': 'documentLibrary'
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('enterprisesearch.sharepoint.com%2C792c7c37-803b-47af-88c2-88d8707aab65%2Ce6ead828-d7a5-4c72-b8e7-0687c6a078e7')/lists",
+        "value": [
+            {
+                "@odata.etag": '"8faa55b1-5a70-47b5-b4d6-794090bfa76f,1"',
+                "createdDateTime": "2023-05-31T16:08:47Z",
+                "description": "",
+                "eTag": '"8faa55b1-5a70-47b5-b4d6-794090bfa76f,1"',
+                "id": "8faa55b1-5a70-47b5-b4d6-794090bfa76f",
+                "lastModifiedDateTime": "2023-05-31T16:08:48Z",
+                "name": "Shared Documents",
+                "webUrl": "http://localhost:10337/sites/PrivateSubsite/Shared Documents",
+                "displayName": "Documents",
+                "createdBy": {
+                    "user": {
+                        "email": "demo@enterprisesearch.onmicrosoft.com",
+                        "id": "baa37bda-0dd1-4799-ae22-f3476c2cf58d",
+                        "displayName": "Enterprise Search",
                     }
-                }
-            ]
-        }
+                },
+                "parentReference": {
+                    "siteId": "enterprisesearch.sharepoint.com,792c7c37-803b-47af-88c2-88d8707aab65,e6ead828-d7a5-4c72-b8e7-0687c6a078e7"
+                },
+                "list": {
+                    "contentTypesEnabled": False,
+                    "hidden": False,
+                    "template": "documentLibrary",
+                },
+            }
+        ],
+    }
+
 
 @app.route("/sites/<string:site_id>/lists/<string:list_id>/items", methods=["GET"])
 def get_site_list_items(site_id, list_id):
     return {
-            '@odata.context': "https://graph.microsoft.com/v1.0/$metadata#sites('enterprisesearch.sharepoint.com%2C792c7c37-803b-47af-88c2-88d8707aab65%2C84b8c2b1-3d4a-46f7-93d6-d2c6c4e9523a')/lists('a3f3ce79-e34d-4c03-8f10-e1399e661a65')/items(fields())",
-            'value': [
-                {
-                    '@odata.etag': '"35aef603-c870-4326-91c3-ffdf59c29677,2"',
-                    'createdDateTime': '2023-06-06T12:44:01Z',
-                    'eTag': '"35aef603-c870-4326-91c3-ffdf59c29677,2"',
-                    'id': '1', 
-                    'lastModifiedDateTime': '2023-06-06T12:44:01Z',
-                    'webUrl': 'http://localhost:10337/sites/ArtemsSiteForTesting/Lists/asldlasdla/1_.000',
-                    'createdBy': {
-                        'user': {
-                            'email': 'demo@enterprisesearch.onmicrosoft.com', 
-                            'id': 'baa37bda-0dd1-4799-ae22-f3476c2cf58d', 
-                            'displayName': 'Enterprise Search'
-                        }
-                    }, 
-                    'lastModifiedBy': {
-                        'user': {
-                            'email': 'demo@enterprisesearch.onmicrosoft.com', 
-                            'id': 'baa37bda-0dd1-4799-ae22-f3476c2cf58d', 
-                            'displayName': 'Enterprise Search'}
-                    }, 
-                    'parentReference': {
-                        'id': 'c3429aae-3cd4-4ba8-a831-c575f8a65aa2', 
-                        'siteId': 'enterprisesearch.sharepoint.com,792c7c37-803b-47af-88c2-88d8707aab65,84b8c2b1-3d4a-46f7-93d6-d2c6c4e9523a'
-                    }, 
-                    'contentType': {
-                        'id': '0x0100B239ACAA35349546A923BB0F799FAD6E00C2E8F4FE62D4BC44AD1071D5AA4DE0B9', 
-                        'name': 'Item'
-                    }, 
-                    'fields@odata.context': "https://graph.microsoft.com/v1.0/$metadata#sites('enterprisesearch.sharepoint.com%2C792c7c37-803b-47af-88c2-88d8707aab65%2C84b8c2b1-3d4a-46f7-93d6-d2c6c4e9523a')/lists('a3f3ce79-e34d-4c03-8f10-e1399e661a65')/items('1')/fields/$entity",
-                    'fields': {
-                        '@odata.etag': '"35aef603-c870-4326-91c3-ffdf59c29677,2"', 
-                        'Title': 'Hello world',
-                        'LinkTitle': 'Hello world', 
-                        'id': '1', 
-                        'ContentType': 'Item', 
-                        'Modified': '2023-06-06T12:44:01Z', 
-                        'Created': '2023-06-06T12:44:01Z', 
-                        'AuthorLookupId': '6', 
-                        'EditorLookupId': '6', 
-                        '_UIVersionString': '2.0', 
-                        'Attachments': True, 
-                        'Edit': '', 
-                        'LinkTitleNoMenu': 'Hello world', 
-                        'ItemChildCount': '0', 
-                        'FolderChildCount': '0', 
-                        '_ComplianceFlags': '', 
-                        '_ComplianceTag': '', 
-                        '_ComplianceTagWrittenTime': '', 
-                        '_ComplianceTagUserId': ''
-                        }
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('enterprisesearch.sharepoint.com%2C792c7c37-803b-47af-88c2-88d8707aab65%2C84b8c2b1-3d4a-46f7-93d6-d2c6c4e9523a')/lists('a3f3ce79-e34d-4c03-8f10-e1399e661a65')/items(fields())",
+        "value": [
+            {
+                "@odata.etag": '"35aef603-c870-4326-91c3-ffdf59c29677,2"',
+                "createdDateTime": "2023-06-06T12:44:01Z",
+                "eTag": '"35aef603-c870-4326-91c3-ffdf59c29677,2"',
+                "id": "1",
+                "lastModifiedDateTime": "2023-06-06T12:44:01Z",
+                "webUrl": "http://localhost:10337/sites/ArtemsSiteForTesting/Lists/asldlasdla/1_.000",
+                "createdBy": {
+                    "user": {
+                        "email": "demo@enterprisesearch.onmicrosoft.com",
+                        "id": "baa37bda-0dd1-4799-ae22-f3476c2cf58d",
+                        "displayName": "Enterprise Search",
                     }
-                ]
+                },
+                "lastModifiedBy": {
+                    "user": {
+                        "email": "demo@enterprisesearch.onmicrosoft.com",
+                        "id": "baa37bda-0dd1-4799-ae22-f3476c2cf58d",
+                        "displayName": "Enterprise Search",
+                    }
+                },
+                "parentReference": {
+                    "id": "c3429aae-3cd4-4ba8-a831-c575f8a65aa2",
+                    "siteId": "enterprisesearch.sharepoint.com,792c7c37-803b-47af-88c2-88d8707aab65,84b8c2b1-3d4a-46f7-93d6-d2c6c4e9523a",
+                },
+                "contentType": {
+                    "id": "0x0100B239ACAA35349546A923BB0F799FAD6E00C2E8F4FE62D4BC44AD1071D5AA4DE0B9",
+                    "name": "Item",
+                },
+                "fields@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('enterprisesearch.sharepoint.com%2C792c7c37-803b-47af-88c2-88d8707aab65%2C84b8c2b1-3d4a-46f7-93d6-d2c6c4e9523a')/lists('a3f3ce79-e34d-4c03-8f10-e1399e661a65')/items('1')/fields/$entity",
+                "fields": {
+                    "@odata.etag": '"35aef603-c870-4326-91c3-ffdf59c29677,2"',
+                    "Title": "Hello world",
+                    "LinkTitle": "Hello world",
+                    "id": "1",
+                    "ContentType": "Item",
+                    "Modified": "2023-06-06T12:44:01Z",
+                    "Created": "2023-06-06T12:44:01Z",
+                    "AuthorLookupId": "6",
+                    "EditorLookupId": "6",
+                    "_UIVersionString": "2.0",
+                    "Attachments": True,
+                    "Edit": "",
+                    "LinkTitleNoMenu": "Hello world",
+                    "ItemChildCount": "0",
+                    "FolderChildCount": "0",
+                    "_ComplianceFlags": "",
+                    "_ComplianceTag": "",
+                    "_ComplianceTagWrittenTime": "",
+                    "_ComplianceTagUserId": "",
+                },
             }
+        ],
+    }
 
-@app.route("/sites/<string:site_name>/_api/lists/GetByTitle('<string:list_title>')/items(<string:list_item_id>)")
+
+@app.route(
+    "/sites/<string:site_name>/_api/lists/GetByTitle('<string:list_title>')/items(<string:list_item_id>)"
+)
 def get_list_item_attachments(site_name, list_title, list_item_id):
-    expand = request.args.get(escape('$expand'))
+    expand = request.args.get(escape("$expand"))
     if expand and "AttachmentFiles" in expand:
         return {
-                'odata.metadata': "https://enterprisesearch.sharepoint.com/sites/Artem'sSiteForTesting/_api/$metadata#SP.ListData.Custom_x0020_Made_x0020_ListListItems/@Element",
-                'odata.type': 'SP.Data.Custom_x0020_Made_x0020_ListListItem',
-                'odata.id': '5484fa3e-6288-4be6-9155-5355bde6a6fc',
-                'odata.etag': '"3"',
-                'odata.editLink': "Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)",
-                'AttachmentFiles@odata.navigationLinkUrl': "Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles",
-                'AttachmentFiles': [
-                    {
-                        'odata.type': 'SP.Attachment',
-                        'odata.id': "http://localhost:10337/sites/Artem'sSiteForTesting/_api/Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles('pride-and-prejudice-145.txt')", 
-                        'odata.editLink': "Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles('pride-and-prejudice-145.txt')", 
-                        'FileName': 'pride-and-prejudice-145.txt', 
-                        'FileNameAsPath': {
-                            'DecodedUrl': 'pride-and-prejudice-145.txt'
-                        },
-                        'ServerRelativePath': {
-                            'DecodedUrl': "/sites/Artem'sSiteForTesting/Lists/Custom Made List/Attachments/1/pride-and-prejudice-145.txt"
-                        }, 
-                        'ServerRelativeUrl': "/sites/Artem'sSiteForTesting/Lists/Custom Made List/Attachments/1/pride-and-prejudice-145.txt"
-                    }, 
-                    {
-                        'odata.type': 'SP.Attachment', 
-                        'odata.id': "http://localhost:10337/sites/Artem'sSiteForTesting/_api/Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles('txt.log')",
-                        'odata.editLink': "Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles('txt.log')",
-                        'FileName': 'txt.log',
-                        'FileNameAsPath': {
-                            'DecodedUrl': 'txt.log'
-                        },
-                        'ServerRelativePath': {
-                            'DecodedUrl': "/sites/Artem'sSiteForTesting/Lists/Custom Made List/Attachments/1/txt.log"
-                        },
-                        'ServerRelativeUrl': "/sites/Artem'sSiteForTesting/Lists/Custom Made List/Attachments/1/txt.log"
-                    }
-                ],
-                'FileSystemObjectType': 0,
-                'Id': 1,
-                'ServerRedirectedEmbedUri': None,
-                'ServerRedirectedEmbedUrl': '',
-                'ContentTypeId': '0x01008A3E09918C44C042809E94957AE584ED0047CD5B88506EC84B8B4A0D415BC12E3D',
-                'Title': 'File with attachment',
-                'OData__ColorTag': None,
-                'ComplianceAssetId': None,
-                'ID': 1,
-                'Modified': '2023-05-25T14:59:06Z',
-                'Created': '2023-05-25T14:58:42Z',
-                'AuthorId': 6,
-                'EditorId': 6,
-                'OData__UIVersionString': '3.0',
-                'Attachments': True,
-                'GUID': '79db5b37-4672-4826-abfe-8dc847d8baa7'
+            "odata.metadata": "https://enterprisesearch.sharepoint.com/sites/Artem'sSiteForTesting/_api/$metadata#SP.ListData.Custom_x0020_Made_x0020_ListListItems/@Element",
+            "odata.type": "SP.Data.Custom_x0020_Made_x0020_ListListItem",
+            "odata.id": "5484fa3e-6288-4be6-9155-5355bde6a6fc",
+            "odata.etag": '"3"',
+            "odata.editLink": "Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)",
+            "AttachmentFiles@odata.navigationLinkUrl": "Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles",
+            "AttachmentFiles": [
+                {
+                    "odata.type": "SP.Attachment",
+                    "odata.id": "http://localhost:10337/sites/Artem'sSiteForTesting/_api/Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles('pride-and-prejudice-145.txt')",
+                    "odata.editLink": "Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles('pride-and-prejudice-145.txt')",
+                    "FileName": "pride-and-prejudice-145.txt",
+                    "FileNameAsPath": {"DecodedUrl": "pride-and-prejudice-145.txt"},
+                    "ServerRelativePath": {
+                        "DecodedUrl": "/sites/Artem'sSiteForTesting/Lists/Custom Made List/Attachments/1/pride-and-prejudice-145.txt"
+                    },
+                    "ServerRelativeUrl": "/sites/Artem'sSiteForTesting/Lists/Custom Made List/Attachments/1/pride-and-prejudice-145.txt",
+                },
+                {
+                    "odata.type": "SP.Attachment",
+                    "odata.id": "http://localhost:10337/sites/Artem'sSiteForTesting/_api/Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles('txt.log')",
+                    "odata.editLink": "Web/Lists(guid'b84d6e6b-5123-47c4-831d-ab6192fdb88e')/Items(1)/AttachmentFiles('txt.log')",
+                    "FileName": "txt.log",
+                    "FileNameAsPath": {"DecodedUrl": "txt.log"},
+                    "ServerRelativePath": {
+                        "DecodedUrl": "/sites/Artem'sSiteForTesting/Lists/Custom Made List/Attachments/1/txt.log"
+                    },
+                    "ServerRelativeUrl": "/sites/Artem'sSiteForTesting/Lists/Custom Made List/Attachments/1/txt.log",
+                },
+            ],
+            "FileSystemObjectType": 0,
+            "Id": 1,
+            "ServerRedirectedEmbedUri": None,
+            "ServerRedirectedEmbedUrl": "",
+            "ContentTypeId": "0x01008A3E09918C44C042809E94957AE584ED0047CD5B88506EC84B8B4A0D415BC12E3D",
+            "Title": "File with attachment",
+            "OData__ColorTag": None,
+            "ComplianceAssetId": None,
+            "ID": 1,
+            "Modified": "2023-05-25T14:59:06Z",
+            "Created": "2023-05-25T14:58:42Z",
+            "AuthorId": 6,
+            "EditorId": 6,
+            "OData__UIVersionString": "3.0",
+            "Attachments": True,
+            "GUID": "79db5b37-4672-4826-abfe-8dc847d8baa7",
         }
     else:
         raise Exception("Nope")
 
+
 @app.route("/sites/<string:site_name>/_api/web/lists/GetByTitle('Site Pages')/items")
 def get_list_item_pages(site_name):
-       return {
-           'odata.metadata': "https://enterprisesearch.sharepoint.com/sites/ArtemsSiteForTesting/_api/$metadata#SP.ListData.SitePagesItems",
-           'value': [
-               {
-                   'odata.type': 'SP.Data.SitePagesItem',
-                   'odata.id': 'c1393c35-8dd0-4440-9563-ac8e4d277227',
-                   'odata.etag': '"3"',
-                   'odata.editLink': "Web/Lists(guid'0deb180c-9812-4ec6-b652-cd80214bb257')/Items(1)",
-                   'FileSystemObjectType': 0,
-                   'Id': 1,
-                   'ServerRedirectedEmbedUri': None,
-                   'ServerRedirectedEmbedUrl': '',
-                   'ContentTypeId': '0x0101009D1CB255DA76424F860D91F20E6C411800534CF5870D924347B78CC6E21791F9E2',
-                   'OData__ColorTag': None,
-                   'ComplianceAssetId': None,
-                   'WikiField': None,
-                   'Title': 'Home',
-                   'CanvasContent1': None,
-                   'BannerImageUrl': None,
-                   'Description': None,
-                   'PromotedState': 0.0,
-                   'FirstPublishedDate': None,
-                   'LayoutWebpartsContent': None,
-                   'OData__AuthorBylineId': None,
-                   '_AuthorBylineStringId': None,
-                   'OData__TopicHeader': None,
-                   'OData__SPSitePageFlags': None,
-                   'OData__SPCallToAction': None,
-                   'OData__OriginalSourceUrl': None,
-                   'OData__OriginalSourceSiteId': None,
-                   'OData__OriginalSourceWebId': None,
-                   'OData__OriginalSourceListId': None,
-                   'OData__OriginalSourceItemId': None,
-                   'ID': 1,
-                   'Created': '2023-05-31T16:08:48Z',
-                   'AuthorId': 6,
-                   'Modified': '2023-05-31T16:08:48Z',
-                   'EditorId': 6,
-                   'OData__CopySource': None,
-                   'CheckoutUserId': None,
-                   'OData__UIVersionString': '1.0',
-                   'GUID': 'ed7424f3-23d0-4c4a-926a-def0f36c7e4a'
-                   }
-               ]
-           }
+    return {
+        "odata.metadata": "https://enterprisesearch.sharepoint.com/sites/ArtemsSiteForTesting/_api/$metadata#SP.ListData.SitePagesItems",
+        "value": [
+            {
+                "odata.type": "SP.Data.SitePagesItem",
+                "odata.id": "c1393c35-8dd0-4440-9563-ac8e4d277227",
+                "odata.etag": '"3"',
+                "odata.editLink": "Web/Lists(guid'0deb180c-9812-4ec6-b652-cd80214bb257')/Items(1)",
+                "FileSystemObjectType": 0,
+                "Id": 1,
+                "ServerRedirectedEmbedUri": None,
+                "ServerRedirectedEmbedUrl": "",
+                "ContentTypeId": "0x0101009D1CB255DA76424F860D91F20E6C411800534CF5870D924347B78CC6E21791F9E2",
+                "OData__ColorTag": None,
+                "ComplianceAssetId": None,
+                "WikiField": None,
+                "Title": "Home",
+                "CanvasContent1": None,
+                "BannerImageUrl": None,
+                "Description": None,
+                "PromotedState": 0.0,
+                "FirstPublishedDate": None,
+                "LayoutWebpartsContent": None,
+                "OData__AuthorBylineId": None,
+                "_AuthorBylineStringId": None,
+                "OData__TopicHeader": None,
+                "OData__SPSitePageFlags": None,
+                "OData__SPCallToAction": None,
+                "OData__OriginalSourceUrl": None,
+                "OData__OriginalSourceSiteId": None,
+                "OData__OriginalSourceWebId": None,
+                "OData__OriginalSourceListId": None,
+                "OData__OriginalSourceItemId": None,
+                "ID": 1,
+                "Created": "2023-05-31T16:08:48Z",
+                "AuthorId": 6,
+                "Modified": "2023-05-31T16:08:48Z",
+                "EditorId": 6,
+                "OData__CopySource": None,
+                "CheckoutUserId": None,
+                "OData__UIVersionString": "1.0",
+                "GUID": "ed7424f3-23d0-4c4a-926a-def0f36c7e4a",
+            }
+        ],
+    }
 
-@app.route("/sites/<string:site_name>/_api/Web/Lists(guid'<string:list_id>')/Items(<string:list_item_id>)/AttachmentFiles('<string:file_name>')/$value", methods=["GET"])
+
+@app.route(
+    "/sites/<string:site_name>/_api/Web/Lists(guid'<string:list_id>')/Items(<string:list_item_id>)/AttachmentFiles('<string:file_name>')/$value",
+    methods=["GET"],
+)
 def get_list_item_attachment(site_name, list_id, list_item_id, file_name):
     return b"lalala lalala this is some content"
+
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=10337)

--- a/tests/sources/fixtures/sharepoint_online/fixture.py
+++ b/tests/sources/fixtures/sharepoint_online/fixture.py
@@ -5,13 +5,7 @@
 #
 """Module to handle api calls received from connector."""
 
-import io
-import os
-import random
-import string
-
-from flask import Flask, escape, request, send_file
-from flask_limiter.util import get_remote_address
+from flask import Flask, escape, request
 
 app = Flask(__name__)
 

--- a/tests/sources/test_generic_database.py
+++ b/tests/sources/test_generic_database.py
@@ -138,8 +138,8 @@ async def test_validate_config_valid_fields():
     # Execute
     try:
         await source.validate_config()
-    except ConfigurableFieldValueError:
-        raise AssertionError("Method raised an exception")
+    except ConfigurableFieldValueError as e:
+        raise AssertionError("Method raised an exception") from e
 
 
 @pytest.mark.parametrize(

--- a/tests/sources/test_google_cloud_storage.py
+++ b/tests/sources/test_google_cloud_storage.py
@@ -29,8 +29,7 @@ def get_gcs_source_object():
         GoogleCloudStorageDataSource: Mocked object of the data source class.
     """
     configuration = DataSourceConfiguration(
-        {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS,
-         "retry_count": 0}
+        {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS, "retry_count": 0}
     )
     mocked_gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
     return mocked_gcs_object

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -150,7 +150,7 @@ def build_resp():
 async def test_get_docs(*args):
     source = create_connector()
     num = 0
-    async for (doc, dl) in source.get_docs():
+    async for (doc, _) in source.get_docs():
         assert doc["id"] in ("one", "two")
         num += 1
 

--- a/tests/sources/test_s3.py
+++ b/tests/sources/test_s3.py
@@ -313,7 +313,7 @@ async def test_get_docs(mock_aws):
     ):
         num = 0
         # Execute
-        async for (doc, dl) in source.get_docs():
+        async for (doc, _) in source.get_docs():
             # Assert
             assert doc["_id"] in (
                 "d0295955cdb6d488a4a1d3f10dbf141b",

--- a/tests/sources/test_sharepoint.py
+++ b/tests/sources/test_sharepoint.py
@@ -1135,11 +1135,7 @@ async def test_get_site_pages_content_when_canvascontent_is_none():
 @pytest.mark.asyncio
 async def test_get_site_page_for_online():
     source = create_source(SharepointDataSource)
-    site_page_response = {"value":[
-        {
-            "CanvasContent1": "<div>dummy test</div>"
-        }
-    ]}
+    site_page_response = {"value": [{"CanvasContent1": "<div>dummy test</div>"}]}
     source.sharepoint_client._api_call = Mock(
         return_value=async_native_coroutine_generator(site_page_response)
     )

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -5,21 +5,17 @@
 #
 import asyncio
 import base64
-import json
 import re
 from datetime import datetime, timedelta, timezone
 from functools import partial
-from unittest import mock
-from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
 import pytest_asyncio
-from aiohttp import StreamReader
 from aiohttp.client_exceptions import ClientResponseError
 from aioresponses import aioresponses
 
-from connectors.source import DataSourceConfiguration
 from connectors.sources.sharepoint_online import (
     WILDCARD,
     GraphAPIToken,
@@ -30,7 +26,6 @@ from connectors.sources.sharepoint_online import (
     SharepointOnlineAdvancedRulesValidator,
     SharepointOnlineClient,
     SharepointOnlineDataSource,
-    SharepointRestAPIToken,
     TokenFetchFailed,
 )
 from tests.commons import AsyncIterator
@@ -511,7 +506,7 @@ class TestSharepointOnlineClient:
         list_item_id = "1"
 
         with pytest.raises(InvalidSharepointTenant) as e:
-            async for attachment in client.site_list_item_attachments(
+            async for _ in client.site_list_item_attachments(
                 site_web_url, list_title, list_item_id
             ):
                 pass
@@ -574,7 +569,7 @@ class TestSharepointOnlineClient:
         page_url_path = f"https://{invalid_tenant_name}.sharepoint.com/random/totally/made/up/page.aspx"
 
         with pytest.raises(InvalidSharepointTenant) as e:
-            async for attachment in client.site_pages(page_url_path):
+            async for _ in client.site_pages(page_url_path):
                 pass
 
         # Assert error message contains both invalid and valid tenant name

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -635,7 +635,13 @@ class TestSharepointOnlineDataSource:
 
     @property
     def sites(self):
-        return [{"id": "1", "webUrl": "https://test.sharepoint.com/site-1", "name": "site-1"}]
+        return [
+            {
+                "id": "1",
+                "webUrl": "https://test.sharepoint.com/site-1",
+                "name": "site-1",
+            }
+        ]
 
     @property
     def site_drives(self):
@@ -655,18 +661,30 @@ class TestSharepointOnlineDataSource:
     @property
     def site_list_items(self):
         return [
-            {"id": "6", "contentType": {"name": "Item"}, "fields": {"Attachments": ""}, "lastModifiedDateTime": self.month_ago},
+            {
+                "id": "6",
+                "contentType": {"name": "Item"},
+                "fields": {"Attachments": ""},
+                "lastModifiedDateTime": self.month_ago,
+            },
             {
                 "id": "7",
                 "contentType": {"name": "Web Template Extensions"},
-                "fields": {}
+                "fields": {},
             },  # Will be ignored!!!
-            {"id": "8", "contentType": {"name": "Something without attachments"}, "fields": {}},
+            {
+                "id": "8",
+                "contentType": {"name": "Something without attachments"},
+                "fields": {},
+            },
         ]
 
     @property
     def site_list_item_attachments(self):
-        return [{"odata.id": "9", "name": "attachment 1.txt"}, { "odata.id": "10", "name": "attachment 2.txt"}]
+        return [
+            {"odata.id": "9", "name": "attachment 1.txt"},
+            {"odata.id": "10", "name": "attachment 2.txt"},
+        ]
 
     @property
     def site_pages(self):
@@ -682,14 +700,15 @@ class TestSharepointOnlineDataSource:
 
     @property
     def valid_tenant(self):
-        return { "NameSpaceType": "VALID" }
+        return {"NameSpaceType": "VALID"}
 
     @pytest_asyncio.fixture
     async def patch_sharepoint_client(self):
         client = AsyncMock()
 
         with patch(
-            'connectors.sources.sharepoint_online.SharepointOnlineClient', return_value=AsyncMock()
+            "connectors.sources.sharepoint_online.SharepointOnlineClient",
+            return_value=AsyncMock(),
         ) as new_mock:
             client = new_mock.return_value
             client.site_collections = AsyncIterator(self.site_collections)
@@ -698,7 +717,9 @@ class TestSharepointOnlineDataSource:
             client.drive_items = AsyncIterator(self.drive_items)
             client.site_lists = AsyncIterator(self.site_lists)
             client.site_list_items = AsyncIterator(self.site_list_items)
-            client.site_list_item_attachments = AsyncIterator(self.site_list_item_attachments)
+            client.site_list_item_attachments = AsyncIterator(
+                self.site_list_item_attachments
+            )
             client.site_pages = AsyncIterator(self.site_pages)
 
             client.graph_api_token = AsyncMock()
@@ -706,7 +727,7 @@ class TestSharepointOnlineDataSource:
             client.rest_api_token = AsyncMock()
             client.rest_api_token.get.return_value = self.rest_api_token
 
-            client.tenant_details=AsyncMock(return_value = self.valid_tenant)
+            client.tenant_details = AsyncMock(return_value=self.valid_tenant)
 
             yield client
 
@@ -723,14 +744,31 @@ class TestSharepointOnlineDataSource:
                 downloads.append(download_func)
 
         assert len(results) == 11
-        assert len([i for i in results if i["object_type"] == "site_collection"]) == len(self.site_collections)
-        assert len([i for i in results if i["object_type"] == "site"]) == len(self.sites)
-        assert len([i for i in results if i["object_type"] == "site_drive"]) == len(self.site_drives)
-        assert len([i for i in results if i["object_type"] == "drive_item"]) == len(self.drive_items)
-        assert len([i for i in results if i["object_type"] == "site_list"]) == len(self.site_lists)
-        assert len([i for i in results if i["object_type"] == "list_item"]) == len(self.site_list_items) - 1 # -1 because one of them is ignored!
-        assert len([i for i in results if i["object_type"] == "list_item_attachment"]) == len(self.site_list_item_attachments)
-        assert len([i for i in results if i["object_type"] == "site_page"]) == len(self.site_pages)
+        assert len(
+            [i for i in results if i["object_type"] == "site_collection"]
+        ) == len(self.site_collections)
+        assert len([i for i in results if i["object_type"] == "site"]) == len(
+            self.sites
+        )
+        assert len([i for i in results if i["object_type"] == "site_drive"]) == len(
+            self.site_drives
+        )
+        assert len([i for i in results if i["object_type"] == "drive_item"]) == len(
+            self.drive_items
+        )
+        assert len([i for i in results if i["object_type"] == "site_list"]) == len(
+            self.site_lists
+        )
+        assert (
+            len([i for i in results if i["object_type"] == "list_item"])
+            == len(self.site_list_items) - 1
+        )  # -1 because one of them is ignored!
+        assert len(
+            [i for i in results if i["object_type"] == "list_item_attachment"]
+        ) == len(self.site_list_item_attachments)
+        assert len([i for i in results if i["object_type"] == "site_page"]) == len(
+            self.site_pages
+        )
 
     def test_get_default_configuration(self):
         config = SharepointOnlineDataSource.get_default_configuration()
@@ -738,7 +776,7 @@ class TestSharepointOnlineDataSource:
         assert config is not None
 
     @pytest.mark.asyncio
-    async def test_validate_config(self, patch_sharepoint_client):      
+    async def test_validate_config(self, patch_sharepoint_client):
         source = create_source(SharepointOnlineDataSource, site_collections=WILDCARD)
 
         await source.validate_config()
@@ -750,24 +788,34 @@ class TestSharepointOnlineDataSource:
         patch_sharepoint_client.rest_api_token.get.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_validate_config_when_invalid_tenant(self, patch_sharepoint_client):      
+    async def test_validate_config_when_invalid_tenant(self, patch_sharepoint_client):
         invalid_tenant_name = "wat"
 
-        source = create_source(SharepointOnlineDataSource, tenant_name=invalid_tenant_name, site_collections=WILDCARD)
-        patch_sharepoint_client.tenant_details.return_value = {"NameSpaceType": "Unknown"}
+        source = create_source(
+            SharepointOnlineDataSource,
+            tenant_name=invalid_tenant_name,
+            site_collections=WILDCARD,
+        )
+        patch_sharepoint_client.tenant_details.return_value = {
+            "NameSpaceType": "Unknown"
+        }
 
         with pytest.raises(Exception) as e:
             await source.validate_config()
 
         assert e.match(invalid_tenant_name)
 
-
     @pytest.mark.asyncio
-    async def test_validate_config_non_existing_collection(self, patch_sharepoint_client):      
+    async def test_validate_config_non_existing_collection(
+        self, patch_sharepoint_client
+    ):
         non_existing_site = "something"
         another_non_existing_site = "something-something"
 
-        source = create_source(SharepointOnlineDataSource, site_collections=[non_existing_site, another_non_existing_site])
+        source = create_source(
+            SharepointOnlineDataSource,
+            site_collections=[non_existing_site, another_non_existing_site],
+        )
 
         with pytest.raises(Exception) as e:
             await source.validate_config()
@@ -778,10 +826,12 @@ class TestSharepointOnlineDataSource:
 
     @pytest.mark.asyncio
     async def test_get_attachment(self, patch_sharepoint_client):
-        attachment = { "odata.id": "1" }
+        attachment = {"odata.id": "1"}
         message = b"This is content of attachment"
+
         async def download_func(attachment_id, async_buffer):
             await async_buffer.write(message)
+
         patch_sharepoint_client.download_attachment = download_func
         source = create_source(SharepointOnlineDataSource)
 
@@ -791,10 +841,17 @@ class TestSharepointOnlineDataSource:
 
     @pytest.mark.asyncio
     async def test_get_content(self, patch_sharepoint_client):
-        drive_item = { "id": "1", "size": 15, "lastModifiedDateTime": datetime.now(timezone.utc), "parentReference": { "driveId": "drive-1" } }
+        drive_item = {
+            "id": "1",
+            "size": 15,
+            "lastModifiedDateTime": datetime.now(timezone.utc),
+            "parentReference": {"driveId": "drive-1"},
+        }
         message = b"This is content of drive item"
+
         async def download_func(drive_id, drive_item_id, async_buffer):
             await async_buffer.write(message)
+
         patch_sharepoint_client.download_drive_item = download_func
         source = create_source(SharepointOnlineDataSource)
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,7 +3,6 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import asyncio
 import json
 import logging
 import time
@@ -61,7 +60,7 @@ def test_tracer():
 
         @tracer.start_as_current_span("trace me")
         def traceable():
-            time.sleep(.1)
+            time.sleep(0.1)
 
         traceable()
         ecs_log = logs[0]
@@ -69,15 +68,11 @@ def test_tracer():
         # make sure it's JSON and we have service.type
         data = json.loads(ecs_log)
 
-        assert data['message'].startswith(
-            '[trace me] traceable took 0.1'
-        )
-
+        assert data["message"].startswith("[trace me] traceable took 0.1")
 
 
 @pytest.mark.asyncio
 async def test_async_tracer():
-
     with unset_logger():
         logger = set_logger(logging.DEBUG, filebeat=True)
         logs = []
@@ -89,21 +84,18 @@ async def test_async_tracer():
 
         @tracer.start_as_current_span("trace me", "special")
         async def traceable():
-            time.sleep(.1)
+            time.sleep(0.1)
 
         await traceable()
         ecs_log = logs[0]
 
         # make sure it's JSON and we have service.type
         data = json.loads(ecs_log)
-        assert data['message'].startswith(
-            '[trace me] special took 0.1'
-        )
+        assert data["message"].startswith("[trace me] special took 0.1")
 
 
 @pytest.mark.asyncio
 async def test_async_tracer_slow():
-
     with unset_logger():
         logger = set_logger(logging.DEBUG, filebeat=True)
         logs = []
@@ -115,17 +107,17 @@ async def test_async_tracer_slow():
 
         @tracer.start_as_current_span("trace me", "special", slow_log=10)
         async def traceable():
-            time.sleep(.1)
+            time.sleep(0.1)
 
         await traceable()
-        assert(len(logs)) == 0
+        assert (len(logs)) == 0
 
         @tracer.start_as_current_span("trace me", "special", slow_log=0.01)
         async def traceable_slow():
-            time.sleep(.1)
+            time.sleep(0.1)
 
         await traceable_slow()
-        assert(len(logs)) == 1
+        assert (len(logs)) == 1
 
 
 @pytest.mark.asyncio
@@ -141,17 +133,15 @@ async def test_trace_async_gen():
 
         @tracer.start_as_current_span("trace me", "special")
         async def gen():
-            yield '1'
-            yield '2'
-            yield '3'
+            yield "1"
+            yield "2"
+            yield "3"
 
-        async for i in gen():
+        async for _ in gen():
             pass
 
         assert len(logs) == 4
 
         for i, log in enumerate(logs):
             data = json.loads(log)
-            assert data['message'].startswith(
-                f'[trace me] {i}-special took'
-            )
+            assert data["message"].startswith(f"[trace me] {i}-special took")

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -224,7 +224,7 @@ async def test_get_existing_ids(mock_responses):
     es = SyncOrchestrator(config)
     extractor = Extractor(es.client, None, "search-some-index")
     ids = []
-    async for doc_id, ts in extractor._get_existing_ids():
+    async for doc_id, _ in extractor._get_existing_ids():
         ids.append(doc_id)
 
     assert ids == ["1", "2"]
@@ -248,7 +248,10 @@ async def test_async_bulk(mock_responses):
                 return
             return {"TEXT": "DATA", "_timestamp": timestamp, "_id": "1"}
 
-        yield {"_id": "1", "_timestamp": datetime.datetime.now().isoformat()}, _dl, "index"
+        yield {
+            "_id": "1",
+            "_timestamp": datetime.datetime.now().isoformat(),
+        }, _dl, "index"
         yield {"_id": "3"}, _dl_none, "index"
 
     await es.async_bulk("search-some-index", get_docs(), pipeline, JobType.FULL)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -838,7 +838,9 @@ async def test_serialize(raw_doc, expected_doc):
 
         assert serialized_doc.keys() == expected_doc.keys()
 
-        for serialized_doc_key, expected_doc_key in zip(serialized_doc, expected_doc):
+        for serialized_doc_key, expected_doc_key in zip(
+            serialized_doc, expected_doc, strict=True
+        ):
             assert serialized_doc[serialized_doc_key] == expected_doc[expected_doc_key]
 
 

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -85,7 +85,9 @@ def create_runner(
 
 @pytest.fixture(autouse=True)
 def elastic_server_mock():
-    with patch("connectors.sync_job_runner.SyncOrchestrator") as elastic_server_klass_mock:
+    with patch(
+        "connectors.sync_job_runner.SyncOrchestrator"
+    ) as elastic_server_klass_mock:
         elastic_server_mock = Mock()
         elastic_server_mock.prepare_content_index = AsyncMock()
         elastic_server_mock.async_bulk = AsyncMock()
@@ -179,7 +181,7 @@ async def test_source_invalid_config():
     assert sync_job_runner.elastic_server is None
     sync_job_runner.connector.sync_starts.assert_awaited()
     sync_job_runner.sync_job.claim.assert_awaited()
-    sync_job_runner.sync_job.done.assert_not_awaited
+    sync_job_runner.sync_job.done.assert_not_awaited()
     sync_job_runner.sync_job.fail.assert_awaited_with(
         ANY, ingestion_stats=ingestion_stats
     )
@@ -203,7 +205,7 @@ async def test_source_not_available():
     assert sync_job_runner.elastic_server is None
     sync_job_runner.connector.sync_starts.assert_awaited()
     sync_job_runner.sync_job.claim.assert_awaited()
-    sync_job_runner.sync_job.done.assert_not_awaited
+    sync_job_runner.sync_job.done.assert_not_awaited()
     sync_job_runner.sync_job.fail.assert_awaited_with(
         ANY, ingestion_stats=ingestion_stats
     )
@@ -228,7 +230,7 @@ async def test_invalid_filtering():
     assert sync_job_runner.elastic_server is None
     sync_job_runner.connector.sync_starts.assert_awaited()
     sync_job_runner.sync_job.claim.assert_awaited()
-    sync_job_runner.sync_job.done.assert_not_awaited
+    sync_job_runner.sync_job.done.assert_not_awaited()
     sync_job_runner.sync_job.fail.assert_awaited_with(
         ANY, ingestion_stats=ingestion_stats
     )
@@ -255,7 +257,7 @@ async def test_async_bulk_error(elastic_server_mock):
     sync_job_runner.connector.sync_starts.assert_awaited()
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.elastic_server.async_bulk.assert_awaited()
-    sync_job_runner.sync_job.done.assert_not_awaited
+    sync_job_runner.sync_job.done.assert_not_awaited()
     sync_job_runner.sync_job.fail.assert_awaited_with(
         error, ingestion_stats=ingestion_stats
     )
@@ -281,7 +283,7 @@ async def test_sync_job_runner(elastic_server_mock):
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.elastic_server.async_bulk.assert_awaited()
     sync_job_runner.sync_job.done.assert_awaited_with(ingestion_stats=ingestion_stats)
-    sync_job_runner.sync_job.fail.assert_not_awaited
+    sync_job_runner.sync_job.fail.assert_not_awaited()
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
     sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job)
@@ -446,7 +448,7 @@ async def test_sync_job_runner_sync_job_not_found(elastic_server_mock):
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.elastic_server.async_bulk.assert_awaited()
     sync_job_runner.sync_job.done.assert_not_awaited()
-    sync_job_runner.sync_job.fail.assert_not_awaited
+    sync_job_runner.sync_job.fail.assert_not_awaited()
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
     sync_job_runner.connector.sync_done.assert_awaited_with(None)
@@ -475,7 +477,7 @@ async def test_sync_job_runner_canceled(elastic_server_mock):
     sync_job_runner.sync_job.claim.assert_awaited()
     sync_job_runner.elastic_server.async_bulk.assert_awaited()
     sync_job_runner.sync_job.done.assert_not_awaited()
-    sync_job_runner.sync_job.fail.assert_not_awaited
+    sync_job_runner.sync_job.fail.assert_not_awaited()
     sync_job_runner.sync_job.cancel.assert_awaited_with(
         ingestion_stats=ingestion_stats | {"total_document_count": total_document_count}
     )


### PR DESCRIPTION
Mistakes were made and when I moved `tests` directory from `connectors` directory, linters and autoformat stopped working on it.

This PR enables both `make lint` and `make autoformat` to work on tests directory and fixes all broken rules.