### PR TITLE
Performance improvements to the ACL sync

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -518,10 +518,11 @@ class SharepointOnlineClient:
         except NotFound:
             return {}
 
-    async def users(self):
+    async def active_users_with_groups(self):
         expand = "transitiveMemberOf"
-        top = 999
-        url = f"{GRAPH_API_URL}/users?$expand={expand}&$top={top}"
+        top = 999  # this is accepted, but does not get taken litterally. Response size seems to max out at 100
+        filter = "accountEnabled eq true"
+        url = f"{GRAPH_API_URL}/users?$expand={expand}&$top={top}&$filter={filter}"
 
         try:
             async for page in self._graph_api_client.scroll(url):
@@ -998,15 +999,6 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "type": "bool",
                 "value": False,
             },
-            "fetch_users_by_site": {
-                "depends_on": [{"field": "use_document_level_security", "value": True}],
-                "display": "toggle",
-                "label": "Discover users by site membership",
-                "order": 8,
-                "tooltip": "When syncing only a small subset of sites, it can be more efficient to only fetch users who have access to those sites. This becomes increasingly inefficient the more sites (and the more users) concerned.",
-                "type": "bool",
-                "value": False,
-            },
         }
 
     async def validate_config(self):
@@ -1196,14 +1188,16 @@ class SharepointOnlineDataSource(BaseDataSource):
         prefixed_groups = set()
 
         expanded_member_groups = user.get("transitiveMemberOf", [])
-        if len(expanded_member_groups) < 100: # $expand param has a max of 100: see: https://learn.microsoft.com/en-us/graph/known-issues#query-parameters
+        if (
+            len(expanded_member_groups) < 100
+        ):  # $expand param has a max of 100: see: https://learn.microsoft.com/en-us/graph/known-issues#query-parameters
             for group in expanded_member_groups:
                 prefixed_groups.add(_prefix_group(group.get("id", None)))
         else:
-            self._logger.debug(f"User {username}: {email} belongs to a lot of groups - paging them separately")
-            async for group in self.client.groups_user_transitive_member_of(
-                user["id"]
-            ):
+            self._logger.debug(
+                f"User {username}: {email} belongs to a lot of groups - paging them separately"
+            )
+            async for group in self.client.groups_user_transitive_member_of(user["id"]):
                 group_id = group["id"]
                 if group_id:
                     prefixed_groups.add(_prefix_group(group_id))
@@ -1271,86 +1265,11 @@ class SharepointOnlineDataSource(BaseDataSource):
             if person_access_control_doc:
                 return person_access_control_doc
 
-        if not self.configuration["fetch_users_by_site"]:
-            self._logger.info("Fetching all users")
-            async for user in self.client.users():
-                user_doc = await process_user(user)
-                if user_doc:
-                    yield user_doc
-        else:
-            self._logger.info("Fetching users site-by-site")
-            async for site_collection in self.client.site_collections():
-                self._logger.debug(
-                    f"Looking at site collection for location: {site_collection.get('dataLocationCode')}"
-                )
-                async for site in self.client.sites(
-                    site_collection["siteCollection"]["hostname"],
-                    self.configuration["site_collections"],
-                ):
-                    site_id = site.get("id")
-                    self._logger.debug(f"Looking at site: {site_id}")
-                    if _already_seen(site_id):
-                        continue
-                    update_already_seen(site_id)
-                    async for user_information in self.client.user_information_list(
-                        site_id
-                    ):
-                        user = user_information["fields"]
-
-                        if is_domain_group(user):
-                            self._logger.debug(
-                                f"Detected a domain group: {user.get('Name')}"
-                            )
-                            domain_group_id = _domain_group_id(user.get("Name"))
-                            self._logger.debug(
-                                f"Detected domain groupId as: {domain_group_id}"
-                            )
-
-                            if domain_group_id:
-                                if _already_seen(domain_group_id):
-                                    continue
-                                update_already_seen(domain_group_id)
-                                async for member_email, member_username in _emails_and_usernames_of_domain_group(
-                                    domain_group_id,
-                                    self.client.group_members,
-                                ):
-                                    if _already_seen(member_email, member_username):
-                                        continue
-
-                                    update_already_seen(member_email, member_username)
-
-                                    member = await self.client.user(member_username)
-                                    member_access_control_doc = (
-                                        await self._user_access_control_doc(member)
-                                    )
-                                    if member_access_control_doc:
-                                        yield member_access_control_doc
-
-                                async for owner_email, owner_username in _emails_and_usernames_of_domain_group(
-                                    domain_group_id,
-                                    self.client.group_owners,
-                                ):
-                                    if _already_seen(owner_email, owner_username):
-                                        continue
-
-                                    update_already_seen(owner_email, owner_username)
-
-                                    owner = await self.client.user(owner_username)
-                                    owner_access_control_doc = (
-                                        await self._user_access_control_doc(owner)
-                                    )
-                                    if owner_access_control_doc:
-                                        yield owner_access_control_doc
-
-                        elif is_person(user):
-                            user_doc = await process_user(user) # pretty sure this is fucked, no user id
-                            if user_doc:
-                                yield user_doc
-
-                        else:
-                            self._logger.debug(
-                                "User information list item  was neither a person nor a group. Skipping..."
-                            )
+        self._logger.info("Fetching all users")
+        async for user in self.client.active_users_with_groups():
+            user_doc = await process_user(user)
+            if user_doc:
+                yield user_doc
 
     async def get_docs(self, filtering=None):
         max_drive_item_age = None

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -519,10 +519,11 @@ class SharepointOnlineClient:
             return {}
 
     async def active_users_with_groups(self):
-        expand = "transitiveMemberOf"
+        expand = "transitiveMemberOf($select=id)"
         top = 999  # this is accepted, but does not get taken litterally. Response size seems to max out at 100
         filter = "accountEnabled eq true"
-        url = f"{GRAPH_API_URL}/users?$expand={expand}&$top={top}&$filter={filter}"
+        select = "UserName,userPrincipalName,Email,mail,transitiveMemberOf,id,createdDateTime"
+        url = f"{GRAPH_API_URL}/users?$expand={expand}&$top={top}&$filter={filter}&$select={select}"
 
         try:
             async for page in self._graph_api_client.scroll(url):

--- a/tests/sources/fixtures/sharepoint_online/connector.json
+++ b/tests/sources/fixtures/sharepoint_online/connector.json
@@ -105,26 +105,6 @@
         "value": false,
         "order": 7,
         "ui_restrictions": []
-      },
-      "fetch_users_by_site": {
-        "depends_on": [
-          {
-            "field": "use_document_level_security",
-            "value": true
-          }
-        ],
-        "display": "toggle",
-        "tooltip": "When only syncing a small subset of sites, it may be more efficient to fetch only the users who have access to those sites. However, this becomes inefficent the more sites (and the more users) that are intended to be synced, as there can be a lot of redundancy in membership between sites. This should not be used if all sites are being synced.",
-        "default_value": null,
-        "label": "Fetch ACLs for users based on site membership",
-        "sensitive": false,
-        "type": "bool",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": false,
-        "order": 8,
-        "ui_restrictions": []
       }
     },
     "custom_scheduling": {},

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -93,10 +93,6 @@ def set_dls_enabled(source, dls_enabled):
     source.configuration.set_field("use_document_level_security", value=dls_enabled)
 
 
-def set_fetch_users_by_site(source, fetch_users_by_site):
-    source.configuration.set_field("fetch_users_by_site", value=fetch_users_by_site)
-
-
 def dls_feature_flag_enabled(value):
     return value
 
@@ -2402,57 +2398,32 @@ class TestSharepointOnlineDataSource:
         assert len(access_control) == 0
 
     @pytest.mark.asyncio
-    @patch(
-        "connectors.sources.sharepoint_online.DEFAULT_GROUPS", DEFAULT_GROUPS_PATCHED
-    )
-    @patch(
-        "connectors.sources.sharepoint_online._emails_and_usernames_of_domain_group",
-        AsyncIterator([("some_email", "some_username")]),
-    )
-    async def test_get_access_control_with_dls_enabled_and_users_by_site(
-        self, patch_sharepoint_client
-    ):
-        source = create_source(SharepointOnlineDataSource)
-        set_dls_enabled(source, True)
-        set_fetch_users_by_site(source, True)
-
-        member = {"Name": "some member"}
-
-        owner = {"Name": "some owner"}
-
-        user_doc_one = {"_id": "user1"}
-        user_doc_two = {"_id": "user2"}
-        user_doc_three = {"_id": "user3"}
-
-        patch_sharepoint_client.user = AsyncMock(side_effect=[member, owner])
-        source._user_access_control_doc = AsyncMock(
-            side_effect=[user_doc_one, user_doc_two, user_doc_three]
-        )
-
-        user_access_control_docs = []
-
-        async for doc in source.get_access_control():
-            user_access_control_docs.append(doc)
-
-        assert len(user_access_control_docs) == 3
-
-    @pytest.mark.asyncio
     async def test_get_access_control_with_dls_enabled_and_fetch_all_users(
         self, patch_sharepoint_client
     ):
         source = create_source(SharepointOnlineDataSource)
         set_dls_enabled(source, True)
-        set_fetch_users_by_site(source, False)
 
+        group = {"@odata.type": "#microsoft.graph.group", "id": "doop"}
         member_email = "member@acme.co"
-        member = {"userPrincipalName": "some member", "EMail": member_email}
+        member = {
+            "userPrincipalName": "some member",
+            "EMail": member_email,
+            "transitiveMemberOf": group,
+        }
         owner_email = "owner@acme.co"
-        owner = {"UserName": "some owner", "mail": owner_email}
+        owner = {
+            "UserName": "some owner",
+            "mail": owner_email,
+            "transitiveMemberOf": group,
+        }
 
         user_doc_one = {"_id": member_email}
         user_doc_two = {"_id": owner_email}
 
-        patch_sharepoint_client.users = AsyncIterator([member, owner])
+        patch_sharepoint_client.active_users_with_groups = AsyncIterator(
+            [member, owner]
+        )
         source._user_access_control_doc = AsyncMock(
             side_effect=[user_doc_one, user_doc_two]
         )


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5162

Speeding up the ACL sync.
- fixes an id-vs-username bug
- Utilizes `$expand=transitiveMemberOf` in a bulk request, to reduce request volume
- Utilizes `$top` to cap out page size
- Utilizes `$filter` to fetch only active users, and not disabled users.
- Utilizes `$select` to fetch only the fields we need, which speeds up response time
- Removes fetching users from UserInformationList because that was broken, and we could not extract User Ids (to then fetch transitive group membership)

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes (follow-up PR)
- [x] Contributed any configuration settings changes to the configuration reference

## Related Pull Requests

- https://github.com/elastic/kibana/pull/161798
- https://github.com/elastic/enterprise-search-pubs/pull/3627
