### PR TITLE
Decouple PostgreSQLDataSource from GenericBaseDataSource

### DIFF
--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -7,10 +7,22 @@
 import ssl
 from urllib.parse import quote
 
+from asyncpg.exceptions._base import InternalClientError
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from connectors.sources.generic_database import GenericBaseDataSource, Queries
-from connectors.utils import get_pem_format
+from connectors.source import BaseDataSource
+from connectors.sources.generic_database import (
+    DEFAULT_FETCH_SIZE,
+    DEFAULT_RETRY_COUNT,
+    DEFAULT_WAIT_MULTIPLIER,
+    WILDCARD,
+    Queries,
+    configured_tables,
+    is_wildcard,
+)
+from connectors.utils import CancellableSleeps, get_pem_format, iso_utc
 
 # Below schemas are system schemas and the tables of the systems schema's will not get indexed
 SYSTEM_SCHEMA = ["pg_toast", "pg_catalog", "information_schema"]
@@ -50,7 +62,7 @@ class PostgreSQLQueries(Queries):
         return "SELECT schema_name FROM information_schema.schemata"
 
 
-class PostgreSQLDataSource(GenericBaseDataSource):
+class PostgreSQLDataSource(BaseDataSource):
     """PostgreSQL"""
 
     name = "PostgreSQL"
@@ -63,46 +75,193 @@ class PostgreSQLDataSource(GenericBaseDataSource):
             configuration (DataSourceConfiguration): Instance of DataSourceConfiguration class.
         """
         super().__init__(configuration=configuration)
+        self._sleeps = CancellableSleeps()
+
+        # Connector configurations
+        self.retry_count = self.configuration["retry_count"]
+
+        # Connection related configurations
+        self.database = self.configuration["database"]
+        self.tables = self.configuration["tables"]
+        self.host = self.configuration["host"]
         self.ssl_enabled = self.configuration["ssl_enabled"]
         self.ssl_ca = self.configuration["ssl_ca"]
-        self.connection_string = f"postgresql+asyncpg://{self.user}:{quote(self.password)}@{self.host}:{self.port}/{self.database}"
+        self.connection_string = f"postgresql+asyncpg://{self.configuration['username']}:{quote(self.configuration['password'])}@{self.host}:{self.configuration['port']}/{self.database}"
         self.queries = PostgreSQLQueries()
-        self.is_async = True
-        self.dialect = "Postgresql"
+        self.engine = None
 
     @classmethod
     def get_default_configuration(cls):
-        """Get the default configuration for database-server configured by user
+        return {
+            "host": {
+                "label": "Host",
+                "order": 1,
+                "type": "str",
+                "value": "127.0.0.1",
+            },
+            "port": {
+                "display": "numeric",
+                "label": "Port",
+                "order": 2,
+                "type": "int",
+                "value": 9090,
+            },
+            "username": {
+                "label": "Username",
+                "order": 3,
+                "type": "str",
+                "value": "admin",
+            },
+            "password": {
+                "label": "Password",
+                "order": 4,
+                "sensitive": True,
+                "type": "str",
+                "value": "Password_123",
+            },
+            "database": {
+                "label": "Database",
+                "order": 5,
+                "type": "str",
+                "value": "xe",
+            },
+            "tables": {
+                "display": "textarea",
+                "label": "Comma-separated list of tables",
+                "options": [],
+                "order": 6,
+                "type": "list",
+                "value": WILDCARD,
+            },
+            "fetch_size": {
+                "default_value": DEFAULT_FETCH_SIZE,
+                "display": "numeric",
+                "label": "Rows fetched per request",
+                "order": 7,
+                "required": False,
+                "type": "int",
+                "ui_restrictions": ["advanced"],
+                "value": DEFAULT_FETCH_SIZE,
+            },
+            "retry_count": {
+                "default_value": DEFAULT_RETRY_COUNT,
+                "display": "numeric",
+                "label": "Retries per request",
+                "order": 8,
+                "required": False,
+                "type": "int",
+                "ui_restrictions": ["advanced"],
+                "value": DEFAULT_RETRY_COUNT,
+            },
+            "ssl_enabled": {
+                "display": "toggle",
+                "label": "Enable SSL verification",
+                "order": 9,
+                "type": "bool",
+                "value": DEFAULT_SSL_ENABLED,
+            },
+            "ssl_ca": {
+                "depends_on": [{"field": "ssl_enabled", "value": True}],
+                "label": "SSL certificate",
+                "order": 10,
+                "type": "str",
+                "value": DEFAULT_SSL_CA,
+            },
+        }
+
+    async def close(self):
+        self._sleeps.cancel()
+
+    async def execute_query(self, query, fetch_many=False, **kwargs):
+        """Executes a query and yield rows
+
+        Args:
+            query (str): Query.
+            fetch_many (bool): Flag to use fetchmany method. Defaults to False.
+
+        Raises:
+            exception: Raise an exception after retrieving
+
+        Yields:
+            list: Column names and query response
+        """
+        size = self.configuration["fetch_size"]
+
+        retry = 1
+        yield_once = True
+
+        rows_fetched = 0
+
+        while retry <= self.retry_count:
+            try:
+                cursor = await self._async_connect(query=query)
+                if fetch_many:
+                    # sending back column names only once
+                    if yield_once:
+                        if kwargs["schema"] is not None:
+                            yield [
+                                f"{kwargs['schema']}_{kwargs['table']}_{column}".lower()
+                                for column in cursor.keys()  # pyright: ignore
+                            ]
+                        else:
+                            yield [
+                                f"{kwargs['table']}_{column}".lower()
+                                for column in cursor.keys()  # pyright: ignore
+                            ]
+                        yield_once = False
+
+                    while True:
+                        rows = cursor.fetchmany(size=size)  # pyright: ignore
+                        rows_length = len(rows)
+
+                        if not rows_length:
+                            break
+
+                        for row in rows:
+                            yield row
+
+                        rows_fetched += rows_length
+                        await self._sleeps.sleep(0)
+                else:
+                    yield cursor.fetchall()  # pyright: ignore
+                break
+            except (InternalClientError, ProgrammingError):
+                raise
+            except Exception as exception:
+                self._logger.warning(
+                    f"Retry count: {retry} out of {self.retry_count}. Exception: {exception}"
+                )
+                if retry == self.retry_count:
+                    raise exception
+                await self._sleeps.sleep(DEFAULT_WAIT_MULTIPLIER**retry)
+                retry += 1
+
+    async def _async_connect(self, query):
+        """Execute the passed query on the Async supported Database server and return cursor.
+
+        Args:
+            query (str): Database query to be executed.
 
         Returns:
-            dictionary: Default configuration
+            cursor: Asynchronous cursor
         """
-        postgresql_configuration = super().get_default_configuration().copy()
-        postgresql_configuration.update(
-            {
-                "ssl_enabled": {
-                    "display": "toggle",
-                    "label": "Enable SSL verification",
-                    "order": 9,
-                    "type": "bool",
-                    "value": DEFAULT_SSL_ENABLED,
-                },
-                "ssl_ca": {
-                    "depends_on": [{"field": "ssl_enabled", "value": True}],
-                    "label": "SSL certificate",
-                    "order": 10,
-                    "type": "str",
-                    "value": DEFAULT_SSL_CA,
-                },
-            }
-        )
-        return postgresql_configuration
+        try:
+            if self.engine is None:
+                self._create_engine()
+            async with self.engine.connect() as connection:  # pyright: ignore
+                cursor = await connection.execute(text(query))
+                return cursor
+        except Exception as exception:
+            self._logger.warning(
+                f"Something went wrong while executing query. Exception: {exception}"
+            )
+            raise
 
     def _create_engine(self):
         """Create async engine for postgresql"""
         self.engine = create_async_engine(
             self.connection_string,
-            connect_args=self.get_connect_args() if self.ssl_enabled else {},
+            connect_args=self.get_connect_args(),
         )
 
     def get_connect_args(self):
@@ -111,11 +270,163 @@ class PostgreSQLDataSource(GenericBaseDataSource):
         Returns:
             dictionary: Connection arguments
         """
+        if not self.ssl_enabled:
+            return {}
+
         pem_format = get_pem_format(key=self.ssl_ca)
         ctx = ssl.create_default_context()
         ctx.load_verify_locations(cadata=pem_format)
         connect_args = {"ssl": ctx}
         return connect_args
+
+    async def ping(self):
+        """Verify the connection with the database-server configured by user"""
+        self._logger.info("Validating the Connector Configuration...")
+        try:
+            await anext(
+                self.execute_query(
+                    query=self.queries.ping(),
+                )
+            )
+            self._logger.info("Successfully connected to Postgresql.")
+        except Exception as e:
+            raise Exception(f"Can't connect to Postgresql on {self.host}") from e
+
+    async def fetch_documents(self, table, schema):
+        """Fetches all the table entries and format them in Elasticsearch documents
+
+        Args:
+            table (str): Name of table
+            schema (str): Name of schema.
+
+        Yields:
+            Dict: Document to be indexed
+        """
+        try:
+            [[row_count]] = await anext(
+                self.execute_query(
+                    query=self.queries.table_data_count(
+                        schema=schema,
+                        table=table,
+                    ),
+                )
+            )
+            if row_count > 0:
+                # Query to get the table's primary key
+                columns = await anext(
+                    self.execute_query(
+                        query=self.queries.table_primary_key(
+                            schema=schema,
+                            table=table,
+                        ),
+                    )
+                )
+                keys = [
+                    f"{schema}_{table}_{column_name}"
+                    for [column_name] in columns
+                    if column_name
+                ]
+                if keys:
+                    try:
+                        last_update_time = await anext(
+                            self.execute_query(
+                                query=self.queries.table_last_update_time(
+                                    schema=schema,
+                                    table=table,
+                                ),
+                            )
+                        )
+                        last_update_time = last_update_time[0][0]
+                    except Exception:
+                        self._logger.warning(
+                            f"Unable to fetch last_updated_time for {table}"
+                        )
+                        last_update_time = None
+                    streamer = self.execute_query(
+                        query=self.queries.table_data(
+                            schema=schema,
+                            table=table,
+                        ),
+                        fetch_many=True,
+                        schema=schema,
+                        table=table,
+                    )
+                    column_names = await anext(streamer)
+                    async for row in streamer:
+                        row = dict(zip(column_names, row, strict=True))
+                        keys_value = ""
+                        for key in keys:
+                            keys_value += (
+                                f"{row.get(key.lower())}_"
+                                if row.get(key.lower())
+                                else ""
+                            )
+                        row.update(
+                            {
+                                "_id": f"{self.database}_{schema}_{table}_{keys_value}",
+                                "_timestamp": last_update_time or iso_utc(),
+                                "Database": self.database,
+                                "Table": table,
+                            }
+                        )
+                        row["schema"] = schema
+                        yield self.serialize(doc=row)
+                else:
+                    self._logger.warning(
+                        f"Skipping {table} table from database {self.database} since no primary key is associated with it. Assign primary key to the table to index it in the next sync interval."
+                    )
+            else:
+                self._logger.warning(f"No rows found for {table}.")
+        except (InternalClientError, ProgrammingError) as exception:
+            self._logger.warning(
+                f"Something went wrong while fetching document for table {table}. Error: {exception}"
+            )
+
+    async def fetch_rows(self, schema=None):
+        """Fetches all the rows from all the tables of the database.
+
+        Args:
+            schema (str): Name of schema. Defaults to None.
+
+        Yields:
+            Dict: Row document to index
+        """
+        tables_to_fetch = await self.get_tables_to_fetch(schema)
+        tables_to_fetch = list(tables_to_fetch)
+        for table in tables_to_fetch:
+            self._logger.debug(f"Found table: {table} in database: {self.database}.")
+            async for row in self.fetch_documents(
+                table=table,
+                schema=schema,
+            ):
+                yield row
+        if len(tables_to_fetch) < 1:
+            if schema:
+                self._logger.warning(
+                    f"Fetched 0 tables for schema: {schema} and database: {self.database}"
+                )
+            else:
+                self._logger.warning(
+                    f"Fetched 0 tables for the database: {self.database}"
+                )
+
+    async def get_tables_to_fetch(self, schema):
+        tables = configured_tables(self.tables)
+        return (
+            map(
+                lambda table: table[0],  # type: ignore
+                await anext(
+                    self.execute_query(
+                        query=self.queries.all_tables(
+                            database=self.database,
+                            schema=schema,
+                        )
+                    )
+                ),
+            )
+            if is_wildcard(tables)
+            else tables
+        )
 
     async def get_docs(self, filtering=None):
         """Executes the logic to fetch databases, tables and rows in async manner.

--- a/tests/sources/test_postgresql.py
+++ b/tests/sources/test_postgresql.py
@@ -114,7 +114,7 @@ class CursorAsync:
         pass
 
 
-def test_get_connect_argss():
+def test_get_connect_args():
     """This function test get_connect_args with dummy certificate"""
     # Setup
     source = create_source(PostgreSQLDataSource)

--- a/tests/sources/test_postgresql.py
+++ b/tests/sources/test_postgresql.py
@@ -126,7 +126,16 @@ def test_get_connect_args():
 
 
 @pytest.mark.asyncio
-async def test_get_docs_postgresql():
+async def test_ping():
+    source = create_source(PostgreSQLDataSource)
+    with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
+        await source.ping()
+
+    await source.close()
+
+
+@pytest.mark.asyncio
+async def test_get_docs():
     # Setup
     source = create_source(PostgreSQLDataSource)
     with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
@@ -159,3 +168,5 @@ async def test_get_docs_postgresql():
 
         # Assert
         assert actual_response == expected_response
+
+        await source.close()


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4067

This PR decouples `PostgreSQLDataSource` from `GenericBaseDataSource`. To make it easier to review, refactoring is not included in this PR, which will be added in a follow-up PR.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)