### PR TITLE
Change sorting for logs

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -335,7 +335,7 @@ class SyncJob(ESDocument):
         await self.index.update(doc_id=self.id, doc=doc)
 
     def _prefix(self):
-        return f"[Sync Job id: {self.id}, connector id: {self.connector_id}, index name: {self.index_name}]"
+        return f"[Connector id: {self.connector_id}, index name: {self.index_name}, Sync job id: {self.id}]"
 
     def _extra(self):
         return {


### PR DESCRIPTION
Minor thing that I found useful: if several jobs are syncing back-to-back, it's easier to distinguish the logs if connector id is first in list.

It also correspond correlation for connector logs (which is just `f"[Connector id: {self.connector_id}, index name: {self.index_name}"`)