### PR TITLE
Typo in new change checking step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,7 +85,7 @@ steps:
             - "connectors/sources/directory.py"
             - "tests/sources/fixtures/dir/**"
             config:
-            - label: "🔨 System Directory"
+              label: "🔨 System Directory"
               command:
                 - ".buildkite/run_nigthly.sh dir small"
               artifact_paths:


### PR DESCRIPTION
Failures like from : https://buildkite.com/elastic/connectors-python/builds/7862#0189dbd4-eacf-4727-91f8-6b4f7f3b04f2

I noticed:
```
- label: "\U0001F528 Azure Blob Storage"
--
  | command:
  | - .buildkite/run_nigthly.sh azure_blob_storage small
  | - label: "\U0001F528 Postgresql"
  | command:
  | - .buildkite/run_nigthly.sh postgresql small
  | - {}
  | - label: "\U0001F528 Oracle Database"
  | command:
  | - .buildkite/run_nigthly.sh oracle small
  | - label: "\U0001F528 Sharepoint Server"
  | command:
```

And guessed that the `- {}` was the reason for the failure.