### PR TITLE
Disable MongoDB serverless nightly + max-rss setting

### DIFF
--- a/.buildkite/nightly_steps.yml
+++ b/.buildkite/nightly_steps.yml
@@ -71,11 +71,11 @@ steps:
       - ".buildkite/run_nigthly.sh mongodb"
     artifact_paths:
       - "perf8-report-*/**/*"
-  - label: "🔨 MongoDB Serverless"
-    command:
-      - ".buildkite/run_nigthly.sh mongodb_serverless"
-    artifact_paths:
-      - "perf8-report-*/**/*"
+#   - label: "🔨 MongoDB Serverless"
+#     command:
+#       - ".buildkite/run_nigthly.sh mongodb_serverless"
+#     artifact_paths:
+#       - "perf8-report-*/**/*"
   - label: "🔨 GitHub"
     command:
       - ".buildkite/run_nigthly.sh github"

--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -58,9 +58,9 @@ then
     $PYTHON fixture.py --name $NAME --action description > description.txt
     if [[ $PLATFORM == "darwin" ]]
     then
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
     else
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --psutil-max-rss $MAX_RSS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
     fi
 else
     $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!


### PR DESCRIPTION
As discussed on a sprint sync, we want to disable some parts of Nightly tests for now that cause flaky behaviour.

Currently identified flaky behaviours:

1. MongoDB Serverless connector test is broken with no visible indication - probably need to revisit the test and see what's going on. This PR disables it.
2. MaxRSS setting choice seems to be a bit random and since we collect metrics every 5 seconds, that means that we could miss some spikes in RSS when running the connector functional test. This PR disables it.

The plan for now is to merge this change and have a [tech-debt issue](https://github.com/elastic/connectors-python/issues/1208) to address ASAP.