### PR TITLE
Add missing asyncio plugin

### DIFF
--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -403,6 +403,7 @@ def test_fetch_file_when_file_is_accessible(file_mock):
     assert response.read() == b"Mock...."
 
 
+@pytest.mark.asyncio
 async def test_close_without_session():
     source = create_source(NASDataSource)
 


### PR DESCRIPTION
The asyncio plugin is missing for one test.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)