### PR TITLE
Fix GCS ingesting too much in ftest

### DIFF
--- a/tests/sources/fixtures/google_cloud_storage/fixture.py
+++ b/tests/sources/fixtures/google_cloud_storage/fixture.py
@@ -12,12 +12,26 @@ import string
 from google.auth.credentials import AnonymousCredentials
 from google.cloud import storage
 
-NUMBER_OF_SMALL_FILES = 9500
-NUMBER_OF_LARGE_FILES = 500
 client_connection = None
 NUMBER_OF_BLOBS_TO_BE_DELETED = 10
 HERE = os.path.dirname(__file__)
 HOSTS = "/etc/hosts"
+
+DATA_SIZE = os.environ.get("DATA_SIZE", "medium")
+
+match DATA_SIZE:
+    case "extra_small":
+        NUMBER_OF_SMALL_FILES = 50
+        NUMBER_OF_LARGE_FILES = 5
+    case "small":
+        NUMBER_OF_SMALL_FILES = 1000
+        NUMBER_OF_LARGE_FILES = 10
+    case "medium":
+        NUMBER_OF_SMALL_FILES = 5000
+        NUMBER_OF_LARGE_FILES = 50
+    case "large":
+        NUMBER_OF_SMALL_FILES = 9500
+        NUMBER_OF_LARGE_FILES = 500
 
 
 class PrerequisiteException(Exception):
@@ -28,6 +42,10 @@ class PrerequisiteException(Exception):
             f"Error while running e2e test for the Google Cloud Storage connector. \nReason: {errors}"
         )
         self.errors = errors
+
+
+def get_num_docs():
+    print(NUMBER_OF_LARGE_FILES + NUMBER_OF_SMALL_FILES - NUMBER_OF_BLOBS_TO_BE_DELETED)
 
 
 def verify():


### PR DESCRIPTION
Fixes GCS functional tests. Issue is that 2GB Elasticsearch is not able to chew through the data that comes in:

```
[FMWK][09:13:04][ERROR] Exception found for task Task-5611: ApiError(429, 'circuit_breaking_exception', '[parent] Data too large, data for [<http_request>] would be [2072318054/1.9gb], which is larger than the limit of [2040109465/1.8gb], real usage: [2061130016/1.9gb], new bytes reserved: [11188038/10.6mb], usages [fielddata=0/0b, eql_sequence=0/0b, model_inference=0/0b, inflight_requests=11188038/10.6mb, request=0/0b]')
```

Option 1 would be to increase Elasticsearch size.

Option 2 was what I did - make the test suite respect DATA_SIZE env variable and reduce the default size of the test fixture for ftest.