### PR TITLE
Remove race condition when killing ingest processes

### DIFF
--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -103,18 +103,26 @@ if [[ $PERF8 == "yes" ]]; then
 fi
 
 # make sure the ingest processes are terminated
+set +e # if the PID disappears right before the kill, that's not an error
 if ps -p $PID > /dev/null
 then
   echo 'Killing the ingest process'
   kill -TERM $PID
   sleep 5
-  kill -KILL $PID
+  if ps -p $PID > /dev/null
+  then
+    kill -KILL $PID
+  fi
 fi
 
 if ps -p $PID_2 > /dev/null
 then
-  echo 'Killing the ingest process'
+  echo 'Killing the second ingest process'
   kill -TERM $PID_2
   sleep 5
-  kill -KILL $PID_2
+  if ps -p $PID_2 > /dev/null
+  then
+    kill -KILL $PID_2
+  fi
 fi
+set -e


### PR DESCRIPTION
See https://elastic.slack.com/archives/C04KMMNAHGB/p1689772818319019

the ftest script ends by terminating the ingest processes. However, because of how we `set -e` and then try a combination of `kill` commands, if the process terminates before the final `kill` is issued, bash returns an error, and we fail the ftest. This PR:

1. only tries a `kill -KILL $PID` if the pid is still present 5 seconds after we tried the first `kill`. This reduces the chance of a race condition, but doesn't eliminate it.
2. sets `set +e` before we start killing things, because at that point, the test has passed, and we don't want to flag it as a failure because we cleaned up faster than expected.