### PR TITLE
Allow file pointers for local data extraction

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -910,8 +910,10 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         if self.configuration["use_text_extraction_service"]:
             self.extraction_service = ExtractionService()
+            self.download_dir = self.extraction_service.get_volume_dir()
         else:
             self.extraction_service = None
+            self.download_dir = None
 
     def _set_internal_logger(self):
         self.client.set_logger(self._logger)
@@ -1687,7 +1689,7 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         try:
             async with NamedTemporaryFile(
-                mode="wb", delete=False, suffix=file_extension
+                mode="wb", delete=False, suffix=file_extension, dir=self.download_dir
             ) as async_buffer:
                 source_file_name = async_buffer.name
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -802,9 +802,6 @@ class ExtractionService:
                 f"Text extraction unexpectedly failed for {filename}. Error: {e}"
             )
 
-        if content:
-            logger.info(f"{filepath} WAS EXTRACTED")
-
         return content
 
     async def file_sender(self, filepath):

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -721,9 +721,7 @@ class ExtractionService:
                 self.volume_dir = self.extraction_config.get(
                     "fileshare_dir", "/app/files"
                 )
-                self.chunk_size = None
             else:
-                self.volume_dir = None
                 self.chunk_size = self.extraction_config.get("stream_chunk_size", 65536)
                 self.headers["content-type"] = "application/octet-stream"
         else:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -714,9 +714,13 @@ class ExtractionService:
             self.timeout = self.extraction_config.get("timeout", 30)
             self.headers = {"accept": "application/json"}
 
-            self.use_file_pointers = self.extraction_config.get("use_file_pointers", False)
+            self.use_file_pointers = self.extraction_config.get(
+                "use_file_pointers", False
+            )
             if self.use_file_pointers:
-                self.volume_dir = self.extraction_config.get("fileshare_dir", "/app/files")
+                self.volume_dir = self.extraction_config.get(
+                    "fileshare_dir", "/app/files"
+                )
                 self.chunk_size = None
             else:
                 self.volume_dir = None
@@ -783,8 +787,10 @@ class ExtractionService:
 
         try:
             async with self._begin_session().put(
-                    f"{self.host}/extract_text/{self.filepointer_params(filepath)}",
-                    data=(self.file_sender(filepath) if not self.use_file_pointers else None)
+                f"{self.host}/extract_text/{self.filepointer_params(filepath)}",
+                data=(
+                    self.file_sender(filepath) if not self.use_file_pointers else None
+                ),
             ) as response:
                 return await self.parse_extraction_resp(filename, response)
         except (ClientConnectionError, ServerTimeoutError) as e:
@@ -810,7 +816,7 @@ class ExtractionService:
 
     def filepointer_params(self, filepath):
         if not self.use_file_pointers:
-            return ''
+            return ""
 
         return f"?local_file_path={filepath}"
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -719,7 +719,7 @@ class ExtractionService:
             )
             if self.use_file_pointers:
                 self.volume_dir = self.extraction_config.get(
-                    "fileshare_dir", "/app/files"
+                    "shared_volume_dir", "/app/files"
                 )
             else:
                 self.chunk_size = self.extraction_config.get("stream_chunk_size", 65536)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -721,7 +721,9 @@ class ExtractionService:
                 self.volume_dir = self.extraction_config.get(
                     "shared_volume_dir", "/app/files"
                 )
+                self.chunk_size = None
             else:
+                self.volume_dir = None
                 self.chunk_size = self.extraction_config.get("stream_chunk_size", 65536)
                 self.headers["content-type"] = "application/octet-stream"
         else:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -713,6 +713,7 @@ class ExtractionService:
             self.host = self.extraction_config.get("host", None)
             self.timeout = self.extraction_config.get("timeout", 30)
             self.headers = {"accept": "application/json"}
+            self.chunk_size = self.extraction_config.get("stream_chunk_size", 65536)
 
             self.use_file_pointers = self.extraction_config.get(
                 "use_file_pointers", False
@@ -721,10 +722,8 @@ class ExtractionService:
                 self.volume_dir = self.extraction_config.get(
                     "shared_volume_dir", "/app/files"
                 )
-                self.chunk_size = None
             else:
                 self.volume_dir = None
-                self.chunk_size = self.extraction_config.get("stream_chunk_size", 65536)
                 self.headers["content-type"] = "application/octet-stream"
         else:
             self.host = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -667,8 +667,12 @@ class TestExtractionService:
         payload = {"extracted_text": "I've been extracted!"}
 
         with patch("builtins.open", mock_open(read_data=b"data")), patch(
-                "connectors.utils.ExtractionService.get_extraction_config",
-                return_value={"host": "http://localhost:8090", "use_file_pointers": True, "shared_volume_dir": "/tmp"},
+            "connectors.utils.ExtractionService.get_extraction_config",
+            return_value={
+                "host": "http://localhost:8090",
+                "use_file_pointers": True,
+                "shared_volume_dir": "/tmp",
+            },
         ):
             mock_responses.put(url, status=200, payload=payload)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -661,6 +661,26 @@ class TestExtractionService:
             assert response == "I've been extracted!"
 
     @pytest.mark.asyncio
+    async def test_extract_text_with_file_pointer(self, mock_responses):
+        filepath = "/tmp/notreal.txt"
+        url = "http://localhost:8090/extract_text/?local_file_path=/tmp/notreal.txt"
+        payload = {"extracted_text": "I've been extracted!"}
+
+        with patch("builtins.open", mock_open(read_data=b"data")), patch(
+                "connectors.utils.ExtractionService.get_extraction_config",
+                return_value={"host": "http://localhost:8090", "use_file_pointers": True, "shared_volume_dir": "/tmp"},
+        ):
+            mock_responses.put(url, status=200, payload=payload)
+
+            extraction_service = ExtractionService()
+            extraction_service._begin_session()
+
+            response = await extraction_service.extract_text(filepath, "notreal.txt")
+            await extraction_service._end_session()
+
+            assert response == "I've been extracted from a local file!"
+
+    @pytest.mark.asyncio
     async def test_extract_text_when_response_isnt_200_logs_warning(
         self, mock_responses, patch_logger
     ):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -664,7 +664,7 @@ class TestExtractionService:
     async def test_extract_text_with_file_pointer(self, mock_responses):
         filepath = "/tmp/notreal.txt"
         url = "http://localhost:8090/extract_text/?local_file_path=/tmp/notreal.txt"
-        payload = {"extracted_text": "I've been extracted!"}
+        payload = {"extracted_text": "I've been extracted from a local file!"}
 
         with patch("builtins.open", mock_open(read_data=b"data")), patch(
             "connectors.utils.ExtractionService.get_extraction_config",


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/5137

Re-enable filepointers as an option for local data extraction.

_(The following instructions will also be added to our official documentation)_

To set this up:
- connectors-python must be run in docker
- you must also run data-extraction-service (use the branch in [this PR](https://github.com/elastic/data-extraction-service/pull/18) if it isn't merged yet)
- the two docker images must share a network and a volume (see below for instructions)

Sample config (note the `host` is no longer `localhost`):

```
extraction_service:
  host: http://host.docker.internal:8090
  use_file_pointers: true
  shared_volume_dir: '/app/files'
```

First make a volume that will be used by both docker containers:

```bash
$ docker volume create --name connectors-volume
```

Follow the [instructions to run connectors-python in docker](https://github.com/elastic/connectors-python/blob/main/docs/DOCKER.md), but when calling `docker run`, be sure to add the value set for `shared_volume_dir` as a volume. Example:

```bash
$ docker run -i --rm --name connectors-python \
  -v ~/connectors-python-config:/config \
  -v connectors-volume:/app/files \
  --network "elastic" --tty --rm \
  connectors-python \
  /app/bin/elastic-ingest -c /config/config.yml
```

Then run data-extraction-service using the same network and volume:

```
$ docker run -p 8090:8090 -i -t --rm --name extraction-service \
  -v ConnectorsVolume:/app/files \
  --network "elastic" \
  extraction-service
```

Then set up a sharepoint online connector and set `use_text_extraction_service: true` and begin ingesting documents!
This set up will also work for file streaming.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference


## Related Pull Requests

https://github.com/elastic/data-extraction-service/pull/18
