### PR TITLE
Slow down SPO fake server to have 50ms latency

### DIFF
--- a/tests/sources/fixtures/sharepoint_online/fixture.py
+++ b/tests/sources/fixtures/sharepoint_online/fixture.py
@@ -6,9 +6,9 @@
 """Module to handle api calls received from connector."""
 
 import os
-import time
 import random
 import string
+import time
 
 from faker import Faker
 from flask import Flask, escape, request
@@ -622,7 +622,8 @@ data_storage.generate()
 
 @app.before_request
 def before_request():
-   time.sleep(PRE_REQUEST_SLEEP)
+    time.sleep(PRE_REQUEST_SLEEP)
+
 
 @app.route("/<string:tenant_id>/oauth2/v2.0/token", methods=["POST"])
 def get_graph_token(tenant_id):

--- a/tests/sources/fixtures/sharepoint_online/fixture.py
+++ b/tests/sources/fixtures/sharepoint_online/fixture.py
@@ -6,6 +6,7 @@
 """Module to handle api calls received from connector."""
 
 import os
+import time
 import random
 import string
 
@@ -18,6 +19,7 @@ from yattag import Doc
 app = Flask(__name__)
 
 THROTTLING = os.environ.get("THROTTLING", False)
+PRE_REQUEST_SLEEP = float(os.environ.get("PRE_REQUEST_SLEEP", "0.05"))
 
 if THROTTLING:
     limiter = Limiter(
@@ -617,6 +619,10 @@ class RandomDataStorage:
 data_storage = RandomDataStorage()
 data_storage.generate()
 
+
+@app.before_request
+def before_request():
+   time.sleep(PRE_REQUEST_SLEEP)
 
 @app.route("/<string:tenant_id>/oauth2/v2.0/token", methods=["POST"])
 def get_graph_token(tenant_id):


### PR DESCRIPTION
## Fixing problems with CI

SPO fixture is fast, and connector is reasonably efficient. Connector is able to oversaturate a 2GB Elasticsearch cluster easily, thus I'm adding a small latency of 50ms to the requests so that connector would work closer to real-life SPO instance - that fixes the ingestion problem as a side-effect.


## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
