### PR TITLE
[Google Drive] Handle failures when fetching file ACLs

### DIFF
--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -1110,9 +1110,11 @@ class GoogleDriveDataSource(BaseDataSource):
                 except HTTPError as exception:
                     # Gracefully handle scenario when the service account does not
                     # have permission to fetch ACL for a file.
-                    self._logger.warning(
-                        f"Unable to fetch permission list for the file {file_name}. Exception: {exception}."
-                    )
+                    exception_log_msg = f"Unable to fetch permission list for the file {file_name}. Exception: {exception}."
+                    if exception.res.status_code == 403:
+                        self._logger.warning(exception_log_msg)
+                    else:
+                        self._logger.error(exception_log_msg)
 
             file_document[ACCESS_CONTROL] = self._process_permissions(permissions)
 

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -242,7 +242,10 @@ class GoogleDriveClient(GoogleAPIClient):
             json_credentials=json_credentials,
             api_name="drive",
             api_version="v3",
-            scopes=["https://www.googleapis.com/auth/drive.readonly"],
+            scopes=[
+                "https://www.googleapis.com/auth/drive.readonly",
+                "https://www.googleapis.com/auth/drive.metadata.readonly",
+            ],
         )
 
     async def ping(self):
@@ -1044,13 +1047,13 @@ class GoogleDriveDataSource(BaseDataSource):
             dict: Formatted file metadata.
         """
 
-        file_id = file.get("id")
+        file_id, file_name = file.get("id"), file.get("name")
 
         file_document = {
             "_id": file_id,
             "created_at": file.get("createdTime"),
             "last_updated": file.get("modifiedTime"),
-            "name": file.get("name"),
+            "name": file_name,
             "size": file.get("size") or 0,  # handle folders and shortcuts
             "_timestamp": file.get("modifiedTime"),
             "mime_type": file.get("mimeType"),
@@ -1100,9 +1103,16 @@ class GoogleDriveDataSource(BaseDataSource):
             # Read more: https://developers.google.com/drive/api/guides/shared-drives-diffs
             permissions = file.get("permissions", [])
             if not permissions:
-                permissions = await self._get_permissions_on_shared_drive(
-                    file_id=file_id
-                )
+                try:
+                    permissions = await self._get_permissions_on_shared_drive(
+                        file_id=file_id
+                    )
+                except HTTPError as exception:
+                    # Gracefully handle scenario when the service account does not
+                    # have permission to fetch ACL for a file.
+                    self._logger.warning(
+                        f"Unable to fetch permission list for the file {file_name}. Exception: {exception}."
+                    )
 
             file_document[ACCESS_CONTROL] = self._process_permissions(permissions)
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1473

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

In certain scenarios the `permissions.list` endpoint will result in `403 insufficientFilePermissions` error. 

For example: someone else (e.g. from outside org) shares a file with you, you then go to drive UI to the "shared with me" tab and share this with the SA with view-only access. This chain of permissions is insufficient according to google to fetch ACL for that file. (Surprisingly the editor access allows to fetch that). See full scenario described in: https://github.com/elastic/connectors-python/issues/1474

Before, the whole sync would fail if we failed to fetch permissions even for a single file. In this PR I'm adding a logic to handle this gracefully and log problematic filenames and corresponding exceptions. 

Also, for the sake of completeness I added `https://www.googleapis.com/auth/drive.metadata.readonly` scope to drive client - to achieve parity with scopes used by older Workplace Search connector and this connector. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)


