### PR TITLE
[Google Drive] Use async os stat operation to check file size

### DIFF
--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -9,7 +9,7 @@ import os
 from functools import cached_property, partial
 
 import aiofiles
-from aiofiles.os import remove
+from aiofiles.os import remove, stat
 from aiofiles.tempfile import NamedTemporaryFile
 from aiogoogle import Aiogoogle, HTTPError
 from aiogoogle.auth.creds import ServiceAccountCreds
@@ -807,7 +807,8 @@ class GoogleDriveDataSource(BaseDataSource):
                 source=temp_file_name,
             )
 
-            file_size = os.stat(temp_file_name).st_size
+            file_stat = await stat(temp_file_name)
+            file_size = file_stat.st_size
 
             async with aiofiles.open(file=temp_file_name, mode="r") as target_file:
                 attachment = (await target_file.read()).strip()


### PR DESCRIPTION
<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Changes

Use async os stat operation to check file size

While checking implementation of `aiohttp_session` I realized that we can use `aiofiles` to get file size in non-blocking way. Here is the link to open-source repo: https://github.com/omarryhan/aiogoogle/blob/master/aiogoogle/sessions/aiohttp_session.py#L17

Use the same async approach in google drive connector.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
