### PR TITLE
Remove ci skipping

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -14,7 +14,6 @@
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "skip_ci_labels": ["skip-ci"],
       "skip_target_branches": [],
-      "skip_ci_on_only_changed": ["^docs/"],
       "always_require_ci_on_changed": []
     }
   ]


### PR DESCRIPTION
doesn't work with our required CI step

See: https://github.com/elastic/connectors-python/pull/1119 and https://elastic.slack.com/archives/C02AV5C8ZDE/p1690793101153619?thread_ts=1690554027.660749&cid=C02AV5C8ZDE