### PR TITLE
Fix broken Sharepoint Online connector when DLS is disabled

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1211,7 +1211,7 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         self._logger.debug(f"Looking at site: {site['id']}")
         if not self._dls_enabled():
-            return []
+            return list(), list()
 
         def _is_site_admin(user):
             return user.get("IsSiteAdmin", False)


### PR DESCRIPTION
## FIxing problems with CI

There is a bug in SPO connector that prevents it from syncing when DLS is disabled, error [in logs](https://buildkite.com/elastic/connectors-python-nightly/builds/966#0189ab32-2753-463c-83f5-089af9cdce9b) is:

```
[FMWK][09:11:00][CRITICAL] [Sync Job id: Qyo3q4kB30ecdP2bAqsU, connector id: sharepoint_online, index name: search-sharepoint_online] The document fetcher failed
--
  | Traceback (most recent call last):
  | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1690794353381591977/elastic/connectors-python-nightly/connectors/es/sink.py", line 387, in get_docs
  | async for count, doc in aenumerate(generator):
  | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1690794353381591977/elastic/connectors-python-nightly/connectors/utils.py", line 689, in aenumerate
  | async for elem in asequence:
  | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1690794353381591977/elastic/connectors-python-nightly/connectors/logger.py", line 134, in __anext__
  | return await self.gen.__anext__()
  | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1690794353381591977/elastic/connectors-python-nightly/connectors/es/sink.py", line 360, in _decorate_with_metrics_span
  | async for doc in generator:
  | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1690794353381591977/elastic/connectors-python-nightly/connectors/sync_job_runner.py", line 310, in prepare_docs
  | async for doc, lazy_download, operation in self.generator():
  | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1690794353381591977/elastic/connectors-python-nightly/connectors/sync_job_runner.py", line 342, in generator
  | async for doc, lazy_download in self.data_provider.get_docs(
  | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1690794353381591977/elastic/connectors-python-nightly/connectors/sources/sharepoint_online.py", line 1474, in get_docs
  | (
  | ValueError: not enough values to unpack (expected 2, got 0)
```

This PR fixes it by actually returning a tuple instead of an empty array (code that calls it expects a tuple)

## Checklists

#### Pre-Review Checklist
- [ ] this PR has a meaningful title
- [ ] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
