### PR TITLE
Add preflight check for unmodified config

### DIFF
--- a/tests/fake_sources.py
+++ b/tests/fake_sources.py
@@ -51,7 +51,7 @@ class FakeSource(BaseDataSource):
 
     @classmethod
     def get_default_configuration(cls):
-        return []
+        return {}
 
     @classmethod
     async def validate_filtering(cls, filtering):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,13 +70,14 @@ def test_config_action(mock_responses, set_env):
     args.log_level = "DEBUG"
     args.config_file = CONFIG
     args.action = ["config"]
-    args.service_type = 'fake'
+    args.service_type = "fake"
     with patch("sys.stdout", new=StringIO()) as patched_stdout:
         result = run(args)
         output = patched_stdout.getvalue().strip()
         assert result == 0
         assert "Could not find a connector for service type" not in output
         assert "Getting default configuration for service type fake" in output
+
 
 def test_run_snowflake(mock_responses, set_env):
     args = mock.MagicMock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,19 @@ def test_run(mock_responses, set_env):
         assert "Bye" in output
 
 
+def test_config_action(mock_responses, set_env):
+    args = mock.MagicMock()
+    args.log_level = "DEBUG"
+    args.config_file = CONFIG
+    args.action = ["config"]
+    args.service_type = 'fake'
+    with patch("sys.stdout", new=StringIO()) as patched_stdout:
+        result = run(args)
+        output = patched_stdout.getvalue().strip()
+        assert result == 0
+        assert "Could not find a connector for service type" not in output
+        assert "Getting default configuration for service type fake" in output
+
 def test_run_snowflake(mock_responses, set_env):
     args = mock.MagicMock()
     args.log_level = "DEBUG"

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -178,6 +178,7 @@ async def test_unmodified_default_config(patched_logger, mock_responses):
         "In your configuration, you must change 'connector_id' and 'service_type' to not be 'changeme'"
     )
 
+
 @pytest.mark.asyncio
 @patch("connectors.preflight_check.logger")
 async def test_missing_mode_config(patched_logger, mock_responses):

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -22,6 +22,8 @@ config = {
         "initial_backoff_duration": 0.1,
     },
     "service": {"preflight_max_attempts": 4, "preflight_idle": 0.1},
+    "connector_id": "connector_1",
+    "service_type": "some_type",
 }
 
 
@@ -114,6 +116,8 @@ async def test_native_config_is_warned(patched_logger, mock_responses):
     mock_index_exists(mock_responses, JOBS_INDEX)
     local_config = config.copy()
     local_config["native_service_types"] = ["foo", "bar"]
+    del local_config["connector_id"]
+    del local_config["service_type"]
     preflight = PreflightCheck(local_config)
     result = await preflight.run()
     assert result is True
@@ -156,3 +160,20 @@ async def test_client_config(patched_logger, mock_responses):
     result = await preflight.run()
     assert result is True
     patched_logger.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("connectors.preflight_check.logger")
+async def test_unmodified_default_config(patched_logger, mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    local_config = config.copy()
+    local_config["connector_id"] = "changeme"
+    local_config["service_type"] = "changeme"
+    preflight = PreflightCheck(local_config)
+    result = await preflight.run()
+    assert result is False
+    patched_logger.errorassert_any_call(
+        "In your configuration, you must change 'connector_id' and 'service_type' to not be 'changeme'"
+    )

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -177,3 +177,19 @@ async def test_unmodified_default_config(patched_logger, mock_responses):
     patched_logger.errorassert_any_call(
         "In your configuration, you must change 'connector_id' and 'service_type' to not be 'changeme'"
     )
+
+@pytest.mark.asyncio
+@patch("connectors.preflight_check.logger")
+async def test_missing_mode_config(patched_logger, mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    local_config = config.copy()
+    del local_config["connector_id"]
+    del local_config["service_type"]
+    preflight = PreflightCheck(local_config)
+    result = await preflight.run()
+    assert result is False
+    patched_logger.errorassert_any_call(
+        "You must configure a 'connector_id' and a 'service_type'"
+    )


### PR DESCRIPTION
See this slack thread: https://elastic.slack.com/archives/C01795T48LQ/p1686824151748759

A recent change switched our `config.yml` to use client mode and deprecate native mode. For folks who were used to using the default `config.yml` without changes, this caused their connectors to stop syncing without any clear error messaging. This PR aims to make the issue clear, and to fail-fast.

```
[FMWK][11:23:55][INFO] Preflight checks...
[FMWK][11:23:55][INFO] Waiting for NodeConfig(scheme='http', host='localhost', port=9200, path_prefix='', headers={}, connections_per_node=10, request_timeout=10.0, http_compress=False, verify_certs=True, ca_certs=None, client_cert=None, client_key=None, ssl_assert_hostname=None, ssl_assert_fingerprint=None, ssl_version=None, ssl_context=None, ssl_show_warn=True, _extras={}) (so far: 0 secs)
[FMWK][11:23:55][ERROR] Unmodified default configuration detected.
[FMWK][11:23:55][ERROR] In your configuration, you must change 'connector_id' and 'service_type' to not be 'changeme'
[FMWK][11:23:55][INFO] Bye
make: *** [run] Error 255

```

## Checklists



#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

* breaking changed introduced in: https://github.com/elastic/connectors-python/pull/1038

## Release Note

`make run` no longer works on a fresh clone of connectors-python. You must modify `config.yml` before you start your connector service.
