### PR TITLE
[SPO] Limit synced fields

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -698,7 +698,7 @@ class SharepointOnlineClient:
             return
         except ClientResponseError:
             # Some site pages don't have the required columns, and it's unclear why
-            self._logger.warn(f"Moving past 400 error for URL: {url}")
+            self._logger.warning(f"Moving past 400 error for URL: {url}")
             return
 
     async def site_page_role_assignments(self, site_web_url, site_page_id):

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -283,7 +283,7 @@ def retryable_aiohttp_call(retries):
                     async for item in func(*args, **kwargs):
                         yield item
                     break
-                except (NotFound, ClientResponseError):
+                except NotFound:
                     raise
                 except Exception:
                     if retry >= retries:
@@ -685,20 +685,32 @@ class SharepointOnlineClient:
     async def site_pages(self, site_web_url):
         self._validate_sharepoint_rest_url(site_web_url)
 
-        select = "Id,Title,LayoutWebpartsContent,CanvasContent1,Description,Created,AuthorId,Modified,EditorId"
+        # select = "Id,Title,LayoutWebpartsContent,CanvasContent1,Description,Created,AuthorId,Modified,EditorId"
+        select = ""  # ^ is what we want, but site pages don't have consistent schemas, and this causes errors. Better to fetch all and slice
         url = f"{site_web_url}/_api/web/lists/GetByTitle('Site%20Pages')/items?$select={select}"
 
         try:
             async for page in self._rest_api_client.scroll(url):
                 for site_page in page:
-                    yield site_page
+                    yield {
+                        k: site_page.get(k, None)
+                        for k in (
+                            "Id",
+                            "Title",
+                            "LayoutWebpartsContent",
+                            "CanvasContent1",
+                            "WikiField",
+                            "Description",
+                            "Created",
+                            "AuthorId",
+                            "Modified",
+                            "EditorId",
+                            "odata.id",
+                        )
+                    }
         except NotFound:
             # I'm not sure if site can have no pages, but given how weird API is I put this here
             # Just to be on a safe side
-            return
-        except ClientResponseError:
-            # Some site pages don't have the required columns, and it's unclear why
-            self._logger.warning(f"Moving past 400 error for URL: {url}")
             return
 
     async def site_page_role_assignments(self, site_web_url, site_page_id):
@@ -1507,7 +1519,7 @@ class SharepointOnlineDataSource(BaseDataSource):
             ]  # Apparently site_page["GUID"] is not globally unique
             site_page["object_type"] = "site_page"
 
-            for html_field in ["LayoutWebpartsContent", "CanvasContent1"]:
+            for html_field in ["LayoutWebpartsContent", "CanvasContent1", "WikiField"]:
                 if html_field in site_page:
                     site_page[html_field] = html_to_text(site_page[html_field])
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -952,14 +952,14 @@ class TestSharepointOnlineClient:
     @pytest.mark.asyncio
     async def test_site_pages(self, client, patch_scroll):
         page_url_path = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/page.aspx"
-        actual_items = ["1", "2", "3", "4"]
+        actual_items = [{"Id": "1"}, {"Id": "2"}, {"Id": "3"}, {"Id": "4"}]
 
         returned_items = await self._execute_scrolling_method(
             partial(client.site_pages, page_url_path), patch_scroll, actual_items
         )
 
         assert len(returned_items) == len(actual_items)
-        assert returned_items == actual_items
+        assert [{"Id": i["Id"]} for i in returned_items] == actual_items
 
     @pytest.mark.asyncio
     async def test_site_pages_not_found(self, client, patch_scroll):


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1268

By using explicit `$select` clauses, we both increase performance and limit what types of fields we index. 

This change adds a few explicit select clauses, and reduces our total fields in a full sync of the koffelab dataset from ~224 to ~70 fields (not counting nested subfields).

There's a good chance that we'll eventually want to make the selected fields configurable.

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
