### PR TITLE
Fix missing await for _site_access_control in get_docs_incrementally for Sharepoint Online connector

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1336,7 +1336,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                 site_collection["siteCollection"]["hostname"],
                 self.configuration["site_collections"],
             ):
-                access_control = self._site_access_control(site)
+                access_control = await self._site_access_control(site)
                 yield self._decorate_with_access_control(
                     site, access_control
                 ), None, OP_INDEX


### PR DESCRIPTION
Found when running tests:

```
tests/sources/test_sharepoint_online.py::TestSharepointOnlineDataSource::test_get_docs_incrementaly
  /Users/artemshelkovnikov/git_tree/connectors-py/tests/sources/test_sharepoint_online.py:1773: RuntimeWarning: coroutine 'SharepointOnlineDataSource._site_access_control' was never awaited
    async for doc, download_func, operation in source.get_docs_incrementally(
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

Looks like `get_docs_incrementally` incorrectly collected permissions or just failed because of it.