### PR TITLE
Properly populate ids for site pages and list items

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -728,7 +728,13 @@ class SharepointOnlineDataSource(BaseDataSource):
                     async for list_item in self.client.site_list_items(
                         site["id"], site_list["id"]
                     ):
-                        list_item["_id"] = list_item["id"]
+                        # List Item IDs are unique within list.
+                        # Therefore we mix in site_list id to it to make sure they are
+                        # globally unique.
+                        # Also we need to remember original ID because when a document
+                        # is yielded, its "id" field is overwritten with content of "_id" field
+                        list_item_natural_id = list_item["id"]
+                        list_item["_id"] = f"{site_list['id']}-{list_item['id']}"
                         list_item["object_type"] = "list_item"
                         list_item["_tempfile_suffix"] = os.path.splitext(
                             list_item.get("FileName", "")
@@ -742,9 +748,11 @@ class SharepointOnlineDataSource(BaseDataSource):
                         ]:  # TODO: make it more flexible. For now I ignore them cause they 404 all the time
                             continue
 
+                        yield list_item, None
+
                         if "Attachments" in list_item["fields"]:
                             async for list_item_attachment in self.client.site_list_item_attachments(
-                                site["webUrl"], site_list["name"], list_item["id"]
+                                site["webUrl"], site_list["name"], list_item_natural_id
                             ):
                                 list_item_attachment["_id"] = list_item_attachment[
                                     "odata.id"
@@ -761,12 +769,10 @@ class SharepointOnlineDataSource(BaseDataSource):
                                 )
                                 yield list_item_attachment, attachment_download_func
 
-                        download_func = None
-
-                        yield list_item, download_func
-
                 async for site_page in self.client.site_pages(site["webUrl"]):
-                    site_page["_id"] = site_page["GUID"]
+                    site_page["_id"] = site_page[
+                        "odata.id"
+                    ]  # Apparantly site_page["GUID"] is not globally unique
                     site_page["object_type"] = "site_page"
 
                     for html_field in ["LayoutWebpartsContent", "CanvasContent1"]:

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -683,7 +683,7 @@ class TestSharepointOnlineDataSource:
 
     @property
     def site_pages(self):
-        return [{"GUID": "thats-not-a-guid"}]
+        return [{"odata.id": "11", "GUID": "thats-not-a-guid"}]
 
     @property
     def graph_api_token(self):


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4701

Found out that some of IDs that were used by the connector before are actually not unique.

For list items I'm mixing in ID of List object that contains items, for Web Pages I switch to `odata.id` - these seem unique.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
