### PR TITLE
[SPO] Deduplicate and correct test name

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,22 +331,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,6 +331,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -528,33 +528,6 @@ class TestMicrosoftAPISession:
         patch_cancellable_sleeps.assert_awaited_with(retry_after)
 
     @pytest.mark.asyncio
-    async def test_call_api_with_404_with_retry_after_header(
-        self,
-        microsoft_api_session,
-        mock_responses,
-        patch_sleep,
-        patch_cancellable_sleeps,
-    ):
-        url = "http://localhost:1234/download-some-sample-file"
-        payload = {"hello": "world"}
-        retry_after = 25
-
-        # First throttle, then do not throttle
-        first_request_error = ClientResponseError(None, None)
-        first_request_error.status = 404
-        first_request_error.message = "Something went wrong"
-        first_request_error.headers = {"Retry-After": str(retry_after)}
-
-        mock_responses.get(url, exception=first_request_error)
-        mock_responses.get(url, payload=payload)
-
-        with pytest.raises(NotFound) as e:
-            async with microsoft_api_session._get(url) as _:
-                pass
-
-        assert e is not None
-
-    @pytest.mark.asyncio
     async def test_call_api_with_429_without_retry_after(
         self,
         microsoft_api_session,
@@ -599,6 +572,33 @@ class TestMicrosoftAPISession:
         mock_responses.get(url, exception=unauthorized_error)
 
         with pytest.raises(PermissionsMissing) as e:
+            async with microsoft_api_session._get(url) as _:
+                pass
+
+        assert e is not None
+
+    @pytest.mark.asyncio
+    async def test_call_api_with_404_with_retry_after_header(
+        self,
+        microsoft_api_session,
+        mock_responses,
+        patch_sleep,
+        patch_cancellable_sleeps,
+    ):
+        url = "http://localhost:1234/download-some-sample-file"
+        payload = {"hello": "world"}
+        retry_after = 25
+
+        # First throttle, then do not throttle
+        first_request_error = ClientResponseError(None, None)
+        first_request_error.status = 404
+        first_request_error.message = "Something went wrong"
+        first_request_error.headers = {"Retry-After": str(retry_after)}
+
+        mock_responses.get(url, exception=first_request_error)
+        mock_responses.get(url, payload=payload)
+
+        with pytest.raises(NotFound) as e:
             async with microsoft_api_session._get(url) as _:
                 pass
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -605,7 +605,7 @@ class TestMicrosoftAPISession:
         assert e is not None
 
     @pytest.mark.asyncio
-    async def test_call_api_with_404_with_retry_after_header(
+    async def test_call_api_with_404_without_retry_after_header(
         self,
         microsoft_api_session,
         mock_responses,


### PR DESCRIPTION
This PR deduplicates the test name `test_call_api_with_404_with_retry_after_header` as one test doesn't use the explicit retry after header. Also moved the test so they're directly together.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description