### PR TITLE
Add debug log on successful text extraction

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -858,7 +858,5 @@ class ExtractionService:
             )
             return ""
 
-        logger.debug(
-            f"Text extraction successful for `{filename}'."
-        )
+        logger.debug(f"Text extraction successful for `{filename}'.")
         return content.get("extracted_text", "")

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -858,5 +858,5 @@ class ExtractionService:
             )
             return ""
 
-        logger.debug(f"Text extraction successful for `{filename}'.")
+        logger.debug(f"Text extraction is successful for `{filename}'.")
         return content.get("extracted_text", "")

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -858,5 +858,5 @@ class ExtractionService:
             )
             return ""
 
-        logger.debug(f"Text extraction is successful for `{filename}'.")
+        logger.debug(f"Text extraction is successful for '{filename}'.")
         return content.get("extracted_text", "")

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -858,4 +858,7 @@ class ExtractionService:
             )
             return ""
 
+        logger.debug(
+            f"Text extraction successful for `{filename}'."
+        )
         return content.get("extracted_text", "")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -695,7 +695,7 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted!"
-            patch_logger.assert_present("Text extraction successful for `notreal.txt'.")
+            patch_logger.assert_present("Text extraction is successful for `notreal.txt'.")
 
     @pytest.mark.asyncio
     async def test_extract_text_with_file_pointer(self, mock_responses, patch_logger):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -695,7 +695,9 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted!"
-            patch_logger.assert_present("Text extraction is successful for 'notreal.txt'.")
+            patch_logger.assert_present(
+                "Text extraction is successful for 'notreal.txt'."
+            )
 
     @pytest.mark.asyncio
     async def test_extract_text_with_file_pointer(self, mock_responses, patch_logger):
@@ -720,7 +722,7 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted from a local file!"
-            patch_logger.assert_present("Text extraction successful for 'notreal.txt'.")
+            patch_logger.assert_present("Text extraction is successful for 'notreal.txt'.")
 
     @pytest.mark.asyncio
     async def test_extract_text_when_response_isnt_200_logs_warning(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -677,7 +677,7 @@ class TestExtractionService:
             assert extraction_service._check_configured() is expected_result
 
     @pytest.mark.asyncio
-    async def test_extract_text(self, mock_responses):
+    async def test_extract_text(self, mock_responses, patch_logger):
         filepath = "tmp/notreal.txt"
         url = "http://localhost:8090/extract_text/"
         payload = {"extracted_text": "I've been extracted!"}
@@ -695,9 +695,12 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted!"
+            patch_logger.assert_present(
+                "Text extraction successful for `notreal.txt'."
+            )
 
     @pytest.mark.asyncio
-    async def test_extract_text_with_file_pointer(self, mock_responses):
+    async def test_extract_text_with_file_pointer(self, mock_responses, patch_logger):
         filepath = "/tmp/notreal.txt"
         url = "http://localhost:8090/extract_text/?local_file_path=/tmp/notreal.txt"
         payload = {"extracted_text": "I've been extracted from a local file!"}
@@ -719,6 +722,9 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted from a local file!"
+            patch_logger.assert_present(
+                "Text extraction successful for `notreal.txt'."
+            )
 
     @pytest.mark.asyncio
     async def test_extract_text_when_response_isnt_200_logs_warning(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -695,7 +695,7 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted!"
-            patch_logger.assert_present("Text extraction is successful for `notreal.txt'.")
+            patch_logger.assert_present("Text extraction is successful for 'notreal.txt'.")
 
     @pytest.mark.asyncio
     async def test_extract_text_with_file_pointer(self, mock_responses, patch_logger):
@@ -720,7 +720,7 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted from a local file!"
-            patch_logger.assert_present("Text extraction successful for `notreal.txt'.")
+            patch_logger.assert_present("Text extraction successful for 'notreal.txt'.")
 
     @pytest.mark.asyncio
     async def test_extract_text_when_response_isnt_200_logs_warning(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -695,9 +695,7 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted!"
-            patch_logger.assert_present(
-                "Text extraction successful for `notreal.txt'."
-            )
+            patch_logger.assert_present("Text extraction successful for `notreal.txt'.")
 
     @pytest.mark.asyncio
     async def test_extract_text_with_file_pointer(self, mock_responses, patch_logger):
@@ -722,9 +720,7 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted from a local file!"
-            patch_logger.assert_present(
-                "Text extraction successful for `notreal.txt'."
-            )
+            patch_logger.assert_present("Text extraction successful for `notreal.txt'.")
 
     @pytest.mark.asyncio
     async def test_extract_text_when_response_isnt_200_logs_warning(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -722,7 +722,9 @@ class TestExtractionService:
             await extraction_service._end_session()
 
             assert response == "I've been extracted from a local file!"
-            patch_logger.assert_present("Text extraction is successful for 'notreal.txt'.")
+            patch_logger.assert_present(
+                "Text extraction is successful for 'notreal.txt'."
+            )
 
     @pytest.mark.asyncio
     async def test_extract_text_when_response_isnt_200_logs_warning(


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5453

During some testing it came up that we should have debug logs for successful text extraction.
This PR adds that log.
