### PR TITLE
[DLS] Prefix target index for access control syncs

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -920,6 +920,8 @@ class SyncJobIndex(ESIndex):
         elastic_config (dict): Elasticsearch configuration and credentials
     """
 
+    ACCESS_CONTROL_INDEX_PREFIX = "search-acl-filter-"
+
     def __init__(self, elastic_config):
         super().__init__(index_name=JOBS_INDEX, elastic_config=elastic_config)
 
@@ -937,11 +939,16 @@ class SyncJobIndex(ESIndex):
 
     async def create(self, connector, trigger_method, job_type):
         filtering = connector.filtering.get_active_filter().transform_filtering()
+        index_name = connector.index_name
+
+        if job_type == JobType.ACCESS_CONTROL:
+            index_name = f"{SyncJobIndex.ACCESS_CONTROL_INDEX_PREFIX}{index_name}"
+
         job_def = {
             "connector": {
                 "id": connector.id,
                 "filtering": filtering,
-                "index_name": connector.index_name,
+                "index_name": index_name,
                 "language": connector.language,
                 "pipeline": connector.pipeline.data,
                 "service_type": connector.service_type,

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -31,6 +31,7 @@ from connectors.source import (
     get_source_klass,
 )
 from connectors.utils import (
+    ACCESS_CONTROL_INDEX_PREFIX,
     deep_merge_dicts,
     filter_nested_dict_by_keys,
     iso_utc,
@@ -920,8 +921,6 @@ class SyncJobIndex(ESIndex):
         elastic_config (dict): Elasticsearch configuration and credentials
     """
 
-    ACCESS_CONTROL_INDEX_PREFIX = "search-acl-filter-"
-
     def __init__(self, elastic_config):
         super().__init__(index_name=JOBS_INDEX, elastic_config=elastic_config)
 
@@ -942,7 +941,7 @@ class SyncJobIndex(ESIndex):
         index_name = connector.index_name
 
         if job_type == JobType.ACCESS_CONTROL:
-            index_name = f"{SyncJobIndex.ACCESS_CONTROL_INDEX_PREFIX}{index_name}"
+            index_name = f"{ACCESS_CONTROL_INDEX_PREFIX}{index_name}"
 
         job_def = {
             "connector": {

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,22 +330,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -330,6 +330,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -29,6 +29,7 @@ from pympler import asizeof
 
 from connectors.logger import logger
 
+ACCESS_CONTROL_INDEX_PREFIX = "search-acl-filter-"
 DEFAULT_CHUNK_SIZE = 500
 DEFAULT_QUEUE_SIZE = 1024
 DEFAULT_DISPLAY_EVERY = 100

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1765,7 +1765,7 @@ async def test_create_job(index_method, trigger_method, set_env):
 )
 @patch("connectors.protocol.SyncJobIndex.index")
 @patch(
-    "connectors.protocol.SyncJobIndex.ACCESS_CONTROL_INDEX_PREFIX",
+    "connectors.utils.ACCESS_CONTROL_INDEX_PREFIX",
     ACCESS_CONTROL_INDEX_PREFIX,
 )
 async def test_create_jobs_with_correct_target_index(

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -190,6 +190,9 @@ ADVANCED_AND_BASIC_RULES_NON_EMPTY = {
 
 SYNC_CURSOR = {"foo": "bar"}
 
+INDEX_NAME = "index_name"
+ACCESS_CONTROL_INDEX_PREFIX = "search-acl-filter-"
+
 
 def test_utc():
     # All dates are in ISO 8601 UTC so we can serialize them
@@ -1746,6 +1749,57 @@ async def test_create_job(index_method, trigger_method, set_env):
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
     await sync_job_index.create(
         connector=connector, trigger_method=trigger_method, job_type=JobType.INCREMENTAL
+    )
+
+    index_method.assert_called_with(expected_index_doc)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "job_type, target_index_name",
+    [
+        (JobType.FULL, INDEX_NAME),
+        (JobType.INCREMENTAL, INDEX_NAME),
+        (JobType.ACCESS_CONTROL, f"{ACCESS_CONTROL_INDEX_PREFIX}{INDEX_NAME}"),
+    ],
+)
+@patch("connectors.protocol.SyncJobIndex.index")
+@patch(
+    "connectors.protocol.SyncJobIndex.ACCESS_CONTROL_INDEX_PREFIX",
+    ACCESS_CONTROL_INDEX_PREFIX,
+)
+async def test_create_jobs_with_correct_target_index(
+    index_method, job_type, target_index_name, set_env
+):
+    connector = Mock()
+    connector.index_name = INDEX_NAME
+    config = load_config(CONFIG)
+
+    expected_index_doc = {
+        "connector": {
+            "id": ANY,
+            "filtering": ANY,
+            "index_name": target_index_name,
+            "language": ANY,
+            "pipeline": ANY,
+            "service_type": ANY,
+            "configuration": ANY,
+        },
+        "trigger_method": JobTriggerMethod.SCHEDULED.value,
+        "job_type": job_type.value,
+        "status": JobStatus.PENDING.value,
+        "indexed_document_count": 0,
+        "indexed_document_volume": 0,
+        "deleted_document_count": 0,
+        "created_at": ANY,
+        "last_seen": ANY,
+    }
+
+    sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    await sync_job_index.create(
+        connector=connector,
+        trigger_method=JobTriggerMethod.SCHEDULED,
+        job_type=job_type,
     )
 
     index_method.assert_called_with(expected_index_doc)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4805

This PR prefixes the target index for sync jobs of type `access_control` with `search-acl-filter-`, which is the prefix for access control indices.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)