### PR TITLE
Fix dropbox ftest config for new structure

### DIFF
--- a/tests/sources/fixtures/dropbox/config.yml
+++ b/tests/sources/fixtures/dropbox/config.yml
@@ -26,8 +26,10 @@ service:
   job_cleanup_interval: 300
   log_level: INFO
 
-connector_id: 'dropbox'
-service_type: 'dropbox'
+connectors:
+  -
+    connector_id: 'dropbox'
+    service_type: 'dropbox'
 
 sources:
   dropbox: connectors.sources.dropbox:DropboxDataSource


### PR DESCRIPTION
Fixes https://buildkite.com/elastic/connectors-python-nightly/builds/945#01899699-6871-4b2c-a428-6fd4b2bd9106

The new dropbox connector hadn't rebased on main recently, and missed the new yaml config structure

## Checklists



#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

