### PR TITLE
[SPO] Tune download/write chunk size

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -63,7 +63,7 @@ else:
 DEFAULT_RETRY_COUNT = 3
 DEFAULT_RETRY_SECONDS = 30
 DEFAULT_PARALLEL_CONNECTION_COUNT = 10
-FILE_WRITE_CHUNK_SIZE = 1024 * 64 # 64KB default SSD page size
+FILE_WRITE_CHUNK_SIZE = 1024 * 64  # 64KB default SSD page size
 MAX_DOCUMENT_SIZE = 10485760
 WILDCARD = "*"
 DRIVE_ITEMS_FIELDS = "id,content.downloadUrl,lastModifiedDateTime,lastModifiedBy,root,deleted,file,folder,package,name,webUrl,createdBy,createdDateTime,size,parentReference"

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -63,7 +63,7 @@ else:
 DEFAULT_RETRY_COUNT = 3
 DEFAULT_RETRY_SECONDS = 30
 DEFAULT_PARALLEL_CONNECTION_COUNT = 10
-FILE_WRITE_CHUNK_SIZE = 1024
+FILE_WRITE_CHUNK_SIZE = 1024 * 64 # 64KB default SSD page size
 MAX_DOCUMENT_SIZE = 10485760
 WILDCARD = "*"
 DRIVE_ITEMS_FIELDS = "id,content.downloadUrl,lastModifiedDateTime,lastModifiedBy,root,deleted,file,folder,package,name,webUrl,createdBy,createdDateTime,size,parentReference"


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/5029

When the chunk_size is 1KB the maximum download speed is 14MB/s. 

<img width="1566" alt="image" src="https://github.com/elastic/connectors-python/assets/314956/65e3b304-4e80-4f19-9440-b83897ed2cd3">

When increased to 64KB the speed goes up ~ 95MB/s - which is the network thoughput limit in the testing hardware environment. 
<img width="1576" alt="image" src="https://github.com/elastic/connectors-python/assets/314956/872b5e74-6777-4cc6-b93f-1f9ff62c8618">

Why 64KB? - it's default page size in the most SSD buffers. In the future, this options should be configurable.  

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference