### PR TITLE
[Commons] Add assert_called_once_with to AsyncIterator

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,22 +331,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,6 +331,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -41,4 +41,20 @@ class AsyncIterator:
         return self.call_count == 0
 
     def assert_called_once(self):
-        return self.call_count == 1
+        if self.call_count != 1:
+            raise AssertionError(
+                f"Expected one call. Actual number of calls: {self.call_count}."
+            )
+
+    def assert_called_once_with(self, *args, **kwargs):
+        self.assert_called_once()
+
+        if len(self.call_args) > 0 and self.call_args[0] != args:
+            raise AssertionError(
+                f"Expected args: {args}. Actual args: {self.call_args[0]}."
+            )
+
+        if len(self.call_kwargs) > 0 and self.call_kwargs[0] != kwargs:
+            raise AssertionError(
+                f"Expected kwargs: {kwargs}. Actual kwargs: {self.call_kwargs[0]}."
+            )

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2168,9 +2168,7 @@ class TestSharepointOnlineDataSource:
                 )
                 for site_list in actual_site_lists
             )
-            assert (
-                patch_sharepoint_client.site_list_role_assignments.assert_called_once()
-            )
+            patch_sharepoint_client.site_list_role_assignments.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_download_function_for_folder(self):

--- a/tests/test_commons.py
+++ b/tests/test_commons.py
@@ -219,9 +219,11 @@ async def test_assert_called_once_with_one_kwarg_and_two_calls():
 
     async_iterator = AsyncIterator(items)
 
+    # first call
     async for _ in async_iterator(argument=argument):
         pass
 
+    # second call
     async for _ in async_iterator(argument=argument):
         pass
 

--- a/tests/test_commons.py
+++ b/tests/test_commons.py
@@ -110,4 +110,180 @@ async def test_assert_called_once():
     async for _ in async_generator:
         pass
 
-    assert async_generator.assert_called_once()
+    async_generator.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_two_calls():
+    items = []
+
+    async_generator = AsyncIterator(items)
+
+    # first call
+    async for _ in async_generator():
+        pass
+
+    # second call
+    async for _ in async_generator():
+        pass
+
+    with pytest.raises(AssertionError):
+        async_generator.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_one_arg():
+    items = [1]
+
+    argument = "some argument"
+
+    async_iterator = AsyncIterator(items)
+
+    async for _ in async_iterator(argument):
+        pass
+
+    async_iterator.assert_called_once_with(argument)
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_wrong_arg():
+    items = [1]
+
+    argument = "some argument"
+    wrong_argument = "wrong argument"
+
+    async_iterator = AsyncIterator(items)
+
+    async for _ in async_iterator(argument):
+        pass
+
+    with pytest.raises(AssertionError):
+        async_iterator.assert_called_once_with(wrong_argument)
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_one_arg_and_two_calls():
+    items = [1]
+
+    argument = "some argument"
+
+    async_iterator = AsyncIterator(items)
+
+    # first call
+    async for _ in async_iterator(argument):
+        pass
+
+    # second call
+    async for _ in async_iterator(argument):
+        pass
+
+    with pytest.raises(AssertionError):
+        async_iterator.assert_called_once_with(argument)
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_three_args():
+    items = [1]
+
+    argument_one = "some argument one"
+    argument_two = "some argument two"
+    argument_three = "some argument three"
+
+    async_iterator = AsyncIterator(items)
+
+    async for _ in async_iterator(argument_one, argument_two, argument_three):
+        pass
+
+    async_iterator.assert_called_once_with(argument_one, argument_two, argument_three)
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_one_kwarg():
+    items = [1]
+
+    argument = "some argument"
+
+    async_iterator = AsyncIterator(items)
+
+    async for _ in async_iterator(argument=argument):
+        pass
+
+    async_iterator.assert_called_once_with(argument=argument)
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_one_kwarg_and_two_calls():
+    items = [1]
+
+    argument = "some argument"
+
+    async_iterator = AsyncIterator(items)
+
+    async for _ in async_iterator(argument=argument):
+        pass
+
+    async for _ in async_iterator(argument=argument):
+        pass
+
+    with pytest.raises(AssertionError):
+        async_iterator.assert_called_once_with(argument=argument)
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_wrong_kwarg():
+    items = [1]
+
+    argument = "some argument"
+    wrong_argument = "wrong argument"
+
+    async_iterator = AsyncIterator(items)
+
+    async for _ in async_iterator(argument=argument):
+        pass
+
+    with pytest.raises(AssertionError):
+        async_iterator.assert_called_once_with(wrong_argument=wrong_argument)
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_three_kwargs():
+    items = [1]
+
+    argument_one = "some argument one"
+    argument_two = "some argument two"
+    argument_three = "some argument three"
+
+    async_iterator = AsyncIterator(items)
+
+    async for _ in async_iterator(
+        argument_one=argument_one,
+        argument_two=argument_two,
+        argument_three=argument_three,
+    ):
+        pass
+
+    async_iterator.assert_called_once_with(
+        argument_one=argument_one,
+        argument_two=argument_two,
+        argument_three=argument_three,
+    )
+
+
+@pytest.mark.asyncio
+async def test_assert_called_once_with_args_and_kwargs():
+    items = [1]
+
+    argument_one = "some argument one"
+    argument_two = "some argument two"
+    argument_three = "some argument three"
+
+    async_iterator = AsyncIterator(items)
+
+    async for _ in async_iterator(
+        argument_one, argument_two=argument_two, argument_three=argument_three
+    ):
+        pass
+
+    async_iterator.assert_called_once_with(
+        argument_one, argument_two=argument_two, argument_three=argument_three
+    )


### PR DESCRIPTION
## Related to https://github.com/elastic/connectors-python/pull/1317

This PR adds `assert_called_once_with` to the `AsyncIterator` fake class. This enables assertions checking that the `AsyncIterator` was called once with specific `*args` and `**kwargs` (need that for the GMail connector tests).

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally