### PR TITLE
[Rich Configurable Fields] Add dev-friendly reference docs

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -50,9 +50,9 @@ This is our main communication index, used to communicate the connector's config
       tooltip: string;      -> Text for populating the Kibana tooltip element
       type: string;         -> The field value type (str, int, bool, list)
       ui_restrictions: string[];    -> List of places in the UI to restrict the field to
-      validations: [                -> Array of rules to validate the field's value against
-        type: string;               -> The validation type
-        constraint: string | number -> The rule to use for this validation
+      validations: [                         -> Array of rules to validate the field's value against
+        type: string;                        -> The validation type
+        constraint: string | number | list;  -> The rule to use for this validation
       ];
       value: any;           -> The value of the field configured in Kibana
     }
@@ -82,9 +82,9 @@ This is our main communication index, used to communicate the connector's config
     };                                  -> Features to enable/disable for this connector
   };
   filtering: [          -> Array of filtering rules, connectors use the first entry by default
-    {          
+    {
       domain: string,     -> what data domain these rules apply to
-      active: {           -> "active" rules are run in jobs. 
+      active: {           -> "active" rules are run in jobs.
         rules: {
           id: string,         -> rule identifier
           policy: string,     -> one of ["include", "exclude"]
@@ -119,7 +119,7 @@ This is our main communication index, used to communicate the connector's config
   last_access_control_sync_status: string:  -> Status of the last access control sync job, or null if no job has been executed
   last_deleted_document_count: number;    -> How many documents were deleted in the last job
   last_incremental_sync_scheduled_at: date; -> Date/time when the last incremental sync job is scheduled (UTC)
-  last_indexed_document_count: number;    -> How many documents were indexed in the last job  
+  last_indexed_document_count: number;    -> How many documents were indexed in the last job
   last_seen: date;      -> Connector writes check-in date-time regularly (UTC)
   last_sync_error: string;   -> Optional last full or incremental sync job error message
   last_sync_status: string;  -> Status of the last content sync job, or null if no job has been executed
@@ -487,7 +487,7 @@ For every half hour, and every time a job is executed, the connector should upda
 For custom connectors, the connector should also update `configuration` field if its status is `created`.
 
 The connector should also sync data for connectors:
-- Read connector definitions from `.elastic-connectors` regularly, and determine whether to sync data based on `scheduling` and `custom_scheduling` values. 
+- Read connector definitions from `.elastic-connectors` regularly, and determine whether to sync data based on `scheduling` and `custom_scheduling` values.
 - Set the index mappings of the to-be-written-to index if not already present.
 - Sync with the data source and index resulting documents into the correct index.
 - Log jobs to `.elastic-connectors-sync-jobs`.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -227,6 +227,15 @@ The connector configuration, expressed as list of RCFs, is stored in the Connect
 
 Rich Configurable Fields are defined as JSON objects with the following key-value pairs:
 
+
+<!---
+You can use online tools to edit the table in visual mode. To edit:
+- copy the table source
+- go to https://www.tablesgenerator.com/markdown_tables
+- file -> paste table data -> paste your clipboard
+- the table will be loaded and ready to edit
+-->
+
 | Key | Description | Value |
 |---|---|---|
 | `default_value` | The value used if `value` is empty (only for non-required fields) | `any` |

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -246,7 +246,7 @@ Rich Configurable Fields are defined as JSON objects with the following key-valu
 Explanation of possible validation rules, where `value` refers to validated value:
 - `less_than` - The `constraint` has to be numeric. Validator checks for `value < constraint`.
 - `greater_than` - The `constraint` has to be numeric. Validator checks for `value > constraint`.
-- `list_type` - The constraint has to be either `'int'` or `'str'`. The `value` has to be of list type. The validator checks the type of each element in the `value` list.
+- `list_type` - The constraint has to be either `int` or `str`. The `value` has to be of list type. The validator checks the type of each element in the `value` list.
 - `included_in` - The constraint has to be of `list` type and include allowed values. The `value` has to be of list type. The validator checks if `value is subset of constraint`
 - `regex` - The constrain has to be a [valid regex expression](https://docs.python.org/3/library/re.html). The `value` has to be `str`. The validator checks if `value` matches the `constraint` regular expression.
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -227,15 +227,6 @@ The connector configuration, expressed as list of RCFs, is stored in the Connect
 
 Rich Configurable Fields are defined as JSON objects with the following key-value pairs:
 
-
-<!---
-You can use online tools to edit the table in visual mode. To edit:
-- copy the table source
-- go to https://www.tablesgenerator.com/markdown_tables
-- file -> paste table data -> paste your clipboard
-- the table will be loaded and ready to edit
--->
-
 | Key | Description | Value |
 |---|---|---|
 | `default_value` | The value used if `value` is empty (only for non-required fields) | `any` |

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -12,6 +12,7 @@
   - [Common patterns](#common-patterns)
     - [Source/Client](#sourceclient)
     - [Async](#async)
+    - [Rich Configurable Fields](#rich-configurable-fields)
   - [Other considerations](#other-considerations)
   - [Sync rules](#sync-rules)
     - [Basic rules vs advanced rules](#basic-rules-vs-advanced-rules)
@@ -215,6 +216,40 @@ When you send work in the background, you will have two options:
 
 When building async I/O-bound connectors, make sure that you provide a way to recycle connections and that you can throttle calls to the backends. This is very important to avoid file descriptors exhaustion and hammering the backend service.
 
+#### Rich Configurable Fields
+
+Each connector needs to define the [get_default_configuration()](../connectors/source.py) method, that returns a list of __Rich Configurable Fields (RCF)__. Those fields are used by Kibana to:
+- render user-friendly connector configuration section that includes informative labels, tooltips and dedicated UI components (`display`)
+- obfuscate sensitive fields
+- perform user input validation with `type` and `validations`
+
+The connector configuration, expressed as list of RCFs, is stored in the Connector index `.elastic-connectors` and is governed by the [Connector Protocol](./CONNECTOR_PROTOCOL.md).
+
+Rich Configurable Fields are defined as JSON objects with the following key-value pairs:
+
+| Key | Description | Value |
+|---|---|---|
+| `default_value` | The value used if `value` is empty (only for non-required fields) | `any` |
+| `depends_on` | Array of dependencies, field will not be validated and displayed in UI unless dependencies are met. Each dependency is represented as an object with `field` and `value` keys, where: <ul><li>`field`: The key for the field that this will depend on</li><li>`value`: The value required to have this dependency met</li></ul> | <ul><li>`field`: `string`</li><li>`value`: `string \| number \| boolean`</li></ul> |
+| `display` | What UI element this field should use | `'dropdown' \| 'numeric' \| 'text' \| 'textarea' \| 'toggle'` |
+| `label` | The label to be displayed for the field in Kibana | `string` |
+| `order` | The order the configurable field will appear in the UI | `number` |
+| `required` | Whether or not the field needs a value | `boolean` |
+| `sensitive` | Whether or not to obfuscate the field in Kibana | `boolean` |
+| `tooltip` | Text for populating the Kibana tooltip element | `string` |
+| `type` | The field value type | `'str' \| 'int' \| 'bool' \| 'list'` |
+| `ui_restrictions` | List of places in the UI to restrict the field to | `string[]`, note: only `'advanced'` place is supported for now  |
+| `validations` | Array of rules to validate the field's value against. Each rule is represented as an object with `type` and `constraint` keys, where: <ul><li>`type`: The validation type</li><li>`constraint`: The rule to use for this validation</li></ul> | <ul><li>`type`: `'less_than' \| 'greater_than' \| 'list_type' \| 'included_in' \| 'regex'`</li><li>`constraint`: `string \| number \| list`</li></ul> |
+| `value` | The value of the field configured in Kibana | `any` |
+
+
+Explanation of possible validation rules, where `value` refers to validated value:
+- `less_than` - The `constraint` has to be numeric. Validator checks for `value < constraint`.
+- `greater_than` - The `constraint` has to be numeric. Validator checks for `value > constraint`.
+- `list_type` - The constraint has to be either `'int'` or `'str'`. The `value` has to be of list type. The validator checks the type of each element in the `value` list.
+- `included_in` - The constraint has to be of `list` type and include allowed values. The `value` has to be of list type. The validator checks if `value is subset of constraint`
+- `regex` - The constrain has to be a [valid regex expression](https://docs.python.org/3/library/re.html). The `value` has to be `str`. The validator checks if `value` matches the `constraint` regular expression.
+
 ### Other considerations
 
 When creating a new connector, there are a number of topics to thoughtfully consider before you begin coding.
@@ -346,7 +381,7 @@ For smaller-payload resources like Users and Groups, this can probably be safely
 ##### When should failure responses be retried?
 
 As discussed above, many APIs utilize rate limits and will issue 429 responses for requests that should be retried later.
-However, sometimes there are other cases that warrant retries. 
+However, sometimes there are other cases that warrant retries.
 
 Some services experience frequent-but-transient timeout issues.
 Some services experiencing a large volume of write operations may sometimes respond with 409 "conflict" codes.
@@ -449,7 +484,7 @@ async def get_docs(self, filtering=None):
         advanced_rules = filtering.get_advanced_rules()
         # your custom advanced rules implementation
     else:
-        # default fetch all data implementation 
+        # default fetch all data implementation
 ```
 
 For example, here you could pass custom queries to a database.
@@ -483,7 +518,7 @@ The framework expects the custom validators to return a `SyncRuleValidationResul
 
 ```python
 class MyValidator(AdvancedRulesValidator):
-    
+
     def validate(self, advanced_rules):
         # custom validation logic
         return SyncRuleValidationResult(...)
@@ -511,7 +546,7 @@ There are two possible ways to validate basic rules:
 - **Every rule gets validated in isolation**. Extend the class `BasicRuleValidator` located in [validation.py](../connectors/filtering/validation.py):
     ```python
     class MyBasicRuleValidator(BasicRuleValidator):
-        
+
         @classmethod
         def validate(cls, rule):
             # custom validation logic
@@ -520,7 +555,7 @@ There are two possible ways to validate basic rules:
 - **Validate the whole set of basic rules**. If you want to validate constraints on the set of rules, for example to detect duplicate or conflicting rules. Extend the class `BasicRulesSetValidator` located in [validation.py](../connectors/filtering/validation.py):
     ```python
     class MyBasicRulesSetValidator(BasicRulesSetValidator):
-        
+
         @classmethod
         def validate(cls, set_of_rules):
             # custom validation logic
@@ -533,7 +568,7 @@ class MyDataSource(BaseDataSource):
 
     @classmethod
     def basic_rules_validators(self):
-        return BaseDataSource.basic_rule_validators() 
+        return BaseDataSource.basic_rule_validators()
                 + [MyBasicRuleValidator, MyBasicRulesSetValidator]
 ```
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1221

- Adds section that explains existing RCFs and their possible values
- Small fix in connector-protocol, the `validations.constraint` can also be a list, when `validations.type` is of  `included_in` type (see[ this code for refrerence](https://github.com/elastic/connectors-python/blob/main/connectors/source.py#L193)) 
- my vscode did some linting of .MD whitespace

## Verification

The table might be tough to verify in github PR diff, I suggest viewing changes on my branch directly. [Preview link](https://github.com/elastic/connectors-python/blob/jedrazb-add-rich-configurable-fields-reference/docs/DEVELOPING.md#rich-configurable-fields)

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
