### PR TITLE
[Refactoring] Remove shadow variables

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,22 +331,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,6 +331,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -542,9 +542,9 @@ class SharepointOnlineClient:
     async def active_users_with_groups(self):
         expand = "transitiveMemberOf($select=id)"
         top = 999  # this is accepted, but does not get taken literally. Response size seems to max out at 100
-        filter = "accountEnabled eq true"
+        filter_ = "accountEnabled eq true"
         select = "UserName,userPrincipalName,Email,mail,transitiveMemberOf,id,createdDateTime"
-        url = f"{GRAPH_API_URL}/users?$expand={expand}&$top={top}&$filter={filter}&$select={select}"
+        url = f"{GRAPH_API_URL}/users?$expand={expand}&$top={top}&$filter={filter_}&$select={select}"
 
         try:
             async for page in self._graph_api_client.scroll(url):
@@ -1412,18 +1412,18 @@ class SharepointOnlineDataSource(BaseDataSource):
         already_seen_ids = set()
 
         def _already_seen(*ids):
-            for id in ids:
-                if id in already_seen_ids:
-                    self._logger.debug(f"We've already seen {id}")
+            for id_ in ids:
+                if id_ in already_seen_ids:
+                    self._logger.debug(f"We've already seen {id_}")
                     return True
 
             return False
 
         def update_already_seen(*ids):
-            for id in ids:
+            for id_ in ids:
                 # We want to make sure to not add 'None' to the already seen sets
-                if id:
-                    already_seen_ids.add(id)
+                if id_:
+                    already_seen_ids.add(id_)
 
         async def process_user(user):
             email = user.get("EMail", user.get("mail", None))


### PR DESCRIPTION
(No issue, since this is super trivial/just three renamings)

It seems to be a bad practice in python to shadow built-in names like `id` and `filter`. Variables with these names should end with `_` for being able to distinguish them from built-in functions and to not confuse many IDEs.

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description