### PR TITLE
Make Sharepoint Online connector retry only specific errors

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -92,6 +92,7 @@ class InternalServerError(Exception):
 
     pass
 
+
 class ThrottledError(Exception):
     """Internal exception class to indicate that request was throttled by the API"""
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -336,7 +336,11 @@ class MicrosoftAPISession:
                         async for item in func(*args, **kwargs):
                             yield item
                         break
-                    except ClientResponseError as e:
+                    except (
+                        ClientResponseError,
+                        PermissionsMissing,
+                        InternalServerError,
+                    ) as e:
                         if retry >= retries:
                             raise e
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -481,6 +481,33 @@ class TestMicrosoftAPISession:
         patch_cancellable_sleeps.assert_awaited_with(retry_after)
 
     @pytest.mark.asyncio
+    async def test_call_api_with_404(
+        self,
+        microsoft_api_session,
+        mock_responses,
+        patch_sleep,
+        patch_cancellable_sleeps,
+    ):
+        url = "http://localhost:1234/download-some-sample-file"
+        payload = {"hello": "world"}
+        retry_after = 25
+
+        # First throttle, then do not throttle
+        first_request_error = ClientResponseError(None, None)
+        first_request_error.status = 404
+        first_request_error.message = "Something went wrong"
+        first_request_error.headers = {"Retry-After": str(retry_after)}
+
+        mock_responses.get(url, exception=first_request_error)
+        mock_responses.get(url, payload=payload)
+
+        with pytest.raises(NotFound) as e:
+            async with microsoft_api_session._call_api(url) as _:
+                pass
+
+        assert e is not None
+
+    @pytest.mark.asyncio
     async def test_call_api_with_429_without_retry_after(
         self,
         microsoft_api_session,


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5119

Problem is that our `retryable` does not support defining which exception types are not retryable, so Sharepoint Online connector retries all calls.

Errors that are retried:
- ThrottledError - these are in general retryable errors that indicate that API is throttling
- PermissionsMissing - errors when server returns "Unauthorized". We can retry them after invalidating the token.
- InternalServerError - 500 errors sometimes also indicate throttling or just an error on the side of the API that's worth to retry

TODO: after this PR is merged we can follow up on our `@retryable` function to make it handle this case instead of us writing our own retryable abstractions.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
