### PR TITLE
Add more verbose messages why drive item is not downloaded for SPO connector

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1508,10 +1508,16 @@ class SharepointOnlineDataSource(BaseDataSource):
             return OP_INDEX
 
     def download_function(self, drive_item, max_drive_item_age):
+        if "folder" in drive_item:
+            self._logger.debug(f"Not downloading folder {drive_item['name']}")
+            return None
+
         if "@microsoft.graph.downloadUrl" not in drive_item:
+            self._logger.debug(f"Not downloading file {drive_item['name']}: field \"@microsoft.graph.downloadUrl\" is missing")
             return None
 
         if "lastModifiedDateTime" not in drive_item:
+            self._logger.debug(f"Not downloading file {drive_item['name']}: field \"lastModifiedDateTime\" is missing")
             return None
 
         modified_date = datetime.strptime(

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1513,11 +1513,15 @@ class SharepointOnlineDataSource(BaseDataSource):
             return None
 
         if "@microsoft.graph.downloadUrl" not in drive_item:
-            self._logger.debug(f"Not downloading file {drive_item['name']}: field \"@microsoft.graph.downloadUrl\" is missing")
+            self._logger.debug(
+                f"Not downloading file {drive_item['name']}: field \"@microsoft.graph.downloadUrl\" is missing"
+            )
             return None
 
         if "lastModifiedDateTime" not in drive_item:
-            self._logger.debug(f"Not downloading file {drive_item['name']}: field \"lastModifiedDateTime\" is missing")
+            self._logger.debug(
+                f"Not downloading file {drive_item['name']}: field \"lastModifiedDateTime\" is missing"
+            )
             return None
 
         modified_date = datetime.strptime(

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1354,8 +1354,16 @@ class TestSharepointOnlineDataSource:
         return [
             DriveItemsPage(
                 items=[
-                    {"id": "3", "lastModifiedDateTime": self.month_ago},
-                    {"id": "4", "lastModifiedDateTime": self.day_ago},
+                    {
+                        "id": "3",
+                        "name": "third.txt",
+                        "lastModifiedDateTime": self.month_ago,
+                    },
+                    {
+                        "id": "4",
+                        "name": "fourth.txt",
+                        "lastModifiedDateTime": self.day_ago,
+                    },
                 ],
                 delta_link="deltalinksample",
             )
@@ -1523,10 +1531,14 @@ class TestSharepointOnlineDataSource:
         return [
             DriveItemsPage(
                 items=[
-                    {"id": "3", "lastModifiedDateTime": self.month_ago},
-                    {"id": "4", "lastModifiedDateTime": self.day_ago},
-                    {"id": "5", "lastModifiedDateTime": self.day_ago},
-                    {"id": "6", "deleted": {"state": "deleted"}},
+                    {
+                        "id": "3",
+                        "name": "third",
+                        "lastModifiedDateTime": self.month_ago,
+                    },
+                    {"id": "4", "name": "fourth", "lastModifiedDateTime": self.day_ago},
+                    {"id": "5", "name": "fifth", "lastModifiedDateTime": self.day_ago},
+                    {"id": "6", "name": "sixth", "deleted": {"state": "deleted"}},
                 ],
                 delta_link="deltalinksample",
             )
@@ -1795,13 +1807,26 @@ class TestSharepointOnlineDataSource:
         assert (operations["delete"]) == deleted
 
     @pytest.mark.asyncio
+    async def test_download_function_for_folder(self):
+        source = create_source(SharepointOnlineDataSource, site_collections=WILDCARD)
+        drive_item = {
+            "name": "folder",
+            "folder": {},
+        }
+
+        download_result = source.download_function(drive_item, None)
+
+        assert download_result is None
+
+    @pytest.mark.asyncio
     async def test_download_function_with_filtering_rule(self):
         source = create_source(SharepointOnlineDataSource, site_collections=WILDCARD)
         max_drive_item_age = 15
         drive_item = {
+            "name": "test",
             "lastModifiedDateTime": str(
                 datetime.utcnow() - timedelta(days=max_drive_item_age + 1)
-            )
+            ),
         }
 
         download_result = source.download_function(drive_item, max_drive_item_age)


### PR DESCRIPTION
Minor adjustment of debug messages for Sharepoint Online connector - when some drive items are ignored, no message is provided for them. This PR fixes it.

Additionally, this PR makes sure we just folders purely by checking drive_item for `folder` key.