### PR TITLE
Get filename for all attachments

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1551,6 +1551,9 @@ class SharepointOnlineDataSource(BaseDataSource):
                     list_item_attachment["_timestamp"] = list_item[
                         "lastModifiedDateTime"
                     ]
+                    list_item_attachment[
+                        "_original_filename"
+                    ] = list_item_attachment.get("FileName", "")
 
                     attachment_download_func = partial(
                         self.get_attachment_content, list_item_attachment
@@ -1674,13 +1677,13 @@ class SharepointOnlineDataSource(BaseDataSource):
             "_timestamp": new_timestamp,
         }
 
-        attachment, body = await self._download_content(
+        attached_file, body = await self._download_content(
             partial(self.client.download_attachment, attachment["odata.id"]),
             attachment["_original_filename"],
         )
 
-        if attachment:
-            doc["_attachment"] = attachment
+        if attached_file:
+            doc["_attachment"] = attached_file
         if body is not None:
             # accept empty strings for body
             doc["body"] = body
@@ -1704,7 +1707,7 @@ class SharepointOnlineDataSource(BaseDataSource):
             "_timestamp": drive_item["lastModifiedDateTime"],
         }
 
-        attachment, body = await self._download_content(
+        attached_file, body = await self._download_content(
             partial(
                 self.client.download_drive_item,
                 drive_item["parentReference"]["driveId"],
@@ -1713,8 +1716,8 @@ class SharepointOnlineDataSource(BaseDataSource):
             drive_item["_original_filename"],
         )
 
-        if attachment:
-            doc["_attachment"] = attachment
+        if attached_file:
+            doc["_attachment"] = attached_file
         if body is not None:
             # accept empty strings for body
             doc["body"] = body


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1154

Ensure that the field `_original_filename` is included in the doc for all attachments.
Also rename some variables for greater clarity.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

