### PR TITLE
Display MSSQL validate_host bool as toggle

### DIFF
--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -102,6 +102,7 @@ class MSSQLDataSource(GenericBaseDataSource):
                     "value": "",
                 },
                 "validate_host": {
+                    "display": "toggle",
                     "label": "Validate host",
                     "order": 12,
                     "type": "bool",


### PR DESCRIPTION
This fixes MSSQL validate_host config field displaying as a text field instead of a toggle.


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
