### PR TITLE
[8.7] Add nightly_docker.yml for docker builds

### DIFF
--- a/.buildkite/nightly_docker.yml
+++ b/.buildkite/nightly_docker.yml
@@ -1,0 +1,10 @@
+agents:
+  provider: "gcp"
+  machineType: "n1-standard-8"
+  useVault: true
+  image: family/enterprise-search-ubuntu-2204-connectors-py
+
+steps:
+  - label: "🏗️ Docker images"
+    command:
+      - ".buildkite/publish_docker.sh"


### PR DESCRIPTION
See fails on https://buildkite.com/elastic/connectors-python-nightly-dockers/builds/33#0188d13a-0658-4204-85e2-d59c71b7484e

Problem is with missing `.buildkite/nightly_docker.yml`.