### PR TITLE
Update configurable field cases

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -565,25 +565,25 @@ class SharepointOnlineDataSource(BaseDataSource):
     def get_default_configuration(cls):
         return {
             "tenant_id": {
-                "label": "Tenant Id",
+                "label": "Tenant ID",
                 "order": 1,
                 "type": "str",
                 "value": "",
             },
             "tenant_name": {  # TODO: when Tenant API is going out of Beta, we can remove this field
-                "label": "Tenant Name",
+                "label": "Tenant name",
                 "order": 2,
                 "type": "str",
                 "value": "",
             },
             "client_id": {
-                "label": "Client Id",
+                "label": "Client ID",
                 "order": 3,
                 "type": "str",
                 "value": "",
             },
             "secret_value": {
-                "label": "Secret Value",
+                "label": "Secret value",
                 "order": 4,
                 "sensitive": True,
                 "type": "str",


### PR DESCRIPTION
## Based on feedback from https://github.com/elastic/kibana/pull/159570

Updating casing for Sharepoint Online connector labels following comment from @sphilipse:

> ...
> 
> Also, we've generally used Sentence case instead of Title Case for these values. So: Tenant Name instead of Tenant Name, and so on for all the others.
> 
> Tenant ID or Tenant id are both preferable toTenant Id.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses=
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
