### PR TITLE
Support multiple connectors in services

### DIFF
--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -132,9 +132,12 @@ class PreflightCheck:
             and deprecated_connector_id
             and deprecated_service_type
         ):
-            configured_connectors[deprecated_connector_id] = {
-                "service_type": deprecated_service_type
-            }
+            configured_connectors.append(
+                {
+                    "connector_id": deprecated_connector_id,
+                    "service_type": deprecated_service_type,
+                }
+            )
 
         if not configured_connectors and not force_allowed_native:
             logger.warning(

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -132,6 +132,9 @@ class PreflightCheck:
             and deprecated_connector_id
             and deprecated_service_type
         ):
+            logger.warning(
+                "The configuration 'connector_id' and 'serivce_type' has been deprecated and will be removed in later release. Please configure the connector in 'connectors'."
+            )
             configured_connectors.append(
                 {
                     "connector_id": deprecated_connector_id,

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -740,8 +740,6 @@ class Connector(ESDocument):
         configured_connector_id = config.get("connector_id", "")
         configured_service_type = config.get("service_type", "")
 
-        logger.info(f"config= {config}, configur")
-
         if self.id != configured_connector_id:
             # check configuration for native and other peripheral connectors
             if self.service_type not in sources:

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -724,7 +724,7 @@ class Connector(ESDocument):
         await self.index.update(doc_id=self.id, doc=doc)
 
     @with_concurrency_control()
-    async def prepare(self, config):
+    async def prepare(self, config, sources):
         """Prepares the connector, given a configuration
         If the connector id and the service type is in the config, we want to
         populate the service type and then sets the default configuration.
@@ -740,16 +740,18 @@ class Connector(ESDocument):
         configured_connector_id = config.get("connector_id", "")
         configured_service_type = config.get("service_type", "")
 
+        logger.info(f"config= {config}, configur")
+
         if self.id != configured_connector_id:
             # check configuration for native and other peripheral connectors
-            if self.service_type not in config["sources"]:
+            if self.service_type not in sources:
                 self.log_debug(
                     f"Peripheral connector has invalid service type {self.service_type}, cannot check configuration formatting."
                 )
                 return
 
             await self.validate_configuration_formatting(
-                config["sources"][self.service_type], self.service_type
+                sources[self.service_type], self.service_type
             )
 
             return
@@ -758,16 +760,16 @@ class Connector(ESDocument):
             self.log_error("Service type is not configured")
             raise ServiceTypeNotConfiguredError("Service type is not configured.")
 
-        if configured_service_type not in config["sources"]:
+        if configured_service_type not in sources:
             raise ServiceTypeNotSupportedError(configured_service_type)
 
         if self.service_type is not None and not self.configuration.is_empty():
             await self.validate_configuration_formatting(
-                config["sources"][configured_service_type], configured_service_type
+                sources[configured_service_type], configured_service_type
             )
 
         doc = {}
-        fqn = config["sources"][configured_service_type]
+        fqn = sources[configured_service_type]
         try:
             source_klass = get_source_klass(fqn)
         except Exception as e:

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -131,7 +131,7 @@ class BaseService(metaclass=_Registry):
                     "connector_id": self.config["connector_id"],
                     "service_type": self.config["service_type"],
                 }
-        logger.info(f"connectors = {connectors}")
+
         return connectors
 
 

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -12,6 +12,7 @@
 """
 import asyncio
 import time
+from copy import deepcopy
 
 from connectors.logger import logger
 from connectors.utils import CancellableSleeps
@@ -71,6 +72,7 @@ class BaseService(metaclass=_Registry):
         self.config = config
         self.service_config = self.config["service"]
         self.es_config = self.config["elasticsearch"]
+        self.connectors = self._parse_connectors()
         self.running = False
         self._sleeps = CancellableSleeps()
         self.errors = [0, time.time()]
@@ -110,6 +112,27 @@ class BaseService(metaclass=_Registry):
 
         self.errors[0] = errors
         self.errors[1] = first
+
+    def _parse_connectors(self):
+        connectors = {}
+        configured_connectors = deepcopy(self.config.get("connectors"))
+        if configured_connectors is not None:
+            for connector in configured_connectors:
+                connector_id = connector.get("connector_id")
+                if connector_id in connectors:
+                    logger.debug(
+                        f"Found duplicate configuration for connector {connector_id}, overriding with the later config"
+                    )
+                connectors[connector_id] = connector
+
+        if not connectors:
+            if "connector_id" in self.config and "service_type" in self.config:
+                connectors[self.config["connector_id"]] = {
+                    "connector_id": self.config["connector_id"],
+                    "service_type": self.config["service_type"],
+                }
+        logger.info(f"connectors = {connectors}")
+        return connectors
 
 
 class MultiService:

--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -120,7 +120,7 @@ class BaseService(metaclass=_Registry):
             for connector in configured_connectors:
                 connector_id = connector.get("connector_id")
                 if connector_id in connectors:
-                    logger.debug(
+                    logger.warning(
                         f"Found duplicate configuration for connector {connector_id}, overriding with the later config"
                     )
                 connectors[connector_id] = connector

--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -21,13 +21,8 @@ class JobCleanUpService(BaseService):
     def __init__(self, config):
         super().__init__(config)
         self.idling = int(self.service_config.get("job_cleanup_interval", 60 * 5))
-        self.native_service_types = self.config.get("native_service_types")
-        if self.native_service_types is None:
-            self.native_service_types = []
-        if "connector_id" in self.config:
-            self.connector_ids = [self.config.get("connector_id")]
-        else:
-            self.connector_ids = []
+        self.native_service_types = self.config.get("native_service_types", []) or []
+        self.connector_ids = list(self.connectors.keys())
         self.connector_index = None
         self.sync_job_index = None
 

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -143,18 +143,9 @@ class JobExecutionService(BaseService):
         self.connector_index = ConnectorIndex(self.es_config)
         self.sync_job_index = SyncJobIndex(self.es_config)
 
-        native_service_types = self.config.get("native_service_types")
-        if native_service_types is None:
-            native_service_types = []
+        native_service_types = self.config.get("native_service_types", []) or []
         logger.debug(f"Native support for {', '.join(native_service_types)}")
-
-        # TODO: we can support multiple connectors but Ruby can't so let's use a
-        # single id
-        # connector_ids = self.config.get("connector_ids", [])
-        if "connector_id" in self.config:
-            connector_ids = [self.config.get("connector_id")]
-        else:
-            connector_ids = []
+        connector_ids = list(self.connectors.keys())
 
         logger.info(
             f"Service started, listening to events from {self.es_config['host']}"

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -49,7 +49,9 @@ class JobSchedulingService(BaseService):
             connector.log_debug("Natively supported")
 
         try:
-            await connector.prepare(self.config)
+            await connector.prepare(
+                self.connectors.get(connector.id, {}), self.config["sources"]
+            )
         except DocumentNotFoundError:
             connector.log_error("Couldn't find connector")
             return
@@ -124,18 +126,9 @@ class JobSchedulingService(BaseService):
         self.connector_index = ConnectorIndex(self.es_config)
         self.sync_job_index = SyncJobIndex(self.es_config)
 
-        native_service_types = self.config.get("native_service_types")
-        if native_service_types is None:
-            native_service_types = []
+        native_service_types = self.config.get("native_service_types", []) or []
         logger.debug(f"Native support for {', '.join(native_service_types)}")
-
-        # TODO: we can support multiple connectors but Ruby can't so let's use a
-        # single id
-        # connector_ids = self.config.get("connector_ids", [])
-        if "connector_id" in self.config:
-            connector_ids = [self.config.get("connector_id")]
-        else:
-            connector_ids = []
+        connector_ids = list(self.connectors.keys())
 
         logger.info(
             f"Service started, listening to events from {self.es_config['host']}"

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -914,13 +914,13 @@ async def test_connector_prepare_different_id():
     config = {
         "connector_id": "2",
         "service_type": "banana",
-        "sources": {},
     }
+    sources = {}
     index = Mock()
     index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
     index.update = AsyncMock()
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    await connector.prepare(config)
+    await connector.prepare(config, sources)
     index.update.assert_not_awaited()
 
 
@@ -973,13 +973,13 @@ async def test_connector_prepare_with_prepared_connector():
     config = {
         "connector_id": doc_id,
         "service_type": "banana",
-        "sources": {"banana": "tests.protocol.test_connectors:Banana"},
     }
+    sources = {"banana": "tests.protocol.test_connectors:Banana"}
     index = Mock()
     index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
     index.update = AsyncMock()
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    await connector.prepare(config)
+    await connector.prepare(config, sources)
     index.update.assert_not_awaited()
 
 
@@ -1018,8 +1018,8 @@ async def test_connector_prepare_with_connector_missing_field_properties_creates
     config = {
         "connector_id": doc_id,
         "service_type": "banana",
-        "sources": {"banana": "tests.protocol.test_connectors:Banana"},
     }
+    sources = {"banana": "tests.protocol.test_connectors:Banana"}
     index = Mock()
     index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
     index.update = AsyncMock()
@@ -1032,7 +1032,7 @@ async def test_connector_prepare_with_connector_missing_field_properties_creates
     expected["one"]["extra_property"] = "hehe"
     del expected["two"]
 
-    await connector.prepare(config)
+    await connector.prepare(config, sources)
     index.update.assert_called_once_with(
         doc_id=doc_id,
         doc={"configuration": expected},
@@ -1054,14 +1054,14 @@ async def test_connector_prepare_with_service_type_not_configured():
     }
     config = {
         "connector_id": doc_id,
-        "sources": {"banana": "tests.protocol.test_connectors:Banana"},
     }
+    sources = {"banana": "tests.protocol.test_connectors:Banana"}
     index = Mock()
     index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
     index.update = AsyncMock()
     connector = Connector(elastic_index=index, doc_source=connector_doc)
     with pytest.raises(ServiceTypeNotConfiguredError):
-        await connector.prepare(config)
+        await connector.prepare(config, sources)
         index.update.assert_not_awaited()
 
 
@@ -1079,14 +1079,14 @@ async def test_connector_prepare_with_service_type_not_supported():
     config = {
         "connector_id": doc_id,
         "service_type": "banana",
-        "sources": {},
     }
+    sources = {}
     index = Mock()
     index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
     index.update = AsyncMock()
     connector = Connector(elastic_index=index, doc_source=connector_doc)
     with pytest.raises(ServiceTypeNotSupportedError):
-        await connector.prepare(config)
+        await connector.prepare(config, sources)
         index.update.assert_not_awaited()
 
 
@@ -1104,14 +1104,14 @@ async def test_connector_prepare_with_data_source_error():
     config = {
         "connector_id": doc_id,
         "service_type": "banana",
-        "sources": {"banana": "foobar"},
     }
+    sources = {"banana": "foobar"}
     index = Mock()
     index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
     index.update = AsyncMock()
     connector = Connector(elastic_index=index, doc_source=connector_doc)
     with pytest.raises(DataSourceError):
-        await connector.prepare(config)
+        await connector.prepare(config, sources)
         index.update.assert_not_awaited()
 
 
@@ -1133,13 +1133,13 @@ async def test_connector_prepare_with_different_features():
     config = {
         "connector_id": doc_id,
         "service_type": "banana",
-        "sources": {"banana": "tests.protocol.test_connectors:Banana"},
     }
+    sources = {"banana": "tests.protocol.test_connectors:Banana"}
     index = Mock()
     index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
     index.update = AsyncMock()
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    await connector.prepare(config)
+    await connector.prepare(config, sources)
     index.update.assert_called_once_with(
         doc_id=doc_id,
         doc={"features": Banana.features()},
@@ -1162,13 +1162,13 @@ async def test_connector_prepare():
     config = {
         "connector_id": doc_id,
         "service_type": "banana",
-        "sources": {"banana": "tests.protocol.test_connectors:Banana"},
     }
+    sources = {"banana": "tests.protocol.test_connectors:Banana"}
     index = Mock()
     index.fetch_response_by_id = AsyncMock(return_value=connector_doc)
     index.update = AsyncMock()
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    await connector.prepare(config)
+    await connector.prepare(config, sources)
     index.update.assert_called_once_with(
         doc_id=doc_id,
         doc={
@@ -1196,8 +1196,8 @@ async def test_connector_prepare_with_race_condition():
     config = {
         "connector_id": doc_id,
         "service_type": "banana",
-        "sources": {"banana": "tests.protocol.test_connectors:Banana"},
     }
+    sources = {"banana": "tests.protocol.test_connectors:Banana"}
     connector_doc_after_update = connector_doc | {
         "_source": {
             "service_type": "banana",
@@ -1217,7 +1217,7 @@ async def test_connector_prepare_with_race_condition():
         )
     )
     connector = Connector(elastic_index=index, doc_source=connector_doc)
-    await connector.prepare(config)
+    await connector.prepare(config, sources)
     index.update.assert_called_once_with(
         doc_id=doc_id,
         doc={

--- a/tests/services/test_base.py
+++ b/tests/services/test_base.py
@@ -145,11 +145,14 @@ def test_parse_connectors():
     local_config = deepcopy(config)
     local_config["connectors"] = [
         {"connector_id": "foo", "service_type": "bar"},
+        {"connector_id": "baz", "service_type": "qux"},
     ]
 
     service = BaseService(local_config)
     assert service.connectors["foo"]["connector_id"] == "foo"
     assert service.connectors["foo"]["service_type"] == "bar"
+    assert service.connectors["baz"]["connector_id"] == "baz"
+    assert service.connectors["baz"]["service_type"] == "qux"
 
 
 def test_parse_connectors_with_duplicate_connectors():

--- a/tests/services/test_base.py
+++ b/tests/services/test_base.py
@@ -6,6 +6,7 @@
 import asyncio
 import functools
 from collections import defaultdict
+from copy import deepcopy
 
 import pytest
 
@@ -126,3 +127,63 @@ async def test_multiservice_stop_gracefully_stops_service_that_takes_too_long_to
     assert (
         not service_2.cancelled
     )  # we're not supposed to cancel it as it's already stopping
+
+
+config = {
+    "elasticsearch": {},
+    "service": {},
+}
+
+
+def test_parse_connectors_with_no_connectors():
+    local_config = deepcopy(config)
+    service = BaseService(local_config)
+    assert not service.connectors
+
+
+def test_parse_connectors():
+    local_config = deepcopy(config)
+    local_config["connectors"] = [
+        {"connector_id": "foo", "service_type": "bar"},
+    ]
+
+    service = BaseService(local_config)
+    assert service.connectors["foo"]["connector_id"] == "foo"
+    assert service.connectors["foo"]["service_type"] == "bar"
+
+
+def test_parse_connectors_with_duplicate_connectors():
+    local_config = deepcopy(config)
+    local_config["connectors"] = [
+        {"connector_id": "foo", "service_type": "bar"},
+        {"connector_id": "foo", "service_type": "baz"},
+    ]
+
+    service = BaseService(local_config)
+    assert len(service.connectors) == 1
+    assert service.connectors["foo"]["connector_id"] == "foo"
+    assert service.connectors["foo"]["service_type"] == "baz"
+
+
+def test_parse_connectors_with_deprecated_config_and_new_config():
+    local_config = deepcopy(config)
+    local_config["connectors"] = [{"connector_id": "foo", "service_type": "bar"}]
+    local_config["connector_id"] = "deprecated"
+    local_config["service_type"] = "deprecated"
+
+    service = BaseService(local_config)
+    assert len(service.connectors) == 1
+    assert service.connectors["foo"]["connector_id"] == "foo"
+    assert service.connectors["foo"]["service_type"] == "bar"
+    assert "deprecated" not in service.connectors
+
+
+def test_parse_connectors_with_deprecated_config():
+    local_config = deepcopy(config)
+    local_config["connector_id"] = "deprecated"
+    local_config["service_type"] = "deprecated"
+
+    service = BaseService(local_config)
+    assert len(service.connectors) == 1
+    assert service.connectors["deprecated"]["connector_id"] == "deprecated"
+    assert service.connectors["deprecated"]["service_type"] == "deprecated"


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4187

This PR makes the following services support both the new connectors config and the deprecated connector config in `config.yml`:
1. Job Scheduling service
2. Job Execution service
3. Job Cleanup service
4. Preflight check

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Customers can now run multiple connector clients/customized connectors in one connector service.