### PR TITLE
Rename SPO advanced filtering rule

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -707,7 +707,7 @@ class SharepointOnlineAdvancedRulesValidator(AdvancedRulesValidator):
     SCHEMA_DEFINITION = {
         "type": "object",
         "properties": {
-            "dontExtractDriveItemsOlderThan": {"type": "integer"},  # in Days
+            "skipExtractingDriveItemsOlderThan": {"type": "integer"},  # in Days
         },
         "additionalProperties": False,
     }
@@ -1139,7 +1139,7 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         if filtering is not None and filtering.has_advanced_rules():
             advanced_rules = filtering.get_advanced_rules()
-            max_drive_item_age = advanced_rules["dontExtractDriveItemsOlderThan"]
+            max_drive_item_age = advanced_rules["skipExtractingDriveItemsOlderThan"]
 
         async for site_collection in self.site_collections():
             yield site_collection, None
@@ -1201,7 +1201,7 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         if filtering is not None and filtering.has_advanced_rules():
             advanced_rules = filtering.get_advanced_rules()
-            max_drive_item_age = advanced_rules["dontExtractDriveItemsOlderThan"]
+            max_drive_item_age = advanced_rules["skipExtractingDriveItemsOlderThan"]
 
         async for site_collection in self.site_collections():
             yield site_collection, None, OP_INDEX

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1173,7 +1173,7 @@ class TestSharepointOnlineAdvancedRulesValidator:
 
     @pytest.mark.asyncio
     async def test_validate(self, validator):
-        valid_rules = {"dontExtractDriveItemsOlderThan": 15}
+        valid_rules = {"skipExtractingDriveItemsOlderThan": 15}
 
         result = await validator.validate(valid_rules)
 
@@ -1181,7 +1181,7 @@ class TestSharepointOnlineAdvancedRulesValidator:
 
     @pytest.mark.asyncio
     async def test_validate_invalid_rule(self, validator):
-        invalid_rules = {"dontExtractDriveItemsOlderThan": "why is this a string"}
+        invalid_rules = {"skipExtractingDriveItemsOlderThan": "why is this a string"}
 
         result = await validator.validate(invalid_rules)
 


### PR DESCRIPTION
Part of discussion here: https://github.com/elastic/enterprise-search-pubs/pull/3557/files/640742dd8d0a6e3cfe3b0ad13fb7ba6cb5f13d99#r1246878303

We want the field to be called "skipExtractingDriveItemsOlderThan" for better clarity.