### PR TITLE
Add extraction service preflight check

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,14 +27,15 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-connector_id: 'changeme'
-service_type: 'changeme'
-
 extraction_service:
+  enabled: false
   host: http://localhost:8090
   text_extraction:
     use_file_pointers: false
     method: 'tika'
+
+connector_id: 'changeme'
+service_type: 'changeme'
 
 sources:
   mongodb: connectors.sources.mongo:MongoDataSource

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -4,6 +4,8 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 
+import aiohttp
+
 from connectors.es import ESClient
 from connectors.logger import logger
 from connectors.protocol import CONNECTORS_INDEX, JOBS_INDEX
@@ -15,6 +17,7 @@ class PreflightCheck:
         self.config = config
         self.elastic_config = config["elasticsearch"]
         self.service_config = config["service"]
+        self.extraction_config = config["extraction_service"]
         self.es_client = ESClient(self.elastic_config)
         self.preflight_max_attempts = int(
             self.service_config.get("preflight_max_attempts", 10)
@@ -41,6 +44,8 @@ class PreflightCheck:
                 logger.critical(f"{self.elastic_config['host']} seem down. Bye!")
                 return False
 
+            await self._check_local_extraction_setup()
+
             valid_configuration = self._validate_configuration()
             available_system_indices = await self._check_system_indices_with_retries()
             return valid_configuration and available_system_indices
@@ -48,6 +53,35 @@ class PreflightCheck:
             self.stop()
             if self.es_client is not None:
                 await self.es_client.close()
+
+    async def _check_local_extraction_setup(self):
+        if not self.extraction_config["enabled"]:
+            return
+
+        try:
+            timeout = aiohttp.ClientTimeout(total=5)
+            session = aiohttp.ClientSession(timeout=timeout)
+            async with session.get(
+                f"{self.extraction_config['host']}/ping/"
+            ) as response:
+                if response.status != 200:
+                    logger.warning(
+                        f"Data extraction service was found at {self.extraction_config['host']} but health-check returned `{response.status}'."
+                    )
+                else:
+                    logger.info(
+                        f"Data extraction service found at {self.extraction_config['host']}."
+                    )
+        except (aiohttp.ClientConnectionError, aiohttp.ServerTimeoutError) as e:
+            logger.critical(
+                f"Expected to find a running instance of data extraction service at {self.extraction_config['host']} but failed. {e}."
+            )
+        except Exception as e:
+            logger.critical(
+                f"Unexpected error occurred while attempting to connect to data extraction service at {self.extraction_config['host']}. {e}."
+            )
+        finally:
+            await session.close()
 
     async def _check_system_indices_with_retries(self):
         attempts = 0

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -60,6 +60,7 @@ class PreflightCheck:
 
         timeout = aiohttp.ClientTimeout(total=5)
         session = aiohttp.ClientSession(timeout=timeout)
+
         try:
             async with session.get(
                 f"{self.extraction_config['host']}/ping/"

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -55,12 +55,12 @@ class PreflightCheck:
                 await self.es_client.close()
 
     async def _check_local_extraction_setup(self):
-        if not self.extraction_config["enabled"]:
+        if not self.extraction_config.get("enabled", False):
             return
 
+        timeout = aiohttp.ClientTimeout(total=5)
+        session = aiohttp.ClientSession(timeout=timeout)
         try:
-            timeout = aiohttp.ClientTimeout(total=5)
-            session = aiohttp.ClientSession(timeout=timeout)
             async with session.get(
                 f"{self.extraction_config['host']}/ping/"
             ) as response:

--- a/tests/fixtures/config.yml
+++ b/tests/fixtures/config.yml
@@ -18,6 +18,13 @@ service:
   max_concurrent_access_control_syncs: 10
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://elsewhere.com:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'fake'
+
 connector_id: '1'
 
 sources:

--- a/tests/sources/fixtures/azure_blob_storage/config.yml
+++ b/tests/sources/fixtures/azure_blob_storage/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'abs'
 service_type: 'azure_blob_storage'
 

--- a/tests/sources/fixtures/confluence/config.yml
+++ b/tests/sources/fixtures/confluence/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'confluence'
 service_type: 'confluence'
 

--- a/tests/sources/fixtures/dir/config.yml
+++ b/tests/sources/fixtures/dir/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'dir'
 service_type: 'dir'
 

--- a/tests/sources/fixtures/google_cloud_storage/config.yml
+++ b/tests/sources/fixtures/google_cloud_storage/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'gcs'
 service_type: 'google_cloud_storage'
 

--- a/tests/sources/fixtures/jira/config.yml
+++ b/tests/sources/fixtures/jira/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'jira'
 service_type: 'jira'
 

--- a/tests/sources/fixtures/mongodb/config.yml
+++ b/tests/sources/fixtures/mongodb/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'mongo'
 service_type: 'mongodb'
 

--- a/tests/sources/fixtures/mongodb_serverless/config.yml
+++ b/tests/sources/fixtures/mongodb_serverless/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'mongo_serverless'
 service_type: 'mongodb'
 

--- a/tests/sources/fixtures/mssql/config.yml
+++ b/tests/sources/fixtures/mssql/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'mssql'
 service_type: 'mssql'
 

--- a/tests/sources/fixtures/mysql/config.yml
+++ b/tests/sources/fixtures/mysql/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'mysql'
 service_type: 'mysql'
 

--- a/tests/sources/fixtures/network_drive/config.yml
+++ b/tests/sources/fixtures/network_drive/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'network_drive'
 service_type: 'network_drive'
 

--- a/tests/sources/fixtures/oracle/config.yml
+++ b/tests/sources/fixtures/oracle/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'oracle'
 service_type: 'oracle'
 

--- a/tests/sources/fixtures/postgresql/config.yml
+++ b/tests/sources/fixtures/postgresql/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'postgres'
 service_type: 'postgresql'
 

--- a/tests/sources/fixtures/s3/config.yml
+++ b/tests/sources/fixtures/s3/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 's3'
 service_type: 's3'
 

--- a/tests/sources/fixtures/servicenow/config.yml
+++ b/tests/sources/fixtures/servicenow/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'servicenow'
 service_type: 'servicenow'
 

--- a/tests/sources/fixtures/sharepoint/config.yml
+++ b/tests/sources/fixtures/sharepoint/config.yml
@@ -26,6 +26,13 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
+extraction_service:
+  enabled: false
+  host: http://localhost:8090
+  text_extraction:
+    use_file_pointers: false
+    method: 'tika'
+
 connector_id: 'sharepoint'
 service_type: 'sharepoint'
 

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -22,6 +22,11 @@ config = {
         "initial_backoff_duration": 0.1,
     },
     "service": {"preflight_max_attempts": 4, "preflight_idle": 0.1},
+    "extraction_service": {
+        "enabled": False,
+        "host": "http://localhost:8090",
+        "text_extraction": {"use_file_pointers": False, "method": "tika"},
+    },
     "connector_id": "connector_1",
     "service_type": "some_type",
 }
@@ -116,8 +121,6 @@ async def test_native_config_is_warned(patched_logger, mock_responses):
     mock_index_exists(mock_responses, JOBS_INDEX)
     local_config = config.copy()
     local_config["native_service_types"] = ["foo", "bar"]
-    del local_config["connector_id"]
-    del local_config["service_type"]
     preflight = PreflightCheck(local_config)
     result = await preflight.run()
     assert result is True
@@ -193,4 +196,60 @@ async def test_missing_mode_config(patched_logger, mock_responses):
     assert result is False
     patched_logger.errorassert_any_call(
         "You must configure a 'connector_id' and a 'service_type'"
+    )
+
+
+@pytest.mark.asyncio
+@patch("connectors.preflight_check.logger")
+async def test_extraction_service_enabled_and_found_writes_info_log(patched_logger, mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    local_config = config.copy()
+    local_config["extraction_service"]["enabled"] = True
+    preflight = PreflightCheck(local_config)
+
+    mock_responses.get(f"{local_config['extraction_service']['host']}/ping/", status=200)
+
+    result = await preflight.run()
+    assert result is True
+
+    patched_logger.info.assert_any_call(
+        f"Data extraction service found at {local_config['extraction_service']['host']}."
+    )
+
+@pytest.mark.asyncio
+@patch("connectors.preflight_check.logger")
+async def test_extraction_service_enabled_but_missing_logs_warning(patched_logger, mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    local_config = config.copy()
+    local_config["extraction_service"]["enabled"] = True
+    preflight = PreflightCheck(local_config)
+
+    mock_responses.get(f"{local_config['extraction_service']['host']}/ping/", status=404)
+
+    result = await preflight.run()
+    assert result is True
+
+    patched_logger.warning.assert_any_call(
+        f"Data extraction service was found at {local_config['extraction_service']['host']} but health-check returned `404'."
+    )
+
+@pytest.mark.asyncio
+@patch("connectors.preflight_check.logger")
+async def test_extraction_service_enabled_but_missing_logs_warning(patched_logger, mock_responses):
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, JOBS_INDEX)
+    local_config = config.copy()
+    local_config["extraction_service"]["enabled"] = True
+    preflight = PreflightCheck(local_config)
+
+    result = await preflight.run()
+    assert result is True
+    # Expected to find a running instance of data extraction service at http://localhost:8090 but failed. Connection refused: GET http://localhost:8090/ping/
+    patched_logger.critical.assert_any_call(
+        f"Expected to find a running instance of data extraction service at {local_config['extraction_service']['host']} but failed. Connection refused: GET {local_config['extraction_service']['host']}/ping/."
     )

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -121,6 +121,8 @@ async def test_native_config_is_warned(patched_logger, mock_responses):
     mock_index_exists(mock_responses, JOBS_INDEX)
     local_config = config.copy()
     local_config["native_service_types"] = ["foo", "bar"]
+    del local_config["connector_id"]
+    del local_config["service_type"]
     preflight = PreflightCheck(local_config)
     result = await preflight.run()
     assert result is True

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -263,7 +263,7 @@ async def test_extraction_service_enabled_but_missing_logs_critical(
 
     result = await preflight.run()
     assert result is True
-    # Expected to find a running instance of data extraction service at http://localhost:8090 but failed. Connection refused: GET http://localhost:8090/ping/
+
     patched_logger.critical.assert_any_call(
         f"Expected to find a running instance of data extraction service at {local_config['extraction_service']['host']} but failed. Connection refused: GET {local_config['extraction_service']['host']}/ping/."
     )

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -201,7 +201,9 @@ async def test_missing_mode_config(patched_logger, mock_responses):
 
 @pytest.mark.asyncio
 @patch("connectors.preflight_check.logger")
-async def test_extraction_service_enabled_and_found_writes_info_log(patched_logger, mock_responses):
+async def test_extraction_service_enabled_and_found_writes_info_log(
+    patched_logger, mock_responses
+):
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONNECTORS_INDEX)
     mock_index_exists(mock_responses, JOBS_INDEX)
@@ -209,7 +211,9 @@ async def test_extraction_service_enabled_and_found_writes_info_log(patched_logg
     local_config["extraction_service"]["enabled"] = True
     preflight = PreflightCheck(local_config)
 
-    mock_responses.get(f"{local_config['extraction_service']['host']}/ping/", status=200)
+    mock_responses.get(
+        f"{local_config['extraction_service']['host']}/ping/", status=200
+    )
 
     result = await preflight.run()
     assert result is True
@@ -218,9 +222,12 @@ async def test_extraction_service_enabled_and_found_writes_info_log(patched_logg
         f"Data extraction service found at {local_config['extraction_service']['host']}."
     )
 
+
 @pytest.mark.asyncio
 @patch("connectors.preflight_check.logger")
-async def test_extraction_service_enabled_but_missing_logs_warning(patched_logger, mock_responses):
+async def test_extraction_service_enabled_but_missing_logs_warning(
+    patched_logger, mock_responses
+):
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONNECTORS_INDEX)
     mock_index_exists(mock_responses, JOBS_INDEX)
@@ -228,7 +235,9 @@ async def test_extraction_service_enabled_but_missing_logs_warning(patched_logge
     local_config["extraction_service"]["enabled"] = True
     preflight = PreflightCheck(local_config)
 
-    mock_responses.get(f"{local_config['extraction_service']['host']}/ping/", status=404)
+    mock_responses.get(
+        f"{local_config['extraction_service']['host']}/ping/", status=404
+    )
 
     result = await preflight.run()
     assert result is True
@@ -237,9 +246,12 @@ async def test_extraction_service_enabled_but_missing_logs_warning(patched_logge
         f"Data extraction service was found at {local_config['extraction_service']['host']} but health-check returned `404'."
     )
 
+
 @pytest.mark.asyncio
 @patch("connectors.preflight_check.logger")
-async def test_extraction_service_enabled_but_missing_logs_warning(patched_logger, mock_responses):
+async def test_extraction_service_enabled_but_missing_logs_warning(
+    patched_logger, mock_responses
+):
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONNECTORS_INDEX)
     mock_index_exists(mock_responses, JOBS_INDEX)

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -251,7 +251,7 @@ async def test_extraction_service_enabled_but_missing_logs_warning(
 
 @pytest.mark.asyncio
 @patch("connectors.preflight_check.logger")
-async def test_extraction_service_enabled_but_missing_logs_warning(
+async def test_extraction_service_enabled_but_missing_logs_critical(
     patched_logger, mock_responses
 ):
     mock_es_info(mock_responses)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4972

Add a preflight check for the extraction service. This will only run when extraction service is enabled from configuration. The connector client should continue to run even if this check fails.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
