### PR TITLE
[SPO] Logs improvements

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -385,7 +385,7 @@ class MicrosoftAPISession:
                         f"Response Code from Sharepoint Server is 429 but Retry-After header is not found, using default retry time: {DEFAULT_RETRY_SECONDS} seconds"
                     )
                     retry_seconds = DEFAULT_RETRY_SECONDS
-                self._logger.debug(
+                self._logger.info(
                     f"Rate Limited by Sharepoint: retry in {retry_seconds} seconds"
                 )
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -403,9 +403,6 @@ class MicrosoftAPISession:
                 raise InternalServerError from e
             else:
                 raise
-            self._logger.debug(
-                f"Rate Limited by Sharepoint: retry in {retry_seconds} seconds"
-            )
 
 
 class SharepointOnlineClient:


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5029

This PR removes some dead code and changes the severity of the log to `info` when we hit HTTP throttling limits. This might be helpful if customers complain about their connectors' speed. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
