### PR TITLE
[GMail/GDrive] Make validate_service_account_json a common method

### DIFF
--- a/connectors/sources/gmail.py
+++ b/connectors/sources/gmail.py
@@ -14,12 +14,13 @@ from connectors.filtering.validation import (
     AdvancedRulesValidator,
     SyncRuleValidationResult,
 )
-from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.source import BaseDataSource
 from connectors.sources.google import (
     GMailClient,
     GoogleDirectoryClient,
     MessageFields,
     UserFields,
+    validate_service_account_json,
 )
 from connectors.utils import base64url_to_base64, iso_utc
 
@@ -158,13 +159,9 @@ class GMailDataSource(BaseDataSource):
             Exception: The format of service account json is invalid.
         """
         await super().validate_config()
-
-        try:
-            json.loads(self.configuration["service_account_credentials"])
-        except ValueError as e:
-            raise ConfigurableFieldValueError(
-                f"Google Drive service account is not a valid JSON. Exception: {e}"
-            ) from e
+        validate_service_account_json(
+            self.configuration["service_account_credentials"], "GMail"
+        )
 
     def advanced_rules_validators(self):
         return [GMailAdvancedRulesValidator()]

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -23,12 +23,15 @@ from connectors.access_control import (
 )
 from connectors.logger import logger
 from connectors.source import BaseDataSource, ConfigurableFieldValueError
+from connectors.sources.google import validate_service_account_json
 from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     RetryStrategy,
     convert_to_b64,
     retryable,
 )
+
+GOOGLE_DRIVE_SERVICE_NAME = "Google Drive"
 
 RETRIES = 3
 RETRY_INTERVAL = 2
@@ -42,13 +45,6 @@ FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 
 DRIVE_ITEMS_FIELDS = "id,createdTime,driveId,modifiedTime,name,size,mimeType,fileExtension,webViewLink,owners,parents"
 DRIVE_ITEMS_FIELDS_WITH_PERMISSIONS = f"{DRIVE_ITEMS_FIELDS},permissions"
-
-# Google Service Account JSON includes "universe_domain" key. That argument is not
-# supported in aiogoogle library in version 5.3.0. The "universe_domain" key is allowed in
-# service account JSON but will be dropped before being passed to aiogoogle.auth.creds.ServiceAccountCreds.
-SERVICE_ACCOUNT_JSON_ALLOWED_KEYS = set(dict(ServiceAccountCreds()).keys()) | {
-    "universe_domain"
-}
 
 # Export Google Workspace documents to TIKA compatible format, prefer 'text/plain' where possible to be
 # mindful of the content extraction service resources
@@ -528,9 +524,13 @@ class GoogleDriveDataSource(BaseDataSource):
         Returns:
             GoogleDriveClient: An instance of the GoogleDriveClient.
         """
-        self._validate_service_account_json()
+        service_account_credentials = self.configuration["service_account_credentials"]
 
-        json_credentials = json.loads(self.configuration["service_account_credentials"])
+        validate_service_account_json(
+            service_account_credentials, GOOGLE_DRIVE_SERVICE_NAME
+        )
+
+        json_credentials = json.loads(service_account_credentials)
 
         return GoogleDriveClient(json_credentials=json_credentials)
 
@@ -541,11 +541,15 @@ class GoogleDriveDataSource(BaseDataSource):
         Returns:
             GoogleAdminDirectoryClient: An instance of the GoogleAdminDirectoryClient.
         """
-        self._validate_service_account_json()
+        service_account_credentials = self.configuration["service_account_credentials"]
+
+        validate_service_account_json(
+            service_account_credentials, "Google Admin Directory"
+        )
 
         self._validate_google_workspace_admin_email()
 
-        json_credentials = json.loads(self.configuration["service_account_credentials"])
+        json_credentials = json.loads(service_account_credentials)
 
         return GoogleAdminDirectoryClient(
             json_credentials=json_credentials,
@@ -560,31 +564,10 @@ class GoogleDriveDataSource(BaseDataSource):
         """
         await super().validate_config()
 
-        self._validate_service_account_json()
+        validate_service_account_json(
+            self.configuration["service_account_credentials"], GOOGLE_DRIVE_SERVICE_NAME
+        )
         self._validate_google_workspace_admin_email()
-
-    def _validate_service_account_json(self):
-        """Validates whether service account JSON is a valid JSON string and
-        checks for unexpected keys.
-
-        Raises:
-            ConfigurableFieldValueError: The service account json is ininvalid.
-        """
-
-        try:
-            json_credentials = json.loads(
-                self.configuration["service_account_credentials"]
-            )
-        except ValueError as e:
-            raise ConfigurableFieldValueError(
-                f"Google Drive service account is not a valid JSON. Exception: {e}"
-            ) from e
-
-        for key in json_credentials.keys():
-            if key not in SERVICE_ACCOUNT_JSON_ALLOWED_KEYS:
-                raise ConfigurableFieldValueError(
-                    f"Google Drive service account JSON contains an unexpected key: '{key}'. Allowed keys are: {SERVICE_ACCOUNT_JSON_ALLOWED_KEYS}"
-                )
 
     def _validate_google_workspace_admin_email(self):
         """

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,22 +331,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -331,6 +331,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/sources/test_gmail.py
+++ b/tests/sources/test_gmail.py
@@ -178,7 +178,7 @@ class TestGMailDataSource:
 
     @pytest.mark.asyncio
     async def test_validate_config_valid(self):
-        valid_json = '{"key": "value"}'
+        valid_json = '{"project_id": "dummy123"}'
 
         async with setup_source() as source:
             source.configuration.set_field(

--- a/tests/sources/test_google.py
+++ b/tests/sources/test_google.py
@@ -8,11 +8,13 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 import pytest_asyncio
 
+from connectors.source import ConfigurableFieldValueError
 from connectors.sources.google import (
     GMailClient,
     GoogleDirectoryClient,
     GoogleServiceAccountClient,
     remove_universe_domain,
+    validate_service_account_json,
 )
 from tests.commons import AsyncIterator
 
@@ -45,6 +47,26 @@ def test_remove_universe_domain():
     remove_universe_domain(json_credentials)
 
     assert universe_domain not in json_credentials
+
+
+def test_validate_service_account_json_when_valid():
+    valid_service_account_credentials = '{"project_id": "dummy123"}'
+
+    try:
+        validate_service_account_json(
+            valid_service_account_credentials, "some google service"
+        )
+    except ConfigurableFieldValueError:
+        raise AssertionError("Should've been a valid config") from None
+
+
+def test_validate_service_account_json_when_invalid():
+    invalid_service_account_credentials = '{"invalid_key": "dummy123"}'
+
+    with pytest.raises(ConfigurableFieldValueError):
+        validate_service_account_json(
+            invalid_service_account_credentials, "some google service"
+        )
 
 
 class TestGoogleServiceAccountClient:


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/5593


This PR moves the method `validate_service_account_json` from `google_drive.py` to the `google.py` module and also makes usage of it in `gmail.py` to avoid code duplication.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)