### PR TITLE
[SPO] Remove domain group id suffixes starting with "_"

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,22 +331,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,6 +331,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -826,11 +826,14 @@ def _domain_group_id(user_info_name):
 
     domain_group_id = name_parts[2]
 
-    if len(domain_group_id) == 0:
-        return None
-
     if "/" in domain_group_id:
         domain_group_id = domain_group_id.split("/")[1]
+
+    if "_" in domain_group_id:
+        domain_group_id = domain_group_id.split("_")[0]
+
+    if len(domain_group_id) == 0:
+        return None
 
     return domain_group_id
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2288,8 +2288,11 @@ class TestSharepointOnlineDataSource:
             ("", None),
             ("abc|", None),
             ("abc|def|", None),
+            ("abc|def|_o", None),
             (f"abc|def|{DOMAIN_GROUP_ID}", DOMAIN_GROUP_ID),
+            (f"abc|def|{DOMAIN_GROUP_ID}_o", DOMAIN_GROUP_ID),
             (f"abc|def|ghi/{DOMAIN_GROUP_ID}", DOMAIN_GROUP_ID),
+            (f"abc|def|ghi/{DOMAIN_GROUP_ID}_o", DOMAIN_GROUP_ID),
         ],
     )
     def test_domain_group_id(self, user_info_name, expected_domain_group_id):


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5061

Some domain group ids have a suffix starting with `_`. We need to remove this suffix to have a valid domain group id.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)