### PR TITLE
Reuse enqueue_docs_to_delete method

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -440,21 +440,7 @@ class Extractor:
             # wait for all downloads to be finished
             await lazy_downloads.join()
 
-        # We delete any document that existed in Elasticsearch that was not
-        # returned by the backend.
-        #
-        # Since we popped out every seen doc, existing_ids has now the ids to delete
-        logger.debug(f"Delete {len(existing_ids)} docs from Elasticsearch")
-        for doc_id in existing_ids.keys():
-            await self.queue.put(
-                {
-                    "_op_type": OP_DELETE,
-                    "_index": self.index,
-                    "_id": doc_id,
-                }
-            )
-            self.total_docs_deleted += 1
-
+        await self.enqueue_docs_to_delete(existing_ids)
         await self.queue.put("END_DOCS")
 
     async def get_docs_incrementally(self, generator):


### PR DESCRIPTION
Found duplicate code block, reuse the existing method.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)