### PR TITLE
Use string interpolation for warning when Retry-After is not provided

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -295,7 +295,7 @@ class MicrosoftAPISession:
                         retry_seconds = int(response_headers["Retry-After"])
                     else:
                         logger.warning(
-                            "Response Code from Sharepoint Server is 429 but Retry-After header is not found, using default retry time: {DEFAULT_RETRY_SECONDS} seconds"
+                            f"Response Code from Sharepoint Server is 429 but Retry-After header is not found, using default retry time: {DEFAULT_RETRY_SECONDS} seconds"
                         )
                         retry_seconds = DEFAULT_RETRY_SECONDS
                     logger.debug(


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4701

Found a string that is formatted without interpolation - fixing it.
