### PR TITLE
Make functional tests poll more often

### DIFF
--- a/tests/sources/fixtures/azure_blob_storage/config.yml
+++ b/tests/sources/fixtures/azure_blob_storage/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/confluence/config.yml
+++ b/tests/sources/fixtures/confluence/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/dir/config.yml
+++ b/tests/sources/fixtures/dir/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/google_cloud_storage/config.yml
+++ b/tests/sources/fixtures/google_cloud_storage/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/jira/config.yml
+++ b/tests/sources/fixtures/jira/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/mongodb/config.yml
+++ b/tests/sources/fixtures/mongodb/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/mongodb_serverless/config.yml
+++ b/tests/sources/fixtures/mongodb_serverless/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/mssql/config.yml
+++ b/tests/sources/fixtures/mssql/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/mysql/config.yml
+++ b/tests/sources/fixtures/mysql/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/network_drive/config.yml
+++ b/tests/sources/fixtures/network_drive/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/oracle/config.yml
+++ b/tests/sources/fixtures/oracle/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/postgresql/config.yml
+++ b/tests/sources/fixtures/postgresql/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/s3/config.yml
+++ b/tests/sources/fixtures/s3/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600

--- a/tests/sources/fixtures/sharepoint/config.yml
+++ b/tests/sources/fixtures/sharepoint/config.yml
@@ -18,7 +18,7 @@ elasticsearch:
   log_level: info
 
 service:
-  idling: 30
+  idling: 5
   heartbeat: 300
   max_errors: 20
   max_errors_span: 600


### PR DESCRIPTION
Attempting to fix functional tests.

Functional tests cron schedule is "1 * * * * *" - meaning at first second of every minute. Service polls every 30 seconds.

If the service starts exactly in the middle of the interval - let's say couple milliseconds over 17:00:31, then there is a chance it'll never work:

next_run(17:00:31.000001) will be reported as "17:01:01" but the service will wake up at "17:01:01.000001" and it's already too late. Service will keep attempting until at some point the rounding will trigger and the job will work.

For now to not spend too much time diving into date times, I'm proposing to just decrease poll interval for functional tests.

When we'll need to support "every minute" schedule, we'll need to address this problem accordingly.