### PR TITLE
Drop standalone isort and use one from ruff distribution

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,0 @@
-[settings]
-profile = black
-skip=lib,bin,include,pyodbc.pyi

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-select = ["A", "E", "F", "B"]
+select = ["A", "I", "E", "F", "B"]
 ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
@@ -17,3 +17,6 @@ target-version = "py310"
 
 [per-file-ignores]
 "tests/*" = ["B017"]
+
+[isort]
+known-first-party=["connectors", "tests"]

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ clean:
 	rm -rf bin lib include
 
 lint: bin/python bin/black bin/elastic-ingest
-	bin/isort --check . --sp .isort.cfg
 	bin/black --check connectors
 	bin/black --check tests
 	bin/black --check setup.py
@@ -46,11 +45,14 @@ lint: bin/python bin/black bin/elastic-ingest
 	bin/pyright tests
 
 autoformat: bin/python bin/black bin/elastic-ingest
-	bin/isort . --sp .isort.cfg
 	bin/black connectors
 	bin/black tests
 	bin/black setup.py
 	bin/black scripts
+	bin/ruff connectors --fix
+	bin/ruff tests --fix
+	bin/ruff setup.py --fix
+	bin/ruff scripts --fix
 
 test:	bin/pytest bin/elastic-ingest
 	bin/pytest --cov-report term-missing --cov-fail-under 92 --cov-report html --cov=connectors --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -10,9 +10,8 @@ import time
 from enum import Enum
 
 from elastic_transport.client_utils import url_to_node_config
-from elasticsearch import ApiError, AsyncElasticsearch, ConflictError
+from elasticsearch import ApiError, AsyncElasticsearch, ConflictError, NotFoundError
 from elasticsearch import ConnectionError as ElasticConnectionError
-from elasticsearch import NotFoundError
 
 from connectors import __version__
 from connectors.logger import logger, set_extra_logger

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,7 +1,6 @@
 # tests
 black==23.7.0
 ruff==0.0.278
-isort==5.12.0
 aioresponses==0.7.4
 pytest==7.4.0
 pytest-cov==4.1.0


### PR DESCRIPTION
Minor linter change - dropping standalone usage of `isort` because `ruff` already has it.

They have slight difference in import sorting, thus the changes in `connectors/es/client.py`