### PR TITLE
Ignore connector configurations with missing connector id

### DIFF
--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -119,6 +119,13 @@ class BaseService(metaclass=_Registry):
         if configured_connectors is not None:
             for connector in configured_connectors:
                 connector_id = connector.get("connector_id")
+                if not connector_id:
+                    logger.warning(
+                        f"Found invalid connector configuration. Connector id is missing for {connector}"
+                    )
+                    continue
+
+                connector_id = str(connector_id)
                 if connector_id in connectors:
                     logger.warning(
                         f"Found duplicate configuration for connector {connector_id}, overriding with the later config"
@@ -127,8 +134,9 @@ class BaseService(metaclass=_Registry):
 
         if not connectors:
             if "connector_id" in self.config and "service_type" in self.config:
-                connectors[self.config["connector_id"]] = {
-                    "connector_id": self.config["connector_id"],
+                connector_id = str(self.config["connector_id"])
+                connectors[connector_id] = {
+                    "connector_id": connector_id,
                     "service_type": self.config["service_type"],
                 }
 

--- a/tests/services/test_base.py
+++ b/tests/services/test_base.py
@@ -168,6 +168,19 @@ def test_parse_connectors_with_duplicate_connectors():
     assert service.connectors["foo"]["service_type"] == "baz"
 
 
+def test_parse_connectors_with_incomplete_connector():
+    local_config = deepcopy(config)
+    local_config["connectors"] = [
+        {"connector_id": "foo", "service_type": "bar"},
+        {"service_type": "qux"},
+    ]
+
+    service = BaseService(local_config)
+    assert len(service.connectors) == 1
+    assert service.connectors["foo"]["connector_id"] == "foo"
+    assert service.connectors["foo"]["service_type"] == "bar"
+
+
 def test_parse_connectors_with_deprecated_config_and_new_config():
     local_config = deepcopy(config)
     local_config["connectors"] = [{"connector_id": "foo", "service_type": "bar"}]


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4187

When a connector is configured without a connector id, this config will be ignored and a warning message will be logged.:
```yaml
connectors:
  -
    # connector_id: foobar
    service_type: mysql
```

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)