### PR TITLE
use only required credentials keys

### DIFF
--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -59,6 +59,16 @@ DEFAULT_PEM_FILE = os.path.join(
     "google_cloud_storage",
     "service_account_dummy_cert.pem",
 )
+REQUIRED_CREDENTIAL_KEYS = [
+    "type",
+    "project_id",
+    "private_key_id",
+    "private_key",
+    "client_email",
+    "client_id",
+    "auth_uri",
+    "token_uri",
+]
 
 
 class GoogleCloudStorageClient:
@@ -237,8 +247,14 @@ class GoogleCloudStorageDataSource(BaseDataSource):
                 max_split=2,
             )
 
+        required_credentials = {
+            key: value
+            for key, value in json_credentials.items()
+            if key in REQUIRED_CREDENTIAL_KEYS
+        }
+
         return GoogleCloudStorageClient(
-            json_credentials=json_credentials,
+            json_credentials=required_credentials,
             retry_count=self.configuration["retry_count"],
         )
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/1044

This PR aims to fix the connection to google cloud storage by using only the required keys from the service account JSON credentials. Following are the keys required for accessing the buckets and their files: "type", "project_id", "private_key_id", "private_key", "client_email", "client_id", "auth_uri" and "token_uri"

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)