### PR TITLE
Remove sync_now flag support

### DIFF
--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -292,7 +292,6 @@ async def prepare(service_type, index_name, config, connector_definition=None):
                 "run_ml_inference": True,
             },
             "sync_cursor": None,
-            "sync_now": False,
             "is_native": False,
         }
 

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -504,10 +504,6 @@ class Connector(ESDocument):
         return self.get("is_native", default=False)
 
     @property
-    def sync_now(self):
-        return self.get("sync_now", default=False)
-
-    @property
     def full_sync_scheduling(self):
         return self.get("scheduling", "full", default={})
 
@@ -609,14 +605,6 @@ class Connector(ESDocument):
             logger.debug(f"'{job_type.value}' sync scheduling is disabled")
             return None
         return next_run(scheduling_property.get("interval"))
-
-    async def reset_sync_now_flag(self):
-        await self.index.update(
-            doc_id=self.id,
-            doc={"sync_now": False},
-            if_seq_no=self._seq_no,
-            if_primary_term=self._primary_term,
-        )
 
     async def _update_datetime(self, field, new_ts):
         await self.index.update(

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -142,7 +142,6 @@ This is our main communication index, used to communicate the connector's config
   service_type: string; -> Service type of the connector
   status: string;       -> Connector status Enum, see below
   sync_cursor: object;  -> Cursor object of the last sync job, used to run incremental sync
-  sync_now: boolean;    -> Flag to signal user wants to initiate a job
 }
 ```
 **Possible values for 'status'**
@@ -316,8 +315,7 @@ This is our main communication index, used to communicate the connector's config
     },
     "service_type" : { "type" : "keyword" },
     "status" : { "type" : "keyword" },
-    "sync_cursor" : { "type" : "object" },
-    "sync_now" : { "type" : "boolean" }
+    "sync_cursor" : { "type" : "object" }
   }
 }
 ```
@@ -489,7 +487,7 @@ For every half hour, and every time a job is executed, the connector should upda
 For custom connectors, the connector should also update `configuration` field if its status is `created`.
 
 The connector should also sync data for connectors:
-- Read connector definitions from `.elastic-connectors` regularly, and determine whether to sync data based on `sync_now` flag, as well as `scheduling` and `custom_scheduling` values. 
+- Read connector definitions from `.elastic-connectors` regularly, and determine whether to sync data based on `scheduling` and `custom_scheduling` values. 
 - Set the index mappings of the to-be-written-to index if not already present.
 - Sync with the data source and index resulting documents into the correct index.
 - Log jobs to `.elastic-connectors-sync-jobs`.
@@ -522,9 +520,9 @@ sequenceDiagram
         and Rule Validation
             Connector->>Elasticsearch: Updates validation state of filtering rules
         and Job
-            Connector->>Elasticsearch: Reads sync_now flag and job schedule and filtering rules
-            opt Sync_now is true or sync_schedule requires synchronization
-                Connector->>Elasticsearch: Sets sync_now to false and last_sync_status to in_progress
+            Connector->>Elasticsearch: Reads job schedule and filtering rules
+            opt sync_schedule requires synchronization
+                Connector->>Elasticsearch: Sets last_sync_status to in_progress
                 Connector->>Data source: Queries data
                 Connector->>Elasticsearch: Indexes filtered data
                 alt Job is successfully completed

--- a/tests/fixtures/connector.json
+++ b/tests/fixtures/connector.json
@@ -3,7 +3,6 @@
         "service_type": "mongodb",
         "index_name": "search-mongodb",
         "sync_cursor": null,
-        "sync_now": true,
         "is_native": true,
         "api_key_id": null,
         "status": "configured",

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -138,7 +138,6 @@ DOC_SOURCE = {
         "service_type": "SERVICE",
         "status": "connected",
         "language": "en",
-        "sync_now": False,
     },
 }
 
@@ -219,7 +218,6 @@ mongo = {
     "created_at": "",
     "updated_at": "",
     "scheduling": {"enabled": True, "interval": "0 * * * *"},
-    "sync_now": True,
 }
 
 
@@ -349,7 +347,6 @@ async def test_connector_properties():
     assert connector.service_type == "test"
     assert connector.configuration.is_empty()
     assert connector.native is False
-    assert connector.sync_now is False
     assert connector.index_name == "search-some-index"
     assert connector.language == "en"
     assert connector.last_sync_status == JobStatus.COMPLETED
@@ -1189,30 +1186,6 @@ async def test_connector_prepare_with_race_condition():
             "configuration": Banana.get_simple_configuration(),
             "status": Status.NEEDS_CONFIGURATION.value,
         },
-        if_seq_no=seq_no,
-        if_primary_term=primary_term,
-    )
-
-
-@pytest.mark.asyncio
-async def test_connector_reset_sync_now_flag():
-    doc_id = "1"
-    seq_no = 1
-    primary_term = 2
-    connector_doc = {
-        "_id": doc_id,
-        "_seq_no": seq_no,
-        "_primary_term": primary_term,
-        "_source": {},
-    }
-    index = Mock()
-    index.update = AsyncMock()
-    connector = Connector(elastic_index=index, doc_source=connector_doc)
-    await connector.reset_sync_now_flag()
-
-    index.update.assert_awaited_once_with(
-        doc_id=doc_id,
-        doc={"sync_now": False},
         if_seq_no=seq_no,
         if_primary_term=primary_term,
     )

--- a/tests/sources/fixtures/mongodb/connector.json
+++ b/tests/sources/fixtures/mongodb/connector.json
@@ -3,7 +3,6 @@
         "service_type": "mongodb",
         "index_name": "search-mongodb",
         "sync_cursor": null,
-        "sync_now": true,
         "is_native": false,
         "api_key_id": null,
         "status": "configured",

--- a/tests/sources/fixtures/mongodb_serverless/connector.json
+++ b/tests/sources/fixtures/mongodb_serverless/connector.json
@@ -3,7 +3,6 @@
   "service_type": "mongodb",
   "index_name": "search-mongodb",
   "sync_cursor": null,
-  "sync_now": false,
   "is_native": false,
   "api_key_id": null,
   "status": "configured",

--- a/tests/sources/fixtures/mysql/connector.json
+++ b/tests/sources/fixtures/mysql/connector.json
@@ -3,7 +3,6 @@
         "index_name": "search-mysql",
         "service_type": "mysql",
         "sync_cursor": null,
-        "sync_now": true,
         "is_native": false,
         "api_key_id": null,
         "status": "configured",

--- a/tests/sources/fixtures/sharepoint_online/connector.json
+++ b/tests/sources/fixtures/sharepoint_online/connector.json
@@ -168,7 +168,6 @@
     },
     "service_type": "sharepoint_online",
     "status": "error",
-    "sync_now": false,
     "id": "cVvIfIgBFjJwEZQVkrcy",
     "last_indexed_document_count": 0,
     "last_deleted_document_count": 0


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4638

This PR removes the `sync_now` flag support:
1. connector service won't schedule a sync job if this flag is set to `true`
2. remove `sync_now` from documentation

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)