### PR TITLE
Download ContentDocuments and extract binary content

### DIFF
--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -4,20 +4,30 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """Salesforce source module responsible to fetch documents from Salesforce."""
+import asyncio
 from contextlib import contextmanager
 from functools import cached_property
 from itertools import groupby
 from threading import Lock
 
+import aiofiles
 import aiohttp
+from aiofiles.os import remove
+from aiofiles.tempfile import NamedTemporaryFile
 from aiohttp.client_exceptions import ClientResponseError
 
 from connectors.logger import logger
 from connectors.source import BaseDataSource
-from connectors.utils import CancellableSleeps, retryable
+from connectors.utils import (
+    TIKA_SUPPORTED_FILETYPES,
+    CancellableSleeps,
+    convert_to_b64,
+    retryable,
+)
 
 RETRIES = 3
 RETRY_INTERVAL = 1
+CHUNK_SIZE = 1024
 
 BASE_URL = "https://<domain>.my.salesforce.com"
 API_VERSION = "v58.0"
@@ -33,6 +43,9 @@ RELEVANT_SOBJECTS = [
     "CaseComment",
     "CaseFeed",
     "Contact",
+    "ContentDocument",
+    "ContentDocumentLink",
+    "ContentVersion",
     "EmailMessage",
     "FeedComment",
     "Lead",
@@ -48,6 +61,7 @@ RELEVANT_SOBJECT_FIELDS = [
     "CommentBody",
     "CommentCount",
     "Company",
+    "ContentSize",
     "ConvertedAccountId",
     "ConvertedContactId",
     "ConvertedDate",
@@ -56,6 +70,7 @@ RELEVANT_SOBJECT_FIELDS = [
     "Description",
     "Email",
     "EndDate",
+    "FileExtension",
     "FirstOpenedDate",
     "FromAddress",
     "FromName",
@@ -65,6 +80,7 @@ RELEVANT_SOBJECT_FIELDS = [
     "LastEditById",
     "LastEditDate",
     "LastModifiedById",
+    "LatestPublishedVersionId",
     "LeadSource",
     "LinkUrl",
     "MessageDate",
@@ -83,6 +99,8 @@ RELEVANT_SOBJECT_FIELDS = [
     "Title",
     "ToAddress",
     "Type",
+    "VersionDataUrl",
+    "VersionNumber",
     "Website",
 ]
 
@@ -137,6 +155,8 @@ class SalesforceClient:
         self._queryable_sobjects = None
         self._queryable_sobject_fields = None
         self._sobjects_cache_by_type = None
+        self._supported_file_types = [x[1:] for x in TIKA_SUPPORTED_FILETYPES]
+        self._content_document_links_join = None
 
         self.base_url = BASE_URL.replace("<domain>", configuration["domain"])
         self.api_token = SalesforceAPIToken(
@@ -183,23 +203,35 @@ class SalesforceClient:
             del self.session
 
     async def get_docs(self):
-        async for account in self.get_accounts():
-            yield account, None
+        all_content_docs = []
 
-        async for opportunity in self.get_opportunities():
-            yield opportunity, None
+        async for account, content_docs in self.get_accounts():
+            all_content_docs.extend(content_docs)
+            yield account
 
-        async for contact in self.get_contacts():
-            yield contact, None
+        async for opportunity, content_docs in self.get_opportunities():
+            all_content_docs.extend(content_docs)
+            yield opportunity
 
-        async for lead in self.get_leads():
-            yield lead, None
+        async for contact, content_docs in self.get_contacts():
+            all_content_docs.extend(content_docs)
+            yield contact
 
-        async for campaign in self.get_campaigns():
-            yield campaign, None
+        async for lead, content_docs in self.get_leads():
+            all_content_docs.extend(content_docs)
+            yield lead
 
-        async for case in self.get_cases():
-            yield case, None
+        async for campaign, content_docs in self.get_campaigns():
+            all_content_docs.extend(content_docs)
+            yield campaign
+
+        async for case, content_docs in self.get_cases():
+            all_content_docs.extend(content_docs)
+            yield case
+
+        all_content_docs = self._combine_duplicate_content_docs(all_content_docs)
+        async for content_doc in self.download_content_documents(all_content_docs):
+            yield content_doc
 
     async def get_accounts(self):
         if not await self._is_queryable("Account"):
@@ -211,7 +243,8 @@ class SalesforceClient:
         query = await self._accounts_query()
         async for records in self._yield_non_bulk_query_pages(query):
             for record in records:
-                yield self.doc_mapper.map_account(record)
+                content_documents = self._parse_content_documents(record)
+                yield self.doc_mapper.map_account(record), content_documents
 
     async def get_opportunities(self):
         if not await self._is_queryable("Opportunity"):
@@ -223,7 +256,8 @@ class SalesforceClient:
         query = await self._opportunities_query()
         async for records in self._yield_non_bulk_query_pages(query):
             for record in records:
-                yield self.doc_mapper.map_opportunity(record)
+                content_documents = self._parse_content_documents(record)
+                yield self.doc_mapper.map_opportunity(record), content_documents
 
     async def get_contacts(self):
         if not await self._is_queryable("Contact"):
@@ -235,12 +269,14 @@ class SalesforceClient:
         query = await self._contacts_query()
         async for records in self._yield_non_bulk_query_pages(query):
             for record in records:
+                content_documents = self._parse_content_documents(record)
+
                 sobjects_by_id = await self.sobjects_cache_by_type()
                 record["Account"] = sobjects_by_id["Account"].get(
                     record.get("AccountId"), {}
                 )
                 record["Owner"] = sobjects_by_id["User"].get(record.get("OwnerId"), {})
-                yield self.doc_mapper.map_contact(record)
+                yield self.doc_mapper.map_contact(record), content_documents
 
     async def get_leads(self):
         if not await self._is_queryable("Lead"):
@@ -252,6 +288,8 @@ class SalesforceClient:
         query = await self._leads_query()
         async for records in self._yield_non_bulk_query_pages(query):
             for record in records:
+                content_documents = self._parse_content_documents(record)
+
                 sobjects_by_id = await self.sobjects_cache_by_type()
                 record["Owner"] = sobjects_by_id["User"].get(record.get("OwnerId"), {})
                 record["ConvertedAccount"] = sobjects_by_id["Account"].get(
@@ -263,7 +301,7 @@ class SalesforceClient:
                 record["ConvertedOpportunity"] = sobjects_by_id["Opportunity"].get(
                     record.get("ConvertedOpportunityId"), {}
                 )
-                yield self.doc_mapper.map_lead(record)
+                yield self.doc_mapper.map_lead(record), content_documents
 
     async def get_campaigns(self):
         if not await self._is_queryable("Campaign"):
@@ -275,7 +313,8 @@ class SalesforceClient:
         query = await self._campaigns_query()
         async for records in self._yield_non_bulk_query_pages(query):
             for record in records:
-                yield self.doc_mapper.map_campaign(record)
+                content_documents = self._parse_content_documents(record)
+                yield self.doc_mapper.map_campaign(record), content_documents
 
     async def get_cases(self):
         if not await self._is_queryable("Case"):
@@ -287,7 +326,7 @@ class SalesforceClient:
         query = await self._cases_query()
         async for records in self._yield_non_bulk_query_pages(query):
             case_feeds_by_case_id = {}
-            if self._is_queryable("CaseFeed") and records:
+            if await self._is_queryable("CaseFeed") and records:
                 case_ids = [x.get("Id") for x in records]
                 case_feeds = await self.get_case_feeds(case_ids)
 
@@ -299,12 +338,27 @@ class SalesforceClient:
                 }
 
             for record in records:
+                content_documents = self._parse_content_documents(record)
+
                 record["Feeds"] = case_feeds_by_case_id.get(record.get("Id"))
-                yield self.doc_mapper.map_case(record)
+                yield self.doc_mapper.map_case(record), content_documents
 
     async def get_case_feeds(self, case_ids):
         query = await self._case_feeds_query(case_ids)
         return await self._execute_non_paginated_query(query)
+
+    async def download_content_documents(self, content_documents):
+        for content_document in content_documents:
+            content_version = content_document.get("LatestPublishedVersion", {}) or {}
+            doc = self.doc_mapper.map_content_document(
+                content_document, content_version
+            )
+
+            download_url = content_version.get("VersionDataUrl")
+            if content_version.get("VersionDataUrl"):
+                doc["_attachment"] = await self._download(download_url)
+
+            yield doc
 
     async def queryable_sobjects(self):
         """Cached async property"""
@@ -398,6 +452,41 @@ class SalesforceClient:
         queryable_fields = sobject_fields.get(sobject, [])
         return [f for f in fields if f.lower() in queryable_fields]
 
+    def _parse_content_documents(self, record):
+        content_docs = []
+        content_links = record.get("ContentDocumentLinks", {}) or {}
+        content_links = content_links.get("records", []) or []
+        for content_link in content_links:
+            content_doc = content_link.get("ContentDocument")
+            if not content_doc:
+                continue
+
+            content_doc["linked_sobject_id"] = record.get("Id")
+            content_docs.append(content_doc)
+
+        return content_docs
+
+    def _combine_duplicate_content_docs(self, content_docs):
+        """Duplicate ContentDocuments may appear linked to multiple SObjects
+        Here we ensure that we don't download any duplicates while retaining links"""
+        grouped = {}
+
+        for content_doc in content_docs:
+            content_doc_id = content_doc["Id"]
+            if content_doc_id in grouped:
+                linked_id = content_doc["linked_sobject_id"]
+                linked_ids = grouped[content_doc_id]["linked_ids"]
+                if linked_id not in linked_ids:
+                    linked_ids.append(linked_id)
+            else:
+                grouped[content_doc_id] = content_doc
+                grouped[content_doc_id]["linked_ids"] = [
+                    content_doc["linked_sobject_id"]
+                ]
+
+        grouped_objects = list(grouped.values())
+        return grouped_objects
+
     async def _yield_non_bulk_query_pages(self, soql_query):
         """loops through query response pages and yields lists of records"""
         url = f"{self.base_url}{QUERY_ENDPOINT}"
@@ -412,7 +501,7 @@ class SalesforceClient:
             if response.get("done", True) is True:
                 break
 
-            url = response.get("nextRecordsUrl")
+            url = f"{self.base_url}{response.get('nextRecordsUrl')}"
             params = None
 
     async def _execute_non_paginated_query(self, soql_query):
@@ -424,6 +513,34 @@ class SalesforceClient:
             params=params,
         )
         return response.get("records")
+
+    async def _download(self, download_url):
+        attachment = None
+        source_file_name = ""
+
+        try:
+            async with NamedTemporaryFile(mode="wb", delete=False) as async_buffer:
+                resp = await self._get(download_url)
+                async for data in resp.content.iter_chunked(CHUNK_SIZE):
+                    await async_buffer.write(data)
+                source_file_name = async_buffer.name
+
+            await asyncio.to_thread(
+                convert_to_b64,
+                source=source_file_name,
+            )
+
+            async with aiofiles.open(file=source_file_name, mode="r") as target_file:
+                attachment = (await target_file.read()).strip()
+        except Exception as e:
+            self._logger.error(
+                f"Exception encountered when processing file: {source_file_name}. Exception: {e}"
+            )
+        finally:
+            if source_file_name:
+                await remove(str(source_file_name))
+
+        return attachment
 
     def _auth_headers(self):
         return {"authorization": f"Bearer {self.api_token.token()}"}
@@ -541,6 +658,9 @@ class SalesforceClient:
             join_builder.with_limit(1)
             query_builder.with_join(join_builder.build())
 
+        doc_links_join = await self.content_document_links_join()
+        query_builder.with_join(doc_links_join)
+
         return query_builder.build()
 
     async def _opportunities_query(self):
@@ -558,6 +678,9 @@ class SalesforceClient:
         query_builder.with_fields(queryable_fields)
         # TODO add uncommon_object_remote_fields
         query_builder.with_fields(["Owner.Id", "Owner.Name", "Owner.Email"])
+
+        doc_links_join = await self.content_document_links_join()
+        query_builder.with_join(doc_links_join)
 
         return query_builder.build()
 
@@ -581,6 +704,10 @@ class SalesforceClient:
         query_builder.with_default_metafields()
         query_builder.with_fields(queryable_fields)
         # TODO add uncommon_object_remote_fields
+
+        doc_links_join = await self.content_document_links_join()
+        query_builder.with_join(doc_links_join)
+
         return query_builder.build()
 
     async def _leads_query(self):
@@ -609,6 +736,10 @@ class SalesforceClient:
         query_builder.with_default_metafields()
         query_builder.with_fields(queryable_fields)
         # TODO add uncommon_object_remote_fields
+
+        doc_links_join = await self.content_document_links_join()
+        query_builder.with_join(doc_links_join)
+
         return query_builder.build()
 
     async def _campaigns_query(self):
@@ -631,6 +762,10 @@ class SalesforceClient:
         # TODO add uncommon_object_remote_fields
         query_builder.with_fields(["Owner.Id", "Owner.Name", "Owner.Email"])
         query_builder.with_fields(["Parent.Id", "Parent.Name"])
+
+        doc_links_join = await self.content_document_links_join()
+        query_builder.with_join(doc_links_join)
+
         return query_builder.build()
 
     async def _cases_query(self):
@@ -659,6 +794,10 @@ class SalesforceClient:
         case_comments_join = await self._case_comments_join_query()
         query_builder.with_join(email_mesasges_join)
         query_builder.with_join(case_comments_join)
+
+        doc_links_join = await self.content_document_links_join()
+        query_builder.with_join(doc_links_join)
+
         return query_builder.build()
 
     async def _email_messages_join_query(self):
@@ -754,6 +893,78 @@ class SalesforceClient:
         query_builder.with_limit(500)
         return query_builder.build()
 
+    async def content_document_links_join(self):
+        """Cached async property for getting downloadable attached files
+        This join is identical for all SObject queries"""
+        if self._content_document_links_join is not None:
+            return self._content_document_links_join
+
+        links_queryable = await self._is_queryable("ContentDocumentLink")
+        docs_queryable = await self._is_queryable("ContentDocument")
+        versions_queryable = await self._is_queryable("ContentVersion")
+        if not all([links_queryable, docs_queryable, versions_queryable]):
+            self._logger.warning(
+                "ContentDocuments, ContentVersions, or ContentDocumentLinks were not queryable, so not including in any queries."
+            )
+            self._content_document_links_join = ""
+            return self._content_document_links_join
+
+        queryable_docs_fields = await self._select_queryable_fields(
+            "ContentDocument",
+            [
+                "Title",
+                "FileExtension",
+                "ContentSize",
+                "Description",
+            ],
+        )
+        queryable_version_fields = await self._select_queryable_fields(
+            "ContentVersion",
+            [
+                "VersionDataUrl",
+                "VersionNumber",
+            ],
+        )
+        queryable_docs_fields = [f"ContentDocument.{x}" for x in queryable_docs_fields]
+        queryable_version_fields = [
+            f"ContentDocument.LatestPublishedVersion.{x}"
+            for x in queryable_version_fields
+        ]
+        where_in_clause = ",".join(f"'{x}'" for x in self._supported_file_types)
+
+        query_builder = SalesforceSoqlBuilder("ContentDocumentLinks")
+        query_builder.with_fields(
+            [
+                "ContentDocument.Id",
+                "ContentDocument.LatestPublishedVersion.Id",
+                "ContentDocument.CreatedDate",
+                "ContentDocument.LastModifiedDate",
+                "ContentDocument.LatestPublishedVersion.CreatedDate",
+            ]
+        )
+        query_builder.with_fields(queryable_docs_fields)
+        query_builder.with_fields(queryable_version_fields)
+        query_builder.with_fields(
+            [
+                "ContentDocument.Owner.Id",
+                "ContentDocument.Owner.Name",
+                "ContentDocument.Owner.Email",
+            ]
+        )
+        query_builder.with_fields(
+            [
+                "ContentDocument.CreatedBy.Id",
+                "ContentDocument.CreatedBy.Name",
+                "ContentDocument.CreatedBy.Email",
+            ]
+        )
+        query_builder.with_where(
+            f"ContentDocument.FileExtension IN ({where_in_clause})"
+        )
+
+        self._content_document_links_join = query_builder.build()
+        return self._content_document_links_join
+
 
 class SalesforceAPIToken:
     def __init__(self, session, base_url, client_id, client_secret):
@@ -837,6 +1048,9 @@ class SalesforceSoqlBuilder:
         self.limit = f"LIMIT {limit}"
 
     def with_join(self, join):
+        if not join:
+            return
+
         self.fields.append(f"(\n{join})\n")
 
     def build(self):
@@ -1063,6 +1277,29 @@ class SalesforceDocMapper:
             "url": f"{self.base_url}/{case.get('Id')}",
         }
 
+    def map_content_document(self, content_document, content_version):
+        owner = content_document.get("Owner", {})
+        created_by = content_document.get("CreatedBy", {}) or {}
+
+        return {
+            "_id": content_document.get("Id"),
+            "content_size": content_document.get("ContentSize"),
+            "created_at": content_document.get("CreatedDate"),
+            "created_by": created_by.get("Name"),
+            "created_by_email": created_by.get("Email"),
+            "description": content_document.get("Description"),
+            "file_extension": content_document.get("FileExtension"),
+            "last_updated": content_document.get("LastModifiedDate"),
+            "linked_ids": sorted(content_document.get("linked_ids")),
+            "owner": owner.get("Name"),
+            "owner_email": owner.get("Email"),
+            "title": f"{content_document.get('Title')}.{content_document.get('FileExtension')}",
+            "type": "content_document",
+            "url": f"{self.base_url}/{content_document.get('Id')}",
+            "version_number": content_version.get("VersionNumber"),
+            "version_url": f"{self.base_url}/{content_version.get('Id')}",
+        }
+
     def _format_address(self, address):
         if not address:
             return None
@@ -1219,10 +1456,6 @@ class SalesforceDataSource(BaseDataSource):
         except Exception as e:
             self._logger.exception(f"Error while connecting to Salesforce: {e}")
             raise
-
-    async def get_content(self, attachment, timestamp=None, doit=False):
-        # TODO implement
-        return
 
     async def get_docs(self, filtering=None):
         await self.salesforce_client.get_token()

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -483,6 +483,8 @@ class SalesforceClient:
                 grouped[content_doc_id]["linked_ids"] = [
                     content_doc["linked_sobject_id"]
                 ]
+                # the id is now in the list of linked_ids so we can delete it
+                del grouped[content_doc_id]["linked_sobject_id"]
 
         grouped_objects = list(grouped.values())
         return grouped_objects

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -155,7 +155,6 @@ class SalesforceClient:
         self._queryable_sobjects = None
         self._queryable_sobject_fields = None
         self._sobjects_cache_by_type = None
-        self._supported_file_types = [x[1:] for x in TIKA_SUPPORTED_FILETYPES]
         self._content_document_links_join = None
 
         self.base_url = BASE_URL.replace("<domain>", configuration["domain"])
@@ -932,7 +931,8 @@ class SalesforceClient:
             f"ContentDocument.LatestPublishedVersion.{x}"
             for x in queryable_version_fields
         ]
-        where_in_clause = ",".join(f"'{x}'" for x in self._supported_file_types)
+        [f"'{x[1:]}'" for x in TIKA_SUPPORTED_FILETYPES]
+        where_in_clause = ",".join([f"'{x[1:]}'" for x in TIKA_SUPPORTED_FILETYPES])
 
         query_builder = SalesforceSoqlBuilder("ContentDocumentLinks")
         query_builder.with_fields(

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -10,6 +10,7 @@ from unittest import TestCase, mock
 
 import pytest
 from aiohttp.client_exceptions import ClientConnectionError
+from aioresponses import CallbackResult
 
 from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.salesforce import (
@@ -27,6 +28,8 @@ from tests.sources.support import create_source
 
 TEST_DOMAIN = "fake"
 TEST_BASE_URL = f"https://{TEST_DOMAIN}.my.salesforce.com"
+TEST_FILE_DOWNLOAD_URL = f"https://{TEST_DOMAIN}.file.force.com"
+TEST_QUERY_MATCH_URL = re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*")
 TEST_CLIENT_ID = "1234"
 TEST_CLIENT_SECRET = "9876"
 
@@ -133,7 +136,7 @@ CONTACT_RESPONSE_PAYLOAD = {
     ],
 }
 
-LEAD_PAYLOAD = {
+LEAD_RESPONSE_PAYLOAD = {
     "records": [
         {
             "attributes": {
@@ -161,7 +164,7 @@ LEAD_PAYLOAD = {
     ]
 }
 
-CAMPAIGN_PAYLOAD = {
+CAMPAIGN_RESPONSE_PAYLOAD = {
     "records": [
         {
             "attributes": {
@@ -197,7 +200,7 @@ CAMPAIGN_PAYLOAD = {
     ]
 }
 
-CASE_PAYLOAD = {
+CASE_RESPONSE_PAYLOAD = {
     "records": [
         {
             "attributes": {
@@ -295,7 +298,7 @@ CASE_PAYLOAD = {
     ]
 }
 
-CASE_FEED_PAYLOAD = {
+CASE_FEED_RESPONSE_PAYLOAD = {
     "records": [
         {
             "attributes": {
@@ -349,6 +352,59 @@ CASE_FEED_PAYLOAD = {
     ]
 }
 
+CONTENT_DOCUMENT_LINKS_PAYLOAD = {
+    "records": [
+        {
+            "attributes": {
+                "type": "ContentDocumentLink",
+                "url": "/services/data/v58.0/sobjects/ContentDocumentLink/content_document_link_id",
+            },
+            "Id": "content_document_link_id",
+            "ContentDocument": {
+                "attributes": {
+                    "type": "ContentDocument",
+                    "url": "/services/data/v58.0/sobjects/ContentDocument/content_document_id",
+                },
+                "Id": "content_document_id",
+                "Description": "A file about a ring.",
+                "Title": "the_ring",
+                "ContentSize": 1000,
+                "FileExtension": "txt",
+                "CreatedDate": "",
+                "LatestPublishedVersion": {
+                    "attributes": {
+                        "type": "ContentVersion",
+                        "url": "/services/data/v58.0/sobjects/ContentVersion/content_version_id",
+                    },
+                    "Id": "content_version_id",
+                    "VersionDataUrl": f"{TEST_FILE_DOWNLOAD_URL}/sfc/servlet.shepherd/version/download/download_id",
+                    "CreatedDate": "",
+                    "VersionNumber": "2",
+                },
+                "Owner": {
+                    "attributes": {
+                        "type": "User",
+                        "url": "/services/data/v58.0/sobjects/User/user_id",
+                    },
+                    "Id": "user_id",
+                    "Name": "Frodo",
+                    "Email": "frodo@tlotr.com",
+                },
+                "CreatedBy": {
+                    "attributes": {
+                        "type": "User",
+                        "url": "/services/data/v58.0/sobjects/User/user_id",
+                    },
+                    "Id": "user_id",
+                    "Name": "Frodo",
+                    "Email": "frodo@tlotr.com",
+                },
+                "LastModifiedDate": "",
+            },
+        }
+    ]
+}
+
 CACHED_SOBJECTS = {
     "Account": {"account_id": {"Id": "account_id", "Name": "TLOTR"}},
     "User": {
@@ -364,14 +420,56 @@ CACHED_SOBJECTS = {
 
 
 @asynccontextmanager
-async def create_salesforce_source():
+async def create_salesforce_source(mock_queryables=True):
     async with create_source(
         SalesforceDataSource,
         domain=TEST_DOMAIN,
         client_id=TEST_CLIENT_ID,
         client_secret=TEST_CLIENT_SECRET,
     ) as source:
+        if mock_queryables is True:
+            source.salesforce_client.sobjects_cache_by_type = mock.AsyncMock(
+                return_value=CACHED_SOBJECTS
+            )
+            source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
+            source.salesforce_client._select_queryable_fields = mock.AsyncMock(
+                return_value=RELEVANT_SOBJECT_FIELDS
+            )
+
         yield source
+
+
+def salesforce_query_callback(url, **kwargs):
+    """Dynamically returns a payload based on query
+    and adds ContentDocumentLinks to each payload
+    """
+    payload = {}
+
+    # get table name after last "FROM" in query
+    query = kwargs["params"]["q"]
+    table_name = re.findall(r"\bFROM\s+(\w+)", query)[-1]
+
+    match table_name:
+        case "Account":
+            payload = ACCOUNT_RESPONSE_PAYLOAD.copy()
+        case "Campaign":
+            payload = CAMPAIGN_RESPONSE_PAYLOAD.copy()
+        case "Case":
+            payload = CASE_RESPONSE_PAYLOAD.copy()
+        case "CaseFeed":
+            payload = CASE_FEED_RESPONSE_PAYLOAD.copy()
+        case "Contact":
+            payload = CONTACT_RESPONSE_PAYLOAD.copy()
+        case "Lead":
+            payload = LEAD_RESPONSE_PAYLOAD.copy()
+        case "Opportunity":
+            payload = OPPORTUNITY_RESPONSE_PAYLOAD.copy()
+
+    if table_name != "CaseFeed":
+        for record in payload["records"]:
+            record["ContentDocumentLinks"] = CONTENT_DOCUMENT_LINKS_PAYLOAD
+
+    return CallbackResult(status=200, payload=payload)
 
 
 def generate_account_doc(identifier):
@@ -531,7 +629,7 @@ async def test_generate_token_with_unexpected_error_retries(
     ["FooField", "BarField", "ArghField"],
 )
 async def test_get_queryable_sobjects(mock_responses, sobject, expected_result):
-    async with create_salesforce_source() as source:
+    async with create_salesforce_source(mock_queryables=False) as source:
         response_payload = {
             "sobjects": [
                 {
@@ -562,7 +660,7 @@ async def test_get_queryable_sobjects(mock_responses, sobject, expected_result):
     ["FooField", "BarField", "ArghField"],
 )
 async def test_get_queryable_fields(mock_responses):
-    async with create_salesforce_source() as source:
+    async with create_salesforce_source(mock_queryables=False) as source:
         expected_fields = [
             {
                 "name": "FooField",
@@ -614,25 +712,13 @@ async def test_get_accounts_when_success(mock_responses):
             "website_url": "www.tlotr.com",
         }
 
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock(
-            return_value=[
-                "Name",
-                "Description",
-                "BillingAddress",
-                "Type",
-                "Website",
-                "Rating",
-                "Department",
-            ]
-        )
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=200,
             payload=ACCOUNT_RESPONSE_PAYLOAD,
         )
-        async for account in source.salesforce_client.get_accounts():
-            assert account == expected_doc
+        async for record, _ in source.salesforce_client.get_accounts():
+            assert record == expected_doc
 
 
 @pytest.mark.asyncio
@@ -640,7 +726,7 @@ async def test_get_accounts_when_paginated_yields_all_pages(mock_responses):
     async with create_salesforce_source() as source:
         response_page_1 = {
             "done": False,
-            "nextRecordsUrl": f"{TEST_BASE_URL}/barbar",
+            "nextRecordsUrl": "/barbar",
             "records": [
                 {
                     "Id": 1234,
@@ -656,10 +742,8 @@ async def test_get_accounts_when_paginated_yields_all_pages(mock_responses):
             ],
         }
 
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock()
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=200,
             payload=response_page_1,
         )
@@ -670,22 +754,21 @@ async def test_get_accounts_when_paginated_yields_all_pages(mock_responses):
         )
 
         yielded_account_ids = []
-        async for account in source.salesforce_client.get_accounts():
-            yielded_account_ids.append(account["_id"])
+        async for record, _ in source.salesforce_client.get_accounts():
+            yielded_account_ids.append(record["_id"])
 
         assert sorted(yielded_account_ids) == [1234, 5678]
 
 
 @pytest.mark.asyncio
 async def test_get_accounts_when_invalid_request(patch_sleep, mock_responses):
-    async with create_salesforce_source() as source:
+    async with create_salesforce_source(mock_queryables=False) as source:
         response_payload = [
             {"message": "Unable to process query.", "errorCode": "INVALID_FIELD"}
         ]
 
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=405,
             payload=response_payload,
         )
@@ -699,8 +782,8 @@ async def test_get_accounts_when_invalid_request(patch_sleep, mock_responses):
 async def test_get_accounts_when_not_queryable_yields_nothing(mock_responses):
     async with create_salesforce_source() as source:
         source.salesforce_client._is_queryable = mock.AsyncMock(return_value=False)
-        async for account in source.salesforce_client.get_accounts():
-            assert account is None
+        async for record, _ in source.salesforce_client.get_accounts():
+            assert record is None
 
 
 @pytest.mark.asyncio
@@ -722,21 +805,13 @@ async def test_get_opportunities_when_success(mock_responses):
             "url": f"{TEST_BASE_URL}/opportunity_id",
         }
 
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock(
-            return_value=[
-                "Name",
-                "Description",
-                "StageName",
-            ]
-        )
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=200,
             payload=OPPORTUNITY_RESPONSE_PAYLOAD,
         )
-        async for account in source.salesforce_client.get_opportunities():
-            assert account == expected_doc
+        async for record, _ in source.salesforce_client.get_opportunities():
+            assert record == expected_doc
 
 
 @pytest.mark.asyncio
@@ -762,30 +837,13 @@ async def test_get_contacts_when_success(mock_responses):
             "url": f"{TEST_BASE_URL}/contact_id",
         }
 
-        source.salesforce_client.sobjects_cache_by_type = mock.AsyncMock(
-            return_value=CACHED_SOBJECTS
-        )
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock(
-            return_value=[
-                "Name",
-                "Description",
-                "Email",
-                "Phone",
-                "Title",
-                "PhotoUrl",
-                "LastModifiedDate" "LeadSource",
-                "AccountId",
-                "OwnerId",
-            ]
-        )
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=200,
             payload=CONTACT_RESPONSE_PAYLOAD,
         )
-        async for account in source.salesforce_client.get_contacts():
-            assert account == expected_doc
+        async for record, _ in source.salesforce_client.get_contacts():
+            assert record == expected_doc
 
 
 @pytest.mark.asyncio
@@ -819,36 +877,13 @@ async def test_get_leads_when_success(mock_responses):
             "url": f"{TEST_BASE_URL}/lead_id",
         }
 
-        source.salesforce_client.sobjects_cache_by_type = mock.AsyncMock(
-            return_value=CACHED_SOBJECTS
-        )
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock(
-            return_value=[
-                "Company",
-                "ConvertedAccountId",
-                "ConvertedContactId",
-                "ConvertedDate",
-                "ConvertedOpportunityId",
-                "Description",
-                "Email",
-                "LeadSource",
-                "Name",
-                "OwnerId",
-                "Phone",
-                "PhotoUrl",
-                "Rating",
-                "Status",
-                "Title",
-            ]
-        )
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=200,
-            payload=LEAD_PAYLOAD,
+            payload=LEAD_RESPONSE_PAYLOAD,
         )
-        async for account in source.salesforce_client.get_leads():
-            assert account == expected_doc
+        async for record, _ in source.salesforce_client.get_leads():
+            assert record == expected_doc
 
 
 @pytest.mark.asyncio
@@ -874,32 +909,17 @@ async def test_get_campaigns_when_success(mock_responses):
             "url": f"{TEST_BASE_URL}/campaign_id",
         }
 
-        source.salesforce_client.sobjects_cache_by_type = mock.AsyncMock(
-            return_value=CACHED_SOBJECTS
-        )
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock(
-            return_value=[
-                "Name",
-                "IsActive",
-                "Type",
-                "Description",
-                "Status",
-                "StartDate",
-                "EndDate",
-            ]
-        )
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=200,
-            payload=CAMPAIGN_PAYLOAD,
+            payload=CAMPAIGN_RESPONSE_PAYLOAD,
         )
-        async for account in source.salesforce_client.get_campaigns():
-            assert account == expected_doc
+        async for record, _ in source.salesforce_client.get_campaigns():
+            assert record == expected_doc
 
 
 @pytest.mark.asyncio
-async def test_get_casess_when_success(mock_responses):
+async def test_get_cases_when_success(mock_responses):
     async with create_salesforce_source() as source:
         expected_doc = {
             "_id": "case_id",
@@ -930,25 +950,65 @@ async def test_get_casess_when_success(mock_responses):
             "url": f"{TEST_BASE_URL}/case_id",
         }
 
-        source.salesforce_client.sobjects_cache_by_type = mock.AsyncMock(
-            return_value=CACHED_SOBJECTS
-        )
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock(
-            return_value=RELEVANT_SOBJECT_FIELDS
+        mock_responses.get(
+            TEST_QUERY_MATCH_URL,
+            status=200,
+            payload=CASE_RESPONSE_PAYLOAD,
         )
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=200,
-            payload=CASE_PAYLOAD,
+            payload=CASE_FEED_RESPONSE_PAYLOAD,
+        )
+        async for record, _ in source.salesforce_client.get_cases():
+            assert record == expected_doc
+
+
+@pytest.mark.asyncio
+async def test_get_all_with_content_docs_when_success(mock_responses):
+    async with create_salesforce_source() as source:
+        expected_doc = {
+            "_id": "content_document_id",
+            "content_size": 1000,
+            "created_at": "",
+            "created_by": "Frodo",
+            "created_by_email": "frodo@tlotr.com",
+            "description": "A file about a ring.",
+            "file_extension": "txt",
+            "last_updated": "",
+            "linked_ids": [
+                "account_id",
+                "campaign_id",
+                "case_id",
+                "contact_id",
+                "lead_id",
+                "opportunity_id",
+            ],  # contains every SObject that is connected to this doc
+            "owner": "Frodo",
+            "owner_email": "frodo@tlotr.com",
+            "title": "the_ring.txt",
+            "type": "content_document",
+            "url": f"{TEST_BASE_URL}/content_document_id",
+            "version_number": "2",
+            "version_url": f"{TEST_BASE_URL}/content_version_id",
+            "_attachment": "Y2h1bmsx",  # base64 for "chunk1"
+        }
+
+        mock_responses.get(
+            f"{TEST_FILE_DOWNLOAD_URL}/sfc/servlet.shepherd/version/download/download_id",
+            status=200,
+            body=b"chunk1",
         )
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
-            status=200,
-            payload=CASE_FEED_PAYLOAD,
+            TEST_QUERY_MATCH_URL, repeat=True, callback=salesforce_query_callback
         )
-        async for account in source.salesforce_client.get_cases():
-            assert account == expected_doc
+
+        content_document_records = []
+        async for record in source.salesforce_client.get_docs():
+            if record["type"] == "content_document":
+                content_document_records.append(record)
+
+        TestCase().assertCountEqual(content_document_records, [expected_doc])
 
 
 @pytest.mark.asyncio
@@ -964,9 +1024,8 @@ async def test_prepare_sobject_cache(mock_responses):
             "id_1": {"Id": "id_1", "Name": "Foo", "Type": "Account"},
             "id_2": {"Id": "id_2", "Name": "Bar", "Type": "Account"},
         }
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=200,
             payload=sobjects,
         )
@@ -1013,16 +1072,13 @@ async def test_request_when_token_invalid_refetches_token(patch_sleep, mock_resp
             status=200,
             payload=token_response_payload,
         )
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock()
-
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=401,
             payload=invalid_token_payload,
         )
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=200,
             payload=ACCOUNT_RESPONSE_PAYLOAD,
         )
@@ -1032,8 +1088,8 @@ async def test_request_when_token_invalid_refetches_token(patch_sleep, mock_resp
             "generate",
             wraps=source.salesforce_client.api_token.generate,
         ) as mock_get_token:
-            async for account in source.salesforce_client.get_accounts():
-                assert account == expected_doc
+            async for record, _ in source.salesforce_client.get_accounts():
+                assert record == expected_doc
                 mock_get_token.assert_called_once()
 
 
@@ -1046,8 +1102,6 @@ async def test_request_when_rate_limited_raises_error_no_retries(mock_responses)
                 "errorCode": "REQUEST_LIMIT_EXCEEDED",
             }
         ]
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock()
         mock_responses.get(
             re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
             status=403,
@@ -1078,8 +1132,6 @@ async def test_request_when_invalid_query_raises_error_no_retries(
                 "errorCode": error_code,
             }
         ]
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock()
         mock_responses.get(
             re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
             status=400,
@@ -1096,10 +1148,8 @@ async def test_request_when_generic_400_raises_error_with_retries(
     patch_sleep, mock_responses
 ):
     async with create_salesforce_source() as source:
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock()
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=400,
             repeat=True,
         )
@@ -1114,10 +1164,8 @@ async def test_request_when_generic_500_raises_error_with_retries(
     patch_sleep, mock_responses
 ):
     async with create_salesforce_source() as source:
-        source.salesforce_client._is_queryable = mock.AsyncMock(return_value=True)
-        source.salesforce_client._select_queryable_fields = mock.AsyncMock()
         mock_responses.get(
-            re.compile(f"{TEST_BASE_URL}/services/data/v58.0/query*"),
+            TEST_QUERY_MATCH_URL,
             status=500,
             repeat=True,
         )

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -973,7 +973,9 @@ async def test_get_cases_when_success(mock_responses):
         (404, None, None),
     ],
 )
-async def test_get_all_with_content_docs_when_success(mock_responses, response_status, response_body, expected_attachment):
+async def test_get_all_with_content_docs_when_success(
+    mock_responses, response_status, response_body, expected_attachment
+):
     async with create_salesforce_source() as source:
         expected_doc = {
             "_id": "content_document_id",
@@ -1222,6 +1224,7 @@ async def test_build_soql_query_with_fields():
         "FROM Test\nWHERE FooField = 'FOO'\nORDER BY CreatedDate DESC\nLIMIT 2"
     )
 
+
 @pytest.mark.asyncio
 async def test_combine_duplicate_content_docs_with_duplicates():
     async with create_salesforce_source(mock_queryables=False) as source:
@@ -1234,21 +1237,14 @@ async def test_combine_duplicate_content_docs_with_duplicates():
                 "Id": "content_doc_1",
                 "linked_sobject_id": "case_id",
             },
-            {
-                "Id": "content_doc_2",
-                "linked_sobject_id": "account_id"
-            }
+            {"Id": "content_doc_2", "linked_sobject_id": "account_id"},
         ]
         expected_docs = [
-            {
-                "Id": "content_doc_1",
-                "linked_ids": ["account_id", "case_id"]
-            },
-            {
-                "Id": "content_doc_2",
-                "linked_ids": ["account_id"]
-            }
+            {"Id": "content_doc_1", "linked_ids": ["account_id", "case_id"]},
+            {"Id": "content_doc_2", "linked_ids": ["account_id"]},
         ]
 
-        combined_docs = source.salesforce_client._combine_duplicate_content_docs(content_docs)
+        combined_docs = source.salesforce_client._combine_duplicate_content_docs(
+            content_docs
+        )
         TestCase().assertCountEqual(combined_docs, expected_docs)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5442

Download `ContentDocument` SObjects that have a connection to existing SObjects.

A single `ContentDocument` can be connected to many SObjects through `ContentDocumentLinks`. This means duplicates are common. To prevent downloading or ingesting duplicates, we hold on to all `ContentDocument` ids until ingestion of all other SObjects is complete. We then ensure there are no duplicates among the files to download. 

When mapping the new doc for a `ContentDocument`, we retain a list of related SObject ids in the field `linked_ids`. These SObject ids are also the ids used in Elastic docs. (Happy to change the `linked_ids` field name).

`ContentDocuments` also have multiple `ContentVersions`. We ingest only the latest version through the relation `LatestPublishedVersion`.

All `ContentDocuments` for a SObject are fetched with a join query alongside the original SObjects, rather than in a dedicated `ContentDocument` query. This reduces the number of queries being made.

- [ContentDocument reference docs](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_contentdocument.htm)
- [ContentVersion reference docs](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_contentversion.htm)

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
