### PR TITLE
lock pymongo version

### DIFF
--- a/requirements/aarch64.txt
+++ b/requirements/aarch64.txt
@@ -3,6 +3,7 @@
 
 aiomysql==0.0.22
 aioboto3==10.3.0
+pymongo==3.13.0
 motor==2.5.1
 smbprotocol==1.9.0
 pymongo[srv]==3.13.0

--- a/requirements/x86_64.txt
+++ b/requirements/x86_64.txt
@@ -2,6 +2,7 @@
 -r framework.txt
 
 aiomysql==0.1.1
+pymongo==4.5.0
 motor==3.0.0
 aioboto3==10.3.0
 smbprotocol==1.9.0


### PR DESCRIPTION
See https://elastic.slack.com/archives/C01795T48LQ/p1692781505612279

The pymongo lib is pulled in not through our framework requirements.txt, but through the OS Arch requirements. It was pinned already in `arm64.txt`, but was pulled in transitively through `motor` from `arch64.txt` and `x86_64.txt`. Motor does not pin the version of pymongo, which means when installing from scratch, this dep can auto increment. 

At some point, we should look into why we're using different versions of pymongo depending on the architecture, but that's out of scope at the moment, as this PR is about creating stability, not opening a can of worms.

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

CI was breaking and was resolved with https://github.com/elastic/connectors-python/pull/1514. This PR just prevents us from getting in a similar spot in the future.

