### PR TITLE
[SPO] Add unique list permissions support

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,22 +331,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,6 +331,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -665,23 +665,39 @@ class SharepointOnlineClient:
     async def site_lists(self, site_id):
         select = "createdDateTime,id,lastModifiedDateTime,name,webUrl,displayName,createdBy,lastModifiedBy"
 
-        async for page in self._graph_api_client.scroll(
-            f"{GRAPH_API_URL}/sites/{site_id}/lists?$select={select}"
-        ):
-            for site_list in page:
-                yield site_list
+        try:
+            async for page in self._graph_api_client.scroll(
+                f"{GRAPH_API_URL}/sites/{site_id}/lists?$select={select}"
+            ):
+                for site_list in page:
+                    yield site_list
+        except NotFound:
+            return
+
+    async def site_list_has_unique_role_assignments(self, site_web_url, site_list_name):
+        self._validate_sharepoint_rest_url(site_web_url)
+
+        url = f"{site_web_url}/_api/lists/GetByTitle('{site_list_name}')/HasUniqueRoleAssignments"
+
+        try:
+            response = await self._rest_api_client.fetch(url)
+            return response.get("value", False)
+        except NotFound:
+            return False
 
     async def site_list_role_assignments(self, site_web_url, site_list_name):
         self._validate_sharepoint_rest_url(site_web_url)
 
-        url = (
-            f"{site_web_url}/_api/lists/GetByTitle('{site_list_name}')/roleassignments"
-        )
+        expand = "Member/users,RoleDefinitionBindings"
+
+        url = f"{site_web_url}/_api/lists/GetByTitle('{site_list_name}')/roleassignments?$expand={expand}"
 
         try:
-            return await self._rest_api_client.fetch(url)
+            async for page in self._rest_api_client.scroll(url):
+                for role_assignment in page:
+                    yield role_assignment
         except NotFound:
-            return {}
+            return
 
     async def site_list_items(self, site_id, list_id):
         select = "createdDateTime,id,lastModifiedDateTime,weburl,createdBy,lastModifiedBy,contentType"
@@ -1124,6 +1140,15 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "type": "bool",
                 "value": True,
             },
+            "fetch_unique_list_permissions": {
+                "depends_on": [{"field": "use_document_level_security", "value": True}],
+                "display": "toggle",
+                "label": "Fetch unique list permissions",
+                "order": 10,
+                "tooltip": "Enable this option to fetch unique list permissions. This setting can increase sync time. If this setting is disabled a list will inherit permissions from its parent site.",
+                "type": "bool",
+                "value": True,
+            },
         }
 
     async def validate_config(self):
@@ -1478,10 +1503,8 @@ class SharepointOnlineDataSource(BaseDataSource):
                         )
 
                 # Sync site list and site list items
-                async for site_list in self.site_lists(site):
-                    yield self._decorate_with_access_control(
-                        site_list, site_access_control
-                    ), None
+                async for site_list in self.site_lists(site, site_access_control):
+                    yield site_list, None
 
                     async for list_item, download_func in self.site_list_items(
                         site_id=site["id"],
@@ -1560,10 +1583,8 @@ class SharepointOnlineDataSource(BaseDataSource):
                         )
 
                 # Sync site list and site list items
-                async for site_list in self.site_lists(site):
-                    yield self._decorate_with_access_control(
-                        site_list, site_access_control
-                    ), None, OP_INDEX
+                async for site_list in self.site_lists(site, site_access_control):
+                    yield site_list, None, OP_INDEX
 
                     async for list_item, download_func in self.site_list_items(
                         site_id=site["id"],
@@ -1741,14 +1762,50 @@ class SharepointOnlineDataSource(BaseDataSource):
 
             yield list_item, None
 
-    async def site_lists(self, site):
+    async def site_lists(self, site, site_access_control):
         async for site_list in self.client.site_lists(site["id"]):
             site_list["_id"] = site_list["id"]
             site_list["object_type"] = "site_list"
+            site_url = site["webUrl"]
+            site_list_name = site_list["name"]
+
+            has_unique_role_assignments = False
+
+            if self.configuration["fetch_unique_list_permissions"]:
+                has_unique_role_assignments = (
+                    await self.client.site_list_has_unique_role_assignments(
+                        site_url, site_list_name
+                    )
+                )
+
+                if has_unique_role_assignments:
+                    self._logger.debug(
+                        f"Fetching unique list permissions for list with id '{site_list['_id']}'. Ignoring parent site permissions."
+                    )
+
+                    site_list_access_control = []
+
+                    async for role_assignment in self.client.site_list_role_assignments(
+                        site_url, site_list_name
+                    ):
+                        site_list_access_control.extend(
+                            await self._get_access_control_from_role_assignment(
+                                role_assignment
+                            )
+                        )
+
+                    site_list = self._decorate_with_access_control(
+                        site_list, site_list_access_control
+                    )
+
+            if not has_unique_role_assignments:
+                site_list = self._decorate_with_access_control(
+                    site_list, site_access_control
+                )
 
             yield site_list
 
-    async def _get_access_control_from_role_assignment(self, url, role_assignment):
+    async def _get_access_control_from_role_assignment(self, role_assignment):
         """Extracts access control from a role assignment.
 
         Args:
@@ -1833,7 +1890,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                 ):
                     page_access_control.extend(
                         await self._get_access_control_from_role_assignment(
-                            url, role_assignment
+                            role_assignment
                         )
                     )
 

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -1,3 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
 class AsyncIterator:
     """
     Async documents generator fake class, which records the args and kwargs it was called with.
@@ -8,6 +13,7 @@ class AsyncIterator:
         self.call_args = []
         self.call_kwargs = []
         self.i = 0
+        self.call_count = 0
 
     def __aiter__(self):
         return self
@@ -21,6 +27,8 @@ class AsyncIterator:
         return item
 
     def __call__(self, *args, **kwargs):
+        self.call_count += 1
+
         if args:
             self.call_args.append(args)
 
@@ -28,3 +36,9 @@ class AsyncIterator:
             self.call_kwargs.append(kwargs)
 
         return self
+
+    def assert_not_called(self):
+        return self.call_count == 0
+
+    def assert_called_once(self):
+        return self.call_count == 1

--- a/tests/sources/fixtures/sharepoint_online/connector.json
+++ b/tests/sources/fixtures/sharepoint_online/connector.json
@@ -145,6 +145,26 @@
         "value": true,
         "order": 9,
         "ui_restrictions": []
+      },
+      "fetch_unique_list_permissions": {
+        "depends_on": [
+          {
+            "field": "use_document_level_security",
+            "value": true
+          }
+        ],
+        "display": "toggle",
+        "tooltip": "Enable this option to fetch unique list permissions. This setting can increase sync time. If this setting is disabled a list will inherit permissions from its parent site.",
+        "default_value": true,
+        "label": "Fetch unique list permissions",
+        "sensitive": false,
+        "type": "bool",
+        "required": true,
+        "options": [],
+        "validations": [],
+        "value": false,
+        "order": 10,
+        "ui_restrictions": []
       }
     },
     "custom_scheduling": {},

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -54,6 +54,10 @@ from connectors.sources.sharepoint_online import (
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
 
+SITE_LIST_ONE_NAME = "site-list-one-name"
+
+SITE_LIST_ONE_ID = "1"
+
 TIMESTAMP_FORMAT_PATCHED = "%Y-%m-%dT%H:%M:%SZ"
 
 ONLY_USERNAMES = True
@@ -110,7 +114,11 @@ def set_dls_enabled(source, dls_enabled):
 
 
 def set_fetch_drive_item_permissions_enabled(source, enabled):
-    source.configuration.set_field("fetch_drive_item_permissions", enabled)
+    source.configuration.set_field("fetch_drive_item_permissions", value=enabled)
+
+
+def set_fetch_unique_list_permissions_enabled(source, enabled):
+    source.configuration.set_field("fetch_unique_list_permissions", value=enabled)
 
 
 def dls_feature_flag_enabled(value):
@@ -123,6 +131,10 @@ def dls_enabled_config_value(value):
 
 def dls_enabled(value):
     return value
+
+
+def access_control_matches(actual, expected):
+    return all([access_control in expected for access_control in actual])
 
 
 class TestMicrosoftSecurityToken:
@@ -1173,29 +1185,60 @@ class TestSharepointOnlineClient:
         assert len(responses) == 0
 
     @pytest.mark.asyncio
-    async def test_site_list_role_assignments(self, client, patch_fetch):
+    async def test_site_list_has_unique_role_assignments(self, client, patch_fetch):
         site_list_role_assignments_url = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/roleassignments"
         site_list_name = "site_list"
 
-        role_assignments = {"value": ["role"]}
-        patch_fetch.return_value = role_assignments
+        patch_fetch.return_value = {"value": True}
 
-        actual_role_assignments = await client.site_list_role_assignments(
+        assert await client.site_page_has_unique_role_assignments(
             site_list_role_assignments_url, site_list_name
+        )
+
+    @pytest.mark.asyncio
+    async def test_site_list_has_unique_role_assignments_not_found(
+        self, client, patch_fetch
+    ):
+        site_list_role_assignments_url = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/roleassignments"
+        site_list_name = "site_list"
+
+        patch_fetch.side_effect = NotFound()
+
+        assert not await client.site_page_has_unique_role_assignments(
+            site_list_role_assignments_url, site_list_name
+        )
+
+    @pytest.mark.asyncio
+    async def test_site_list_role_assignments(self, client, patch_scroll):
+        site_list_role_assignments_url = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/roleassignments"
+        site_list_name = "site_list"
+
+        role_assignments = [{"value": ["role"]}]
+
+        actual_role_assignments = await self._execute_scrolling_method(
+            partial(
+                client.site_page_role_assignments,
+                site_list_role_assignments_url,
+                site_list_name,
+            ),
+            patch_scroll,
+            role_assignments,
         )
 
         assert actual_role_assignments == role_assignments
 
     @pytest.mark.asyncio
-    async def test_site_list_role_assignments_not_found(self, client, patch_fetch):
+    async def test_site_list_role_assignments_not_found(self, client, patch_scroll):
         site_list_role_assignments_url = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/roleassignments"
         site_list_name = "site_list"
 
-        patch_fetch.side_effect = NotFound
+        patch_scroll.side_effect = NotFound
 
-        role_assignments = await client.site_list_role_assignments(
+        role_assignments = []
+        async for role_assignment in client.site_list_role_assignments(
             site_list_role_assignments_url, site_list_name
-        )
+        ):
+            role_assignments.append(role_assignment)
 
         assert len(role_assignments) == 0
 
@@ -1521,7 +1564,11 @@ class TestSharepointOnlineDataSource:
 
     @property
     def site_lists(self):
-        return [{"id": "5", "name": "My test list"}]
+        return [{"id": SITE_LIST_ONE_ID, "name": SITE_LIST_ONE_NAME}]
+
+    @property
+    def site_list_has_unique_role_assignments(self):
+        return True
 
     @property
     def site_list_items(self):
@@ -1758,8 +1805,8 @@ class TestSharepointOnlineDataSource:
             client.drive_items_permissions_batch = AsyncIterator(
                 self.drive_items_permissions_batch
             )
-            client.site_list_role_assignments = AsyncMock(
-                return_value=self.site_list_role_assignments
+            client.site_list_role_assignments = AsyncIterator(
+                [self.site_list_role_assignments]
             )
             client.site_list_item_role_assignments = AsyncMock(
                 return_value=self.site_list_item_role_assignments
@@ -1776,6 +1823,9 @@ class TestSharepointOnlineDataSource:
             client.site_drives = AsyncIterator(self.site_drives)
             client.drive_items = self.drive_items_func
             client.site_lists = AsyncIterator(self.site_lists)
+            client.site_list_has_unique_role_assignments = AsyncMock(
+                return_value=self.site_list_has_unique_role_assignments
+            )
             client.site_list_items = AsyncIterator(self.site_list_items)
             client.site_list_item_attachments = AsyncIterator(
                 self.site_list_item_attachments
@@ -1844,9 +1894,6 @@ class TestSharepointOnlineDataSource:
         ALLOW_ACCESS_CONTROL_PATCHED,
     )
     async def test_get_docs_with_access_control(self, patch_sharepoint_client):
-        def _access_control_matches(actual, expected):
-            return all([access_control in expected for access_control in actual])
-
         group = "group"
         email = "email"
         user = "user"
@@ -1877,7 +1924,7 @@ class TestSharepointOnlineDataSource:
         assert len(sites) == len(self.sites)
         assert all(
             [
-                _access_control_matches(
+                access_control_matches(
                     site[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
                 )
                 for site in sites
@@ -1887,7 +1934,7 @@ class TestSharepointOnlineDataSource:
         assert len(site_drives) == len(self.site_drives)
         assert all(
             [
-                _access_control_matches(
+                access_control_matches(
                     site_drive[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
                 )
                 for site_drive in site_drives
@@ -1905,7 +1952,7 @@ class TestSharepointOnlineDataSource:
         ]
         assert all(
             [
-                _access_control_matches(
+                access_control_matches(
                     drive_item[ALLOW_ACCESS_CONTROL_PATCHED],
                     expected_drive_item_access_control,
                 )
@@ -1916,7 +1963,7 @@ class TestSharepointOnlineDataSource:
         assert len(site_lists) == len(self.site_lists)
         assert all(
             [
-                _access_control_matches(
+                access_control_matches(
                     site_list[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
                 )
                 for site_list in site_lists
@@ -1928,7 +1975,7 @@ class TestSharepointOnlineDataSource:
         )  # -1 because one of them is ignored!
         assert all(
             [
-                _access_control_matches(
+                access_control_matches(
                     list_item[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
                 )
                 for list_item in list_items
@@ -1938,7 +1985,7 @@ class TestSharepointOnlineDataSource:
         assert len(list_item_attachments) == len(self.site_list_item_attachments)
         assert all(
             [
-                _access_control_matches(
+                access_control_matches(
                     list_item_attachment[ALLOW_ACCESS_CONTROL_PATCHED],
                     expected_access_control,
                 )
@@ -1949,7 +1996,7 @@ class TestSharepointOnlineDataSource:
         assert len(site_pages) == len(self.site_pages)
         assert all(
             [
-                _access_control_matches(
+                access_control_matches(
                     site_page[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
                 )
                 for site_page in site_pages
@@ -2010,6 +2057,63 @@ class TestSharepointOnlineDataSource:
         )
 
         assert (operations["delete"]) == deleted
+
+    @pytest.mark.asyncio
+    async def test_site_lists(self, patch_sharepoint_client):
+        source = create_source(SharepointOnlineDataSource)
+        set_dls_enabled(source, True)
+        set_fetch_unique_list_permissions_enabled(source, False)
+
+        site = {"id": "1", "webUrl": "some url"}
+        site_access_control = ["some site specific access control"]
+        site_lists = []
+
+        async for site_list in source.site_lists(site, site_access_control):
+            site_lists.append(site_list)
+
+        assert len(site_lists) == len(self.site_lists)
+        assert all(
+            access_control_matches(site_list[ACCESS_CONTROL], site_access_control)
+            for site_list in site_lists
+        )
+        assert patch_sharepoint_client.site_list_role_assignments.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_site_lists_with_unique_role_assignments(
+        self, patch_sharepoint_client
+    ):
+        source = create_source(SharepointOnlineDataSource)
+        set_dls_enabled(source, True)
+        set_fetch_unique_list_permissions_enabled(source, True)
+
+        site = {"id": "1", "webUrl": "some url"}
+        site_access_control = ["some site specific access control"]
+        site_list_access_control = [
+            {
+                "Member": {
+                    "odata.type": "SP.User",
+                    "UserPrincipalName": USER_TWO_NAME,
+                },
+            }
+        ]
+        expected_access_control = _prefix_user(USER_TWO_NAME)
+
+        patch_sharepoint_client.site_list_role_assignments = AsyncIterator(
+            site_list_access_control
+        )
+        patch_sharepoint_client.has_unique_role_assignments.return_value = True
+
+        actual_site_lists = []
+
+        async for site_list in source.site_lists(site, site_access_control):
+            actual_site_lists.append(site_list)
+
+        assert len(actual_site_lists) == len(self.site_lists)
+        assert all(
+            access_control_matches(site_list[ACCESS_CONTROL], expected_access_control)
+            for site_list in actual_site_lists
+        )
+        assert patch_sharepoint_client.site_list_role_assignments.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_download_function_for_folder(self):
@@ -2909,10 +3013,9 @@ class TestSharepointOnlineDataSource:
         self, role_assignment, expected_access_control
     ):
         source = create_source(SharepointOnlineDataSource)
-        url = "some url"
 
         access_control = await source._get_access_control_from_role_assignment(
-            url, role_assignment
+            role_assignment
         )
 
         assert len(access_control) == len(expected_access_control)

--- a/tests/test_commons.py
+++ b/tests/test_commons.py
@@ -1,0 +1,113 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+import pytest
+
+from tests.commons import AsyncIterator
+
+
+@pytest.mark.asyncio
+async def test_async_generation():
+    items = [1, 2, 3]
+
+    async_generator = AsyncIterator(items)
+
+    yielded_items = []
+    async for item in async_generator:
+        yielded_items.append(item)
+
+    assert yielded_items == items
+
+
+@pytest.mark.asyncio
+async def test_call_args():
+    items = [1]
+
+    async_generator = AsyncIterator(items)
+
+    arg_one = "arg one"
+    arg_two = "arg two"
+
+    # first call
+    async for _ in async_generator(arg_one, arg_two):
+        pass
+
+    arg_three = "arg three"
+    arg_four = "arg four"
+
+    # second call
+    async for _ in async_generator(arg_three, arg_four):
+        pass
+
+    first_call_args = async_generator.call_args[0]
+    second_call_args = async_generator.call_args[1]
+
+    assert len(async_generator.call_args) == 2
+
+    assert first_call_args[0] == arg_one
+    assert first_call_args[1] == arg_two
+
+    assert second_call_args[0] == arg_three
+    assert second_call_args[1] == arg_four
+
+
+@pytest.mark.asyncio
+async def test_call_kwargs():
+    items = [1]
+
+    async_generator = AsyncIterator(items)
+
+    kwarg_one_value = "kwarg one value"
+    kwarg_two_value = "kwarg two value"
+
+    # first call
+    async for _ in async_generator(
+        kwarg_one_key=kwarg_one_value, kwarg_two_key=kwarg_two_value
+    ):
+        pass
+
+    kwarg_three_value = "kwarg three value"
+    kwarg_four_value = "kwarg four value"
+
+    # second call
+    async for _ in async_generator(
+        kwarg_three_key=kwarg_three_value, kwarg_four_key=kwarg_four_value
+    ):
+        pass
+
+    first_call_kwargs = async_generator.call_kwargs[0]
+    second_call_kwargs = async_generator.call_kwargs[1]
+
+    assert len(async_generator.call_kwargs) == 2
+
+    assert first_call_kwargs["kwarg_one_key"] == kwarg_one_value
+    assert first_call_kwargs["kwarg_two_key"] == kwarg_two_value
+
+    assert second_call_kwargs["kwarg_three_key"] == kwarg_three_value
+    assert second_call_kwargs["kwarg_four_key"] == kwarg_four_value
+
+
+@pytest.mark.asyncio
+async def test_assert_not_called():
+    items = []
+
+    async_generator = AsyncIterator(items)
+    assert async_generator.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once():
+    items = []
+
+    async_generator = AsyncIterator(items)
+
+    async for _ in async_generator():
+        pass
+
+    # not a direct call on the generator -> call count still 1
+    async for _ in async_generator:
+        pass
+
+    assert async_generator.assert_called_once()


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5363

This PR adds support for unique site list permissions, which broke the inheritance to their parent site. This is guarded through a new RFC `fetch_unique_list_permissions`.

Also added some missing tests around `site_lists` and extended the `AsyncIterator` with some new assertions (which are needed for the `site_lists` tests) and added missing tests for this class, too.

Note: a separate PR will be opened for the Kibana RFC

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)