### PR TITLE
Ignore deleted files when choosing a download function

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1526,6 +1526,8 @@ class SharepointOnlineDataSource(BaseDataSource):
 
     def download_function(self, drive_item, max_drive_item_age):
         if "deleted" in drive_item:
+            # deleted drive items do not contain `name` property in the payload
+            # so drive_item['id'] is used
             self._logger.debug(
                 f"Not downloading the item id={drive_item['id']} because it has been deleted"
             )

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1525,6 +1525,13 @@ class SharepointOnlineDataSource(BaseDataSource):
             return OP_INDEX
 
     def download_function(self, drive_item, max_drive_item_age):
+        if "deleted" in drive_item:
+            self._logger.debug(
+                f"Not downloading the item id={drive_item['id']} because it has been deleted"
+            )
+
+            return None
+
         if "folder" in drive_item:
             self._logger.debug(f"Not downloading folder {drive_item['name']}")
             return None

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1819,15 +1819,11 @@ class TestSharepointOnlineDataSource:
 
         assert download_result is None
 
-
     @pytest.mark.asyncio
     async def test_download_function_for_deleted_item(self):
         source = create_source(SharepointOnlineDataSource, site_collections=WILDCARD)
         # deleted items don't have `name` property
-        drive_item = {
-            "id": 'testid',
-            "deleted": { "state": "deleted" }
-        }
+        drive_item = {"id": "testid", "deleted": {"state": "deleted"}}
 
         download_result = source.download_function(drive_item, None)
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1819,6 +1819,20 @@ class TestSharepointOnlineDataSource:
 
         assert download_result is None
 
+
+    @pytest.mark.asyncio
+    async def test_download_function_for_deleted_item(self):
+        source = create_source(SharepointOnlineDataSource, site_collections=WILDCARD)
+        # deleted items don't have `name` property
+        drive_item = {
+            "id": 'testid',
+            "deleted": { "state": "deleted" }
+        }
+
+        download_result = source.download_function(drive_item, None)
+
+        assert download_result is None
+
     @pytest.mark.asyncio
     async def test_download_function_with_filtering_rule(self):
         source = create_source(SharepointOnlineDataSource, site_collections=WILDCARD)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5135

The incremental sync is used to ignore deleted files filtering them by `@microsoft.graph.downloadUrl`. It worked well when we checked that property first. However, the check was moved down so it made the service fail when the `folder` is deleted because deleted items don't have the `name` property.

This PR will add an explicit validation and ignore all deleted items.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
