### PR TITLE
[Google Drive] Obfuscate Service account JSON in the UI

### DIFF
--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -223,6 +223,7 @@ class GoogleDriveDataSource(BaseDataSource):
             "service_account_credentials": {
                 "display": "textarea",
                 "label": "Google Drive service account JSON",
+                "sensitive": True,
                 "order": 1,
                 "type": "str",
                 "value": "",

--- a/tests/sources/fixtures/google_drive/connector.json
+++ b/tests/sources/fixtures/google_drive/connector.json
@@ -7,7 +7,7 @@
       "tooltip": null,
       "default_value": null,
       "label": "Google Drive service account JSON",
-      "sensitive": false,
+      "sensitive": true,
       "type": "str",
       "required": true,
       "options": [],


### PR DESCRIPTION
## Changes

Hide the service account JSON in the UI, mark it as sensitive field. 

<img width="760" alt="Screenshot 2023-07-17 at 18 10 15" src="https://github.com/elastic/connectors-python/assets/14121688/f32e8d56-c720-4fe5-a55c-2d727fa24a95">


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
