### PR TITLE
Add backport automations for the pre-8.10 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,7 @@
 {
   "targetBranchChoices": [
     { "name": "main", "checked": true },
+    "pre-8.10-stable",
     "8.9",
     "8.8"
   ],
@@ -8,6 +9,7 @@
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v8.10.0(.0)?$": "main",
+    "^vpre-8.10-stable$": "pre-8.10-stable",
     "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
   },
   "upstream": "elastic/connectors-python"


### PR DESCRIPTION
This makes it so that anything labeled with `vpre-8.10-stable` can automatically be backported. 

