### PR TITLE
Use per-connector api key to sync data if configured

### DIFF
--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -3,6 +3,8 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+from copy import deepcopy
+
 from connectors.es.client import License
 from connectors.es.index import DocumentNotFoundError
 from connectors.es.license import requires_platinum_license
@@ -78,7 +80,7 @@ class JobExecutionService(BaseService):
             source_klass=source_klass,
             sync_job=sync_job,
             connector=connector,
-            es_config=self.es_config,
+            es_config=self._override_es_config(connector),
         )
         await self.content_syncs.put(sync_job_runner.execute)
 
@@ -93,7 +95,7 @@ class JobExecutionService(BaseService):
             source_klass=source_klass,
             sync_job=sync_job,
             connector=connector,
-            es_config=self.es_config,
+            es_config=self._override_es_config(connector),
         )
         await self.access_control_syncs.put(sync_job_runner.execute)
 
@@ -204,3 +206,18 @@ class JobExecutionService(BaseService):
                 self.sync_job_index.stop_waiting()
                 await self.sync_job_index.close()
         return 0
+
+    def _override_es_config(self, connector):
+        es_config = deepcopy(self.es_config)
+        if connector.id not in self.connectors:
+            return es_config
+
+        api_key = self.connectors[connector.id].get("api_key", None)
+        if not api_key:
+            return es_config
+
+        es_config.pop("username", None)
+        es_config.pop("password", None)
+        es_config["api_key"] = api_key
+
+        return es_config

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -538,6 +538,7 @@ def test_load_max_concurrent_access_control_syncs_fallback_on_default():
 
 
 def test_override_es_config():
+    connector_api_key = "connector_api_key"
     config = {
         "elasticsearch": {
             "username": "username",
@@ -550,7 +551,7 @@ def test_override_es_config():
             {
                 "connector_id": "foo",
                 "service_type": "bar",
-                "api_key": "connector_api_key",
+                "api_key": connector_api_key,
             }
         ],
     }
@@ -561,4 +562,4 @@ def test_override_es_config():
     override_config = service._override_es_config(connector)
     assert "username" not in override_config
     assert "password" not in override_config
-    assert override_config["api_key"] == "connector_api_key"
+    assert override_config["api_key"] == connector_api_key

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -535,3 +535,30 @@ def test_load_max_concurrent_access_control_syncs_from_config():
 )
 def test_load_max_concurrent_access_control_syncs_fallback_on_default():
     assert load_max_concurrent_access_control_syncs({}) == MAX_SIX_CONCURRENT_SYNCS
+
+
+def test_override_es_config():
+    config = {
+        "elasticsearch": {
+            "username": "username",
+            "password": "password",
+            "api_key": "global_api_key",
+        },
+        "service": {"idling": 30},
+        "sources": [],
+        "connectors": [
+            {
+                "connector_id": "foo",
+                "service_type": "bar",
+                "api_key": "connector_api_key",
+            }
+        ],
+    }
+
+    service = JobExecutionService(config)
+    connector = Mock()
+    connector.id = "foo"
+    override_config = service._override_es_config(connector)
+    assert "username" not in override_config
+    assert "password" not in override_config
+    assert override_config["api_key"] == "connector_api_key"


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4187

This PR makes use of the per-connector API key to run the sync job if it's configured.


## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)