### PR TITLE
[Google Drive] Remove debug print() statement

### DIFF
--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -587,8 +587,6 @@ class GoogleDriveDataSource(BaseDataSource):
 
     async def ping(self):
         """Verify the connection with Google Drive"""
-        print("Max concurrency:")
-        print(self._max_concurrency())
         try:
             await self.google_drive_client.ping()
             self._logger.info("Successfully connected to the Google Drive.")


### PR DESCRIPTION
## Changes

Remove the print() statement that I used to verify and debug advanced RCF default value from the config 
