### PR TITLE
Add incremental sync support to SyncJobRunner

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -257,6 +257,9 @@ class SyncJob(ESDocument):
     def job_type(self):
         return JobType(self.get("job_type"))
 
+    def is_content_sync(self):
+        return self.job_type in (JobType.FULL, JobType.INCREMENTAL)
+
     async def validate_filtering(self, validator):
         validation_result = await validator.validate_filtering(self.filtering)
 

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -247,9 +247,14 @@ class SyncJobRunner:
                 await self.sync_job.done(ingestion_stats=ingestion_stats)
 
         if await self.reload_connector():
+            sync_cursor = (
+                self.data_provider.sync_cursor()
+                if self.sync_job.is_content_sync()
+                else None
+            )
             await self.connector.sync_done(
                 self.sync_job if await self.reload_sync_job() else None,
-                cursor=self.data_provider.sync_cursor(),
+                cursor=sync_cursor,
             )
 
         logger.info(

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -101,7 +101,12 @@ class SyncJobRunner:
         self.running = True
 
         await self.sync_starts()
-        await self.sync_job.claim()
+        sync_cursor = (
+            self.connector.sync_cursor
+            if self.sync_job.job_type == JobType.INCREMENTAL
+            else None
+        )
+        await self.sync_job.claim(sync_cursor=sync_cursor)
         self._start_time = time.time()
 
         try:
@@ -243,7 +248,8 @@ class SyncJobRunner:
 
         if await self.reload_connector():
             await self.connector.sync_done(
-                self.sync_job if await self.reload_sync_job() else None
+                self.sync_job if await self.reload_sync_job() else None,
+                cursor=self.data_provider.sync_cursor(),
             )
 
         logger.info(

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -724,6 +724,20 @@ async def test_sync_job_properties():
     assert isinstance(sync_job.job_type, JobType)
 
 
+@pytest.mark.parametrize(
+    "job_type, is_content_sync",
+    [
+        (JobType.FULL, True),
+        (JobType.INCREMENTAL, True),
+        (JobType.ACCESS_CONTROL, False),
+    ],
+)
+def test_is_content_sync(job_type, is_content_sync):
+    source = {"_id": "1", "_source": {"job_type": job_type.value}}
+    sync_job = SyncJob(elastic_index=None, doc_source=source)
+    assert sync_job.is_content_sync() == is_content_sync
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "validation_result_state, validation_result_errors, should_raise_exception",

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -212,7 +212,9 @@ async def test_source_not_changed(job_type, sync_cursor):
     sync_job_runner.sync_job.fail.assert_not_awaited()
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )
 
 
 @pytest.mark.parametrize(
@@ -241,7 +243,9 @@ async def test_source_invalid_config(job_type):
     )
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )
 
 
 @pytest.mark.parametrize(
@@ -268,7 +272,9 @@ async def test_source_not_available(job_type):
     )
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )
 
 
 @pytest.mark.parametrize("job_type", [JobType.FULL, JobType.INCREMENTAL])
@@ -294,7 +300,9 @@ async def test_invalid_filtering(job_type, elastic_server_mock):
     )
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )
 
 
 @pytest.mark.asyncio
@@ -350,7 +358,9 @@ async def test_async_bulk_error(job_type, elastic_server_mock):
     )
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )
 
 
 @pytest.mark.asyncio
@@ -403,7 +413,9 @@ async def test_sync_job_runner(job_type, elastic_server_mock):
     sync_job_runner.sync_job.fail.assert_not_awaited()
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )
 
 
 @pytest.mark.parametrize(
@@ -434,7 +446,9 @@ async def test_sync_job_runner_suspend(job_type, elastic_server_mock):
     sync_job_runner.sync_job.suspend.assert_awaited_with(
         ingestion_stats=ingestion_stats
     )
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )
 
 
 @patch("connectors.sync_job_runner.ES_ID_SIZE_LIMIT", 1)
@@ -456,7 +470,7 @@ async def test_prepare_docs_when_original_id_and_hashed_id_too_long_then_skip_do
 @pytest.mark.parametrize("_id", ["ab", 1, 1.5])
 @pytest.mark.asyncio
 async def test_prepare_docs_when_original_id_below_limit_then_yield_doc_with_original_id(
-        _id,
+    _id,
 ):
     sync_job_runner = create_runner_yielding_docs(docs=[({"_id": _id}, None)])
 
@@ -516,7 +530,9 @@ async def test_sync_job_runner_reporting_metadata(job_type, elastic_server_mock)
     sync_job_runner.sync_job.suspend.assert_awaited_with(
         ingestion_stats=ingestion_stats | {"total_document_count": TOTAL_DOCUMENT_COUNT}
     )
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )
 
 
 @pytest.mark.parametrize(
@@ -614,7 +630,9 @@ async def test_sync_job_runner_canceled(job_type, elastic_server_mock):
         ingestion_stats=ingestion_stats | {"total_document_count": TOTAL_DOCUMENT_COUNT}
     )
     sync_job_runner.sync_job.suspend.assert_not_awaited()
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )
 
 
 @pytest.mark.parametrize(
@@ -650,4 +668,6 @@ async def test_sync_job_runner_not_running(job_type, elastic_server_mock):
     )
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
-    sync_job_runner.connector.sync_done.assert_awaited_with(sync_job_runner.sync_job, cursor=SYNC_CURSOR)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=SYNC_CURSOR
+    )


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4637

This PR makes sure the sync cursor is stored to `SyncJob` when claiming the job, and the connector is updated with the latest `sync_cursor` when the sync job completes.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)