### PR TITLE
[Commons] Use AssertionError instead of returning a boolean

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,22 +331,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,6 +331,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -38,7 +38,10 @@ class AsyncIterator:
         return self
 
     def assert_not_called(self):
-        return self.call_count == 0
+        if self.call_count != 0:
+            raise AssertionError(
+                f"Expected zero calls. Actual number of calls: {self.call_count}"
+            )
 
     def assert_called_once(self):
         if self.call_count != 1:

--- a/tests/test_commons.py
+++ b/tests/test_commons.py
@@ -94,7 +94,20 @@ async def test_assert_not_called():
     items = []
 
     async_generator = AsyncIterator(items)
-    assert async_generator.assert_not_called()
+    async_generator.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_assert_not_called_with_one_call():
+    items = []
+
+    async_generator = AsyncIterator(items)
+
+    async for _ in async_generator():
+        pass
+
+    with pytest.raises(AssertionError):
+        async_generator.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR adapts `assert_not_called` to raise `AssertionError`, if something is wrong instead of returning `False` adhering to the other signatures in `AsyncIterator` (and to signatures of other test frameworks).

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally