### PR TITLE
Make extraction service config optional

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,13 +27,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'changeme'
 service_type: 'changeme'
 

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -17,7 +17,7 @@ class PreflightCheck:
         self.config = config
         self.elastic_config = config["elasticsearch"]
         self.service_config = config["service"]
-        self.extraction_config = config["extraction_service"]
+        self.extraction_config = config.get("extraction_service", None)
         self.es_client = ESClient(self.elastic_config)
         self.preflight_max_attempts = int(
             self.service_config.get("preflight_max_attempts", 10)
@@ -55,7 +55,10 @@ class PreflightCheck:
                 await self.es_client.close()
 
     async def _check_local_extraction_setup(self):
-        if not self.extraction_config.get("enabled", False):
+        if self.extraction_config is None:
+            logger.info(
+                "Extraction service is not configured, skipping its preflight check."
+            )
             return
 
         timeout = aiohttp.ClientTimeout(total=5)

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1305,7 +1305,8 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         if attachment:
             doc["_attachment"] = attachment
-        if body:
+        if body is not None:
+            # accept empty strings for body
             doc["body"] = body
 
         return doc
@@ -1338,7 +1339,8 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         if attachment:
             doc["_attachment"] = attachment
-        if body:
+        if body is not None:
+            # accept empty strings for body
             doc["body"] = body
 
         return doc
@@ -1361,9 +1363,11 @@ class SharepointOnlineDataSource(BaseDataSource):
             source_file_name = async_buffer.name
 
         if self.configuration["use_text_extraction_service"]:
-            body = await self.extraction_service.extract_text(
-                source_file_name, original_filename
-            )
+            body = ""
+            if self.extraction_service._check_configured():
+                body = await self.extraction_service.extract_text(
+                    source_file_name, original_filename
+                )
         else:
             await asyncio.to_thread(
                 convert_to_b64,

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -677,16 +677,18 @@ class ExtractionService:
         ) as file:
             config = yaml.safe_load(file)
 
+        self.session = None
+
         self.extraction_config = config.get("extraction_service", None)
         if self.extraction_config is not None:
             self.host = self.extraction_config.get("host", None)
         else:
             self.host = None
-            logger.warning(
-                "Extraction service has been initialised but no extraction service configuration was found."
-            )
 
-        self.session = None
+        if self.host is None:
+            logger.warning(
+                "Extraction service has been initialised but no extraction service configuration was found. No text will be extracted for this sync."
+            )
 
     def _check_configured(self):
         if self.host is not None:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -677,11 +677,22 @@ class ExtractionService:
         ) as file:
             config = yaml.safe_load(file)
 
-        self.host = config["extraction_service"]["host"]
-        self.use_file_pointers = config["extraction_service"]["text_extraction"][
-            "use_file_pointers"
-        ]
+        self.extraction_config = config.get("extraction_service", None)
+        if self.extraction_config is not None:
+            self.host = self.extraction_config.get("host", None)
+        else:
+            self.host = None
+            logger.warning(
+                "Extraction service has been initialised but no extraction service configuration was found."
+            )
+
         self.session = None
+
+    def _check_configured(self):
+        if self.host is not None:
+            return True
+
+        return False
 
     def _begin_session(self):
         if self.session is not None:
@@ -706,18 +717,21 @@ class ExtractionService:
         """
 
         content = ""
+
+        if self._check_configured is False:
+            # an empty host means configuration was not set correctly
+            # a warning is already raised in __init__
+            return content
+
+        if self.session is None:
+            self._begin_session()
+
         filename = (
             original_filename if original_filename else os.path.basename(filepath)
         )
 
         try:
-            if self.session is None:
-                self._begin_session()
-
-            if self.use_file_pointers:
-                content = await self.extract_with_file_pointer(filepath, filename)
-            else:
-                content = await self.extract_with_file_send(filepath, filename)
+            content = await self.extract_with_file_send(filepath, filename)
         except (ClientConnectionError, ServerTimeoutError) as e:
             logger.error(
                 f"Connection to {self.host} failed while extracting data from {filename}. Error: {e}"
@@ -726,20 +740,6 @@ class ExtractionService:
             logger.error(f"Text extraction unexpectedly failed. Error: {e}")
 
         return content
-
-    async def extract_with_file_pointer(self, filepath, filename):
-        """Sends a request to tika-server to extract text from a file.
-        Sends the filename as a request parameter, which tika will pick up and extract.
-
-        Returns a parsed response
-        """
-        params = {"local_file_path": filepath}
-
-        async with self._begin_session().post(
-            f"{self.host}/extract_local_file_text/",
-            json=params,
-        ) as response:
-            return await self.parse_extraction_resp(filename, response)
 
     async def extract_with_file_send(self, filepath, filename):
         """Sends a request to tika-server to extract text from a file.

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -720,7 +720,7 @@ class ExtractionService:
 
         content = ""
 
-        if self._check_configured is False:
+        if self._check_configured() is False:
             # an empty host means configuration was not set correctly
             # a warning is already raised in __init__
             return content

--- a/tests/fixtures/config.yml
+++ b/tests/fixtures/config.yml
@@ -18,13 +18,6 @@ service:
   max_concurrent_access_control_syncs: 10
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://elsewhere.com:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'fake'
-
 connector_id: '1'
 
 sources:

--- a/tests/sources/fixtures/azure_blob_storage/config.yml
+++ b/tests/sources/fixtures/azure_blob_storage/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'abs'
 service_type: 'azure_blob_storage'
 

--- a/tests/sources/fixtures/confluence/config.yml
+++ b/tests/sources/fixtures/confluence/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'confluence'
 service_type: 'confluence'
 

--- a/tests/sources/fixtures/dir/config.yml
+++ b/tests/sources/fixtures/dir/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'dir'
 service_type: 'dir'
 

--- a/tests/sources/fixtures/google_cloud_storage/config.yml
+++ b/tests/sources/fixtures/google_cloud_storage/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'gcs'
 service_type: 'google_cloud_storage'
 

--- a/tests/sources/fixtures/jira/config.yml
+++ b/tests/sources/fixtures/jira/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'jira'
 service_type: 'jira'
 

--- a/tests/sources/fixtures/mongodb/config.yml
+++ b/tests/sources/fixtures/mongodb/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'mongo'
 service_type: 'mongodb'
 

--- a/tests/sources/fixtures/mongodb_serverless/config.yml
+++ b/tests/sources/fixtures/mongodb_serverless/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'mongo_serverless'
 service_type: 'mongodb'
 

--- a/tests/sources/fixtures/mssql/config.yml
+++ b/tests/sources/fixtures/mssql/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'mssql'
 service_type: 'mssql'
 

--- a/tests/sources/fixtures/mysql/config.yml
+++ b/tests/sources/fixtures/mysql/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'mysql'
 service_type: 'mysql'
 

--- a/tests/sources/fixtures/network_drive/config.yml
+++ b/tests/sources/fixtures/network_drive/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'network_drive'
 service_type: 'network_drive'
 

--- a/tests/sources/fixtures/oracle/config.yml
+++ b/tests/sources/fixtures/oracle/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'oracle'
 service_type: 'oracle'
 

--- a/tests/sources/fixtures/postgresql/config.yml
+++ b/tests/sources/fixtures/postgresql/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'postgres'
 service_type: 'postgresql'
 

--- a/tests/sources/fixtures/s3/config.yml
+++ b/tests/sources/fixtures/s3/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 's3'
 service_type: 's3'
 

--- a/tests/sources/fixtures/servicenow/config.yml
+++ b/tests/sources/fixtures/servicenow/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'servicenow'
 service_type: 'servicenow'
 

--- a/tests/sources/fixtures/sharepoint_server/config.yml
+++ b/tests/sources/fixtures/sharepoint_server/config.yml
@@ -26,13 +26,6 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-extraction_service:
-  enabled: false
-  host: http://localhost:8090
-  text_extraction:
-    use_file_pointers: false
-    method: 'tika'
-
 connector_id: 'sharepoint_server'
 service_type: 'sharepoint_server'
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1405,6 +1405,7 @@ class TestSharepointOnlineDataSource:
         assert "body" not in download_result
 
     @pytest.mark.asyncio
+    @patch("connectors.utils.ExtractionService._check_configured", lambda *_: True)
     async def test_get_attachment_with_text_extraction_enabled_adds_body(
         self, patch_sharepoint_client
     ):
@@ -1430,9 +1431,36 @@ class TestSharepointOnlineDataSource:
             assert "_attachment" not in download_result
 
     @pytest.mark.asyncio
+    @patch("connectors.utils.ExtractionService._check_configured", lambda *_: False)
+    async def test_get_attachment_with_text_extraction_enabled_but_not_configured_adds_empty_string(
+        self, patch_sharepoint_client
+    ):
+        attachment = {"odata.id": "1", "_original_filename": "file.ppt"}
+        message = "This is the text content of drive item"
+
+        with patch(
+            "connectors.utils.ExtractionService.extract_text", return_value=message
+        ) as extraction_service_mock:
+
+            async def download_func(attachment_id, async_buffer):
+                await async_buffer.write(bytes(message, "utf-8"))
+
+            patch_sharepoint_client.download_attachment = download_func
+            source = create_source(
+                SharepointOnlineDataSource, use_text_extraction_service=True
+            )
+
+            download_result = await source.get_attachment_content(attachment, doit=True)
+
+            extraction_service_mock.assert_not_called()
+            assert download_result["body"] == ""
+            assert "_attachment" not in download_result
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "filesize, expect_download", [(15, True), (10485761, False)]
     )
+    @patch("connectors.utils.ExtractionService._check_configured", lambda *_: True)
     async def test_get_drive_item_content(
         self, patch_sharepoint_client, filesize, expect_download
     ):
@@ -1461,6 +1489,7 @@ class TestSharepointOnlineDataSource:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("filesize", [(15), (10485761)])
+    @patch("connectors.utils.ExtractionService._check_configured", lambda *_: True)
     async def test_get_content_with_text_extraction_enabled_adds_body(
         self, patch_sharepoint_client, filesize
     ):
@@ -1489,6 +1518,39 @@ class TestSharepointOnlineDataSource:
 
             extraction_service_mock.assert_called_once()
             assert download_result["body"] == message
+            assert "_attachment" not in download_result
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("filesize", [(15), (10485761)])
+    @patch("connectors.utils.ExtractionService._check_configured", lambda *_: False)
+    async def test_get_content_with_text_extraction_enabled_but_not_configured_adds_empty_string(
+        self, patch_sharepoint_client, filesize
+    ):
+        drive_item = {
+            "id": "1",
+            "size": filesize,
+            "lastModifiedDateTime": datetime.now(timezone.utc),
+            "parentReference": {"driveId": "drive-1"},
+            "_original_filename": "file.txt",
+        }
+        message = "This is the text content of drive item"
+
+        with patch(
+            "connectors.utils.ExtractionService.extract_text", return_value=message
+        ) as extraction_service_mock:
+
+            async def download_func(drive_id, drive_item_id, async_buffer):
+                await async_buffer.write(bytes(message, "utf-8"))
+
+            patch_sharepoint_client.download_drive_item = download_func
+            source = create_source(
+                SharepointOnlineDataSource, use_text_extraction_service=True
+            )
+
+            download_result = await source.get_drive_item_content(drive_item, doit=True)
+
+            extraction_service_mock.assert_not_called()
+            assert download_result["body"] == ""
             assert "_attachment" not in download_result
 
     @pytest.mark.asyncio

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -22,11 +22,6 @@ config = {
         "initial_backoff_duration": 0.1,
     },
     "service": {"preflight_max_attempts": 4, "preflight_idle": 0.1},
-    "extraction_service": {
-        "enabled": False,
-        "host": "http://localhost:8090",
-        "text_extraction": {"use_file_pointers": False, "method": "tika"},
-    },
     "connector_id": "connector_1",
     "service_type": "some_type",
 }
@@ -210,7 +205,7 @@ async def test_extraction_service_enabled_and_found_writes_info_log(
     mock_index_exists(mock_responses, CONNECTORS_INDEX)
     mock_index_exists(mock_responses, JOBS_INDEX)
     local_config = config.copy()
-    local_config["extraction_service"]["enabled"] = True
+    local_config["extraction_service"] = {"host": "http://localhost:8090"}
     preflight = PreflightCheck(local_config)
 
     mock_responses.get(
@@ -234,7 +229,7 @@ async def test_extraction_service_enabled_but_missing_logs_warning(
     mock_index_exists(mock_responses, CONNECTORS_INDEX)
     mock_index_exists(mock_responses, JOBS_INDEX)
     local_config = config.copy()
-    local_config["extraction_service"]["enabled"] = True
+    local_config["extraction_service"] = {"host": "http://localhost:8090"}
     preflight = PreflightCheck(local_config)
 
     mock_responses.get(
@@ -258,7 +253,7 @@ async def test_extraction_service_enabled_but_missing_logs_critical(
     mock_index_exists(mock_responses, CONNECTORS_INDEX)
     mock_index_exists(mock_responses, JOBS_INDEX)
     local_config = config.copy()
-    local_config["extraction_service"]["enabled"] = True
+    local_config["extraction_service"] = {"host": "http://localhost:8090"}
     preflight = PreflightCheck(local_config)
 
     result = await preflight.run()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -594,25 +594,26 @@ class TestExtractionService:
         with aioresponses() as m:
             yield m
 
-    def test_check_configured_when_configuration_ok_returns_true(self):
-        mock_config = {
-            "extraction_service": {
-                "host": "http://localhost:8090",
-            }
-        }
-
+    @pytest.mark.parametrize(
+        "mock_config, expected_result",
+        [
+            (
+                {
+                    "extraction_service": {
+                        "host": "http://localhost:8090",
+                    }
+                },
+                True,
+            ),
+            ({"something_else": "???"}, False),
+            ({"extraction_service": {"not_a_host": "!!!m"}}, False),
+        ],
+    )
+    def test_check_configured(self, mock_config, expected_result):
         with patch("yaml.safe_load") as mock_safe_load:
             mock_safe_load.return_value = mock_config
             extraction_service = ExtractionService()
-            assert extraction_service._check_configured() is True
-
-    def test_check_configured_when_configuration_missing_returns_false(self):
-        mock_config = {"something_else": "???"}
-
-        with patch("yaml.safe_load") as mock_safe_load:
-            mock_safe_load.return_value = mock_config
-            extraction_service = ExtractionService()
-            assert extraction_service._check_configured() is False
+            assert extraction_service._check_configured() is expected_result
 
     @pytest.mark.asyncio
     async def test_extract_text(self, mock_responses):


### PR DESCRIPTION
### Related to https://github.com/elastic/enterprise-search-team/issues/4972

Make the `extraction_service` config setting optional.
This is to prevent users from needing to manage this configuration even if they aren't using this feature.

- Revert all config changes made in https://github.com/elastic/connectors-python/pull/1089
- Convert configuration check-up to be based on `extraction_service` configuration presence rather than an enabled flag.
- Don't attempt to extract content if `extraction_service` has not been configured.
- Remove the file-pointer extraction method
  - This feature did not make it in time for 8.9 FF on the data-extraction-service side, but we will re-add it in 8.10.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

## Related Pull Requests

This is a follow-up PR based on feedback here: https://github.com/elastic/connectors-python/pull/1089#discussion_r1235272058
