### PR TITLE
[Refactoring] Split up test_get_pem_format tests

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,22 +331,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,6 +331,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -521,44 +521,41 @@ def test_evaluate_timedelta():
     assert expected_response == "2023-02-19T14:25:05.158843"
 
 
-def test_get_pem_format():
-    """This function tests prepare private key and certificate with dummy values"""
-    # Setup
-    expected_formated_pem_key = """-----BEGIN PRIVATE KEY-----
+def test_get_pem_format_with_postfix():
+    expected_formatted_pem_key = """-----BEGIN PRIVATE KEY-----
 PrivateKey
 -----END PRIVATE KEY-----"""
     private_key = "-----BEGIN PRIVATE KEY----- PrivateKey -----END PRIVATE KEY-----"
 
-    # Execute
-    formated_privat_key = get_pem_format(
+    formatted_private_key = get_pem_format(
         key=private_key, postfix="-----END PRIVATE KEY-----"
     )
-    assert formated_privat_key == expected_formated_pem_key
+    assert formatted_private_key == expected_formatted_pem_key
 
-    # Setup
-    expected_formated_certificate = """-----BEGIN CERTIFICATE-----
+
+def test_get_pem_format_multiline():
+    expected_formatted_certificate = """-----BEGIN CERTIFICATE-----
 Certificate1
 Certificate2
 -----END CERTIFICATE-----"""
     certificate = "-----BEGIN CERTIFICATE----- Certificate1 Certificate2 -----END CERTIFICATE-----"
 
-    # Execute
-    formated_certificate = get_pem_format(key=certificate)
-    assert formated_certificate == expected_formated_certificate
+    formatted_certificate = get_pem_format(key=certificate)
+    assert formatted_certificate == expected_formatted_certificate
 
-    # Setup
-    expected_formated_multi_certificate = """-----BEGIN CERTIFICATE-----
+
+def test_get_pem_format_multiple_certificates():
+    expected_formatted_multiple_certificates = """-----BEGIN CERTIFICATE-----
 Certificate1
 -----END CERTIFICATE-----
 -----BEGIN CERTIFICATE-----
 Certificate2
 -----END CERTIFICATE-----
 """
-    multi_certificate = "-----BEGIN CERTIFICATE----- Certificate1 -----END CERTIFICATE----- -----BEGIN CERTIFICATE----- Certificate2 -----END CERTIFICATE-----"
+    multiple_certificates = "-----BEGIN CERTIFICATE----- Certificate1 -----END CERTIFICATE----- -----BEGIN CERTIFICATE----- Certificate2 -----END CERTIFICATE-----"
 
-    # Execute
-    formated_multi_certificate = get_pem_format(key=multi_certificate)
-    assert formated_multi_certificate == expected_formated_multi_certificate
+    formatted_multi_certificate = get_pem_format(key=multiple_certificates)
+    assert formatted_multi_certificate == expected_formatted_multiple_certificates
 
 
 def test_hash_id():


### PR DESCRIPTION
(No issue, this was a non-functional 2 minute change)

This PR splits up the `test_get_pem_format` tests to make it more obvious what exactly failed (I've struggled to detect a problem at a first glance, when I changed something in `get_pem_format`). Also corrected some variable name typos.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests