### PR TITLE
Do not download unsupported files

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1667,6 +1667,12 @@ class SharepointOnlineDataSource(BaseDataSource):
         if not doit:
             return
 
+        if not self.is_supported_format(attachment["_original_filename"]):
+            self._logger.debug(
+                f"Not downloading attachment {attachment['_original_filename']}: file type is not supported"
+            )
+            return
+
         # We don't know attachment sizes unfortunately, so cannot properly ignore them
 
         # Okay this gets weird.

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -27,6 +27,7 @@ from connectors.filtering.validation import (
 from connectors.logger import logger
 from connectors.source import BaseDataSource
 from connectors.utils import (
+    TIKA_SUPPORTED_FILETYPES,
     CacheWithTimeout,
     CancellableSleeps,
     ExtractionService,
@@ -1625,6 +1626,12 @@ class SharepointOnlineDataSource(BaseDataSource):
             )
             return None
 
+        if not self.is_supported_format(drive_item["name"]):
+            self._logger.debug(
+                f"Not downloading file {drive_item['name']}: file type is not supported"
+            )
+            return None
+
         if "lastModifiedDateTime" not in drive_item:
             self._logger.debug(
                 f"Not downloading file {drive_item['name']}: field \"lastModifiedDateTime\" is missing"
@@ -1775,3 +1782,13 @@ class SharepointOnlineDataSource(BaseDataSource):
 
     def advanced_rules_validators(self):
         return [SharepointOnlineAdvancedRulesValidator()]
+
+    def is_supported_format(self, filename):
+        if "." not in filename:
+            return False
+
+        attachment_extension = list(os.path.splitext(filename))
+        if attachment_extension[-1].lower() not in TIKA_SUPPORTED_FILETYPES:
+            return False
+
+        return True

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1793,7 +1793,7 @@ class SharepointOnlineDataSource(BaseDataSource):
         if "." not in filename:
             return False
 
-        attachment_extension = list(os.path.splitext(filename))
+        attachment_extension = os.path.splitext(filename)
         if attachment_extension[-1].lower() in TIKA_SUPPORTED_FILETYPES:
             return True
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1788,7 +1788,7 @@ class SharepointOnlineDataSource(BaseDataSource):
             return False
 
         attachment_extension = list(os.path.splitext(filename))
-        if attachment_extension[-1].lower() not in TIKA_SUPPORTED_FILETYPES:
-            return False
+        if attachment_extension[-1].lower() in TIKA_SUPPORTED_FILETYPES:
+            return True
 
-        return True
+        return False

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2007,7 +2007,7 @@ class TestSharepointOnlineDataSource:
 
         download_result = await source.get_attachment_content(attachment, doit=True)
 
-        assert download_result == None
+        assert download_result is None
 
     @pytest.mark.asyncio
     @patch("connectors.utils.ExtractionService._check_configured", lambda *_: True)

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1863,7 +1863,13 @@ class TestSharepointOnlineDataSource:
     @pytest.mark.asyncio
     async def test_download_function_for_unsupported_file(self):
         source = create_source(SharepointOnlineDataSource, site_collections=WILDCARD)
-        drive_item = {"id": "testid", "name": "filename.randomextention"}
+        drive_item = {
+            "id": "testid",
+            "name": "filename.randomextention",
+            "@microsoft.graph.downloadUrl": "http://localhost/filename",
+            "lastModifiedDateTime": "2023-07-10T22:12:56Z",
+            "size": 10,
+        }
 
         download_result = source.download_function(drive_item, None)
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1990,8 +1990,13 @@ class TestSharepointOnlineDataSource:
         assert "body" not in download_result
 
     @pytest.mark.asyncio
-    async def test_get_attachment_content_unsupported_file_type(self, patch_sharepoint_client):
-        attachment = {"odata.id": "1", "_original_filename": "file.unsupported_extention"}
+    async def test_get_attachment_content_unsupported_file_type(
+        self, patch_sharepoint_client
+    ):
+        attachment = {
+            "odata.id": "1",
+            "_original_filename": "file.unsupported_extention",
+        }
         message = b"This is content of attachment"
 
         async def download_func(attachment_id, async_buffer):

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1990,6 +1990,21 @@ class TestSharepointOnlineDataSource:
         assert "body" not in download_result
 
     @pytest.mark.asyncio
+    async def test_get_attachment_content_unsupported_file_type(self, patch_sharepoint_client):
+        attachment = {"odata.id": "1", "_original_filename": "file.unsupported_extention"}
+        message = b"This is content of attachment"
+
+        async def download_func(attachment_id, async_buffer):
+            await async_buffer.write(message)
+
+        patch_sharepoint_client.download_attachment = download_func
+        source = create_source(SharepointOnlineDataSource)
+
+        download_result = await source.get_attachment_content(attachment, doit=True)
+
+        assert download_result == None
+
+    @pytest.mark.asyncio
     @patch("connectors.utils.ExtractionService._check_configured", lambda *_: True)
     async def test_get_attachment_with_text_extraction_enabled_adds_body(
         self, patch_sharepoint_client

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1861,6 +1861,15 @@ class TestSharepointOnlineDataSource:
         assert download_result is None
 
     @pytest.mark.asyncio
+    async def test_download_function_for_unsupported_file(self):
+        source = create_source(SharepointOnlineDataSource, site_collections=WILDCARD)
+        drive_item = {"id": "testid", "name": "filename.randomextention"}
+
+        download_result = source.download_function(drive_item, None)
+
+        assert download_result is None
+
+    @pytest.mark.asyncio
     async def test_download_function_with_filtering_rule(self):
         source = create_source(SharepointOnlineDataSource, site_collections=WILDCARD)
         max_drive_item_age = 15


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5155

There is no need to download files that can't be processed successfully in the extraction service or ingest pipeline.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
