### PR TITLE
Remove value field from connector default RCFs (batch 2)

### DIFF
--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -69,19 +69,16 @@ class AzureBlobStorageDataSource(BaseDataSource):
                 "label": "Azure Blob Storage account name",
                 "order": 1,
                 "type": "str",
-                "value": "devstoreaccount1",
             },
             "account_key": {
                 "label": "Azure Blob Storage account key",
                 "order": 2,
                 "type": "str",
-                "value": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
             },
             "blob_endpoint": {
                 "label": "Azure Blob Storage blob endpoint",
                 "order": 3,
                 "type": "str",
-                "value": "http://127.0.0.1:10000/devstoreaccount1",
             },
             "retry_count": {
                 "default_value": DEFAULT_RETRY_COUNT,
@@ -91,7 +88,6 @@ class AzureBlobStorageDataSource(BaseDataSource):
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": DEFAULT_RETRY_COUNT,
             },
             "concurrent_downloads": {
                 "default_value": MAX_CONCURRENT_DOWNLOADS,
@@ -104,7 +100,6 @@ class AzureBlobStorageDataSource(BaseDataSource):
                 "validations": [
                     {"type": "less_than", "constraint": MAX_CONCURRENT_DOWNLOADS + 1}
                 ],
-                "value": MAX_CONCURRENT_DOWNLOADS,
             },
         }
 

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -242,6 +242,7 @@ class ConfluenceDataSource(BaseDataSource):
                 ],
                 "order": 1,
                 "type": "str",
+                "value": CONFLUENCE_SERVER,
             },
             "username": {
                 "depends_on": [{"field": "data_source", "value": CONFLUENCE_SERVER}],

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -242,14 +242,12 @@ class ConfluenceDataSource(BaseDataSource):
                 ],
                 "order": 1,
                 "type": "str",
-                "value": CONFLUENCE_SERVER,
             },
             "username": {
                 "depends_on": [{"field": "data_source", "value": CONFLUENCE_SERVER}],
                 "label": "Confluence Server username",
                 "order": 2,
                 "type": "str",
-                "value": "admin",
             },
             "password": {
                 "depends_on": [{"field": "data_source", "value": CONFLUENCE_SERVER}],
@@ -257,14 +255,12 @@ class ConfluenceDataSource(BaseDataSource):
                 "sensitive": True,
                 "order": 3,
                 "type": "str",
-                "value": "abc@123",
             },
             "account_email": {
                 "depends_on": [{"field": "data_source", "value": CONFLUENCE_CLOUD}],
                 "label": "Confluence Cloud account email",
                 "order": 4,
                 "type": "str",
-                "value": "me@example.com",
             },
             "api_token": {
                 "depends_on": [{"field": "data_source", "value": CONFLUENCE_CLOUD}],
@@ -272,13 +268,11 @@ class ConfluenceDataSource(BaseDataSource):
                 "sensitive": True,
                 "order": 5,
                 "type": "str",
-                "value": "abc#123",
             },
             "confluence_url": {
                 "label": "Confluence URL",
                 "order": 6,
                 "type": "str",
-                "value": "http://127.0.0.1:9696",
             },
             "spaces": {
                 "display": "textarea",
@@ -286,21 +280,18 @@ class ConfluenceDataSource(BaseDataSource):
                 "order": 7,
                 "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
                 "type": "list",
-                "value": WILDCARD,
             },
             "ssl_enabled": {
                 "display": "toggle",
                 "label": "Enable SSL",
                 "order": 8,
                 "type": "bool",
-                "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],
                 "label": "SSL certificate",
                 "order": 9,
                 "type": "str",
-                "value": "",
             },
             "retry_count": {
                 "default_value": 3,
@@ -310,7 +301,6 @@ class ConfluenceDataSource(BaseDataSource):
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": 3,
             },
             "concurrent_downloads": {
                 "default_value": MAX_CONCURRENT_DOWNLOADS,
@@ -323,7 +313,6 @@ class ConfluenceDataSource(BaseDataSource):
                 "validations": [
                     {"type": "less_than", "constraint": MAX_CONCURRENT_DOWNLOADS + 1}
                 ],
-                "value": MAX_CONCURRENT_DOWNLOADS,
             },
             "use_document_level_security": {
                 "depends_on": [{"field": "data_source", "value": CONFLUENCE_CLOUD}],
@@ -332,7 +321,6 @@ class ConfluenceDataSource(BaseDataSource):
                 "order": 12,
                 "tooltip": "Document level security ensures identities and permissions set in confluence are maintained in Elasticsearch. This enables you to restrict and personalize read-access users have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
-                "value": False,
             },
         }
 

--- a/connectors/sources/dropbox.py
+++ b/connectors/sources/dropbox.py
@@ -552,28 +552,24 @@ class DropboxDataSource(BaseDataSource):
                 "required": False,
                 "tooltip": "Path is ignored when Advanced Sync Rules are used.",
                 "type": "str",
-                "value": "/",
             },
             "app_key": {
                 "label": "App Key",
                 "sensitive": True,
                 "order": 2,
                 "type": "str",
-                "value": "",
             },
             "app_secret": {
                 "label": "App secret",
                 "sensitive": True,
                 "order": 3,
                 "type": "str",
-                "value": "abc#123",
             },
             "refresh_token": {
                 "label": "Refresh token",
                 "sensitive": True,
                 "order": 4,
                 "type": "str",
-                "value": "",
             },
             "retry_count": {
                 "default_value": RETRY_COUNT,
@@ -583,7 +579,6 @@ class DropboxDataSource(BaseDataSource):
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": RETRY_COUNT,
             },
             "concurrent_downloads": {
                 "default_value": MAX_CONCURRENT_DOWNLOADS,
@@ -593,7 +588,6 @@ class DropboxDataSource(BaseDataSource):
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": MAX_CONCURRENT_DOWNLOADS,
             },
         }
 

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -883,14 +883,12 @@ class GitHubDataSource(BaseDataSource):
                 "label": "GitHub URL",
                 "order": 2,
                 "type": "str",
-                "value": "http://127.0.0.1:9091",
             },
             "token": {
                 "label": "GitHub Token",
                 "order": 3,
                 "sensitive": True,
                 "type": "str",
-                "value": "changeme",
             },
             "repositories": {
                 "display": "textarea",
@@ -898,21 +896,18 @@ class GitHubDataSource(BaseDataSource):
                 "order": 4,
                 "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
                 "type": "list",
-                "value": WILDCARD,
             },
             "ssl_enabled": {
                 "display": "toggle",
                 "label": "Enable SSL",
                 "order": 5,
                 "type": "bool",
-                "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],
                 "label": "SSL certificate",
                 "order": 6,
                 "type": "str",
-                "value": "",
             },
             "retry_count": {
                 "display_value": RETRIES,
@@ -923,7 +918,6 @@ class GitHubDataSource(BaseDataSource):
                 "type": "int",
                 "ui_restrictions": ["advanced"],
                 "value": RETRIES,
-                "validations": [{"type": "less_than", "constraint": 10}],
             },
         }
 

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -129,33 +129,28 @@ class NASDataSource(BaseDataSource):
                 "label": "Username",
                 "order": 1,
                 "type": "str",
-                "value": "admin",
             },
             "password": {
                 "label": "Password",
                 "order": 2,
                 "sensitive": True,
                 "type": "str",
-                "value": "abc@123",
             },
             "server_ip": {
                 "label": "SMB IP",
                 "order": 3,
                 "type": "str",
-                "value": "127.0.0.1",
             },
             "server_port": {
                 "display": "numeric",
                 "label": "SMB port",
                 "order": 4,
                 "type": "int",
-                "value": 445,
             },
             "drive_path": {
                 "label": "SMB path",
                 "order": 5,
                 "type": "str",
-                "value": "Folder1",
             },
         }
 

--- a/connectors/sources/servicenow.py
+++ b/connectors/sources/servicenow.py
@@ -502,20 +502,17 @@ class ServiceNowDataSource(BaseDataSource):
                 "label": "Service URL",
                 "order": 1,
                 "type": "str",
-                "value": "http://127.0.0.1:9318",
             },
             "username": {
                 "label": "Username",
                 "order": 2,
                 "type": "str",
-                "value": "",
             },
             "password": {
                 "label": "Password",
                 "order": 3,
                 "sensitive": True,
                 "type": "str",
-                "value": "",
             },
             "services": {
                 "display": "textarea",
@@ -523,7 +520,6 @@ class ServiceNowDataSource(BaseDataSource):
                 "order": 4,
                 "tooltip": "List of services is ignored when Advanced Sync Rules are used.",
                 "type": "list",
-                "value": "*",
             },
             "retry_count": {
                 "default_value": RETRIES,
@@ -533,7 +529,6 @@ class ServiceNowDataSource(BaseDataSource):
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": RETRIES,
             },
             "concurrent_downloads": {
                 "default_value": MAX_CONCURRENT_CLIENT_SUPPORT,
@@ -543,7 +538,6 @@ class ServiceNowDataSource(BaseDataSource):
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": MAX_CONCURRENT_CLIENT_SUPPORT,
             },
         }
 

--- a/tests/sources/fixtures/azure_blob_storage/connector.json
+++ b/tests/sources/fixtures/azure_blob_storage/connector.json
@@ -1,0 +1,120 @@
+{
+        "name": "azure_blob_storage",
+        "index_name": "search-azure_blob_storage",
+        "service_type": "azure_blob_storage",
+        "sync_cursor": null,
+        "is_native": false,
+        "api_key_id": null,
+        "status": "configured",
+        "language": "en",
+        "last_access_control_sync_error": null,
+        "last_access_control_sync_status": null,
+        "last_sync_status": "canceled",
+        "last_sync_error": null,
+        "last_synced": null,
+        "last_seen": null,
+        "created_at": null,
+        "updated_at": null,
+        "configuration": {
+                "account_name": {
+                        "label": "Azure Blob Storage account name",
+                        "order": 1,
+                        "type": "str",
+                        "value": "devstoreaccount1"
+                },
+                "account_key": {
+                        "label": "Azure Blob Storage account key",
+                        "order": 2,
+                        "type": "str",
+                        "value": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+                },
+                "blob_endpoint": {
+                        "label": "Azure Blob Storage blob endpoint",
+                        "order": 3,
+                        "type": "str",
+                        "value": "http://127.0.0.1:10000/devstoreaccount1"
+                },
+                "retry_count": {
+                        "default_value": 3,
+                        "display": "numeric",
+                        "label": "Retries per request",
+                        "order": 4,
+                        "required": false,
+                        "type": "int",
+                        "ui_restrictions": ["advanced"],
+                        "value": null
+                },
+                "concurrent_downloads": {
+                        "default_value": 100,
+                        "display": "numeric",
+                        "label": "Maximum concurrent downloads",
+                        "order": 5,
+                        "required": false,
+                        "type": "int",
+                        "ui_restrictions": ["advanced"],
+                        "validations": [
+                                {"type": "less_than", "constraint": 101}
+                        ],
+                        "value": null
+                }
+        },
+        "filtering": [
+                {
+                        "domain": "DEFAULT",
+                        "draft": {
+                            "advanced_snippet": {
+                                "updated_at": "2023-01-31T16:41:27.341Z",
+                                "created_at": "2023-01-31T16:38:49.244Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
+                            }
+                        },
+                        "active": {
+                            "advanced_snippet": {
+                                "updated_at": "2023-01-31T16:41:27.341Z",
+                                "created_at": "2023-01-31T16:38:49.244Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
+                            }
+                        }
+                }
+
+        ],
+        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
+        "pipeline": {
+                "extract_binary_content": true,
+                "name": "ent-search-generic-ingestion",
+                "reduce_whitespace": true,
+                "run_ml_inference": true
+        }
+}

--- a/tests/sources/fixtures/confluence/connector.json
+++ b/tests/sources/fixtures/confluence/connector.json
@@ -1,0 +1,180 @@
+{
+        "name": "confluence",
+        "index_name": "search-confluence",
+        "service_type": "confluence",
+        "sync_cursor": null,
+        "is_native": false,
+        "api_key_id": null,
+        "status": "configured",
+        "language": "en",
+        "last_access_control_sync_error": null,
+        "last_access_control_sync_status": null,
+        "last_sync_status": "canceled",
+        "last_sync_error": null,
+        "last_synced": null,
+        "last_seen": null,
+        "created_at": null,
+        "updated_at": null,
+        "configuration": {
+                "data_source": {
+                        "display": "dropdown",
+                        "label": "Confluence data source",
+                        "options": [
+                                {"label": "Confluence Cloud", "value": "confluence_cloud"},
+                                {"label": "Confluence Server", "value": "confluence_server"}
+                        ],
+                        "order": 1,
+                        "type": "str",
+                        "value": "confluence_server"
+                },
+                "username": {
+                        "depends_on": [{"field": "data_source", "value": "confluence_server"}],
+                        "label": "Confluence Server username",
+                        "order": 2,
+                        "type": "str",
+                        "value": "admin"
+                },
+                "password": {
+                        "depends_on": [{"field": "data_source", "value": "confluence_server"}],
+                        "label": "Confluence Server password",
+                        "sensitive": true,
+                        "order": 3,
+                        "type": "str",
+                        "value": "abc@123"
+                },
+                "account_email": {
+                        "depends_on": [{"field": "data_source", "value": "confluence_cloud"}],
+                        "label": "Confluence Cloud account email",
+                        "order": 4,
+                        "type": "str",
+                        "value": "me@example.com"
+                },
+                "api_token": {
+                        "depends_on": [{"field": "data_source", "value": "confluence_cloud"}],
+                        "label": "Confluence Cloud API token",
+                        "sensitive": true,
+                        "order": 5,
+                        "type": "str",
+                        "value": "abc#123"
+                },
+                "confluence_url": {
+                        "label": "Confluence URL",
+                        "order": 6,
+                        "type": "str",
+                        "value": "http://127.0.0.1:9696"
+                },
+                "spaces": {
+                        "display": "textarea",
+                        "label": "Confluence space keys",
+                        "order": 7,
+                        "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
+                        "type": "list",
+                        "value": "*"
+                },
+                "ssl_enabled": {
+                        "display": "toggle",
+                        "label": "Enable SSL",
+                        "order": 8,
+                        "type": "bool",
+                        "value": false
+                },
+                "ssl_ca": {
+                        "depends_on": [{"field": "ssl_enabled", "value": true}],
+                        "label": "SSL certificate",
+                        "order": 9,
+                        "type": "str",
+                        "value": ""
+                },
+                "retry_count": {
+                        "default_value": 3,
+                        "display": "numeric",
+                        "label": "Retries per request",
+                        "order": 10,
+                        "required": false,
+                        "type": "int",
+                        "ui_restrictions": ["advanced"],
+                        "value": 3
+                },
+                "concurrent_downloads": {
+                        "default_value": 50,
+                        "display": "numeric",
+                        "label": "Maximum concurrent downloads",
+                        "order": 11,
+                        "required": false,
+                        "type": "int",
+                        "ui_restrictions": ["advanced"],
+                        "validations": [
+                                {"type": "less_than", "constraint": 51}
+                        ],
+                        "value": 50
+                },
+                "use_document_level_security": {
+                        "depends_on": [{"field": "data_source", "value": "confluence_cloud"}],
+                        "display": "toggle",
+                        "label": "Enable document level security",
+                        "order": 12,
+                        "tooltip": "Document level security ensures identities and permissions set in confluence are maintained in Elasticsearch. This enables you to restrict and personalize read-access users have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
+                        "type": "bool",
+                        "value": false
+                }
+        },
+        "filtering": [
+                {
+                        "domain": "DEFAULT",
+                        "draft": {
+                            "advanced_snippet": {
+                                "updated_at": "2023-01-31T16:41:27.341Z",
+                                "created_at": "2023-01-31T16:38:49.244Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
+                            }
+                        },
+                        "active": {
+                            "advanced_snippet": {
+                                "updated_at": "2023-01-31T16:41:27.341Z",
+                                "created_at": "2023-01-31T16:38:49.244Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
+                            }
+                        }
+                }
+
+        ],
+        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
+        "pipeline": {
+                "extract_binary_content": true,
+                "name": "ent-search-generic-ingestion",
+                "reduce_whitespace": true,
+                "run_ml_inference": true
+        }
+}

--- a/tests/sources/fixtures/github/connector.json
+++ b/tests/sources/fixtures/github/connector.json
@@ -1,85 +1,137 @@
 {
-    "name": "github",
-    "service_type": "github",
-    "index_name": "search-github",
-    "sync_cursor": null,
-    "is_native": false,
-    "api_key_id": null,
-    "status": "configured",
-    "language": "en",
-    "last_access_control_sync_error": null,
-    "last_access_control_sync_status": null,
-    "last_sync_status": null,
-    "last_sync_error": null,
-    "last_synced": null,
-    "last_seen": null,
-    "created_at": null,
-    "updated_at": null,
-    "configuration": {
-        "data_source": {
-            "display": "dropdown",
-            "label": "GitHub data source",
-            "options": [
-                {"label": "GitHub Cloud", "value": "github_cloud"},
-                {"label": "GitHub Server", "value": "github_server"}
-            ],
-            "order": 1,
-            "type": "str",
-            "value": "github_server"
+        "name": "github",
+        "index_name": "search-github",
+        "service_type": "github",
+        "sync_cursor": null,
+        "is_native": false,
+        "api_key_id": null,
+        "status": "configured",
+        "language": "en",
+        "last_access_control_sync_error": null,
+        "last_access_control_sync_status": null,
+        "last_sync_status": "canceled",
+        "last_sync_error": null,
+        "last_synced": null,
+        "last_seen": null,
+        "created_at": null,
+        "updated_at": null,
+        "configuration": {
+                "data_source": {
+                        "display": "dropdown",
+                        "label": "GitHub data source",
+                        "options": [
+                                {"label": "GitHub Cloud", "value": "github_cloud"},
+                                {"label": "GitHub Server", "value": "github_server"}
+                        ],
+                        "order": 1,
+                        "type": "str",
+                        "value": "github_server"
+                },
+                "host": {
+                        "depends_on": [{"field": "data_source", "value": "github_server"}],
+                        "label": "GitHub URL",
+                        "order": 2,
+                        "type": "str",
+                        "value": "http://127.0.0.1:9091"
+                },
+                "token": {
+                        "label": "GitHub Token",
+                        "order": 3,
+                        "sensitive": true,
+                        "type": "str",
+                        "value": "changeme"
+                },
+                "repositories": {
+                        "display": "textarea",
+                        "label": "List of repositories",
+                        "order": 4,
+                        "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
+                        "type": "list",
+                        "value": "*"
+                },
+                "ssl_enabled": {
+                        "display": "toggle",
+                        "label": "Enable SSL",
+                        "order": 5,
+                        "type": "bool",
+                        "value": false
+                },
+                "ssl_ca": {
+                        "depends_on": [{"field": "ssl_enabled", "value": true}],
+                        "label": "SSL certificate",
+                        "order": 6,
+                        "type": "str",
+                        "value": ""
+                },
+                "retry_count": {
+                        "display_value": 3,
+                        "display": "numeric",
+                        "label": "Maximum retries per request",
+                        "order": 7,
+                        "required": false,
+                        "type": "int",
+                        "ui_restrictions": ["advanced"],
+                        "value": 3,
+                        "validations": [{"type": "less_than", "constraint": 10}]
+                }
         },
-        "host": {
-            "depends_on": [{"field": "data_source", "value": "github_server"}],
-            "label": "GitHub URL",
-            "order": 2,
-            "type": "str",
-            "value": "http://127.0.0.1:9091"
-        },
-        "token": {
-            "label": "GitHub Token",
-            "order": 3,
-            "sensitive": true,
-            "type": "str",
-            "value": "changeme"
-        },
-        "repositories": {
-            "display": "textarea",
-            "label": "List of repositories",
-            "order": 4,
-            "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
-            "type": "list",
-            "value": "*"
-        },
-        "ssl_enabled": {
-            "display": "toggle",
-            "label": "Enable SSL",
-            "order": 5,
-            "type": "bool",
-            "value": false
-        },
-        "ssl_ca": {
-            "depends_on": [{"field": "ssl_enabled", "value": true}],
-            "label": "SSL certificate",
-            "order": 6,
-            "type": "str",
-            "value": ""
-        },
-        "retry_count": {
-            "display_value": 3,
-            "display": "numeric",
-            "label": "Maximum retries per request",
-            "order": 7,
-            "required": false,
-            "type": "int",
-            "ui_restrictions": ["advanced"],
-            "value": 3,
-            "validations": [{"type": "less_than", "constraint": 10}]
+        "filtering": [
+                {
+                        "domain": "DEFAULT",
+                        "draft": {
+                            "advanced_snippet": {
+                                "updated_at": "2023-01-31T16:41:27.341Z",
+                                "created_at": "2023-01-31T16:38:49.244Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
+                            }
+                        },
+                        "active": {
+                            "advanced_snippet": {
+                                "updated_at": "2023-01-31T16:41:27.341Z",
+                                "created_at": "2023-01-31T16:38:49.244Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
+                            }
+                        }
+                }
+
+        ],
+        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
+        "pipeline": {
+                "extract_binary_content": true,
+                "name": "ent-search-generic-ingestion",
+                "reduce_whitespace": true,
+                "run_ml_inference": true
         }
-    },
-    "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-    "pipeline": {
-        "extract_binary_content": true,
-        "name": "ent-search-generic-ingestion",
-        "reduce_whitespace": true,
-        "run_ml_inference": true
-    }
 }

--- a/tests/sources/fixtures/github/connector.json
+++ b/tests/sources/fixtures/github/connector.json
@@ -1,0 +1,85 @@
+{
+    "name": "github",
+    "service_type": "github",
+    "index_name": "search-github",
+    "sync_cursor": null,
+    "is_native": false,
+    "api_key_id": null,
+    "status": "configured",
+    "language": "en",
+    "last_access_control_sync_error": null,
+    "last_access_control_sync_status": null,
+    "last_sync_status": null,
+    "last_sync_error": null,
+    "last_synced": null,
+    "last_seen": null,
+    "created_at": null,
+    "updated_at": null,
+    "configuration": {
+        "data_source": {
+            "display": "dropdown",
+            "label": "GitHub data source",
+            "options": [
+                {"label": "GitHub Cloud", "value": "github_cloud"},
+                {"label": "GitHub Server", "value": "github_server"}
+            ],
+            "order": 1,
+            "type": "str",
+            "value": "github_server"
+        },
+        "host": {
+            "depends_on": [{"field": "data_source", "value": "github_server"}],
+            "label": "GitHub URL",
+            "order": 2,
+            "type": "str",
+            "value": "http://127.0.0.1:9091"
+        },
+        "token": {
+            "label": "GitHub Token",
+            "order": 3,
+            "sensitive": true,
+            "type": "str",
+            "value": "changeme"
+        },
+        "repositories": {
+            "display": "textarea",
+            "label": "List of repositories",
+            "order": 4,
+            "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
+            "type": "list",
+            "value": "*"
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "Enable SSL",
+            "order": 5,
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [{"field": "ssl_enabled", "value": true}],
+            "label": "SSL certificate",
+            "order": 6,
+            "type": "str",
+            "value": ""
+        },
+        "retry_count": {
+            "display_value": 3,
+            "display": "numeric",
+            "label": "Maximum retries per request",
+            "order": 7,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": ["advanced"],
+            "value": 3,
+            "validations": [{"type": "less_than", "constraint": 10}]
+        }
+    },
+    "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
+    "pipeline": {
+        "extract_binary_content": true,
+        "name": "ent-search-generic-ingestion",
+        "reduce_whitespace": true,
+        "run_ml_inference": true
+    }
+}

--- a/tests/sources/fixtures/network_drive/connector.json
+++ b/tests/sources/fixtures/network_drive/connector.json
@@ -1,0 +1,111 @@
+{
+        "name": "network_drive",
+        "index_name": "search-network_drive",
+        "service_type": "network_drive",
+        "sync_cursor": null,
+        "is_native": false,
+        "api_key_id": null,
+        "status": "configured",
+        "language": "en",
+        "last_access_control_sync_error": null,
+        "last_access_control_sync_status": null,
+        "last_sync_status": "canceled",
+        "last_sync_error": null,
+        "last_synced": null,
+        "last_seen": null,
+        "created_at": null,
+        "updated_at": null,
+        "configuration": {
+                "username": {
+                        "label": "Username",
+                        "order": 1,
+                        "type": "str",
+                        "value": "admin"
+                },
+                "password": {
+                        "label": "Password",
+                        "order": 2,
+                        "sensitive": true,
+                        "type": "str",
+                        "value": "abc@123"
+                },
+                "server_ip": {
+                        "label": "SMB IP",
+                        "order": 3,
+                        "type": "str",
+                        "value": "127.0.0.1"
+                },
+                "server_port": {
+                        "display": "numeric",
+                        "label": "SMB port",
+                        "order": 4,
+                        "type": "int",
+                        "value": 445
+                },
+                "drive_path": {
+                        "label": "SMB path",
+                        "order": 5,
+                        "type": "str",
+                        "value": "Folder1"
+                }
+        },
+        "filtering": [
+                {
+                        "domain": "DEFAULT",
+                        "draft": {
+                            "advanced_snippet": {
+                                "updated_at": "2023-01-31T16:41:27.341Z",
+                                "created_at": "2023-01-31T16:38:49.244Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
+                            }
+                        },
+                        "active": {
+                            "advanced_snippet": {
+                                "updated_at": "2023-01-31T16:41:27.341Z",
+                                "created_at": "2023-01-31T16:38:49.244Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
+                            }
+                        }
+                }
+
+        ],
+        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
+        "pipeline": {
+                "extract_binary_content": true,
+                "name": "ent-search-generic-ingestion",
+                "reduce_whitespace": true,
+                "run_ml_inference": true
+        }
+}

--- a/tests/sources/test_azure_blob_storage.py
+++ b/tests/sources/test_azure_blob_storage.py
@@ -12,23 +12,10 @@ from unittest.mock import Mock, patch
 import pytest
 from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
 
-from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError
 from connectors.sources.azure_blob_storage import AzureBlobStorageDataSource
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
-
-
-def test_get_configuration():
-    """Test get_configuration method of AzureBlobStorageDataSource class"""
-
-    # Setup
-    klass = AzureBlobStorageDataSource
-
-    # Execute
-    config = DataSourceConfiguration(klass.get_default_configuration())
-
-    # Assert
-    assert config["account_name"] == "devstoreaccount1"
 
 
 @pytest.mark.asyncio

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -5,6 +5,7 @@
 #
 """Tests the Confluence database source class methods"""
 import ssl
+from contextlib import asynccontextmanager
 from copy import copy
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,7 +14,7 @@ import pytest
 from aiohttp import StreamReader
 from freezegun import freeze_time
 
-from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError
 from connectors.sources.confluence import (
     CONFLUENCE_CLOUD,
     CONFLUENCE_SERVER,
@@ -311,6 +312,21 @@ PAGE_RESTRICTION_RESPONSE = {
 }
 
 
+@asynccontextmanager
+async def create_confluence_source():
+    async with create_source(
+        ConfluenceDataSource,
+        data_source=CONFLUENCE_SERVER,
+        username="admin",
+        password="changeme",
+        confluence_url=HOST_URL,
+        spaces="*",
+        ssl_enabled=False,
+        use_document_level_security=False,
+    ) as source:
+        yield source
+
+
 class JSONAsyncMock(AsyncMock):
     def __init__(self, json, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -331,7 +347,8 @@ async def test_validate_configuration_with_invalid_concurrent_downloads():
     """Test validate configuration method of BaseDataSource class with invalid concurrent downloads"""
 
     # Setup
-    async with create_source(ConfluenceDataSource, concurrent_downloads=1000) as source:
+    async with create_confluence_source() as source:
+        source.configuration.get_field("concurrent_downloads").value = 100000
         # Execute
         with pytest.raises(ConfigurableFieldValueError):
             await source.validate_config()
@@ -339,7 +356,7 @@ async def test_validate_configuration_with_invalid_concurrent_downloads():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "extras",
+    "configs",
     [
         (
             # Confluence Server with blank dependent fields
@@ -364,10 +381,12 @@ async def test_validate_configuration_with_invalid_concurrent_downloads():
     ],
 )
 async def test_validate_configuration_with_invalid_dependency_fields_raises_error(
-    extras,
+    configs,
 ):
     # Setup
-    async with create_source(ConfluenceDataSource, **extras) as source:
+    async with create_confluence_source() as source:
+        for k, v in configs.items():
+            source.configuration.get_field(k).value = v
         # Execute
         with pytest.raises(ConfigurableFieldValueError):
             await source.validate_config()
@@ -375,7 +394,7 @@ async def test_validate_configuration_with_invalid_dependency_fields_raises_erro
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "extras",
+    "configs",
     [
         (
             # Confluence Server with blank non-dependent fields
@@ -404,9 +423,12 @@ async def test_validate_configuration_with_invalid_dependency_fields_raises_erro
     ],
 )
 async def test_validate_config_with_valid_dependency_fields_does_not_raise_error(
-    extras,
+    configs,
 ):
-    async with create_source(ConfluenceDataSource, **extras) as source:
+    async with create_confluence_source() as source:
+        for k, v in configs.items():
+            source.configuration.get_field(k).value = v
+
         await source.validate_config()
 
 
@@ -416,11 +438,13 @@ async def test_validate_config_when_ssl_enabled_and_ssl_ca_not_empty_does_not_ra
     mock_get,
 ):
     with patch.object(ssl, "create_default_context", return_value=MockSSL()):
-        async with create_source(
-            ConfluenceDataSource,
-            ssl_enabled=True,
-            ssl_ca="-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----",
-        ) as source:
+        async with create_confluence_source() as source:
+            source.configuration.get_field("ssl_enabled").value = True
+            source.configuration.get_field(
+                "ssl_ca"
+            ).value = (
+                "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"
+            )
             await source.validate_config()
 
 
@@ -429,7 +453,7 @@ async def test_tweak_bulk_options():
     """Test tweak_bulk_options method of BaseDataSource class"""
 
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source.concurrent_downloads = 10
         options = {"concurrent_downloads": 5}
 
@@ -444,7 +468,7 @@ async def test_close_with_client_session():
     """Test close method for closing the existing session"""
 
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source.confluence_client._get_session()
 
         # Execute
@@ -457,7 +481,7 @@ async def test_close_with_client_session():
 async def test_close_without_client_session():
     """Test close method when the session does not exist"""
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         # Execute
         await source.close()
 
@@ -466,7 +490,7 @@ async def test_close_without_client_session():
 
 @pytest.mark.asyncio
 async def test_remote_validation_when_space_keys_are_valid():
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source.spaces = ["DM", "ES"]
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(
@@ -479,7 +503,7 @@ async def test_remote_validation_when_space_keys_are_valid():
 
 @pytest.mark.asyncio
 async def test_remote_validation_when_space_keys_are_unavailable_then_raise_exception():
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source.spaces = ["ES", "CS"]
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(
@@ -502,17 +526,6 @@ class MockSSL:
         pass
 
 
-@pytest.mark.asyncio
-async def test_configuration():
-    """Tests the get_default_configurations method of the Confluence source class."""
-    # Setup
-    config = DataSourceConfiguration(
-        config=ConfluenceDataSource.get_default_configuration()
-    )
-
-    assert config["confluence_url"] == HOST_URL
-
-
 @pytest.mark.parametrize(
     "field, data_source",
     [
@@ -525,7 +538,7 @@ async def test_configuration():
 )
 @pytest.mark.asyncio
 async def test_validate_configuration_for_empty_fields(field, data_source):
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source.confluence_client.configuration.get_field(
             "data_source"
         ).value = data_source
@@ -543,7 +556,7 @@ async def test_ping_with_ssl(mock_get):
 
     # Execute
     mock_get.return_value.__aenter__.return_value.status = 200
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source.confluence_client.ssl_enabled = True
         source.confluence_client.certificate = (
             "-----BEGIN CERTIFICATE----- Certificate -----END CERTIFICATE-----"
@@ -563,7 +576,7 @@ async def test_ping_for_failed_connection_exception(mock_get):
     """Tests the ping functionality when connection can not be established to Confluence."""
 
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         # Execute
         with patch.object(
             ConfluenceClient, "api_call", side_effect=Exception("Something went wrong")
@@ -576,7 +589,7 @@ async def test_ping_for_failed_connection_exception(mock_get):
 async def test_validate_configuration_for_ssl_enabled():
     """This function tests _validate_configuration when certification is empty and ssl is enabled"""
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source.ssl_enabled = True
 
         # Execute
@@ -588,7 +601,7 @@ async def test_validate_configuration_for_ssl_enabled():
 @pytest.mark.asyncio
 async def test_fetch_spaces():
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(
             return_value=JSONAsyncMock(RESPONSE_SPACE)
@@ -602,7 +615,7 @@ async def test_fetch_spaces():
 @pytest.mark.asyncio
 async def test_fetch_documents():
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(return_value=JSONAsyncMock(RESPONSE_PAGE))
 
@@ -615,7 +628,7 @@ async def test_fetch_documents():
 @pytest.mark.asyncio
 async def test_fetch_attachments():
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(
             return_value=JSONAsyncMock(RESPONSE_ATTACHMENT)
@@ -634,7 +647,7 @@ async def test_fetch_attachments():
 
 @pytest.mark.asyncio
 async def test_search_by_query():
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(
             return_value=JSONAsyncMock(RESPONSE_SEARCH_RESULT)
@@ -651,7 +664,7 @@ async def test_search_by_query():
 @pytest.mark.asyncio
 async def test_download_attachment():
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(return_value=StreamReaderAsyncMock())
 
@@ -672,7 +685,7 @@ async def test_download_attachment():
 @pytest.mark.asyncio
 async def test_download_attachment_with_upper_extension():
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(return_value=StreamReaderAsyncMock())
 
@@ -697,7 +710,7 @@ async def test_download_attachment_with_upper_extension():
 async def test_download_attachment_when_filesize_is_large_then_download_skips():
     """Tests the download attachments method for file size greater than max limit."""
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(return_value=StreamReaderAsyncMock())
 
@@ -723,7 +736,7 @@ async def test_download_attachment_when_filesize_is_large_then_download_skips():
 async def test_download_attachment_when_unsupported_filetype_used_then_fail_download_skips():
     """Tests the download attachments method for file type is not supported"""
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(return_value=StreamReaderAsyncMock())
 
@@ -775,7 +788,7 @@ async def test_get_docs(spaces_patch, pages_patch, attachment_patch, content_pat
     """Tests the get_docs method"""
 
     # Setup
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         expected_responses = [
             EXPECTED_SPACE,
             EXPECTED_PAGE,
@@ -795,7 +808,7 @@ async def test_get_docs(spaces_patch, pages_patch, attachment_patch, content_pat
 @pytest.mark.asyncio
 async def test_get_session():
     """Test that the instance of session returned is always the same for the datasource class."""
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         first_instance = source.confluence_client._get_session()
         second_instance = source.confluence_client._get_session()
         assert first_instance is second_instance
@@ -803,7 +816,7 @@ async def test_get_session():
 
 @pytest.mark.asyncio
 async def test_get_access_control_dls_disabled():
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source._dls_enabled = MagicMock(return_value=False)
 
         acl = []
@@ -922,7 +935,7 @@ async def test_get_access_control_dls_enabled():
         },
     }
 
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source._dls_enabled = MagicMock(return_value=True)
 
         source.atlassian_access_control.fetch_all_users = AsyncIterator([mock_users])
@@ -994,7 +1007,7 @@ async def test_get_access_control_dls_enabled():
 async def test_get_docs_dls_enabled(
     spaces_patch, pages_patch, attachment_patch, content_patch
 ):
-    async with create_source(ConfluenceDataSource) as source:
+    async with create_confluence_source() as source:
         source._dls_enabled = MagicMock(return_value=True)
 
         expected_responses = [

--- a/tests/sources/test_dropbox.py
+++ b/tests/sources/test_dropbox.py
@@ -350,15 +350,6 @@ def setup_dropbox(source):
 
 
 @pytest.mark.asyncio
-async def test_configuration():
-    """Tests the get configurations method of the Dropbox source class."""
-    config = DataSourceConfiguration(
-        config=DropboxDataSource.get_default_configuration()
-    )
-    assert config["path"] == PATH
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "field",
     ["app_key", "app_secret", "refresh_token"],

--- a/tests/sources/test_dropbox.py
+++ b/tests/sources/test_dropbox.py
@@ -16,7 +16,7 @@ from freezegun import freeze_time
 
 from connectors.filtering.validation import SyncRuleValidationResult
 from connectors.protocol import Filter
-from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError
 from connectors.sources.dropbox import (
     DropBoxAdvancedRulesValidator,
     DropboxClient,

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -4,8 +4,8 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """Tests the Github source class methods"""
-from unittest.mock import ANY, AsyncMock, Mock, patch
 from contextlib import asynccontextmanager
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import aiohttp
 import pytest
@@ -13,7 +13,7 @@ from aiohttp.client_exceptions import ClientResponseError
 
 from connectors.filtering.validation import SyncRuleValidationResult
 from connectors.protocol import Filter
-from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError
 from connectors.sources.github import (
     GitHubAdvancedRulesValidator,
     GitHubDataSource,
@@ -411,9 +411,16 @@ MOCK_COMMITS = [
     }
 ]
 
+
 @asynccontextmanager
 async def create_github_source():
-    async with  create_source(GitHubDataSource, data_source="github-server", token="changeme", repositories="*", ssl_enabled=False) as source:
+    async with create_source(
+        GitHubDataSource,
+        data_source="github-server",
+        token="changeme",
+        repositories="*",
+        ssl_enabled=False,
+    ) as source:
         yield source
 
 

--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -17,7 +17,6 @@ from smbprotocol.exceptions import LogonFailure, SMBOSError
 
 from connectors.filtering.validation import SyncRuleValidationResult
 from connectors.protocol import Filter
-from connectors.source import DataSourceConfiguration
 from connectors.sources.network_drive import (
     NASDataSource,
     NetworkDriveAdvancedRulesValidator,
@@ -96,18 +95,6 @@ def side_effect_function(MAX_CHUNK_SIZE):
         return None
     READ_COUNT += 1
     return b"Mock...."
-
-
-def test_get_configuration():
-    """Tests the get configurations method of the Network Drive source class."""
-    # Setup
-    klass = NASDataSource
-
-    # Execute
-    config = DataSourceConfiguration(config=klass.get_default_configuration())
-
-    # Assert
-    assert config["server_ip"] == "127.0.0.1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related to https://github.com/elastic/connectors-python/issues/606

Remove `value` field from connector default RCFs, allowing them to be initialised as a type-safe empty value.

- azure_blob_storage
- confluence
- dropbox
- github
- network_drive
- servicenow

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

## Related PRs

- https://github.com/elastic/connectors-python/pull/1323
- https://github.com/elastic/connectors-python/pull/761
- https://github.com/elastic/connectors-python/pull/1540