### PR TITLE
Close data source after running a validation

### DIFF
--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -89,9 +89,12 @@ class JobSchedulingService(BaseService):
 
         source_klass = get_source_klass(self.source_list[connector.service_type])
         if connector.features.sync_rules_enabled():
-            validator = source_klass(connector.configuration)
-            validator.set_logger(connector.logger)
-            await connector.validate_filtering(validator=validator)
+            try:
+                validator = source_klass(connector.configuration)
+                validator.set_logger(connector.logger)
+                await connector.validate_filtering(validator=validator)
+            finally:
+                await validator.close()
 
         if connector.features.document_level_security_enabled():
             (

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -89,10 +89,10 @@ class JobSchedulingService(BaseService):
 
         source_klass = get_source_klass(self.source_list[connector.service_type])
         if connector.features.sync_rules_enabled():
+            data_source = source_klass(connector.configuration)
+            data_source.set_logger(connector.logger)
             try:
-                data_source = source_klass(connector.configuration)
-                data_source.set_logger(connector.logger)
-                await data_source.validate_filtering(validator=validator)
+                await connector.validate_filtering(validator=data_source)
             finally:
                 await data_source.close()
 

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -90,11 +90,11 @@ class JobSchedulingService(BaseService):
         source_klass = get_source_klass(self.source_list[connector.service_type])
         if connector.features.sync_rules_enabled():
             try:
-                validator = source_klass(connector.configuration)
-                validator.set_logger(connector.logger)
-                await connector.validate_filtering(validator=validator)
+                data_source = source_klass(connector.configuration)
+                data_source.set_logger(connector.logger)
+                await data_source.validate_filtering(validator=validator)
             finally:
-                await validator.close()
+                await data_source.close()
 
         if connector.features.document_level_security_enabled():
             (

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -126,6 +126,7 @@ def mock_connector(
     connector.validate_filtering = AsyncMock()
     connector.next_sync = Mock(return_value=next_sync)
 
+    connector.close = AsyncMock()
     connector.prepare = AsyncMock(side_effect=prepare_exception)
     connector.heartbeat = AsyncMock()
     connector.reload = AsyncMock()
@@ -155,6 +156,7 @@ async def test_connector_ready_to_sync(
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
+    connector.close.assert_awaited()
     connector.update_last_sync_scheduled_at_by_job_type.assert_awaited()
 
     for job_type in JOB_TYPES:

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -156,7 +156,6 @@ async def test_connector_ready_to_sync(
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
-    connector.close.assert_awaited()
     connector.update_last_sync_scheduled_at_by_job_type.assert_awaited()
 
     for job_type in JOB_TYPES:


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1147

We need to run validation for connectors when filtering is enabled. The validation requires creating the instance of the connector, but somehow the code was never closing the connector to deallocate resources needed for validation.

This PR fixes it by closing the connector after the validation happens.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
