### PR TITLE
Small renames for download functions in SPO connector + important comment for attachment download

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -690,7 +690,9 @@ class SharepointOnlineDataSource(BaseDataSource):
                                     f"Not downloading file {drive_item['name']} of size {drive_item['size']}"
                                 )
                             else:
-                                download_func = partial(self.get_drive_item_content, drive_item)
+                                download_func = partial(
+                                    self.get_drive_item_content, drive_item
+                                )
 
                         yield drive_item, download_func
 
@@ -752,7 +754,7 @@ class SharepointOnlineDataSource(BaseDataSource):
         # We don't know attachment sizes unfortunately, so cannot properly ignore them
 
         # Okay this gets weird.
-        # There's no way to learn whether List Item Attachment changed or not 
+        # There's no way to learn whether List Item Attachment changed or not
         # Response does not contain metadata on LastUpdated or any dates,
         # but along with that IDs for attachments are actually these attachments'
         # file names. So if someone creates a file text.txt with content "hello",

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -690,7 +690,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                                     f"Not downloading file {drive_item['name']} of size {drive_item['size']}"
                                 )
                             else:
-                                download_func = partial(self.get_content, drive_item)
+                                download_func = partial(self.get_drive_item_content, drive_item)
 
                         yield drive_item, download_func
 
@@ -727,7 +727,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                                     "lastModifiedDateTime"
                                 ]
                                 attachment_download_func = partial(
-                                    self.get_attachment, list_item_attachment
+                                    self.get_attachment_content, list_item_attachment
                                 )
                                 yield list_item_attachment, attachment_download_func
 
@@ -745,21 +745,33 @@ class SharepointOnlineDataSource(BaseDataSource):
 
                     yield site_page, None
 
-    async def get_attachment(self, attachment, timestamp=None, doit=False):
+    async def get_attachment_content(self, attachment, timestamp=None, doit=False):
         if not doit:
             return
 
         # We don't know attachment sizes unfortunately, so cannot properly ignore them
 
+        # Okay this gets weird.
+        # There's no way to learn whether List Item Attachment changed or not 
+        # Response does not contain metadata on LastUpdated or any dates,
+        # but along with that IDs for attachments are actually these attachments'
+        # file names. So if someone creates a file text.txt with content "hello",
+        # runs a sync, then deletes this file and creates again with different content,
+        # the model returned from API will not change at all. It will have same ID,
+        # same everything. But it will already be an absolutely new document.
+        # Therefore every time we try to download the attachment we say that
+        # it was just recently created so that framework would always re-download it.
+        new_timestamp = datetime.utcnow()
+
         return {
             "_id": attachment["odata.id"],
-            "_timestamp": datetime.utcnow(),  # TODO: attachments cannot be modified in-place, so we can consider that object ids are permanent
+            "_timestamp": new_timestamp,
             "_attachment": await self._download_content(
                 partial(self.client.download_attachment, attachment["odata.id"])
             ),
         }
 
-    async def get_content(self, drive_item, timestamp=None, doit=False):
+    async def get_drive_item_content(self, drive_item, timestamp=None, doit=False):
         document_size = int(drive_item["size"])
 
         if not (doit and document_size):

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -820,7 +820,7 @@ class TestSharepointOnlineDataSource:
         assert e.match(another_non_existing_site)
 
     @pytest.mark.asyncio
-    async def test_get_attachment(self, patch_sharepoint_client):
+    async def test_get_attachment_content(self, patch_sharepoint_client):
         attachment = {"odata.id": "1"}
         message = b"This is content of attachment"
 
@@ -830,12 +830,12 @@ class TestSharepointOnlineDataSource:
         patch_sharepoint_client.download_attachment = download_func
         source = create_source(SharepointOnlineDataSource)
 
-        download_result = await source.get_attachment(attachment, doit=True)
+        download_result = await source.get_attachment_content(attachment, doit=True)
 
         assert download_result["_attachment"] == base64.b64encode(message).decode()
 
     @pytest.mark.asyncio
-    async def test_get_content(self, patch_sharepoint_client):
+    async def test_get_drive_item_content(self, patch_sharepoint_client):
         drive_item = {
             "id": "1",
             "size": 15,
@@ -850,6 +850,6 @@ class TestSharepointOnlineDataSource:
         patch_sharepoint_client.download_drive_item = download_func
         source = create_source(SharepointOnlineDataSource)
 
-        download_result = await source.get_content(drive_item, doit=True)
+        download_result = await source.get_drive_item_content(drive_item, doit=True)
 
         assert download_result["_attachment"] == base64.b64encode(message).decode()


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4701

Renaming 2 functions:
- get_attachment -> get_attachment_content
- get_content -> get_drive_item_content

Adding a comment to get_attachment_content that explains something about timestamps and why we always need to subextract attachments.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)