### PR TITLE
Make configs nest correctly

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 import pytest
 
-from connectors.config import _update_config_field, load_config
+from connectors.config import _nest_configs, load_config
 
 HERE = os.path.dirname(__file__)
 FIXTURES_DIR = os.path.abspath(os.path.join(HERE, "fixtures"))
@@ -48,33 +48,33 @@ def test_config_with_invalid_log_level(set_env):
         assert e.match("Unexpected log level.*")
 
 
-def test_update_config_when_nested_field_does_not_exist():
+def test_nest_config_when_nested_field_does_not_exist():
     config = {}
 
-    _update_config_field(config, "test.nested.property", 50)
+    _nest_configs(config, "test.nested.property", 50)
 
     assert config["test"]["nested"]["property"] == 50
 
 
-def test_update_config_when_nested_field_exists():
+def test_nest_config_when_nested_field_exists():
     config = {"test": {"nested": {"property": 25}}}
 
-    _update_config_field(config, "test.nested.property", 50)
+    _nest_configs(config, "test.nested.property", 50)
 
     assert config["test"]["nested"]["property"] == 50
 
 
-def test_update_config_when_root_field_does_not_exist():
+def test_nest_config_when_root_field_does_not_exist():
     config = {}
 
-    _update_config_field(config, "test", 50)
+    _nest_configs(config, "test", 50)
 
     assert config["test"] == 50
 
 
-def test_update_config_when_root_field_does_exists():
+def test_nest_config_when_root_field_does_exists():
     config = {"test": 10}
 
-    _update_config_field(config, "test", 50)
+    _nest_configs(config, "test", 50)
 
     assert config["test"] == 50


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1471

This fixes two bugs.

1. it ensures that inline configs (`elasticsearch.host: some_value`) are correctly nested, like:

```
elasticsearch:
  host:  some_value
```

2.  It ensures that nested configs are not stored twice in the resulting dict - both nested, and flattened (`flatten=False` in EnvYAML)

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

