### PR TITLE
Add _dls_enabled() before fetching unique permissions

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1802,7 +1802,10 @@ class SharepointOnlineDataSource(BaseDataSource):
 
             has_unique_role_assignments = False
 
-            if self.configuration["fetch_unique_list_item_permissions"]:
+            if (
+                self._dls_enabled()
+                and self.configuration["fetch_unique_list_item_permissions"]
+            ):
                 has_unique_role_assignments = (
                     await self.client.site_list_item_has_unique_role_assignments(
                         site_web_url, site_list_name, list_item_natural_id
@@ -1866,7 +1869,10 @@ class SharepointOnlineDataSource(BaseDataSource):
 
             has_unique_role_assignments = False
 
-            if self.configuration["fetch_unique_list_permissions"]:
+            if (
+                self._dls_enabled()
+                and self.configuration["fetch_unique_list_permissions"]
+            ):
                 has_unique_role_assignments = (
                     await self.client.site_list_has_unique_role_assignments(
                         site_url, site_list_name
@@ -1979,7 +1985,10 @@ class SharepointOnlineDataSource(BaseDataSource):
             has_unique_role_assignments = False
 
             # ignore parent site permissions and use unique per page permissions ("unique permissions" means breaking the inheritance to the parent site)
-            if self.configuration["fetch_unique_page_permissions"]:
+            if (
+                self._dls_enabled()
+                and self.configuration["fetch_unique_page_permissions"]
+            ):
                 has_unique_role_assignments = (
                     await self.client.site_page_has_unique_role_assignments(
                         url, site_page["Id"]

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1849,9 +1849,11 @@ class SharepointOnlineDataSource(BaseDataSource):
                     list_item_attachment[
                         "_original_filename"
                     ] = list_item_attachment.get("FileName", "")
-                    list_item_attachment[ACCESS_CONTROL] = list_item.get(
-                        ACCESS_CONTROL, []
-                    )
+
+                    if self._dls_enabled():
+                        list_item_attachment[ACCESS_CONTROL] = list_item.get(
+                            ACCESS_CONTROL, []
+                        )
 
                     attachment_download_func = partial(
                         self.get_attachment_content, list_item_attachment

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -1934,6 +1934,9 @@ class TestSharepointOnlineDataSource:
                 self.site_pages
             )
 
+            for item in results:
+                assert ACCESS_CONTROL not in item
+
     @pytest.mark.asyncio
     @patch(
         "connectors.sources.sharepoint_online.ACCESS_CONTROL",


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1443

Adding `_dls_enabled()` condition check for logic that fetches unique DLS permissions. Without this check, permissions are fetched even if DLS is disabled, making connector really slow (permission calls are expensive for DLS, plus some of them call for permissions in N+1 style: per item, which slows thing down more)

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
