### PR TITLE
Fix logging when source did not change

### DIFF
--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -115,7 +115,7 @@ class SyncJobRunner:
             )
             self.data_provider.set_logger(self.sync_job.logger)
             if not await self.data_provider.changed():
-                self.sync_job.info("No change in remote source, skipping sync")
+                self.sync_job.log_info("No change in remote source, skipping sync")
                 await self._sync_done(sync_status=JobStatus.COMPLETED)
                 return
 


### PR DESCRIPTION
## Addressing feedback in https://github.com/elastic/connectors-python/pull/1464#discussion_r1301626737

Seems like the PR https://github.com/elastic/connectors-python/pull/1464 introduced a small bug, when attempting to log a line.

This PR fixes it.