### PR TITLE
Fix mongodb tests by removing mocking of _get_socket + patching admin ping call

### DIFF
--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -6,7 +6,7 @@
 import asyncio
 from datetime import datetime
 from unittest import mock
-from unittest.mock import Mock
+from unittest.mock import Mock, AsyncMock
 
 import pytest
 from bson.decimal128 import Decimal128
@@ -131,7 +131,6 @@ def build_resp():
 @mock.patch(
     "pymongo.topology.Topology._select_servers_loop", lambda *x: [mock.MagicMock()]
 )
-@mock.patch("pymongo.mongo_client.MongoClient._get_socket")
 @mock.patch(
     "pymongo.mongo_client.MongoClient._run_operation", lambda *xi, **kw: build_resp()
 )
@@ -157,12 +156,13 @@ async def test_get_docs(*args):
 @mock.patch(
     "pymongo.topology.Topology._select_servers_loop", lambda *x: [mock.MagicMock()]
 )
-@mock.patch("pymongo.mongo_client.MongoClient._get_socket")
 @mock.patch(
     "pymongo.mongo_client.MongoClient._run_operation", lambda *xi, **kw: build_resp()
 )
-@pytest.mark.asyncio
 async def test_ping_when_called_then_does_not_raise(*args):
+    admin_mock = Mock()
+    command_mock = AsyncMock()
+    admin_mock.command = command_mock
     async with create_source(
         MongoDataSource,
         host="mongodb://127.0.0.1:27021",
@@ -172,6 +172,7 @@ async def test_ping_when_called_then_does_not_raise(*args):
         user="foo",
         password="password",
     ) as source:
+        source.client.admin = admin_mock
         await source.ping()
 
 

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -6,7 +6,7 @@
 import asyncio
 from datetime import datetime
 from unittest import mock
-from unittest.mock import Mock, AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from bson.decimal128 import Decimal128


### PR DESCRIPTION
MongoDB connector tests broke with new release of MongoDB client - `motor`C  lib depends on it with `>=4.4,<5` expression.

This PR updates the failing tests to not override `_get_socket` private method that is not defined in the new library version any more.