### PR TITLE
Make tests fail on warnings; add some warnings to ignore list

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,15 @@ addopts =
   -v
 filterwarnings =
   error
+; botocore has this warning that is reported by them to be irrelevant
   ignore:.*urllib3.contrib.pyopenssl.*:DeprecationWarning:botocore.*
+; latest main of aioresponses does not have this problem, but current package uses deprecated pkg_resources API
+  ignore:.*pkg_resources.*:DeprecationWarning
+; SQLAlchemy uses deprecated APIs internally
+  ignore:.*dbapi().*:DeprecationWarning
+; aiogoogle inherits on top of AioHttpSession, which is not recommended by aiohttp
   ignore:Inheritance class AiohttpSession from ClientSession is discouraged:DeprecationWarning
+; aiogoogle inherits on top of RetryableAioHttpSession, which is not recommended by aiohttp
   ignore:Inheritance class RetryableAiohttpSession from ClientSession is discouraged:DeprecationWarning
+; pytest may generate its own warnings in some situations, such as improper usage or deprecated features.
+  ignore::pytest.PytestUnraisableExceptionWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+asyncio_mode = auto
+addopts =
+  -v
+filterwarnings =
+  error
+  ignore:.*urllib3.contrib.pyopenssl.*:DeprecationWarning:botocore.*
+  ignore::DeprecationWarning:aiogoogle.*

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ filterwarnings =
   error
   ignore:.*urllib3.contrib.pyopenssl.*:DeprecationWarning:botocore.*
   ignore:Inheritance class AiohttpSession from ClientSession is discouraged:DeprecationWarning
+  ignore:Inheritance class RetryableAiohttpSession from ClientSession is discouraged:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@ addopts =
 filterwarnings =
   error
   ignore:.*urllib3.contrib.pyopenssl.*:DeprecationWarning:botocore.*
-  ignore::DeprecationWarning:aiogoogle.*
+  ignore:Inheritance class AiohttpSession from ClientSession is discouraged:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[tools:pytest]
-asyncio_mode = auto


### PR DESCRIPTION
This PR makes 2 things:

1. Makes our regular tests fail if a warning happens
2. Ignores several warnings that are not relevant to us (see comments in the ini file)
