### PR TITLE
Use API key if both API key and basic auth are configured

### DIFF
--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -51,17 +51,17 @@ class ESClient:
         }
         logger.debug(f"Host is {self.host}")
 
-        if "username" in config:
-            if "api_key" in config:
-                raise KeyError(
-                    "You can't use basic auth ('username' and 'password') and 'api_key' at the same time in config.yml"
+        if "api_key" in config:
+            logger.debug(f"Connecting with an API Key ({config['api_key'][:5]}...)")
+            options["api_key"] = config["api_key"]
+            if "username" in config:
+                logger.debug(
+                    "API key will be used instead of basic auth ('username' and 'password')"
                 )
+        elif "username" in config:
             auth = config["username"], config["password"]
             options["basic_auth"] = auth
             logger.debug(f"Connecting using Basic Auth (user: {config['username']})")
-        elif "api_key" in config:
-            logger.debug(f"Connecting with an Api Key ({config['api_key'][:5]}...)")
-            options["api_key"] = config["api_key"]
 
         if config.get("ssl", False):
             options["verify_certs"] = True


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4187

For Elasticsearch config, if both API key and basic auth are configured, API key will take precedence.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)