### PR TITLE
Refactor execute_query function

### DIFF
--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -401,7 +401,7 @@ class PostgreSQLDataSource(BaseDataSource):
                                 schema=schema, table=table
                             )
                         )
-                    except Exception as e:
+                    except Exception:
                         self._logger.warning(
                             f"Unable to fetch last_updated_time for {table}"
                         )

--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -146,7 +146,7 @@ class PostgreSQLClient:
             map(
                 lambda table: table[0],  # type: ignore
                 await anext(
-                    fetch_all(
+                    fetch_all(  # type: ignore
                         cursor_func=partial(
                             self.get_cursor,
                             self.queries.all_tables(

--- a/tests/sources/test_generic_database.py
+++ b/tests/sources/test_generic_database.py
@@ -146,7 +146,9 @@ COLUMN_NAMES = ["Column_1", "Column_2"]
 )
 def test_map_column_names(schema, table, prefix):
     mapped_column_names = map_column_names(COLUMN_NAMES, schema, table)
-    for column_name, mapped_column_name in zip(COLUMN_NAMES, mapped_column_names):
+    for column_name, mapped_column_name in zip(
+        COLUMN_NAMES, mapped_column_names, strict=True
+    ):
         assert f"{prefix}{column_name}".lower() == mapped_column_name
 
 

--- a/tests/sources/test_postgresql.py
+++ b/tests/sources/test_postgresql.py
@@ -80,40 +80,39 @@ class CursorAsync:
         """
         if self.first_call:
             self.first_call = False
-            return [
-                (
-                    1,
-                    "abcd",
-                ),
-                (
-                    1,
-                    "xyz",
-                ),
-            ]
+
+            self.query = str(self.query)
+            query_object = PostgreSQLQueries()
+            if self.query == query_object.all_schemas():
+                return [(SCHEMA,)]
+            elif self.query == query_object.all_tables(database="xe", schema=SCHEMA):
+                return [(TABLE,)]
+            elif self.query == query_object.table_data_count(
+                schema=SCHEMA, table=TABLE
+            ):
+                return [(10,)]
+            elif self.query == query_object.table_primary_key(
+                schema=SCHEMA, table=TABLE
+            ):
+                return [("ids",)]
+            elif self.query == query_object.table_last_update_time(
+                schema=SCHEMA, table=TABLE
+            ):
+                return [("2023-02-21T08:37:15+00:00",)]
+            elif self.query == query_object.ping():
+                return [(2,)]
+            else:
+                return [
+                    (
+                        1,
+                        "abcd",
+                    ),
+                    (
+                        1,
+                        "xyz",
+                    ),
+                ]
         return []
-
-    def fetchall(self):
-        """This method returns results of query
-
-        Returns:
-            list: List of rows
-        """
-        self.query = str(self.query)
-        query_object = PostgreSQLQueries()
-        if self.query == query_object.all_schemas():
-            return [(SCHEMA,)]
-        elif self.query == query_object.all_tables(database="xe", schema=SCHEMA):
-            return [(TABLE,)]
-        elif self.query == query_object.table_data_count(schema=SCHEMA, table=TABLE):
-            return [(10,)]
-        elif self.query == query_object.table_primary_key(schema=SCHEMA, table=TABLE):
-            return [("ids",)]
-        elif self.query == query_object.table_last_update_time(
-            schema=SCHEMA, table=TABLE
-        ):
-            return [("2023-02-21T08:37:15+00:00",)]
-        elif self.query == query_object.ping():
-            return [(2,)]
 
     async def __aexit__(self, exception_type, exception_value, exception_traceback):
         """Make sure the dummy database connection gets closed"""


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/4067

This PR refactor the `execute_query` function to `fetch` function, which
1. yields column names first if `fetch_columns` is true
2. fetches rows by `fetch_size` and yields rows one by one
3. uses `@retryable` to handle retry logic

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)