### PR TITLE
deprecate native mode configurably

### DIFF
--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -41,7 +41,7 @@ class PreflightCheck:
                 logger.critical(f"{self.elastic_config['host']} seem down. Bye!")
                 return False
 
-            self._check_configuration_validity()
+            self._validate_configuration()
             return await self._check_system_indices_with_retries()
         finally:
             self.stop()
@@ -72,7 +72,7 @@ class PreflightCheck:
                     await self._sleeps.sleep(self.preflight_idle)
         return False
 
-    def _check_configuration_validity(self):
+    def _validate_configuration(self):
         # "Native" mode
         configured_native_types = "native_service_types" in self.config
         force_allowed_native = self.config.get("_force_allow_native", False)

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -77,11 +77,20 @@ class PreflightCheck:
         configured_native_types = "native_service_types" in self.config
         force_allowed_native = self.config.get("_force_allow_native", False)
         if configured_native_types and not force_allowed_native:
-            logger.warning("The configuration 'native_service_types' has been deprecated. Please remove this configuration.")
-            logger.warning("Native Connectors are only supported internal to Elastic Cloud deployments, which this process is not.")
+            logger.warning(
+                "The configuration 'native_service_types' has been deprecated. Please remove this configuration."
+            )
+            logger.warning(
+                "Native Connectors are only supported internal to Elastic Cloud deployments, which this process is not."
+            )
 
         # Connector client mode
         configured_connector_id = self.config.get("connector_id", None)
         configred_service_type = self.config.get("service_type", None)
-        if not (configured_connector_id and configred_service_type) and not force_allowed_native:
-            logger.warning("Please update your config.yml to explicitly configure a 'connector_id' and a 'service_type'")
+        if (
+            not (configured_connector_id and configred_service_type)
+            and not force_allowed_native
+        ):
+            logger.warning(
+                "Please update your config.yml to explicitly configure a 'connector_id' and a 'service_type'"
+            )

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -12,6 +12,7 @@ from connectors.utils import CancellableSleeps
 
 class PreflightCheck:
     def __init__(self, config):
+        self.config = config
         self.elastic_config = config["elasticsearch"]
         self.service_config = config["service"]
         self.es_client = ESClient(self.elastic_config)
@@ -40,6 +41,7 @@ class PreflightCheck:
                 logger.critical(f"{self.elastic_config['host']} seem down. Bye!")
                 return False
 
+            self._check_configuration_validity()
             return await self._check_system_indices_with_retries()
         finally:
             self.stop()
@@ -69,3 +71,17 @@ class PreflightCheck:
                     attempts += 1
                     await self._sleeps.sleep(self.preflight_idle)
         return False
+
+    def _check_configuration_validity(self):
+        # "Native" mode
+        configured_native_types = "native_service_types" in self.config
+        force_allowed_native = self.config.get("_force_allow_native", False)
+        if configured_native_types and not force_allowed_native:
+            logger.warning("The configuration 'native_service_types' has been deprecated. Please remove this configuration.")
+            logger.warning("Native Connectors are only supported internal to Elastic Cloud deployments, which this process is not.")
+
+        # Connector client mode
+        configured_connector_id = self.config.get("connector_id", None)
+        configred_service_type = self.config.get("service_type", None)
+        if not (configured_connector_id and configred_service_type) and not force_allowed_native:
+            logger.warning("Please update your config.yml to explicitly configure a 'connector_id' and a 'service_type'")

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -5,7 +5,8 @@
 #
 
 import pytest
-
+import connectors
+from unittest.mock import MagicMock, Mock, patch
 from connectors.preflight_check import PreflightCheck
 from connectors.protocol import CONNECTORS_INDEX, JOBS_INDEX
 
@@ -102,3 +103,43 @@ async def test_index_exist_transient_error(mock_responses):
     preflight = PreflightCheck(config)
     result = await preflight.run()
     assert result is True
+
+@pytest.mark.asyncio
+@patch("connectors.preflight_check.logger")
+async def test_native_config_is_warned(patched_logger, mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    config["native_service_types"] = ["foo", "bar"]
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is True
+    patched_logger.warning.assert_any_call("The configuration 'native_service_types' has been deprecated. Please remove this configuration.")
+    patched_logger.warning.assert_any_call("Native Connectors are only supported internal to Elastic Cloud deployments, which this process is not.")
+    patched_logger.warning.assert_any_call("Please update your config.yml to explicitly configure a 'connector_id' and a 'service_type'")
+
+@pytest.mark.asyncio
+@patch("connectors.preflight_check.logger")
+async def test_native_config_is_forced(patched_logger, mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    config["native_service_types"] = ["foo", "bar"]
+    config["_force_allow_native"] = True
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is True
+    patched_logger.warning.assert_not_called()
+
+@pytest.mark.asyncio
+@patch("connectors.preflight_check.logger")
+async def test_client_config(patched_logger, mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    config["connector_id"] = "foo"
+    config["service_type"] = "bar"
+    preflight = PreflightCheck(config)
+    result = await preflight.run()
+    assert result is True
+    patched_logger.warning.assert_not_called()

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -4,9 +4,10 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 
+from unittest.mock import patch
+
 import pytest
-import connectors
-from unittest.mock import MagicMock, Mock, patch
+
 from connectors.preflight_check import PreflightCheck
 from connectors.protocol import CONNECTORS_INDEX, JOBS_INDEX
 
@@ -104,6 +105,7 @@ async def test_index_exist_transient_error(mock_responses):
     result = await preflight.run()
     assert result is True
 
+
 @pytest.mark.asyncio
 @patch("connectors.preflight_check.logger")
 async def test_native_config_is_warned(patched_logger, mock_responses):
@@ -114,9 +116,16 @@ async def test_native_config_is_warned(patched_logger, mock_responses):
     preflight = PreflightCheck(config)
     result = await preflight.run()
     assert result is True
-    patched_logger.warning.assert_any_call("The configuration 'native_service_types' has been deprecated. Please remove this configuration.")
-    patched_logger.warning.assert_any_call("Native Connectors are only supported internal to Elastic Cloud deployments, which this process is not.")
-    patched_logger.warning.assert_any_call("Please update your config.yml to explicitly configure a 'connector_id' and a 'service_type'")
+    patched_logger.warning.assert_any_call(
+        "The configuration 'native_service_types' has been deprecated. Please remove this configuration."
+    )
+    patched_logger.warning.assert_any_call(
+        "Native Connectors are only supported internal to Elastic Cloud deployments, which this process is not."
+    )
+    patched_logger.warning.assert_any_call(
+        "Please update your config.yml to explicitly configure a 'connector_id' and a 'service_type'"
+    )
+
 
 @pytest.mark.asyncio
 @patch("connectors.preflight_check.logger")
@@ -130,6 +139,7 @@ async def test_native_config_is_forced(patched_logger, mock_responses):
     result = await preflight.run()
     assert result is True
     patched_logger.warning.assert_not_called()
+
 
 @pytest.mark.asyncio
 @patch("connectors.preflight_check.logger")

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -112,8 +112,9 @@ async def test_native_config_is_warned(patched_logger, mock_responses):
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONNECTORS_INDEX)
     mock_index_exists(mock_responses, JOBS_INDEX)
-    config["native_service_types"] = ["foo", "bar"]
-    preflight = PreflightCheck(config)
+    local_config = config.copy()
+    local_config["native_service_types"] = ["foo", "bar"]
+    preflight = PreflightCheck(local_config)
     result = await preflight.run()
     assert result is True
     patched_logger.warning.assert_any_call(
@@ -133,9 +134,10 @@ async def test_native_config_is_forced(patched_logger, mock_responses):
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONNECTORS_INDEX)
     mock_index_exists(mock_responses, JOBS_INDEX)
-    config["native_service_types"] = ["foo", "bar"]
-    config["_force_allow_native"] = True
-    preflight = PreflightCheck(config)
+    local_config = config.copy()
+    local_config["native_service_types"] = ["foo", "bar"]
+    local_config["_force_allow_native"] = True
+    preflight = PreflightCheck(local_config)
     result = await preflight.run()
     assert result is True
     patched_logger.warning.assert_not_called()
@@ -147,9 +149,10 @@ async def test_client_config(patched_logger, mock_responses):
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONNECTORS_INDEX)
     mock_index_exists(mock_responses, JOBS_INDEX)
-    config["connector_id"] = "foo"
-    config["service_type"] = "bar"
-    preflight = PreflightCheck(config)
+    local_config = config.copy()
+    local_config["connector_id"] = "foo"
+    local_config["service_type"] = "bar"
+    preflight = PreflightCheck(local_config)
     result = await preflight.run()
     assert result is True
     patched_logger.warning.assert_not_called()


### PR DESCRIPTION
## part of https://github.com/elastic/enterprise-search-team/issues/4732

- Adds deprecation warnings when running in Native mode
- Adds a new config, `_force_allow_native`, which bypasses ignores these deprecation warnings.

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Contributed any configuration settings changes to the configuration reference (separate issue)



## Related Pull Requests

* Corresponding ent-search pr: https://github.com/elastic/ent-search/pull/7558

## Release Note

Running self-managed connectors in "native" mode is deprecated starting in 8.9.0.