### PR TITLE
Fix Ftest in Network Drive connector

### DIFF
--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -38,6 +38,7 @@ class NASDataSource(BaseDataSource):
         self.server_ip = self.configuration["server_ip"]
         self.port = self.configuration["server_port"]
         self.drive_path = self.configuration["drive_path"]
+        self.session = None
 
     @classmethod
     def get_default_configuration(cls):
@@ -83,7 +84,7 @@ class NASDataSource(BaseDataSource):
 
     def create_connection(self):
         """Creates an SMB session to the shared drive."""
-        smbclient.register_session(
+        self.session = smbclient.register_session(
             server=self.server_ip,
             username=self.username,
             password=self.password,
@@ -98,6 +99,8 @@ class NASDataSource(BaseDataSource):
 
     async def close(self):
         """Close all the open smb sessions"""
+        if self.session is None:
+            return
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(
             executor=None,

--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -401,3 +401,11 @@ def test_fetch_file_when_file_is_accessible(file_mock):
 
     # Assert
     assert response.read() == b"Mock...."
+
+
+async def test_close_without_session():
+    source = create_source(NASDataSource)
+
+    await source.close()
+
+    assert source.session is None


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/1249

Add an if-block in close method of Network Drive that checks if session was previously registered:

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

