### PR TITLE
Enable linter rule to report shadowing issues

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-select = ["E", "F", "B"]
+select = ["A", "E", "F", "B"]
 ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/connectors/logger.py
+++ b/connectors/logger.py
@@ -65,7 +65,7 @@ class ColorFormatter(logging.Formatter):
             fmt=self.BOLD_RED + self.custom_format + self.RESET, datefmt=self.DATE_FMT
         )
 
-    def format(self, record):
+    def format(self, record):  # noqa: A003
         formatter = getattr(self, f"{record.levelname.lower()}_formatter")
         return formatter.format(record)
 

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -58,7 +58,7 @@ class Field:
         depends_on=None,
         label=None,
         required=True,
-        type="str",
+        field_type="str",
         validations=None,
         value=None,
     ):
@@ -69,23 +69,23 @@ class Field:
         if validations is None:
             validations = []
 
-        self.default_value = self._convert(default_value, type)
+        self.default_value = self._convert(default_value, field_type)
         self.depends_on = depends_on
         self.label = label
         self.name = name
         self.required = required
-        self._type = type
+        self._field_type = field_type
         self.validations = validations
-        self._value = self._convert(value, type)
+        self._value = self._convert(value, field_type)
 
     @property
-    def type(self):
-        return self._type
+    def field_type(self):
+        return self._field_type
 
-    @type.setter
-    def type(self, value):
-        self._type = value
-        self.value = self._convert(self.value, self._type)
+    @field_type.setter
+    def field_type(self, value):
+        self._field_type = value
+        self.value = self._convert(self.value, self.field_type)
 
     @property
     def value(self):
@@ -105,18 +105,18 @@ class Field:
     def value(self, value):
         self._value = value
 
-    def _convert(self, value, type_):
+    def _convert(self, value, field_type):
         if not isinstance(value, str):
             # we won't convert the value if it's not a str
             return value
 
-        if type_ == "int":
+        if field_type == "int":
             return int(value)
-        elif type_ == "float":
+        elif field_type == "float":
             return float(value)
-        elif type_ == "bool":
+        elif field_type == "bool":
             return value.lower() in ("y", "yes", "true", "1")
-        elif type_ == "list":
+        elif field_type == "list":
             return [item.strip() for item in value.split(",")]
         return value
 
@@ -241,7 +241,7 @@ class DataSourceConfiguration:
         for name, item in default_config.items():
             self._defaults[name] = item["value"]
             if name in self._config:
-                self._config[name].type = item["type"]
+                self._config[name].field_type = item["type"]
 
     def __getitem__(self, key):
         if key not in self._config and key in self._defaults:
@@ -263,12 +263,19 @@ class DataSourceConfiguration:
         depends_on=None,
         label=None,
         required=True,
-        type="str",
+        field_type="str",
         validations=None,
         value=None,
     ):
         self._config[name] = Field(
-            name, default_value, depends_on, label, required, type, validations, value
+            name,
+            default_value,
+            depends_on,
+            label,
+            required,
+            field_type,
+            validations,
+            value,
         )
 
     def get_field(self, name):

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -747,8 +747,8 @@ class GoogleDriveDataSource(BaseDataSource):
         drives = await self.google_drive_client.get_all_drives()
 
         # for paths let's treat drives as top level folders
-        for id, drive_name in drives.items():
-            folders[id] = {"name": drive_name, "parents": []}
+        for id_, drive_name in drives.items():
+            folders[id_] = {"name": drive_name, "parents": []}
 
         self._logger.info(f"Resolving folder paths for {len(folders)} folders")
 

--- a/connectors/sources/servicenow.py
+++ b/connectors/sources/servicenow.py
@@ -228,8 +228,8 @@ class ServiceNowClient:
             {"name": "Accept", "value": "application/json"},
         ]
         apis = []
-        for id in ids:
-            params = {"table_sys_id": id}
+        for id_ in ids:
+            params = {"table_sys_id": id_}
             apis.append(
                 {
                     "id": str(uuid.uuid4()),

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -180,7 +180,7 @@ class MicrosoftSecurityToken:
         Returns:
             str: bearer token for one of Microsoft services"""
 
-        cached_value = self._token_cache.get()
+        cached_value = self._token_cache.get_value()
 
         if cached_value:
             return cached_value
@@ -206,7 +206,7 @@ class MicrosoftSecurityToken:
                         f"Failed to authorize to Sharepoint REST API. Response Status: {e.status}, Message: {e.message}"
                     ) from e
 
-        self._token_cache.set(access_token, now + timedelta(seconds=expires_in))
+        self._token_cache.set_value(access_token, now + timedelta(seconds=expires_in))
 
         return access_token
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -662,7 +662,7 @@ class CacheWithTimeout:
     Example of usage:
 
     cache = CacheWithTimeout()
-    cache.set(50, datetime.datetime.now() + datetime.timedelta(5)
+    cache.set_value(50, datetime.datetime.now() + datetime.timedelta(5)
     value = cache.get() # 50
     sleep(5)
     value = cache.get() # None
@@ -672,7 +672,7 @@ class CacheWithTimeout:
         self._value = None
         self._expiration_date = None
 
-    def get(self):
+    def get_value(self):
         """Get the value that's stored inside if it hasn't expired.
 
         If the expiration_date is past due, None is returned instead.
@@ -685,7 +685,7 @@ class CacheWithTimeout:
 
         return None
 
-    def set(self, value, expiration_date):
+    def set_value(self, value, expiration_date):
         """Set the value in the cache with expiration date.
 
         Once expiration_date is past due, the value will be lost.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,6 @@ class Logger:
         if exc_info:
             self.logs.append(traceback.format_exc())
 
-    def assert_check(self, callable):
-        for log in self.logs:
-            if callable(log):
-                return
-        raise AssertionError(f"{callable} returned False for {self.logs}")
-
     def assert_instance(self, instance):
         for log in self.logs:
             if isinstance(log, instance):

--- a/tests/es/test_settings.py
+++ b/tests/es/test_settings.py
@@ -152,14 +152,14 @@ def test_settings_supported_language():
     assert isinstance(actual, dict)
     assert "analysis" in actual
     assert "filter" in actual["analysis"]
-    filter = actual["analysis"]["filter"]
+    analysis_filter = actual["analysis"]["filter"]
 
     for k in (
         f"{language_code}-stem-filter",
         f"{language_code}-stop-words-filter",
         f"{language_code}-elision",
     ):
-        assert k in filter
+        assert k in analysis_filter
 
 
 def test_settings_none_language():

--- a/tests/services/test_job_cleanup.py
+++ b/tests/services/test_job_cleanup.py
@@ -31,17 +31,17 @@ def create_service():
     return JobCleanUpService(CONFIG)
 
 
-def mock_connector(id="1", index_name="index_name"):
+def mock_connector(connector_id="1", index_name="index_name"):
     connector = Mock()
-    connector.id = id
+    connector.id = connector_id
     connector.index_name = index_name
     connector.sync_done = AsyncMock()
     return connector
 
 
-def mock_sync_job(id="1", connector_id="1", index_name="index_name"):
+def mock_sync_job(sync_job_id="1", connector_id="1", index_name="index_name"):
     job = Mock()
-    job.job_id = id
+    job.job_id = sync_job_id
     job.connector_id = connector_id
     job.index_name = index_name
     job.fail = AsyncMock()

--- a/tests/sources/fixtures/confluence/fixture.py
+++ b/tests/sources/fixtures/confluence/fixture.py
@@ -31,7 +31,7 @@ class ConfluenceAPI:
         self.app.route("/rest/api/space", methods=["GET"])(self.get_spaces)
         self.app.route("/rest/api/content/search", methods=["GET"])(self.get_content)
         self.app.route(
-            "/rest/api/content/<string:id>/child/attachment", methods=["GET"]
+            "/rest/api/content/<string:content_id>/child/attachment", methods=["GET"]
         )(self.get_attachments)
         self.app.route(
             "/download/attachments/<string:content_id>/<string:attachment_id>",
@@ -121,7 +121,7 @@ class ConfluenceAPI:
             )
         return content
 
-    def get_attachments(self, id):
+    def get_attachments(self, content_id):
         """Function to handle get attachments calls
 
         Args:
@@ -140,14 +140,14 @@ class ConfluenceAPI:
 
         for attachment_count in range(self.attachment_start_at, self.attachment_end_at):
             attachment = {
-                "id": f"attachment_{id}_{attachment_count}",
-                "title": f"attachment_{id}_{attachment_count}.py",
+                "id": f"attachment_{content_id}_{attachment_count}",
+                "title": f"attachment_{content_id}_{attachment_count}.py",
                 "type": "attachment",
                 "version": {"when": "2023-01-03T09:24:50.633Z"},
                 "extensions": {"fileSize": FILE_SIZE},
                 "_links": {
-                    "download": f"/download/attachments/{id}/attachment_{id}_{attachment_count}.py",
-                    "webui": f"/pages/viewpageattachments.action?pageId={id}&preview=attachment_{id}_{attachment_count}.py",
+                    "download": f"/download/attachments/{content_id}/attachment_{content_id}_{attachment_count}.py",
+                    "webui": f"/pages/viewpageattachments.action?pageId={content_id}&preview=attachment_{content_id}_{attachment_count}.py",
                 },
             }
             attachments["results"].append(attachment)

--- a/tests/sources/fixtures/google_drive/fixture.py
+++ b/tests/sources/fixtures/google_drive/fixture.py
@@ -67,13 +67,13 @@ def files_list():
             "kind": "drive#file",
             "mimeType": "text/plain",
             "id": generate_random_string(length=16),
-            "name": f"file_name_{id}",
+            "name": f"file_name_{id_}",
             "fileExtension": "txt",
             "size": 12345,
             "modifiedTime": 1687860674,
             "parents": [],
         }
-        for id in range(DOCS_COUNT.get(DATA_SIZE, "small"))
+        for id_ in range(DOCS_COUNT.get(DATA_SIZE, "small"))
     ]
     return {"nextPageToken": "dummyToken", "files": files_list}
 

--- a/tests/sources/fixtures/jira/fixture.py
+++ b/tests/sources/fixtures/jira/fixture.py
@@ -90,8 +90,8 @@ def get_all_issues():
     return all_issues
 
 
-@app.route("/rest/api/2/issue/<string:id>", methods=["GET"])
-def get_issue(id):
+@app.route("/rest/api/2/issue/<string:issue_id>", methods=["GET"])
+def get_issue(issue_id):
     """Function to handle get issue calls with the id passed as argument
     Args:
         id (str): Issue id
@@ -99,8 +99,8 @@ def get_issue(id):
         issue (dictionary): dictionary of issue data.
     """
     issue = {
-        "id": id,
-        "key": f"DP-{id}",
+        "id": issue_id,
+        "key": f"DP-{issue_id}",
         "fields": {
             "issuetype": {"name": "Task"},
             "project": {"key": "DP", "name": "Demo Project"},

--- a/tests/sources/fixtures/sharepoint_server/fixture.py
+++ b/tests/sources/fixtures/sharepoint_server/fixture.py
@@ -91,18 +91,18 @@ def generate_attachment_data():
     return io.BytesIO(bytes(GENERATED_DATA["extra_small"], encoding="utf-8"))
 
 
-def adjust_document_id_size(id):
+def adjust_document_id_size(document_id):
     """
     This methods make sure that all the documemts ids are min 36 bytes like in Sharepoint
     """
 
-    bytesize = len(id)
+    bytesize = len(document_id)
 
     if bytesize >= DOC_ID_SIZE:
-        return id
+        return document_id
 
     addition = "".join(["0" for _ in range(DOC_ID_SIZE - bytesize - 1)])
-    return f"{id}-{addition}"
+    return f"{document_id}-{addition}"
 
 
 @app.route("/sites/<string:site_collections>/_api/web/webs", methods=["GET"])

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -565,8 +565,8 @@ async def test_get_retry_after():
                 }
             }
         )
-        await source.github_client._get_retry_after(type="core")
-        await source.github_client._get_retry_after(type="graphql")
+        await source.github_client._get_retry_after(resource_type="core")
+        await source.github_client._get_retry_after(resource_type="graphql")
 
 
 @pytest.mark.asyncio

--- a/tests/sources/test_mysql.py
+++ b/tests/sources/test_mysql.py
@@ -592,7 +592,7 @@ async def setup_mysql_source(source, database="", client=None):
         client = MagicMock()
 
     source.configuration.set_field(
-        name="database", label="Database", value=database, type="str"
+        name="database", label="Database", value=database, field_type="str"
     )
 
     source.database = database

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -71,15 +71,15 @@ def test_field():
     # stupid holder
     f = Field("name")
     assert f.label == "name"
-    assert f.type == "str"
+    assert f.field_type == "str"
 
 
 def test_field_convert():
-    assert Field("name", value="1", type="int").value == 1
-    assert Field("name", value="1.2", type="float").value == 1.2
-    assert Field("name", value="YeS", type="bool").value
-    assert Field("name", value="1,2,3", type="list").value == ["1", "2", "3"]
-    assert not Field("name", value="false", type="bool").value
+    assert Field("name", value="1", field_type="int").value == 1
+    assert Field("name", value="1.2", field_type="float").value == 1.2
+    assert Field("name", value="YeS", field_type="bool").value
+    assert Field("name", value="1,2,3", field_type="list").value == ["1", "2", "3"]
+    assert not Field("name", value="false", field_type="bool").value
 
 
 def test_data_source_configuration():
@@ -98,7 +98,7 @@ def test_default():
 
 
 @pytest.mark.parametrize(
-    "type, required, default_value, value, expected_value",
+    "field_type, required, default_value, value, expected_value",
     [
         # these include examples that would not normally validate
         # that is because `.value` does care about validation, it only returns a value
@@ -133,12 +133,12 @@ def test_default():
     ],
 )
 def test_value_returns_correct_value(
-    type, required, default_value, value, expected_value
+    field_type, required, default_value, value, expected_value
 ):
     assert (
         Field(
             "name",
-            type=type,
+            field_type=field_type,
             required=required,
             default_value=default_value,
             value=value,
@@ -148,7 +148,7 @@ def test_value_returns_correct_value(
 
 
 class MyConnector:
-    id = "1"
+    id = "1"  # noqa A003
     service_type = "yea"
 
     def __init__(self, *args):


### PR DESCRIPTION
Minor improvement:

Enabling `A` rules for `ruff`:

https://beta.ruff.rs/docs/rules/builtin-variable-shadowing/ - Checks for variable (and function) assignments that use the same name as a builtin.

https://beta.ruff.rs/docs/rules/builtin-argument-shadowing/ - Checks for any function arguments that use the same name as a builtin.

https://beta.ruff.rs/docs/rules/builtin-attribute-shadowing/ - Checks for any class attributes or methods that use the same name as a builtin.

