### PR TITLE
Fix the nightly for serverless

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -11,3 +11,5 @@ git+https://github.com/elastic/perf8#egg=perf8
 freezegun>=0.3.4
 pytest-fail-slow>=0.3.0
 pyright>=1.1.295
+requests>=2.31.0
+retry>=0.9.2

--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -49,6 +49,7 @@ $PYTHON -m pip install -r $NAME/requirements.txt
 fi
 $PYTHON fixture.py --name $NAME --action setup
 $PYTHON fixture.py --name $NAME --action start_stack
+$PYTHON fixture.py --name $NAME --action check_stack
 $ROOT_DIR/bin/fake-kibana --index-name $INDEX_NAME --service-type $SERVICE_TYPE --connector-definition $NAME/connector.json --debug
 $PYTHON fixture.py --name $NAME --action load
 $PYTHON fixture.py --name $NAME --action sync
@@ -79,7 +80,6 @@ $PYTHON fixture.py --name $NAME --action monitor --pid $PID_2
 
 NUM_DOCS=`$PYTHON fixture.py --name $NAME --action get_num_docs`
 $PYTHON $ROOT_DIR/scripts/verify.py --index-name $INDEX_NAME --service-type $NAME --size $NUM_DOCS
-$PYTHON fixture.py --name $NAME --action stop_stack
 $PYTHON fixture.py --name $NAME --action teardown
 
 # Wait for PERF8 to compile the report
@@ -101,4 +101,5 @@ if [[ $PERF8 == "yes" ]]; then
     exit $STATUS
 fi
 
-
+# stopping the stack as a final step once everything else is done.
+$PYTHON fixture.py --name $NAME --action stop_stack

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -113,6 +113,7 @@ def main(args=None):
     if args.action in ("start_stack", "stop_stack"):
         os.chdir(os.path.join(os.path.dirname(__file__), args.name))
         if args.action == "start_stack":
+            os.system("docker compose pull")
             os.system("docker compose up -d")
             # TODO: do better
             time.sleep(30)

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -6,14 +6,37 @@
 import importlib
 import importlib.util
 import os
+import pprint
 import signal
 import sys
 import time
 from argparse import ArgumentParser
 
+import requests
 from elasticsearch import Elasticsearch
+from requests.adapters import HTTPAdapter, Retry
+from requests.auth import HTTPBasicAuth
+from retry import retry
+from urllib3.exceptions import ProtocolError
 
 CONNECTORS_INDEX = ".elastic-connectors"
+
+
+@retry(tries=3, delay=1.0)
+def wait_for_es(url="http://localhost:9200", user="elastic", password="changeme"):
+    print("Waiting for Elasticsearch to be up and running")
+    basic = HTTPBasicAuth(user, password)
+    s = requests.Session()
+    retries = Retry(total=5, backoff_factor=1.0, status_forcelist=[500, 502, 503, 504])
+    s.mount("http://", HTTPAdapter(max_retries=retries))
+    try:
+        return s.get(url, auth=basic).json()
+    except Exception as e:
+        # we're going to display some docker info here
+        print(f"Failed to reach out Elasticsearch {repr(e)}")
+        os.system("docker ps -a")
+        os.system("docker logs es01")
+        raise
 
 
 def _parser():
@@ -27,6 +50,7 @@ def _parser():
             "load",
             "remove",
             "start_stack",
+            "check_stack",
             "stop_stack",
             "setup",
             "teardown",
@@ -115,8 +139,6 @@ def main(args=None):
         if args.action == "start_stack":
             os.system("docker compose pull")
             os.system("docker compose up -d")
-            # TODO: do better
-            time.sleep(30)
         else:
             os.system("docker compose down --volumes")
         return
@@ -155,6 +177,9 @@ def main(args=None):
             print(
                 f'Running an e2e test for {args.name} with a {os.environ.get("DATA_SIZE", "medium")} corpus.'
             )
+        elif args.action == "check_stack":
+            # default behavior: we wait until elasticsearch is responding
+            pprint.pprint(wait_for_es())
         else:
             print(
                 f"Fixture {args.name} does not have an {args.action} action, skipping"


### PR DESCRIPTION
The serverless job was failing because it takes a little bit longer on cloud to be ready.

- [ ] Implemented a more robust step to wait for Elasticsearch to be ready
- [ ] Now pulling for fresh images everytime 