### PR TITLE
Update Dropbox SDK to 11.36.2

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -19,5 +19,5 @@ asyncpg==0.27.0
 python-tds==1.12.0
 sqlalchemy-pytds==0.3.5
 pyOpenSSL==23.1.1
-dropbox==11.36.0
+dropbox==11.36.2
 beautifulsoup4==4.12.2


### PR DESCRIPTION
### Closes: https://github.com/elastic/enterprise-search-team/issues/5017

This will fix the dependency tree caused by this error: 

```
....
  File "/Users/jedr/connectors-qa/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3170, in __init__
    super(Requirement, self).__init__(requirement_string)
  File "/Users/jedr/connectors-qa/lib/python3.10/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 37, in __init__
    raise InvalidRequirement(str(e)) from e
pkg_resources.extern.packaging.requirements.InvalidRequirement: Expected closing RIGHT_PARENTHESIS
    stone (>=2.*)
          ~~~~^
make: *** [bin/elastic-ingest] Error 1
```

Related PRs: 
* https://github.com/dropbox/dropbox-sdk-python/pull/456/files


## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
