### PR TITLE
Don't run memray for ftest, run only for ftrace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ release: install
 ftest: bin/pytest bin/elastic-ingest
 	tests/ftest.sh $(NAME) $(PERF8)
 
+ftrace: bin/pytest bin/elastic-ingest
+	PERF8_TRACE=true tests/ftest.sh $(NAME) $(PERF8)
+
 run: install
 	bin/elastic-ingest
 

--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -19,10 +19,18 @@ PLATFORM='unknown'
 MAX_RSS="200M"
 MAX_DURATION=600
 
+export PERF8_TRACE=${PERF8_TRACE:-False}
 export REFRESH_RATE="${REFRESH_RATE:-5}"
 export DATA_SIZE="${DATA_SIZE:-medium}"
 export RUNNING_FTEST=True
 export VERSION='8.10.0-SNAPSHOT'
+
+if [ "$PERF8_TRACE" = true ]; then
+    echo 'Tracing is enabled, memray stats will be delivered'
+    PLUGINS='--asyncstats --memray --psutil'
+else
+    PLUGINS='--asyncstats --psutil'
+fi
 
 PERF8_BIN=${PERF8_BIN:-$ROOT_DIR/bin/perf8}
 PYTHON=${PYTHON:-$ROOT_DIR/bin/python}
@@ -58,9 +66,9 @@ then
     $PYTHON fixture.py --name $NAME --action description > description.txt
     if [[ $PLATFORM == "darwin" ]]
     then
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME $PLUGINS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
     else
-      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME --asyncstats --memray --psutil --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
+      $PERF8_BIN --refresh-rate $REFRESH_RATE -t $ROOT_DIR/perf8-report-$NAME $PLUGINS --max-duration $MAX_DURATION --description description.txt -c $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!
     fi
 else
     $ELASTIC_INGEST --config-file $NAME/config.yml --debug & PID=$!


### PR DESCRIPTION
##  Minor CI improvement

Memray is a plugin that's used for tracing the memory usage of the connectors. It uses lots of memory, disk, and provides a report that's not possible to see in our nightlies - it's just too big.

This PR makes it so, that memray does not run when running `make ftest`. To make it run, it's possible to use a separate command - `make ftrace`. `make ftrace` will enable memray plugin for ftest run.

## Checklists

#### Pre-Review Checklist
- [ ] this PR has a meaningful title
- [ ] this PR has a thorough description
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)