### PR TITLE
Fix minor issues with data extraction service

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -612,9 +612,10 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "display": "toggle",
                 "label": "Use text extraction service",
                 "order": 6,
-                "type": "bool",
-                "value": False,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+                "type": "bool",
+                "ui_restrictions": ["advanced"],
+                "value": False,
             },
         }
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -757,11 +757,11 @@ class ExtractionService:
         content = await response.json()
 
         if response.status != 200:
-            logger.warn(
+            logger.warning(
                 f"Extraction service could not parse `{filename}'. Status: [{response.status}]."
             )
         if content.get("error"):
-            logger.warn(
+            logger.warning(
                 f"Extraction service could not parse `{filename}'; {content.get('error', 'unexpected error')}: {content.get('message', 'unknown cause')}"
             )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -617,7 +617,7 @@ class TestExtractionService:
                 extraction_service._begin_session()
 
                 response = await extraction_service.extract_text(filepath)
-                extraction_service._end_session()
+                await extraction_service._end_session()
 
                 assert response == "I've been extracted!"
 


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4575

- Alphabetise `use_text_extraction_service` configurable field property ordering
- Add `ui_restrictions` to `use_text_extraction_service`
- Replace deprecated `.warn` with `.warning`
- Add missing `await`

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
