### PR TITLE
Add colored logging

### DIFF
--- a/connectors/logger.py
+++ b/connectors/logger.py
@@ -23,6 +23,7 @@ logger = None
 
 class ColorFormatter(logging.Formatter):
     GREY = "\x1b[38;20m"
+    GREEN = "\x1b[32;20m"
     YELLOW = "\x1b[33;20m"
     RED = "\x1b[31;20m"
     BOLD_RED = "\x1b[31;1m"
@@ -43,7 +44,7 @@ class ColorFormatter(logging.Formatter):
     @cached_property
     def info_formatter(self):
         return logging.Formatter(
-            fmt=self.GREY + self.custom_format + self.RESET, datefmt=self.DATE_FMT
+            fmt=self.GREEN + self.custom_format + self.RESET, datefmt=self.DATE_FMT
         )
 
     @cached_property

--- a/connectors/logger.py
+++ b/connectors/logger.py
@@ -11,7 +11,7 @@ import inspect
 import logging
 import time
 from datetime import datetime
-from functools import wraps
+from functools import cached_property, wraps
 from typing import AsyncGenerator
 
 import ecs_logging
@@ -21,11 +21,52 @@ from connectors import __version__
 logger = None
 
 
-def _formatter(prefix):
-    return logging.Formatter(
-        fmt="[" + prefix + "][%(asctime)s][%(levelname)s] %(message)s",
-        datefmt="%H:%M:%S",
-    )
+class ColorFormatter(logging.Formatter):
+    GREY = "\x1b[38;20m"
+    YELLOW = "\x1b[33;20m"
+    RED = "\x1b[31;20m"
+    BOLD_RED = "\x1b[31;1m"
+    RESET = "\x1b[0m"
+
+    DATE_FMT = "%H:%M:%S"
+
+    def __init__(self, prefix):
+        self.custom_format = "[" + prefix + "][%(asctime)s][%(levelname)s] %(message)s"
+        super().__init__()
+
+    @cached_property
+    def debug_formatter(self):
+        return logging.Formatter(
+            fmt=self.GREY + self.custom_format + self.RESET, datefmt=self.DATE_FMT
+        )
+
+    @cached_property
+    def info_formatter(self):
+        return logging.Formatter(
+            fmt=self.GREY + self.custom_format + self.RESET, datefmt=self.DATE_FMT
+        )
+
+    @cached_property
+    def warning_formatter(self):
+        return logging.Formatter(
+            fmt=self.YELLOW + self.custom_format + self.RESET, datefmt=self.DATE_FMT
+        )
+
+    @cached_property
+    def error_formatter(self):
+        return logging.Formatter(
+            fmt=self.RED + self.custom_format + self.RESET, datefmt=self.DATE_FMT
+        )
+
+    @cached_property
+    def critical_formatter(self):
+        return logging.Formatter(
+            fmt=self.BOLD_RED + self.custom_format + self.RESET, datefmt=self.DATE_FMT
+        )
+
+    def format(self, record):
+        formatter = getattr(self, f"{record.levelname.lower()}_formatter")
+        return formatter.format(record)
 
 
 class ExtraLogger(logging.Logger):
@@ -53,7 +94,7 @@ def set_logger(log_level=logging.INFO, filebeat=False):
     if filebeat:
         formatter = ecs_logging.StdlibFormatter()
     else:
-        formatter = _formatter("FMWK")
+        formatter = ColorFormatter("FMWK")
 
     if logger is None:
         logging.setLoggerClass(ExtraLogger)
@@ -77,7 +118,7 @@ def set_extra_logger(logger, log_level=logging.INFO, prefix="BYOC", filebeat=Fal
     if filebeat:
         handler.setFormatter(ecs_logging.StdlibFormatter())
     else:
-        formatter = _formatter(prefix)
+        formatter = ColorFormatter(prefix)
         handler.setFormatter(formatter)
     handler.setLevel(log_level)
     logger.addHandler(handler)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -151,7 +151,7 @@ async def test_trace_async_gen():
     "log_level, color",
     [
         ("debug", ColorFormatter.GREY),
-        ("info", ColorFormatter.GREY),
+        ("info", ColorFormatter.GREEN),
         ("warning", ColorFormatter.YELLOW),
         ("error", ColorFormatter.RED),
         ("critical", ColorFormatter.BOLD_RED),

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 import pytest
 
 import connectors.logger
-from connectors.logger import logger, set_logger, tracer
+from connectors.logger import ColorFormatter, logger, set_logger, tracer
 
 
 @contextmanager
@@ -145,3 +145,50 @@ async def test_trace_async_gen():
         for i, log in enumerate(logs):
             data = json.loads(log)
             assert data["message"].startswith(f"[trace me] {i}-special took")
+
+
+@pytest.mark.parametrize(
+    "log_level, color",
+    [
+        ("debug", ColorFormatter.GREY),
+        ("info", ColorFormatter.GREY),
+        ("warning", ColorFormatter.YELLOW),
+        ("error", ColorFormatter.RED),
+        ("critical", ColorFormatter.BOLD_RED),
+    ],
+)
+def test_colored_logging(log_level, color):
+    with unset_logger():
+        logger = set_logger(logging.DEBUG, filebeat=False)
+        logs = []
+
+        def _w(msg):
+            logs.append(msg)
+
+        logger.handlers[0].stream.write = _w
+
+        getattr(logger, log_level)("foobar")
+
+        assert len(logs) == 1
+        assert logs[0].startswith(color)
+
+
+def test_colored_logging_with_filebeat():
+    with unset_logger():
+        logger = set_logger(logging.DEBUG, filebeat=True)
+        logs = []
+
+        def _w(msg):
+            logs.append(msg)
+
+        logger.handlers[0].stream.write = _w
+
+        logger.debug("foobar")
+        logger.info("foobar")
+        logger.warning("foobar")
+        logger.error("foobar")
+        logger.critical("foobar")
+
+        assert len(logs) == 5
+        for log in logs:
+            assert not log.startswith("\x1b")


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5187

This PR adds colored logging, so that log messages of different log levels will have different colors. This will only work in terminals, and logs for Cloud will remain unchanged.

Example output:
![image](https://github.com/elastic/connectors-python/assets/54903978/3e9474a7-f900-4372-bf96-9439a89ae6d5)


## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)