### PR TITLE
Fix log message for access control sync after refactoring

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -607,7 +607,6 @@ class Extractor:
         )
 
 
-
 class IndexMissing(Exception):
     pass
 

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -380,12 +380,7 @@ class Extractor:
             async for count, doc in aenumerate(generator):
                 doc, lazy_download, operation = doc
                 if count % self.display_every == 0:
-                    self._logger.info(
-                        "Sync in progress -- "
-                        f"created: {self.total_docs_created} | "
-                        f"updated: {self.total_docs_updated} | "
-                        f"deleted: {self.total_docs_deleted}"
-                    )
+                    self._log_progress()
 
                 doc_id = doc["id"] = doc.pop("_id")
 
@@ -466,12 +461,7 @@ class Extractor:
             async for count, doc in aenumerate(generator):
                 doc, lazy_download, operation = doc
                 if count % self.display_every == 0:
-                    self._logger.info(
-                        "Sync progress -- "
-                        f"created: {self.total_docs_created} | "
-                        f"updated: {self.total_docs_updated} | "
-                        f"deleted: {self.total_docs_deleted}"
-                    )
+                    self._log_progress()
 
                 doc_id = doc["id"] = doc.pop("_id")
 
@@ -551,7 +541,7 @@ class Extractor:
                 doc, _, _ = doc
                 count += 1
                 if count % self.display_every == 0:
-                    self._logger.info(str(self))
+                    self._log_progress()
 
                 doc_id = doc["id"] = doc.pop("_id")
                 doc_exists = doc_id in existing_ids
@@ -607,6 +597,15 @@ class Extractor:
                 }
             )
             self.total_docs_deleted += 1
+
+    def _log_progress(self):
+        self._logger.info(
+            "Sync progress -- "
+            f"created: {self.total_docs_created} | "
+            f"updated: {self.total_docs_updated} | "
+            f"deleted: {self.total_docs_deleted}"
+        )
+
 
 
 class IndexMissing(Exception):


### PR DESCRIPTION
Minor fix for broken log messages for access sync.

Previous refactoring changed the format of progress log messages, but access control syncs were affected.

Before the fix the message does not contain access control sync stats:
![image](https://github.com/elastic/connectors-python/assets/12238374/91bfc24e-029a-47a5-b7e7-a52da2005344)

With this fix, access control syncs will use same format for logging as other syncs, for example:

```
[FMWK][11:19:59][INFO] [Connector id: 0GvSJooBdGhCfc5tqbUT, index name: search-spo, Sync job id: 02vVJooBdGhCfc5tYbWR] Sync progress -- created: 700 | updated: 0 | deleted: 0
[FMWK][11:20:06][INFO] [Connector id: 0GvSJooBdGhCfc5tqbUT, index name: search-spo, Sync job id: 02vVJooBdGhCfc5tYbWR] Sync progress -- created: 800 | updated: 0 | deleted: 0
[FMWK][11:20:12][INFO] [Connector id: 0GvSJooBdGhCfc5tqbUT, index name: search-spo, Sync job id: 02vVJooBdGhCfc5tYbWR] Sync progress -- created: 900 | updated: 0 | deleted: 0
```