### PR TITLE
[Salesforce] Add soql builder and ingest accounts

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -52,4 +52,4 @@ sources:
   servicenow: connectors.sources.servicenow:ServiceNowDataSource
   sharepoint_online: connectors.sources.sharepoint_online:SharepointOnlineDataSource
   github: connectors.sources.github:GitHubDataSource
-  salesforce: connectors.sources.github:SalesforceDataSource
+  salesforce: connectors.sources.salesforce:SalesforceDataSource

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -72,7 +72,7 @@ class SalesforceClient:
         self.token = resp_json["access_token"]
         self.token_issued_at = resp_json["issued_at"]
         self.token_refresh_enabled = enable_refresh
-        self._logger.debug(f"Salesforce token retrieved.")
+        self._logger.debug("Salesforce token retrieved.")
 
     @retryable(
         retries=RETRIES,
@@ -93,11 +93,13 @@ class SalesforceClient:
                     "Type",
                     "Website",
                     "Rating",
+                    "Department",
                 ]
             )
         )
-
         query = query_builder.build()
+
+        # TODO handle pagination
         resp = await self._yield_non_bulk_query_pages(query)
         resp_json = await resp.json()
         for record in resp_json.get("records", []):

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -8,22 +8,28 @@ from functools import cached_property
 
 import aiohttp
 
+from connectors.logger import logger
 from connectors.source import BaseDataSource
 from connectors.utils import retryable
 
 RETRIES = 3
 RETRY_INTERVAL = 1
 
-BASE_URL = "https://{domain}.my.salesforce.com"
+BASE_URL = "https://<domain>.my.salesforce.com"
+API_VERSION = "v58.0"
 TOKEN_ENDPOINT = "/services/oauth2/token"
+QUERY_ENDPOINT = f"/services/data/{API_VERSION}/query"
 
 
 class SalesforceClient:
     def __init__(self, configuration):
+        self._logger = logger
+
         self.token = None
         self.token_issued_at = None
+        self.token_refresh_enabled = False
 
-        self.base_url = BASE_URL.replace("{domain}", configuration["domain"])
+        self.base_url = BASE_URL.replace("<domain>", configuration["domain"])
         self.client_id = configuration["client_id"]
         self.client_secret = configuration["client_secret"]
         self.token_payload = {
@@ -42,31 +48,112 @@ class SalesforceClient:
             raise_for_status=True,
         )
 
+    async def ping(self):
+        # TODO ping something of value (this could be config check instead)
+        await self._api_request(self.base_url, "head")
+
+    async def close(self):
+        self._token_cleanup()
+        if self.session is not None:
+            await self.session.close()
+            del self.session
+
     @retryable(
         retries=RETRIES,
         interval=RETRY_INTERVAL,
     )
-    async def get_token(self):
+    async def get_token(self, enable_refresh=True):
+        # TODO add refresh method
+        self._logger.debug("Fetching Salesforce token...")
         resp = await self._api_request(
             f"{self.base_url}{TOKEN_ENDPOINT}", "post", data=self.token_payload
         )
         resp_json = await resp.json()
         self.token = resp_json["access_token"]
         self.token_issued_at = resp_json["issued_at"]
+        self.token_refresh_enabled = enable_refresh
+        self._logger.debug(f"Salesforce token retrieved.")
 
-    async def ping(self):
-        await self._api_request(self.base_url, "head")
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+    )
+    async def get_accounts(self):
+        # TODO prepare cache
 
-    async def close_session(self):
-        if self.session is not None:
-            await self.session.close()
-            del self.session
+        query_builder = SalesforceSoqlBuilder("Account")
+        query_builder.with_id()
+        query_builder.with_default_metafields()
+        query_builder.with_fields(
+            self._select_queryable_fields(
+                [
+                    "Name",
+                    "Description",
+                    "BillingAddress",
+                    "Type",
+                    "Website",
+                    "Rating",
+                ]
+            )
+        )
+
+        query = query_builder.build()
+        resp = await self._yield_non_bulk_query_pages(query)
+        resp_json = await resp.json()
+        for record in resp_json.get("records", []):
+            record["_id"] = record["Id"]
+            yield record
+
+    async def _yield_non_bulk_query_pages(self, soql_query):
+        return await self._api_request(
+            f"{self.base_url}{QUERY_ENDPOINT}",
+            "get",
+            headers=self._auth_headers(),
+            params={"q": soql_query},
+        )
+
+    def _select_queryable_fields(self, fields):
+        # TODO check if fields queryable first from cache
+        return fields
+
+    def _token_cleanup(self):
+        self.token = None
+        self.token_issued_at = None
+        self.token_refresh_enabled = False
 
     def _auth_headers(self):
         return {"authorization": f"Bearer {self.token}"}
 
-    async def _api_request(self, url, method, data=None):
-        return await getattr(self.session, method)(url=url, data=data)
+    async def _api_request(self, url, method, headers=None, data=None, params=None):
+        # TODO improve error handling
+        return await getattr(self.session, method)(
+            url=url, headers=headers, data=data, params=params
+        )
+
+
+class SalesforceSoqlBuilder:
+    def __init__(self, table):
+        self.table_name = table
+        self.fields = []
+
+    def with_id(self):
+        self.fields.append("Id")
+
+    def with_default_metafields(self):
+        self.fields.extend(["CreatedDate", "LastModifiedDate"])
+
+    def with_fields(self, fields):
+        self.fields.extend(fields)
+
+    def build(self):
+        select_columns = ",\n".join(set(self.fields))
+
+        query_lines = []
+        query_lines.append(f"SELECT {select_columns}")
+        query_lines.append(f"FROM {self.table_name}")
+        # TODO expand functionality when needed (where, order_by, limit, etc)
+
+        return "\n".join(query_lines)
 
 
 class SalesforceDataSource(BaseDataSource):
@@ -86,14 +173,17 @@ class SalesforceDataSource(BaseDataSource):
     def get_default_configuration(cls):
         return {
             "client_id": {
+                "label": "Client ID",
                 "type": "str",
                 "value": "",
             },
             "client_secret": {
+                "label": "Client Secret",
                 "type": "str",
                 "value": "",
             },
             "domain": {
+                "label": "Domain",
                 "type": "str",
                 "value": "",
             },
@@ -103,7 +193,7 @@ class SalesforceDataSource(BaseDataSource):
         self.configuration.check_valid()
 
     async def close(self):
-        await self.salesforce_client.close_session()
+        await self.salesforce_client.close()
 
     async def ping(self):
         try:
@@ -118,5 +208,9 @@ class SalesforceDataSource(BaseDataSource):
         return
 
     async def get_docs(self, filtering=None):
-        # TODO implement
-        yield {"foo": "bar"}, None
+        # TODO rename
+        await self.salesforce_client.get_token()
+
+        # TODO filtering
+        async for account in self.salesforce_client.get_accounts():
+            yield account, None

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -150,9 +150,7 @@ class SalesforceSoqlBuilder:
     def build(self):
         select_columns = ",\n".join(set(self.fields))
 
-        query_lines = []
-        query_lines.append(f"SELECT {select_columns}")
-        query_lines.append(f"FROM {self.table_name}")
+        query_lines = [f"SELECT {select_columns}", f"FROM {self.table_name}"]
         # TODO expand functionality when needed (where, order_by, limit, etc)
 
         return "\n".join(query_lines)

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -4,6 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """Tests the Salesforce source class methods"""
+import re
 import time
 from unittest import mock
 
@@ -11,7 +12,8 @@ import pytest
 from aiohttp.client_exceptions import ClientConnectionError
 
 from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
-from connectors.sources.salesforce import SalesforceDataSource
+from connectors.sources.salesforce import SalesforceDataSource, SalesforceSoqlBuilder
+from tests.commons import AsyncIterator
 from tests.sources.support import create_source
 
 TEST_DOMAIN = "fake"
@@ -68,10 +70,11 @@ async def test_get_token_with_successful_connection(mock_responses):
         f"{TEST_BASE_URL}/services/oauth2/token", status=200, payload=response_payload
     )
     await source.salesforce_client.get_token()
-    await source.close()
 
     assert source.salesforce_client.token == "foo"
     assert source.salesforce_client.token_issued_at == SECONDS_SINCE_EPOCH
+
+    await source.close()
 
 
 @pytest.mark.asyncio
@@ -102,3 +105,86 @@ async def test_get_token_with_bad_domain_raises_error(
     with pytest.raises(ClientConnectionError):
         await source.salesforce_client.get_token()
     await source.close()
+
+
+@pytest.mark.asyncio
+async def test_get_accounts_when_success(mock_responses):
+    expected_record = {
+        "attributes": {
+            "type": "Account",
+            "url": "/services/data/v58.0/sobjects/Account/1234",
+        },
+        "Id": "1234",
+    }
+    source = create_source(
+        SalesforceDataSource,
+        domain=TEST_DOMAIN,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+    )
+    response_payload = {
+        "totalSize": "2",
+        "done": True,
+        "records": [expected_record],
+    }
+
+    source.salesforce_client.get_accounts = mock.Mock(
+        return_value=AsyncIterator([{**expected_record, "_id": "1234"}])
+    )
+    mock_responses.get(
+        re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+        status=200,
+        payload=response_payload,
+    )
+    async for account in source.salesforce_client.get_accounts():
+        assert account["Id"] == "1234"
+        assert account["_id"] == "1234"
+
+    await source.close()
+
+
+@pytest.mark.asyncio
+@mock.patch("connectors.utils.apply_retry_strategy")
+async def test_get_accounts_when_invalid_request(apply_retry_strategy, mock_responses):
+    source = create_source(
+        SalesforceDataSource,
+        domain=TEST_DOMAIN,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+    )
+    response_payload = [
+        {"message": "Unable to process query.", "errorCode": "INVALID_FIELD"}
+    ]
+
+    mock_responses.get(
+        re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+        status=400,
+        payload=response_payload,
+    )
+    with pytest.raises(ClientConnectionError):
+        async for _ in source.salesforce_client.get_accounts():
+            # TODO confirm error message when error handling is improved
+            pass
+
+    await source.close()
+
+
+@pytest.mark.asyncio
+async def test_build_soql_query_with_fields():
+    expected_columns = [
+        "Id",
+        "CreatedDate",
+        "LastModifiedDate",
+        "FooField",
+        "BarField",
+    ]
+
+    builder = SalesforceSoqlBuilder("Test")
+    builder.with_id()
+    builder.with_default_metafields()
+    builder.with_fields(["FooField", "BarField"])
+    query = builder.build()
+
+    assert query.startswith("SELECT ")
+    assert all(col in query for col in expected_columns)
+    assert query.endswith("FROM Test")


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5441

This PR adds two things to the salesforce connector:

- `SalesforceSoqlBuilder` is a class that will be used to build soql queries for salesforce requests. This will be identical to how it is implemented in Workplace Search ([relevant code](https://github.com/elastic/ent-search/blob/main/connectors/lib/connectors/content_sources/salesforce/soql_query_builder.rb))
- `get_accounts` fetches all accounts for the current configured user and ingests that data as documents

There are many `TODO`s in this PR, so I can keep track of missing work. They will be addressed before the `salesforce-connector` branch is merged into main.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
