### PR TITLE
[Salesforce] Add salesforce connector skeleton

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -52,3 +52,4 @@ sources:
   servicenow: connectors.sources.servicenow:ServiceNowDataSource
   sharepoint_online: connectors.sources.sharepoint_online:SharepointOnlineDataSource
   github: connectors.sources.github:GitHubDataSource
+  salesforce: connectors.sources.github:SalesforceDataSource

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -1,0 +1,123 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+"""Salesforce source module responsible to fetch documents from Salesforce."""
+import aiohttp
+
+from connectors.source import BaseDataSource
+from connectors.utils import retryable
+
+RETRIES = 3
+RETRY_INTERVAL = 1
+
+BASE_URL = "https://{domain}.my.salesforce.com"
+TOKEN_ENDPOINT = "/services/oauth2/token"
+
+
+class SalesforceClient:
+    def __init__(self, configuration):
+        self.session = None
+        self.token = None
+        self.token_issued_at = None
+
+        self.base_url = BASE_URL.replace("{domain}", configuration["domain"])
+        self.client_id = configuration["client_id"]
+        self.client_secret = configuration["client_secret"]
+        self.token_payload = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+
+    def set_logger(self, logger_):
+        self._logger = logger_
+
+    def _get_session(self):
+        if self.session is not None:
+            return self.session
+
+        self.session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=None),
+            raise_for_status=True,
+        )
+        return self.session
+
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+    )
+    async def get_token(self):
+        resp = await self._api_request(
+            f"{self.base_url}{TOKEN_ENDPOINT}", "post", data=self.token_payload
+        )
+        resp_json = await resp.json()
+        self.token = resp_json["access_token"]
+        self.token_issued_at = resp_json["issued_at"]
+
+    async def ping(self):
+        await self._api_request(self.base_url, "head")
+
+    async def close_session(self):
+        if self.session is not None:
+            await self.session.close()
+
+    def _auth_headers(self):
+        return {"authorization": f"Bearer {self.token}"}
+
+    async def _api_request(self, url, method, data=None):
+        return await getattr(self._get_session(), method)(url=url, data=data)
+
+
+class SalesforceDataSource(BaseDataSource):
+    """Salesforce"""
+
+    name = "Salesforce"
+    service_type = "salesforce"
+
+    def __init__(self, configuration):
+        super().__init__(configuration=configuration)
+        self.salesforce_client = SalesforceClient(configuration=configuration)
+
+    def _set_internal_logger(self):
+        self.salesforce_client.set_logger(self._logger)
+
+    @classmethod
+    def get_default_configuration(cls):
+        return {
+            "client_id": {
+                "type": "str",
+                "value": "",
+            },
+            "client_secret": {
+                "type": "str",
+                "value": "",
+            },
+            "domain": {
+                "type": "str",
+                "value": "",
+            },
+        }
+
+    async def validate_config(self):
+        self.configuration.check_valid()
+
+    async def close(self):
+        await self.salesforce_client.close_session()
+
+    async def ping(self):
+        try:
+            await self.salesforce_client.ping()
+            self._logger.debug("Successfully connected to Salesforce.")
+        except Exception as e:
+            self._logger.exception(f"Error while connecting to Salesforce: {e}")
+            raise
+
+    async def get_content(self, attachment, timestamp=None, doit=False):
+        # TODO implement
+        return
+
+    async def get_docs(self, filtering=None):
+        # TODO implement
+        yield {"foo": "bar"}, None

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """Salesforce source module responsible to fetch documents from Salesforce."""
-from functools import cached_property, partial
+from functools import cached_property
 
 import aiohttp
 

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -1,0 +1,104 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+"""Tests the Salesforce source class methods"""
+import time
+from unittest import mock
+
+import pytest
+from aiohttp.client_exceptions import ClientConnectionError
+
+from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
+from connectors.sources.salesforce import SalesforceDataSource
+from tests.sources.support import create_source
+
+TEST_DOMAIN = "fake"
+TEST_BASE_URL = f"https://{TEST_DOMAIN}.my.salesforce.com"
+TEST_CLIENT_ID = "1234"
+TEST_CLIENT_SECRET = "9876"
+SECONDS_SINCE_EPOCH = int(time.time())
+
+
+def test_get_default_configuration():
+    config = DataSourceConfiguration(SalesforceDataSource.get_default_configuration())
+    expected_fields = ["client_id", "client_secret", "domain"]
+
+    assert all(field in config.to_dict() for field in expected_fields)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["client_id", "client_secret", "domain"])
+async def test_validate_config_missing_fields_then_raise(field):
+    source = create_source(SalesforceDataSource)
+    source.configuration.set_field(name=field, value="")
+
+    with pytest.raises(ConfigurableFieldValueError):
+        await source.validate_config()
+
+
+@pytest.mark.asyncio
+async def test_ping_with_successful_connection(mock_responses):
+    source = create_source(SalesforceDataSource, domain=TEST_DOMAIN)
+    mock_responses.head(TEST_BASE_URL, status=200)
+
+    await source.ping()
+    await source.close()
+
+
+@pytest.mark.asyncio
+async def test_get_token_with_successful_connection(mock_responses):
+    source = create_source(
+        SalesforceDataSource,
+        domain=TEST_DOMAIN,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+    )
+    response_payload = {
+        "access_token": "foo",
+        "signature": "bar",
+        "instance_url": "https://fake.my.salesforce.com",
+        "id": "https://login.salesforce.com/id/1234",
+        "token_type": "Bearer",
+        "issued_at": SECONDS_SINCE_EPOCH,
+    }
+
+    mock_responses.post(
+        f"{TEST_BASE_URL}/services/oauth2/token", status=200, payload=response_payload
+    )
+    await source.salesforce_client.get_token()
+    await source.close()
+
+    assert source.salesforce_client.token == "foo"
+    assert source.salesforce_client.token_issued_at == SECONDS_SINCE_EPOCH
+
+
+@pytest.mark.asyncio
+@mock.patch("connectors.utils.apply_retry_strategy")
+async def test_get_token_with_bad_domain_raises_error(
+    apply_retry_strategy, mock_responses
+):
+    source = create_source(
+        SalesforceDataSource,
+        domain=TEST_DOMAIN,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+    )
+    apply_retry_strategy.return_value = mock.Mock()
+
+    response_payload = {
+        "access_token": "foo",
+        "signature": "bar",
+        "instance_url": "https://fake.my.salesforce.com",
+        "id": "https://login.salesforce.com/id/1234",
+        "token_type": "Bearer",
+        "issued_at": SECONDS_SINCE_EPOCH,
+    }
+
+    mock_responses.post(
+        f"{TEST_BASE_URL}/services/oauth2/token", status=400, payload=response_payload
+    )
+    with pytest.raises(ClientConnectionError):
+        await source.salesforce_client.get_token()
+    await source.close()


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5438

Adds the skeleton for Salesforce connector.
Includes the following basic functionality:

- configuration with validation
- ping
- get_token

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
