### PR TITLE
Populate webUrl for site pages and list item attachments

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1847,7 +1847,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                     ] = list_item_attachment.get("FileName", "")
                     if (
                         "ServerRelativePath" in list_item_attachment
-                        and "DecodedUrl" in list_item_attachment.get("ServerRelativePath", "")
+                        and "DecodedUrl" in list_item_attachment.get("ServerRelativePath", {})
                     ):
                         list_item_attachment[
                             "webUrl"

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1778,9 +1778,9 @@ class SharepointOnlineDataSource(BaseDataSource):
     async def site_list_items(
         self, site, site_list_id, site_list_name, site_access_control
     ):
-        site_id = site["id"]
-        site_web_url = site["webUrl"]
-        site_collection = site["siteCollection"]["hostname"]
+        site_id = site.get("id")
+        site_web_url = site.get("webUrl")
+        site_collection = site.get("siteCollection", {}).get("hostname")
         async for list_item in self.client.site_list_items(site_id, site_list_id):
             # List Item IDs are unique within list.
             # Therefore we mix in site_list id to it to make sure they are

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1641,9 +1641,8 @@ class SharepointOnlineDataSource(BaseDataSource):
                     yield site_list, None, OP_INDEX
 
                     async for list_item, download_func in self.site_list_items(
-                        site_id=site["id"],
+                        site=site,
                         site_list_id=site_list["id"],
-                        site_web_url=site["webUrl"],
                         site_list_name=site_list["name"],
                         site_access_control=site_access_control,
                     ):

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1847,7 +1847,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                     ] = list_item_attachment.get("FileName", "")
                     if (
                         "ServerRelativePath" in list_item_attachment
-                        and "DecodedUrl" in list_item_attachment["ServerRelativePath"]
+                        and "DecodedUrl" in list_item_attachment.get("ServerRelativePath", "")
                     ):
                         list_item_attachment[
                             "webUrl"

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1847,7 +1847,8 @@ class SharepointOnlineDataSource(BaseDataSource):
                     ] = list_item_attachment.get("FileName", "")
                     if (
                         "ServerRelativePath" in list_item_attachment
-                        and "DecodedUrl" in list_item_attachment.get("ServerRelativePath", {})
+                        and "DecodedUrl"
+                        in list_item_attachment.get("ServerRelativePath", {})
                     ):
                         list_item_attachment[
                             "webUrl"

--- a/tests/sources/fixtures/sharepoint_online/fixture.py
+++ b/tests/sources/fixtures/sharepoint_online/fixture.py
@@ -324,6 +324,9 @@ class RandomDataStorage:
                     "webUrl": f"{ROOT}/sites/{site['name']}",
                     "createdDateTime": "2023-05-31T16:08:46Z",
                     "lastModifiedDateTime": "2023-05-31T16:08:48Z",
+                    "siteCollection": {
+                        "hostname": ROOT
+                    }
                 }
             )
 

--- a/tests/sources/fixtures/sharepoint_online/fixture.py
+++ b/tests/sources/fixtures/sharepoint_online/fixture.py
@@ -324,9 +324,7 @@ class RandomDataStorage:
                     "webUrl": f"{ROOT}/sites/{site['name']}",
                     "createdDateTime": "2023-05-31T16:08:46Z",
                     "lastModifiedDateTime": "2023-05-31T16:08:48Z",
-                    "siteCollection": {
-                        "hostname": ROOT
-                    }
+                    "siteCollection": {"hostname": ROOT},
                 }
             )
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1574,7 +1574,7 @@ class TestSharepointOnlineDataSource:
                 "id": "1",
                 "webUrl": "https://test.sharepoint.com/site-1",
                 "name": "site-1",
-                "siteCollection": self.site_collections[0]["siteCollection"]
+                "siteCollection": self.site_collections[0]["siteCollection"],
             }
         ]
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1574,6 +1574,7 @@ class TestSharepointOnlineDataSource:
                 "id": "1",
                 "webUrl": "https://test.sharepoint.com/site-1",
                 "name": "site-1",
+                "siteCollection": self.site_collections[0]["siteCollection"]
             }
         ]
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1435

This PR updates the logic that yields site pages and list item attachments. These fields are missing from objects as they are loaded with Rest API.

For site pages webUrl is populated from `EncodedAbsUrl` that is requested additionally.
For attachments it's populated from existing fields.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally

## Release Note

SPO connector now populates webUrl for Site Pages and List Item Attachments
