### PR TITLE
[8.9] [SPO] Check if DLS RFC is enabled (#1123)

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -828,6 +828,14 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "type": "bool",
                 "value": False,
             },
+            "use_document_level_security": {
+                "display": "toggle",
+                "label": "Enable document level security",
+                "order": 7,
+                "tooltip": "Document level security ensures identities and permissions set in Sharepoint Online are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
+                "type": "bool",
+                "value": False,
+            },
         }
 
     async def validate_config(self):
@@ -1077,7 +1085,10 @@ class SharepointOnlineDataSource(BaseDataSource):
         if self._features is None:
             return False
 
-        return self._features.document_level_security_enabled()
+        if not self._features.document_level_security_enabled():
+            return False
+
+        return self.configuration["use_document_level_security"]
 
     def access_control_query(self, access_control):
         return {"query": {"template": {"params": {"access_control": access_control}}}}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[SPO] Check if DLS RFC is enabled (#1123)](https://github.com/elastic/connectors-python/pull/1123)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)