### PR TITLE
Revert "Make files HTML with large binary garbage to increase file size (#1269)"

### DIFF
--- a/tests/sources/fixtures/sharepoint_online/fixture.py
+++ b/tests/sources/fixtures/sharepoint_online/fixture.py
@@ -83,29 +83,16 @@ match DATA_SIZE:
         NUMBER_OF_LIST_ITEMS = 10
         NUMBER_OF_LIST_ITEM_ATTACHMENTS = 5
 
-
-fake_large_image = fake.pystr(min_chars=1 << 20, max_chars=1 << 20 + 1)
-
-
-def _generate_html(text, number_of_large_images):
-    images = []
-    for _ in range(number_of_large_images):
-        images.append(f"<img src='{fake_large_image}'/>")
-
-    large_html = f"<html><head></head><body><div>{text}</div><div>{'<br/>'.join(images)}</div></body></html>"
-
-    return large_html
-
-
-small_text = _generate_html(fake.text(max_nb_chars=5000), 0)
-medium_text = _generate_html(fake.text(max_nb_chars=20000), 1)
-large_text = _generate_html(fake.text(max_nb_chars=100000), 10)
+small_text = fake.text(max_nb_chars=5000)
+medium_text = fake.text(max_nb_chars=20000)
+large_text = fake.text(max_nb_chars=100000)
 
 small_text_bytesize = len(small_text.encode("utf-8"))
 medium_text_bytesize = len(medium_text.encode("utf-8"))
 large_text_bytesize = len(large_text.encode("utf-8"))
 
 fake_binary_image = fake.pystr(min_chars=65536, max_chars=65536 << 1)
+
 
 TOTAL_RECORD_COUNT = NUMBER_OF_SITES * (
     1 * NUMBER_OF_DRIVE_ITEMS
@@ -196,7 +183,7 @@ class RandomDataStorage:
                     drive_item["name"] = fake.word()
                 else:
                     drive_item["folder"] = False
-                    drive_item["name"] = fake.file_name(extension="html")
+                    drive_item["name"] = fake.file_name(extension="txt")
 
                     if j % 5 == 0:  # Every 5th is medium
                         self.drive_item_content[drive_item["id"]] = medium_text


### PR DESCRIPTION
This reverts commit `01e48e4884c03c22d7c182ad8177bb2e0df5830b`

## Closes https://github.com/elastic/connectors-py/issues/###


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

See discussion in: https://elastic.slack.com/archives/C04KMMNAHGB/p1690377683388729 

The changes in that PR were causing: `elasticsearch.ApiError: ApiError(429, 'circuit_breaking_exception', '[parent] Data too large, data for [<http_request>] would be [2076451632/1.9gb], which is larger than the limit of [2040109465/1.8gb], real usage: [2076451632/1.9gb]` in SPO ftests, effectively failing our nightlies. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] Tested the changes locally
