### PR TITLE
Add connector.json for ServiceNow

### DIFF
--- a/tests/sources/fixtures/servicenow/connector.json
+++ b/tests/sources/fixtures/servicenow/connector.json
@@ -1,0 +1,205 @@
+{
+  "api_key_id": "",
+  "configuration": {
+    "password": {
+      "depends_on": [],
+      "display": "text",
+      "tooltip": null,
+      "default_value": null,
+      "label": "Password",
+      "sensitive": true,
+      "type": "str",
+      "required": true,
+      "options": [],
+      "validations": [],
+      "value": "pwd@123",
+      "order": 3,
+      "ui_restrictions": []
+    },
+    "concurrent_downloads": {
+      "depends_on": [],
+      "display": "numeric",
+      "tooltip": null,
+      "default_value": 10,
+      "label": "Maximum concurrent downloads",
+      "sensitive": false,
+      "type": "int",
+      "required": false,
+      "options": [],
+      "validations": [],
+      "value": 10,
+      "order": 6,
+      "ui_restrictions": [
+        "advanced"
+      ]
+    },
+    "retry_count": {
+      "depends_on": [],
+      "display": "numeric",
+      "tooltip": null,
+      "default_value": 3,
+      "label": "Retries per request",
+      "sensitive": false,
+      "type": "int",
+      "required": false,
+      "options": [],
+      "validations": [],
+      "value": 3,
+      "order": 5,
+      "ui_restrictions": [
+        "advanced"
+      ]
+    },
+    "services": {
+      "depends_on": [],
+      "display": "textarea",
+      "tooltip": "List of services is ignored when Advanced Sync Rules are used.",
+      "default_value": null,
+      "label": "Comma-separated list of services",
+      "sensitive": false,
+      "type": "list",
+      "required": true,
+      "options": [],
+      "validations": [],
+      "value": "*",
+      "order": 4,
+      "ui_restrictions": []
+    },
+    "url": {
+      "depends_on": [],
+      "display": "text",
+      "tooltip": null,
+      "default_value": null,
+      "label": "Service URL",
+      "sensitive": false,
+      "type": "str",
+      "required": true,
+      "options": [],
+      "validations": [],
+      "value": "http://127.0.0.1:9318",
+      "order": 1,
+      "ui_restrictions": []
+    },
+    "username": {
+      "depends_on": [],
+      "display": "text",
+      "tooltip": null,
+      "default_value": null,
+      "label": "Username",
+      "sensitive": false,
+      "type": "str",
+      "required": true,
+      "options": [],
+      "validations": [],
+      "value": "some_test_user",
+      "order": 2,
+      "ui_restrictions": []
+    }
+  },
+  "custom_scheduling": {},
+  "description": null,
+  "error": null,
+  "features": {
+    "incremental_sync": {
+      "enabled": false
+    },
+    "document_level_security": {
+      "enabled": false
+    },
+    "sync_rules": {
+      "advanced": {
+        "enabled": false
+      },
+      "basic": {
+        "enabled": true
+      }
+    }
+  },
+  "filtering": [
+    {
+      "active": {
+        "advanced_snippet": {
+          "created_at": "2023-08-03T11:30:14.061Z",
+          "updated_at": "2023-08-03T11:30:14.061Z",
+          "value": {}
+        },
+        "rules": [
+          {
+            "created_at": "2023-08-03T11:30:14.061Z",
+            "field": "_",
+            "id": "DEFAULT",
+            "order": 0,
+            "policy": "include",
+            "rule": "regex",
+            "updated_at": "2023-08-03T11:30:14.061Z",
+            "value": ".*"
+          }
+        ],
+        "validation": {
+          "errors": [],
+          "state": "valid"
+        }
+      },
+      "domain": "DEFAULT",
+      "draft": {
+        "advanced_snippet": {
+          "created_at": "2023-08-03T11:30:14.061Z",
+          "updated_at": "2023-08-03T11:30:14.061Z",
+          "value": {}
+        },
+        "rules": [
+          {
+            "created_at": "2023-08-03T11:30:14.061Z",
+            "field": "_",
+            "id": "DEFAULT",
+            "order": 0,
+            "policy": "include",
+            "rule": "regex",
+            "updated_at": "2023-08-03T11:30:14.061Z",
+            "value": ".*"
+          }
+        ],
+        "validation": {
+          "errors": [],
+          "state": "valid"
+        }
+      }
+    }
+  ],
+  "index_name": "search-servicenow",
+  "is_native": false,
+  "language": null,
+  "last_access_control_sync_error": null,
+  "last_access_control_sync_scheduled_at": null,
+  "last_access_control_sync_status": null,
+  "last_incremental_sync_scheduled_at": null,
+  "last_seen": "2023-08-03T11:31:00.668430+00:00",
+  "last_sync_error": null,
+  "last_sync_scheduled_at": null,
+  "last_sync_status": null,
+  "last_synced": null,
+  "name": "servicenow",
+  "pipeline": {
+    "extract_binary_content": true,
+    "name": "ent-search-generic-ingestion",
+    "reduce_whitespace": true,
+    "run_ml_inference": true
+  },
+  "scheduling": {
+    "access_control": {
+      "enabled": false,
+      "interval": "0 0 0 * * ?"
+    },
+    "full": {
+      "enabled": true,
+      "interval": "1 * * * * ?"
+    },
+    "incremental": {
+      "enabled": false,
+      "interval": "0 0 0 * * ?"
+    }
+  },
+  "service_type": "servicenow",
+  "status": "configured",
+  "sync_now": false
+}


### PR DESCRIPTION
Fixed Nightly CI - after recent commit to change default configs for ServiceNow connector, CI broke as default configs don't pass validation.

This PR adds `connector.json` file that contains stub username/password, so that connector passes validation.