### PR TITLE
[SPO] Decrease the filesize for SPO ftests to fix nightlies

### DIFF
--- a/tests/sources/fixtures/sharepoint_online/fixture.py
+++ b/tests/sources/fixtures/sharepoint_online/fixture.py
@@ -84,7 +84,7 @@ match DATA_SIZE:
         NUMBER_OF_LIST_ITEM_ATTACHMENTS = 5
 
 
-fake_large_image = fake.pystr(min_chars=1 << 20, max_chars=1 << 20 + 1)
+fake_large_image = fake.pystr(min_chars=1 << 15, max_chars=1 << 15 + 1)
 
 
 def _generate_html(text, number_of_large_images):
@@ -97,9 +97,9 @@ def _generate_html(text, number_of_large_images):
     return large_html
 
 
-small_text = _generate_html(fake.text(max_nb_chars=5000), 0)
-medium_text = _generate_html(fake.text(max_nb_chars=20000), 1)
-large_text = _generate_html(fake.text(max_nb_chars=100000), 10)
+small_text = _generate_html(fake.text(max_nb_chars=500), 0)
+medium_text = _generate_html(fake.text(max_nb_chars=5000), 1)
+large_text = _generate_html(fake.text(max_nb_chars=10000), 5)
 
 small_text_bytesize = len(small_text.encode("utf-8"))
 medium_text_bytesize = len(medium_text.encode("utf-8"))


### PR DESCRIPTION
## Fix failing nightlies

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

In #1269 the filzesize in ftests was increased significantly and it causes following errors: `elasticsearch.ApiError: ApiError(429, 'circuit_breaking_exception', '[parent] Data too large, data for [<http_request>] would be [2076451632/1.9gb], which is larger than the limit of [2040109465/1.8gb], real usage: [2076451632/1.9gb]` 


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

