### PR TITLE
Log filename for failed extractions

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,14 +27,15 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-connector_id: 'changeme'
-service_type: 'changeme'
-
 extraction_service:
+  enabled: false
   host: http://localhost:8090
   text_extraction:
     use_file_pointers: false
     method: 'tika'
+
+connector_id: 'changeme'
+service_type: 'changeme'
 
 sources:
   mongodb: connectors.sources.mongo:MongoDataSource

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -320,8 +320,9 @@ class Extractor:
             self.total_downloads += 1
             data.pop("_id", None)
             data.pop(TIMESTAMP_FIELD, None)
-            data.pop("_tempfile_suffix", None)
             doc.update(data)
+
+        doc.pop("_original_filename", None)
 
         await self.queue.put(
             {

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -627,7 +627,6 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "order": 6,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
-                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }
@@ -719,14 +718,19 @@ class SharepointOnlineDataSource(BaseDataSource):
                                 logger.warning(
                                     f"Not downloading file {drive_item['name']}: last modified on {drive_item['lastModifiedDateTime']}"
                                 )
-                            elif drive_item["size"] > MAX_DOCUMENT_SIZE:
+                            elif (
+                                drive_item["size"] > MAX_DOCUMENT_SIZE
+                                and not self.configuration[
+                                    "use_text_extraction_service"
+                                ]
+                            ):
                                 logger.warning(
                                     f"Not downloading file {drive_item['name']} of size {drive_item['size']}"
                                 )
                             else:
-                                drive_item["_tempfile_suffix"] = os.path.splitext(
-                                    drive_item.get("name", "")
-                                )[-1]
+                                drive_item["_original_filename"] = drive_item.get(
+                                    "name", ""
+                                )
                                 download_func = partial(
                                     self.get_drive_item_content, drive_item
                                 )
@@ -750,9 +754,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                         list_item_natural_id = list_item["id"]
                         list_item["_id"] = f"{site_list['id']}-{list_item['id']}"
                         list_item["object_type"] = "list_item"
-                        list_item["_tempfile_suffix"] = os.path.splitext(
-                            list_item.get("FileName", "")
-                        )[-1]
+                        list_item["_original_filename"] = list_item.get("FileName", "")
 
                         content_type = list_item["contentType"]["name"]
 
@@ -820,7 +822,7 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         attachment, body = await self._download_content(
             partial(self.client.download_attachment, attachment["odata.id"]),
-            attachment["_tempfile_suffix"],
+            attachment["_original_filename"],
         )
 
         if attachment:
@@ -836,7 +838,10 @@ class SharepointOnlineDataSource(BaseDataSource):
         if not (doit and document_size):
             return
 
-        if document_size > MAX_DOCUMENT_SIZE:
+        if (
+            document_size > MAX_DOCUMENT_SIZE
+            and not self.configuration["use_text_extraction_service"]
+        ):
             return
 
         doc = {
@@ -850,7 +855,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                 drive_item["parentReference"]["driveId"],
                 drive_item["id"],
             ),
-            drive_item["_tempfile_suffix"],
+            drive_item["_original_filename"],
         )
 
         if attachment:
@@ -860,13 +865,14 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         return doc
 
-    async def _download_content(self, download_func, tempfile_suffix):
+    async def _download_content(self, download_func, original_filename):
         attachment = None
         body = None
         source_file_name = ""
+        file_extension = os.path.splitext(original_filename)[-1]
 
         async with NamedTemporaryFile(
-            mode="wb", delete=False, suffix=tempfile_suffix
+            mode="wb", delete=False, suffix=file_extension
         ) as async_buffer:
             # download_func should always be a partial with async_buffer as last argument that is not filled by the caller!
             # E.g. if download_func is download_drive_item(drive_id, item_id, async_buffer) then it
@@ -877,7 +883,9 @@ class SharepointOnlineDataSource(BaseDataSource):
             source_file_name = async_buffer.name
 
         if self.configuration["use_text_extraction_service"]:
-            body = await self.extraction_service.extract_text(source_file_name)
+            body = await self.extraction_service.extract_text(
+                source_file_name, original_filename
+            )
         else:
             await asyncio.to_thread(
                 convert_to_b64,

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -203,6 +203,11 @@ class SyncJobRunner:
             self.sync_job.index_name, mappings=mappings
         )
 
+        content_extraction_enabled = (
+            self.sync_job.configuration.get("use_text_extraction_service")
+            or self.sync_job.pipeline["extract_binary_content"]
+        )
+
         await self.elastic_server.async_bulk(
             self.sync_job.index_name,
             self.prepare_docs(),
@@ -210,7 +215,7 @@ class SyncJobRunner:
             job_type,
             filter_=self.sync_job.filtering,
             sync_rules_enabled=sync_rules_enabled,
-            content_extraction_enabled=self.sync_job.pipeline["extract_binary_content"],
+            content_extraction_enabled=content_extraction_enabled,
             options=bulk_options,
         )
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -975,7 +975,9 @@ class TestSharepointOnlineDataSource:
             assert "_attachment" not in download_result
 
     @pytest.mark.asyncio
-    async def test_get_drive_item_content_file_too_big_doesnt_download(self, patch_sharepoint_client):
+    async def test_get_drive_item_content_file_too_big_doesnt_download(
+        self, patch_sharepoint_client
+    ):
         drive_item = {
             "id": "1",
             "size": 10485761,
@@ -990,7 +992,9 @@ class TestSharepointOnlineDataSource:
         assert download_result is None
 
     @pytest.mark.asyncio
-    async def test_get_drive_item_content_file_size_with_extraction_service(self, patch_sharepoint_client):
+    async def test_get_drive_item_content_file_size_with_extraction_service(
+        self, patch_sharepoint_client
+    ):
         drive_item = {
             "id": "1",
             "size": 10485761,
@@ -1001,8 +1005,9 @@ class TestSharepointOnlineDataSource:
         message = "This is the text content of drive item"
 
         with patch(
-                "connectors.utils.ExtractionService.extract_text", return_value=message
+            "connectors.utils.ExtractionService.extract_text", return_value=message
         ) as extraction_service_mock:
+
             async def download_func(drive_id, drive_item_id, async_buffer):
                 await async_buffer.write(bytes(message, "utf-8"))
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -973,3 +973,46 @@ class TestSharepointOnlineDataSource:
             extraction_service_mock.assert_called_once()
             assert download_result["body"] == message
             assert "_attachment" not in download_result
+
+    @pytest.mark.asyncio
+    async def test_get_drive_item_content_file_too_big_doesnt_download(self, patch_sharepoint_client):
+        drive_item = {
+            "id": "1",
+            "size": 10485761,
+            "lastModifiedDateTime": datetime.now(timezone.utc),
+            "parentReference": {"driveId": "drive-1"},
+            "_original_filename": "file.txt",
+        }
+        source = create_source(SharepointOnlineDataSource)
+
+        download_result = await source.get_drive_item_content(drive_item, doit=True)
+
+        assert download_result is None
+
+    @pytest.mark.asyncio
+    async def test_get_drive_item_content_file_size_with_extraction_service(self, patch_sharepoint_client):
+        drive_item = {
+            "id": "1",
+            "size": 10485761,
+            "lastModifiedDateTime": datetime.now(timezone.utc),
+            "parentReference": {"driveId": "drive-1"},
+            "_original_filename": "file.txt",
+        }
+        message = "This is the text content of drive item"
+
+        with patch(
+                "connectors.utils.ExtractionService.extract_text", return_value=message
+        ) as extraction_service_mock:
+            async def download_func(drive_id, drive_item_id, async_buffer):
+                await async_buffer.write(bytes(message, "utf-8"))
+
+            patch_sharepoint_client.download_drive_item = download_func
+            source = create_source(
+                SharepointOnlineDataSource, use_text_extraction_service=True
+            )
+
+            download_result = await source.get_drive_item_content(drive_item, doit=True)
+
+            extraction_service_mock.assert_called_once()
+            assert download_result["body"] == message
+            assert "_attachment" not in download_result

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -882,7 +882,7 @@ class TestSharepointOnlineDataSource:
 
     @pytest.mark.asyncio
     async def test_get_attachment_content(self, patch_sharepoint_client):
-        attachment = {"odata.id": "1", "_tempfile_suffix": ".ppt"}
+        attachment = {"odata.id": "1", "_original_filename": "file.ppt"}
         message = b"This is content of attachment"
 
         async def download_func(attachment_id, async_buffer):
@@ -900,7 +900,7 @@ class TestSharepointOnlineDataSource:
     async def test_get_attachment_with_text_extraction_enabled_adds_body(
         self, patch_sharepoint_client
     ):
-        attachment = {"odata.id": "1", "_tempfile_suffix": ".ppt"}
+        attachment = {"odata.id": "1", "_original_filename": "file.ppt"}
         message = "This is the text content of drive item"
 
         with patch(
@@ -928,7 +928,7 @@ class TestSharepointOnlineDataSource:
             "size": 15,
             "lastModifiedDateTime": datetime.now(timezone.utc),
             "parentReference": {"driveId": "drive-1"},
-            "_tempfile_suffix": ".txt",
+            "_original_filename": "file.txt",
         }
         message = b"This is content of drive item"
 
@@ -952,7 +952,7 @@ class TestSharepointOnlineDataSource:
             "size": 15,
             "lastModifiedDateTime": datetime.now(timezone.utc),
             "parentReference": {"driveId": "drive-1"},
-            "_tempfile_suffix": ".txt",
+            "_original_filename": "file.txt",
         }
         message = "This is the text content of drive item"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -616,7 +616,9 @@ class TestExtractionService:
                 extraction_service = ExtractionService()
                 extraction_service._begin_session()
 
-                response = await extraction_service.extract_text(filepath)
+                response = await extraction_service.extract_text(
+                    filepath, "notreal.txt"
+                )
                 await extraction_service._end_session()
 
                 assert response == "I've been extracted!"
@@ -642,7 +644,9 @@ class TestExtractionService:
                 extraction_service = ExtractionService()
                 extraction_service._begin_session()
 
-                response = await extraction_service.extract_text(filepath)
+                response = await extraction_service.extract_text(
+                    filepath, "notreal.txt"
+                )
                 await extraction_service._end_session()
 
                 assert response == "I've been extracted!"
@@ -669,7 +673,9 @@ class TestExtractionService:
                 extraction_service = ExtractionService()
                 extraction_service._begin_session()
 
-                response = await extraction_service.extract_text(filepath)
+                response = await extraction_service.extract_text(
+                    filepath, "notreal.txt"
+                )
                 await extraction_service._end_session()
                 assert response == ""
 
@@ -703,7 +709,9 @@ class TestExtractionService:
                 extraction_service = ExtractionService()
                 extraction_service._begin_session()
 
-                response = await extraction_service.extract_text(filepath)
+                response = await extraction_service.extract_text(
+                    filepath, "notreal.txt"
+                )
                 await extraction_service._end_session()
                 assert response == ""
 


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4508

Add the following misc changes to SharePoint Online local content extraction:
- Download files in either of the following cases:
  - the pipeline `binary_content_extraction` is `True` 
  - the configurable field `use_text_extraction_service` is `True`
- Use real file names in failed extraction logs
- Remove file size download limit when `use_text_extraction_service` is `True`
- Catch `ClientConnectionError` as well as `ServerTimeoutError`

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference


<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
