### PR TITLE
[SPO] Change permission inheritance logic for driveItems

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1483,9 +1483,12 @@ class SharepointOnlineDataSource(BaseDataSource):
                                     "lastModifiedDateTime"
                                 )
 
-                                drive_item = self._decorate_with_access_control(
-                                    drive_item, site_access_control
-                                )
+                                # Drive items should inherit site access controls only if
+                                # 'fetch_drive_item_permissions' is disabled in the config
+                                if not self.configuration["fetch_drive_item_permissions"]:
+                                    drive_item = self._decorate_with_access_control(
+                                        drive_item, site_access_control
+                                    )
 
                                 yield drive_item, self.download_function(
                                     drive_item, max_drive_item_age

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1485,7 +1485,9 @@ class SharepointOnlineDataSource(BaseDataSource):
 
                                 # Drive items should inherit site access controls only if
                                 # 'fetch_drive_item_permissions' is disabled in the config
-                                if not self.configuration["fetch_drive_item_permissions"]:
+                                if not self.configuration[
+                                    "fetch_drive_item_permissions"
+                                ]:
                                     drive_item = self._decorate_with_access_control(
                                         drive_item, site_access_control
                                     )

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -135,8 +135,10 @@ def dls_enabled(value):
 def access_control_matches(actual, expected):
     return all([access_control in expected for access_control in actual])
 
+
 def access_control_is_equal(actual, expected):
     return set(actual) == set(expected)
+
 
 class TestMicrosoftSecurityToken:
     class StubMicrosoftSecurityToken(MicrosoftSecurityToken):
@@ -2209,7 +2211,9 @@ class TestSharepointOnlineDataSource:
         "connectors.sources.sharepoint_online.ACCESS_CONTROL",
         ALLOW_ACCESS_CONTROL_PATCHED,
     )
-    async def test_drive_items_permissions_when_fetch_drive_item_permissions_enabled(self, patch_sharepoint_client):
+    async def test_drive_items_permissions_when_fetch_drive_item_permissions_enabled(
+        self, patch_sharepoint_client
+    ):
         group = _prefix_group("do-not-inherit-me")
         email = _prefix_email("should-not@be-inherited.com")
         user = _prefix_user("sorry-no-access-here")
@@ -2257,7 +2261,6 @@ class TestSharepointOnlineDataSource:
                 for drive_item in drive_items
             ]
         )
-
 
     @pytest.mark.asyncio
     async def test_download_function_for_deleted_item(self):


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5471


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

When `fetch_drive_item_permissions` is enabled don't propagate the `site_access_control` permissions to drive items

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
