### PR TITLE
Remove value field from connector default RCFs (batch 3)

### DIFF
--- a/connectors/sources/gmail.py
+++ b/connectors/sources/gmail.py
@@ -105,43 +105,30 @@ class GMailDataSource(BaseDataSource):
         Returns:
             dict: Default configuration.
         """
-        default_credentials = {
-            "type": "service_account",
-            "project_id": "dummy_project_id",
-            "private_key_id": "abc",
-            "private_key": "",
-            "client_email": "123-abc@developer.gserviceaccount.com",
-            "client_id": "123-abc.apps.googleusercontent.com",
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "http://localhost:4444/token",
-        }
 
         return {
             "service_account_credentials": {
                 "display": "textarea",
                 "label": "GMail service account JSON",
                 "order": 1,
-                "type": "str",
-                "value": json.dumps(default_credentials),
                 "required": True,
+                "type": "str",
             },
             "subject": {
                 "display": "text",
                 "label": "Subject",
                 "order": 2,
+                "required": True,
                 "tooltip": "Admin account email address",
                 "type": "str",
-                "value": "subject",
-                "required": True,
             },
             "customer_id": {
                 "display": "text",
                 "label": "Google customer id",
                 "order": 3,
+                "required": True,
                 "tooltip": "Google admin console -> Account -> Settings -> Customer Id",
                 "type": "str",
-                "value": "",
-                "required": True,
             },
             "use_document_level_security": {
                 "display": "toggle",
@@ -149,7 +136,6 @@ class GMailDataSource(BaseDataSource):
                 "order": 4,
                 "tooltip": "Document level security ensures identities and permissions set in GMail are maintained in Elasticsearch. This enables you to restrict and personalize read-access users have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
-                "value": True,
             },
         }
 

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -209,16 +209,6 @@ class GoogleCloudStorageDataSource(BaseDataSource):
         Returns:
             dictionary: Default configuration.
         """
-        default_credentials = {
-            "type": "service_account",
-            "project_id": "dummy_project_id",
-            "private_key_id": "abc",
-            "private_key": DEFAULT_PEM_KEY,
-            "client_email": "123-abc@developer.gserviceaccount.com",
-            "client_id": "123-abc.apps.googleusercontent.com",
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "http://localhost:4444/token",
-        }
 
         return {
             "service_account_credentials": {
@@ -226,7 +216,6 @@ class GoogleCloudStorageDataSource(BaseDataSource):
                 "label": "Google Cloud service account JSON",
                 "order": 1,
                 "type": "str",
-                "value": json.dumps(default_credentials),
             },
             "retry_count": {
                 "default_value": DEFAULT_RETRY_COUNT,
@@ -236,7 +225,6 @@ class GoogleCloudStorageDataSource(BaseDataSource):
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": DEFAULT_RETRY_COUNT,
             },
         }
 

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -483,7 +483,6 @@ class GoogleDriveDataSource(BaseDataSource):
                 "order": 1,
                 "tooltip": "This connectors authenticates as a service account to synchronize content from Google Drive.",
                 "type": "str",
-                "value": "",
             },
             "use_document_level_security": {
                 "display": "toggle",
@@ -491,7 +490,6 @@ class GoogleDriveDataSource(BaseDataSource):
                 "order": 2,
                 "tooltip": "Document level security ensures identities and permissions set in Google Drive are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
-                "value": False,
             },
             "google_workspace_admin_email": {
                 "depends_on": [{"field": "use_document_level_security", "value": True}],
@@ -501,7 +499,6 @@ class GoogleDriveDataSource(BaseDataSource):
                 "tooltip": "In order to use Document Level Security you need to enable Google Workspace domain-wide delegation of authority for your service account. A service account with delegated authority can impersonate admin user with sufficient permissions to fetch all users and their corresponding permissions.",
                 "type": "str",
                 "validations": [{"type": "regex", "constraint": EMAIL_REGEX_PATTERN}],
-                "value": "admin@your-organization.com",
             },
             "max_concurrency": {
                 "default_value": GOOGLE_API_MAX_CONCURRENCY,
@@ -513,7 +510,6 @@ class GoogleDriveDataSource(BaseDataSource):
                 "type": "int",
                 "ui_restrictions": ["advanced"],
                 "validations": [{"type": "greater_than", "constraint": 0}],
-                "value": GOOGLE_API_MAX_CONCURRENCY,
             },
         }
 

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -292,7 +292,6 @@ class JiraDataSource(BaseDataSource):
                 "label": "Jira Server username",
                 "order": 2,
                 "type": "str",
-                "value": "admin",
             },
             "password": {
                 "depends_on": [{"field": "data_source", "value": JIRA_SERVER}],
@@ -300,14 +299,12 @@ class JiraDataSource(BaseDataSource):
                 "sensitive": True,
                 "order": 3,
                 "type": "str",
-                "value": "changeme",
             },
             "account_email": {
                 "depends_on": [{"field": "data_source", "value": JIRA_CLOUD}],
                 "label": "Jira Cloud service account id",
                 "order": 4,
                 "type": "str",
-                "value": "me@example.com",
             },
             "api_token": {
                 "depends_on": [{"field": "data_source", "value": JIRA_CLOUD}],
@@ -315,13 +312,11 @@ class JiraDataSource(BaseDataSource):
                 "order": 5,
                 "sensitive": True,
                 "type": "str",
-                "value": "abc#123",
             },
             "jira_url": {
                 "label": "Jira host url",
                 "order": 6,
                 "type": "str",
-                "value": "http://127.0.0.1:8080",
             },
             "projects": {
                 "display": "textarea",
@@ -329,21 +324,18 @@ class JiraDataSource(BaseDataSource):
                 "order": 7,
                 "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
                 "type": "list",
-                "value": "*",
             },
             "ssl_enabled": {
                 "display": "toggle",
                 "label": "Enable SSL",
                 "order": 8,
                 "type": "bool",
-                "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],
                 "label": "SSL certificate",
                 "order": 9,
                 "type": "str",
-                "value": "",
             },
             "retry_count": {
                 "default_value": 3,
@@ -353,7 +345,6 @@ class JiraDataSource(BaseDataSource):
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": 3,
             },
             "concurrent_downloads": {
                 "default_value": MAX_CONCURRENT_DOWNLOADS,
@@ -366,7 +357,6 @@ class JiraDataSource(BaseDataSource):
                 "validations": [
                     {"type": "less_than", "constraint": MAX_CONCURRENT_DOWNLOADS + 1}
                 ],
-                "value": MAX_CONCURRENT_DOWNLOADS,
             },
             "use_document_level_security": {
                 "display": "toggle",
@@ -375,7 +365,6 @@ class JiraDataSource(BaseDataSource):
                 "order": 12,
                 "tooltip": "Document level security ensures identities and permissions set in Jira are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
-                "value": False,
             },
         }
 

--- a/connectors/sources/onedrive.py
+++ b/connectors/sources/onedrive.py
@@ -297,20 +297,17 @@ class OneDriveDataSource(BaseDataSource):
                 "label": "Azure application Client ID",
                 "order": 1,
                 "type": "str",
-                "value": "",
             },
             "client_secret": {
                 "label": "Azure application Client Secret",
                 "order": 2,
                 "sensitive": True,
                 "type": "str",
-                "value": "",
             },
             "tenant_id": {
                 "label": "Azure application Tenant ID",
                 "order": 3,
                 "type": "str",
-                "value": "",
             },
             "retry_count": {
                 "default_value": 3,
@@ -320,7 +317,6 @@ class OneDriveDataSource(BaseDataSource):
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
-                "value": 3,
             },
         }
 

--- a/tests/sources/fixtures/google_cloud_storage/connector.json
+++ b/tests/sources/fixtures/google_cloud_storage/connector.json
@@ -1,0 +1,148 @@
+{
+  "api_key_id": null,
+  "configuration": {
+    "service_account_credentials": {
+      "depends_on": [],
+      "display": "textarea",
+      "tooltip": null,
+      "default_value": null,
+      "label": "Google Cloud service account JSON",
+      "sensitive": true,
+      "type": "str",
+      "required": true,
+      "options": [],
+      "validations": [],
+      "value": "{\"type\": \"service_account\", \"project_id\": \"dummy_project_id\", \"private_key_id\": \"abc\", \"private_key\": \"\\n-----BEGIN PRIVATE KEY-----\\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDY3E8o1NEFcjMM\\nHW/5ZfFJw29/8NEqpViNjQIx95Xx5KDtJ+nWn9+OW0uqsSqKlKGhAdAo+Q6bjx2c\\nuXVsXTu7XrZUY5Kltvj94DvUa1wjNXs606r/RxWTJ58bfdC+gLLxBfGnB6CwK0YQ\\nxnfpjNbkUfVVzO0MQD7UP0Hl5ZcY0Puvxd/yHuONQn/rIAieTHH1pqgW+zrH/y3c\\n59IGThC9PPtugI9ea8RSnVj3PWz1bX2UkCDpy9IRh9LzJLaYYX9RUd7++dULUlat\\nAaXBh1U6emUDzhrIsgApjDVtimOPbmQWmX1S60mqQikRpVYZ8u+NDD+LNw+/Eovn\\nxCj2Y3z1AgMBAAECggEAWDBzoqO1IvVXjBA2lqId10T6hXmN3j1ifyH+aAqK+FVl\\nGjyWjDj0xWQcJ9ync7bQ6fSeTeNGzP0M6kzDU1+w6FgyZqwdmXWI2VmEizRjwk+/\\n/uLQUcL7I55Dxn7KUoZs/rZPmQDxmGLoue60Gg6z3yLzVcKiDc7cnhzhdBgDc8vd\\nQorNAlqGPRnm3EqKQ6VQp6fyQmCAxrr45kspRXNLddat3AMsuqImDkqGKBmF3Q1y\\nxWGe81LphUiRqvqbyUlh6cdSZ8pLBpc9m0c3qWPKs9paqBIvgUPlvOZMqec6x4S6\\nChbdkkTRLnbsRr0Yg/nDeEPlkhRBhasXpxpMUBgPywKBgQDs2axNkFjbU94uXvd5\\nznUhDVxPFBuxyUHtsJNqW4p/ujLNimGet5E/YthCnQeC2P3Ym7c3fiz68amM6hiA\\nOnW7HYPZ+jKFnefpAtjyOOs46AkftEg07T9XjwWNPt8+8l0DYawPoJgbM5iE0L2O\\nx8TU1Vs4mXc+ql9F90GzI0x3VwKBgQDqZOOqWw3hTnNT07Ixqnmd3dugV9S7eW6o\\nU9OoUgJB4rYTpG+yFqNqbRT8bkx37iKBMEReppqonOqGm4wtuRR6LSLlgcIU9Iwx\\nyfH12UWqVmFSHsgZFqM/cK3wGev38h1WBIOx3/djKn7BdlKVh8kWyx6uC8bmV+E6\\nOoK0vJD6kwKBgHAySOnROBZlqzkiKW8c+uU2VATtzJSydrWm0J4wUPJifNBa/hVW\\ndcqmAzXC9xznt5AVa3wxHBOfyKaE+ig8CSsjNyNZ3vbmr0X04FoV1m91k2TeXNod\\njMTobkPThaNm4eLJMN2SQJuaHGTGERWC0l3T18t+/zrDMDCPiSLX1NAvAoGBAN1T\\nVLJYdjvIMxf1bm59VYcepbK7HLHFkRq6xMJMZbtG0ryraZjUzYvB4q4VjHk2UDiC\\nlhx13tXWDZH7MJtABzjyg+AI7XWSEQs2cBXACos0M4Myc6lU+eL+iA+OuoUOhmrh\\nqmT8YYGu76/IBWUSqWuvcpHPpwl7871i4Ga/I3qnAoGBANNkKAcMoeAbJQK7a/Rn\\nwPEJB+dPgNDIaboAsh1nZhVhN5cvdvCWuEYgOGCPQLYQF0zmTLcM+sVxOYgfy8mV\\nfbNgPgsP5xmu6dw2COBKdtozw0HrWSRjACd1N4yGu75+wPCcX/gQarcjRcXXZeEa\\nNtBLSfcqPULqD+h7br9lEJio\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"123-abc@developer.gserviceaccount.com\", \"client_id\": \"123-abc.apps.googleusercontent.com\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"http://localhost:4444/token\"}",
+      "order": 1,
+      "ui_restrictions": []
+    },
+    "retry_count": {
+      "depends_on": [],
+      "display": "numeric",
+      "tooltip": "",
+      "default_value": 3,
+      "label": "Maximum retries for failed requests",
+      "sensitive": false,
+      "type": "int",
+      "required": false,
+      "options": [],
+      "validations": [
+        {
+          "constraint": 0,
+          "type": "greater_than"
+        }
+      ],
+      "value": null,
+      "order": 2,
+      "ui_restrictions": [
+        "advanced"
+      ]
+    }
+  },
+  "custom_scheduling": {},
+  "description": null,
+  "error": null,
+  "features": {
+    "incremental_sync": {
+      "enabled": false
+    },
+    "document_level_security": {
+      "enabled": false
+    },
+    "sync_rules": {
+      "advanced": {
+        "enabled": false
+      },
+      "basic": {
+        "enabled": true
+      }
+    }
+  },
+  "filtering": [
+    {
+      "active": {
+        "advanced_snippet": {
+          "created_at": "2023-06-30T08:20:14.686Z",
+          "updated_at": "2023-06-30T08:20:14.686Z",
+          "value": {}
+        },
+        "rules": [
+          {
+            "created_at": "2023-06-30T08:20:14.686Z",
+            "field": "_",
+            "id": "DEFAULT",
+            "order": 0,
+            "policy": "include",
+            "rule": "regex",
+            "updated_at": "2023-06-30T08:20:14.686Z",
+            "value": ".*"
+          }
+        ],
+        "validation": {
+          "errors": [],
+          "state": "valid"
+        }
+      },
+      "domain": "DEFAULT",
+      "draft": {
+        "advanced_snippet": {
+          "created_at": "2023-06-30T08:20:14.686Z",
+          "updated_at": "2023-06-30T08:20:14.686Z",
+          "value": {}
+        },
+        "rules": [
+          {
+            "created_at": "2023-06-30T08:20:14.686Z",
+            "field": "_",
+            "id": "DEFAULT",
+            "order": 0,
+            "policy": "include",
+            "rule": "regex",
+            "updated_at": "2023-06-30T08:20:14.686Z",
+            "value": ".*"
+          }
+        ],
+        "validation": {
+          "errors": [],
+          "state": "valid"
+        }
+      }
+    }
+  ],
+  "index_name": "search-google_cloud_storage",
+  "is_native": false,
+  "language": null,
+  "last_access_control_sync_error": null,
+  "last_access_control_sync_scheduled_at": null,
+  "last_access_control_sync_status": null,
+  "last_incremental_sync_scheduled_at": null,
+  "last_seen": "2023-06-30T09:26:21.281198+00:00",
+  "last_sync_error": null,
+  "last_sync_scheduled_at": null,
+  "last_sync_status": null,
+  "last_synced": null,
+  "name": "google-drive",
+  "pipeline": {
+    "extract_binary_content": true,
+    "name": "ent-search-generic-ingestion",
+    "reduce_whitespace": true,
+    "run_ml_inference": true
+  },
+  "scheduling": {
+    "access_control": {
+      "enabled": false,
+      "interval": "0 0 0 * * ?"
+    },
+    "full": {
+      "enabled": true,
+      "interval": "* * * * * 1"
+    },
+    "incremental": {
+      "enabled": false,
+      "interval": "0 0 0 * * ?"
+    }
+  },
+  "service_type": "google_cloud_storage",
+  "status": "configured",
+  "sync_now": true
+}

--- a/tests/sources/fixtures/jira/connector.json
+++ b/tests/sources/fixtures/jira/connector.json
@@ -1,0 +1,212 @@
+{
+  "api_key_id": null,
+  "configuration": {
+    "data_source": {
+      "display": "dropdown",
+      "label": "Jira data source",
+      "options": [
+        {"label": "Jira Cloud", "value": "jira_cloud"},
+        {"label": "Jira Server", "value": "jira_server"}
+      ],
+      "order": 1,
+      "type": "str",
+      "value": "jira_cloud"
+    },
+    "username": {
+      "depends_on": [{"field": "data_source", "value": "jira_server"}],
+      "label": "Jira Server username",
+      "order": 2,
+      "type": "str",
+      "value": "admin"
+    },
+    "password": {
+      "depends_on": [{"field": "data_source", "value": "jira_server"}],
+      "label": "Jira Server password",
+      "sensitive": true,
+      "order": 3,
+      "type": "str",
+      "value": "changeme"
+    },
+    "account_email": {
+      "depends_on": [{"field": "data_source", "value": "jira_cloud"}],
+      "label": "Jira Cloud service account id",
+      "order": 4,
+      "type": "str",
+      "value": "me@example.com"
+    },
+    "api_token": {
+      "depends_on": [{"field": "data_source", "value": "jira_cloud"}],
+      "label": "Jira Cloud API token",
+      "order": 5,
+      "sensitive": true,
+      "type": "str",
+      "value": "abc#123"
+    },
+    "jira_url": {
+      "label": "Jira host url",
+      "order": 6,
+      "type": "str",
+      "value": "http://127.0.0.1:8080"
+    },
+    "projects": {
+      "display": "textarea",
+      "label": "Jira project keys",
+      "order": 7,
+      "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
+      "type": "list",
+      "value": "*"
+    },
+    "ssl_enabled": {
+      "display": "toggle",
+      "label": "Enable SSL",
+      "order": 8,
+      "type": "bool",
+      "value": false
+    },
+    "ssl_ca": {
+      "depends_on": [{"field": "ssl_enabled", "value": true}],
+      "label": "SSL certificate",
+      "order": 9,
+      "type": "str",
+      "value": ""
+    },
+    "retry_count": {
+      "default_value": 3,
+      "display": "numeric",
+      "label": "Retries for failed requests",
+      "order": 10,
+      "required": false,
+      "type": "int",
+      "ui_restrictions": ["advanced"],
+      "value": 3
+    },
+    "concurrent_downloads": {
+      "default_value": 100,
+      "display": "numeric",
+      "label": "Maximum concurrent downloads",
+      "order": 11,
+      "required": false,
+      "type": "int",
+      "ui_restrictions": ["advanced"],
+      "validations": [
+        {"type": "less_than", "constraint": 101}
+      ],
+      "value": 100
+    },
+    "use_document_level_security": {
+      "display": "toggle",
+      "depends_on": [{"field": "data_source", "value": "jira_cloud"}],
+      "label": "Enable document level security",
+      "order": 12,
+      "tooltip": "Document level security ensures identities and permissions set in Jira are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
+      "type": "bool",
+      "value": false
+    }
+  },
+  "custom_scheduling": {},
+  "description": null,
+  "error": null,
+  "features": {
+    "incremental_sync": {
+      "enabled": false
+    },
+    "document_level_security": {
+      "enabled": false
+    },
+    "sync_rules": {
+      "advanced": {
+        "enabled": false
+      },
+      "basic": {
+        "enabled": true
+      }
+    }
+  },
+  "filtering": [
+    {
+      "active": {
+        "advanced_snippet": {
+          "created_at": "2023-06-30T08:20:14.686Z",
+          "updated_at": "2023-06-30T08:20:14.686Z",
+          "value": {}
+        },
+        "rules": [
+          {
+            "created_at": "2023-06-30T08:20:14.686Z",
+            "field": "_",
+            "id": "DEFAULT",
+            "order": 0,
+            "policy": "include",
+            "rule": "regex",
+            "updated_at": "2023-06-30T08:20:14.686Z",
+            "value": ".*"
+          }
+        ],
+        "validation": {
+          "errors": [],
+          "state": "valid"
+        }
+      },
+      "domain": "DEFAULT",
+      "draft": {
+        "advanced_snippet": {
+          "created_at": "2023-06-30T08:20:14.686Z",
+          "updated_at": "2023-06-30T08:20:14.686Z",
+          "value": {}
+        },
+        "rules": [
+          {
+            "created_at": "2023-06-30T08:20:14.686Z",
+            "field": "_",
+            "id": "DEFAULT",
+            "order": 0,
+            "policy": "include",
+            "rule": "regex",
+            "updated_at": "2023-06-30T08:20:14.686Z",
+            "value": ".*"
+          }
+        ],
+        "validation": {
+          "errors": [],
+          "state": "valid"
+        }
+      }
+    }
+  ],
+  "index_name": "search-jira",
+  "is_native": false,
+  "language": null,
+  "last_access_control_sync_error": null,
+  "last_access_control_sync_scheduled_at": null,
+  "last_access_control_sync_status": null,
+  "last_incremental_sync_scheduled_at": null,
+  "last_seen": "2023-06-30T09:26:21.281198+00:00",
+  "last_sync_error": null,
+  "last_sync_scheduled_at": null,
+  "last_sync_status": null,
+  "last_synced": null,
+  "name": "google-drive",
+  "pipeline": {
+    "extract_binary_content": true,
+    "name": "ent-search-generic-ingestion",
+    "reduce_whitespace": true,
+    "run_ml_inference": true
+  },
+  "scheduling": {
+    "access_control": {
+      "enabled": false,
+      "interval": "0 0 0 * * ?"
+    },
+    "full": {
+      "enabled": true,
+      "interval": "* * * * * 1"
+    },
+    "incremental": {
+      "enabled": false,
+      "interval": "0 0 0 * * ?"
+    }
+  },
+  "service_type": "jira",
+  "status": "configured",
+  "sync_now": true
+}

--- a/tests/sources/test_gmail.py
+++ b/tests/sources/test_gmail.py
@@ -3,6 +3,8 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import json
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -110,16 +112,25 @@ def test_message_doc(message, expected_doc):
     assert _message_doc(message) == expected_doc
 
 
-def setup_source():
-    source = create_source(GMailDataSource)
-    source._service_account_credentials = MagicMock()
+@asynccontextmanager
+async def create_gmail_source(dls_enabled=False):
+    async with create_source(
+        GMailDataSource,
+        service_account_credentials=json.dumps(JSON_CREDENTIALS),
+        subject="subject",
+        customer_id="foo",
+        use_document_level_security=dls_enabled,
+    ) as source:
+        source.set_features(
+            Features({"document_level_security": {"enabled": dls_enabled}})
+        )
+        source.configuration.get_field(
+            "use_document_level_security"
+        ).value = dls_enabled
 
-    return source
+        source._service_account_credentials = MagicMock()
 
-
-def set_dls_enabled(source, dls_enabled):
-    source.set_features(Features({"document_level_security": {"enabled": dls_enabled}}))
-    source.configuration.get_field("use_document_level_security").value = dls_enabled
+        yield source
 
 
 class TestGMailDataSource:
@@ -143,7 +154,7 @@ class TestGMailDataSource:
     async def test_ping_successful(
         self, patch_gmail_client, patch_google_directory_client
     ):
-        async with setup_source() as source:
+        async with create_gmail_source() as source:
             patch_gmail_client.ping = AsyncMock()
             patch_google_directory_client.ping = AsyncMock()
 
@@ -156,7 +167,7 @@ class TestGMailDataSource:
     async def test_ping_gmail_client_fails(
         self, patch_gmail_client, patch_google_directory_client
     ):
-        async with setup_source() as source:
+        async with create_gmail_source() as source:
             patch_gmail_client.ping = AsyncMock(
                 side_effect=Exception("Something went wrong")
             )
@@ -169,7 +180,7 @@ class TestGMailDataSource:
     async def test_ping_google_directory_client_fails(
         self, patch_gmail_client, patch_google_directory_client
     ):
-        async with setup_source() as source:
+        async with create_gmail_source() as source:
             patch_gmail_client.ping = AsyncMock()
             patch_google_directory_client.ping = AsyncMock(side_effect=Exception)
 
@@ -180,7 +191,7 @@ class TestGMailDataSource:
     async def test_validate_config_valid(self):
         valid_json = '{"project_id": "dummy123"}'
 
-        async with setup_source() as source:
+        async with create_gmail_source() as source:
             source.configuration.get_field(
                 "service_account_credentials"
             ).value = valid_json
@@ -193,7 +204,7 @@ class TestGMailDataSource:
 
     @pytest.mark.asyncio
     async def test_validate_config_invalid(self):
-        async with setup_source() as source:
+        async with create_gmail_source() as source:
             source.configuration.get_field(
                 "service_account_credentials"
             ).value = "invalid json"
@@ -208,8 +219,7 @@ class TestGMailDataSource:
         users = [{UserFields.EMAIL.value: "user@google.com"}]
         patch_google_directory_client.users = AsyncIterator(users)
 
-        async with setup_source() as source:
-            set_dls_enabled(source, False)
+        async with create_gmail_source() as source:
             actual_users = []
 
             async for user in source.get_access_control():
@@ -233,8 +243,7 @@ class TestGMailDataSource:
         ]
         patch_google_directory_client.users = AsyncIterator(users)
 
-        async with setup_source() as source:
-            set_dls_enabled(source, True)
+        async with create_gmail_source(dls_enabled=True) as source:
             actual_users = []
 
             async for user in source.get_access_control():
@@ -266,9 +275,7 @@ class TestGMailDataSource:
         patch_gmail_client.messages = AsyncIterator(messages)
         patch_gmail_client.message = AsyncMock(side_effect=messages)
 
-        async with setup_source() as source:
-            set_dls_enabled(source, False)
-
+        async with create_gmail_source() as source:
             actual_messages = []
 
             async for doc in source.get_docs(filtering=None):
@@ -299,8 +306,7 @@ class TestGMailDataSource:
         patch_gmail_client.messages = AsyncIterator(messages)
         patch_gmail_client.message = AsyncMock(side_effect=messages)
 
-        async with setup_source() as source:
-            set_dls_enabled(source, False)
+        async with create_gmail_source() as source:
             actual_messages = []
             message_query = "some query"
             filter_ = Filter(
@@ -338,9 +344,7 @@ class TestGMailDataSource:
         patch_gmail_client.messages = AsyncIterator(messages)
         patch_gmail_client.message = AsyncMock(side_effect=messages)
 
-        async with setup_source() as source:
-            set_dls_enabled(source, True)
-
+        async with create_gmail_source(dls_enabled=True) as source:
             actual_messages = []
 
             async for doc in source.get_docs(filtering=None):
@@ -375,8 +379,7 @@ class TestGMailDataSource:
         patch_gmail_client.messages = AsyncIterator(messages)
         patch_gmail_client.message = AsyncMock(side_effect=messages)
 
-        async with setup_source() as source:
-            set_dls_enabled(source, True)
+        async with create_gmail_source(dls_enabled=True) as source:
             actual_messages = []
             message_query = "some query"
             filter_ = Filter(

--- a/tests/sources/test_gmail.py
+++ b/tests/sources/test_gmail.py
@@ -33,6 +33,22 @@ DATE = "2023-01-24T04:07:19+00:00"
 JSON_CREDENTIALS = {"key": "value"}
 
 
+@asynccontextmanager
+async def create_gmail_source(dls_enabled=False):
+    async with create_source(
+        GMailDataSource,
+        service_account_credentials=json.dumps(JSON_CREDENTIALS),
+        subject="subject",
+        customer_id="foo",
+        use_document_level_security=dls_enabled,
+    ) as source:
+        source.set_features(
+            Features({"document_level_security": {"enabled": dls_enabled}})
+        )
+        source._service_account_credentials = MagicMock()
+
+        yield source
+
 class TestGMailAdvancedRulesValidator:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -110,27 +126,6 @@ CREATION_DATE = "2023-01-01T13:37:00"
 @freeze_time(DATE)
 def test_message_doc(message, expected_doc):
     assert _message_doc(message) == expected_doc
-
-
-@asynccontextmanager
-async def create_gmail_source(dls_enabled=False):
-    async with create_source(
-        GMailDataSource,
-        service_account_credentials=json.dumps(JSON_CREDENTIALS),
-        subject="subject",
-        customer_id="foo",
-        use_document_level_security=dls_enabled,
-    ) as source:
-        source.set_features(
-            Features({"document_level_security": {"enabled": dls_enabled}})
-        )
-        source.configuration.get_field(
-            "use_document_level_security"
-        ).value = dls_enabled
-
-        source._service_account_credentials = MagicMock()
-
-        yield source
 
 
 class TestGMailDataSource:

--- a/tests/sources/test_gmail.py
+++ b/tests/sources/test_gmail.py
@@ -49,6 +49,7 @@ async def create_gmail_source(dls_enabled=False):
 
         yield source
 
+
 class TestGMailAdvancedRulesValidator:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/sources/test_google_cloud_storage.py
+++ b/tests/sources/test_google_cloud_storage.py
@@ -6,7 +6,7 @@
 """Tests the Google Cloud Storage source class methods.
 """
 import asyncio
-import json
+from contextlib import asynccontextmanager
 from unittest import mock
 
 import pytest
@@ -16,55 +16,30 @@ from aiogoogle.models import Request, Response
 
 from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.google_cloud_storage import GoogleCloudStorageDataSource
+from tests.sources.support import create_source
 
 SERVICE_ACCOUNT_CREDENTIALS = '{"project_id": "dummy123"}'
 API_NAME = "storage"
 API_VERSION = "v1"
 
 
-def get_gcs_source_object():
-    """Creates the mocked Google cloud storage object.
-
-    Returns:
-        GoogleCloudStorageDataSource: Mocked object of the data source class.
-    """
-    configuration = DataSourceConfiguration(
-        {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS, "retry_count": 0}
-    )
-    mocked_gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
-    return mocked_gcs_object
-
-
-def test_get_configuration():
-    """Tests the get configurations method of the Google Cloud source class."""
-
-    # Setup
-
-    google_cloud_storage_object = GoogleCloudStorageDataSource
-
-    # Execute
-
-    config = DataSourceConfiguration(
-        config=google_cloud_storage_object.get_default_configuration()
-    )
-
-    # Assert
-
-    assert type(config["service_account_credentials"]) == str
-    assert json.loads(
-        config["service_account_credentials"].encode("unicode_escape").decode()
-    )
+@asynccontextmanager
+async def create_gcs_source():
+    async with create_source(
+        GoogleCloudStorageDataSource,
+        service_account_credentials=SERVICE_ACCOUNT_CREDENTIALS,
+        retry_count=0,
+    ) as source:
+        yield source
 
 
 @pytest.mark.asyncio
 async def test_empty_configuration():
     """Tests the validity of the configurations passed to the Google Cloud source class."""
 
-    # Setup
     configuration = DataSourceConfiguration({"service_account_credentials": ""})
     gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
 
-    # Execute
     with pytest.raises(
         ConfigurableFieldValueError,
         match="Field validation errors: 'Service_account_credentials' cannot be empty.",
@@ -74,13 +49,11 @@ async def test_empty_configuration():
 
 @pytest.mark.asyncio
 async def test_raise_on_invalid_configuration():
-    # Setup
     configuration = DataSourceConfiguration(
         {"service_account_credentials": "{'abc':'bcd','cd'}"}
     )
     gcs_object = GoogleCloudStorageDataSource(configuration=configuration)
 
-    # Execute
     with pytest.raises(
         ConfigurableFieldValueError,
         match="Google Cloud service account is not a valid JSON",
@@ -92,40 +65,33 @@ async def test_raise_on_invalid_configuration():
 async def test_ping_for_successful_connection(catch_stdout):
     """Tests the ping functionality for ensuring connection to Google Cloud Storage."""
 
-    # Setup
-
     expected_response = {
         "kind": "storage#serviceAccount",
         "email_address": "serviceaccount@email.com",
     }
-    mocked_gcs_object = get_gcs_source_object()
-    as_service_account_response = asyncio.Future()
-    as_service_account_response.set_result(expected_response)
+    async with create_gcs_source() as source:
+        as_service_account_response = asyncio.Future()
+        as_service_account_response.set_result(expected_response)
 
-    # Execute
-
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=as_service_account_response
-    ):
-        await mocked_gcs_object.ping()
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=as_service_account_response
+        ):
+            await source.ping()
 
 
 @pytest.mark.asyncio
 async def test_ping_for_failed_connection(catch_stdout):
     """Tests the ping functionality when connection can not be established to Google Cloud Storage."""
 
-    # Setup
-
-    mocked_gcs_object = get_gcs_source_object()
-
-    # Execute
-    with mock.patch.object(
-        Aiogoogle, "discover", side_effect=Exception("Something went wrong")
-    ):
-        with pytest.raises(Exception):
-            await mocked_gcs_object.ping()
+    async with create_gcs_source() as source:
+        with mock.patch.object(
+            Aiogoogle, "discover", side_effect=Exception("Something went wrong")
+        ):
+            with pytest.raises(Exception):
+                await source.ping()
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "previous_documents_list, updated_documents_list",
     [
@@ -166,7 +132,7 @@ async def test_ping_for_failed_connection(catch_stdout):
         )
     ],
 )
-def test_get_blob_document(previous_documents_list, updated_documents_list):
+async def test_get_blob_document(previous_documents_list, updated_documents_list):
     """Tests the function which modifies the fetched blobs and maps the values to keys.
 
     Args:
@@ -174,34 +140,18 @@ def test_get_blob_document(previous_documents_list, updated_documents_list):
         updated_documents_list (list): List of the documents returned by the method.
     """
 
-    # Setup
-    mocked_gcs_object = get_gcs_source_object()
-
-    # Execute and Assert
-    assert updated_documents_list == list(
-        mocked_gcs_object.get_blob_document(blobs=previous_documents_list[0])
-    )
+    async with create_gcs_source() as source:
+        assert updated_documents_list == list(
+            source.get_blob_document(blobs=previous_documents_list[0])
+        )
 
 
 @pytest.mark.asyncio
 async def test_fetch_buckets():
     """Tests the method which lists the storage buckets available in Google Cloud Storage."""
 
-    # Setup
-    mocked_gcs_object = get_gcs_source_object()
-    expected_response = {
-        "kind": "storage#objects",
-        "items": [
-            {
-                "kind": "storage#object",
-                "id": "bucket_1",
-                "updated": "2011-10-12T00:00:00Z",
-                "name": "bucket_1",
-            }
-        ],
-    }
-    expected_bucket_list = [
-        {
+    async with create_gcs_source() as source:
+        expected_response = {
             "kind": "storage#objects",
             "items": [
                 {
@@ -212,128 +162,133 @@ async def test_fetch_buckets():
                 }
             ],
         }
-    ]
-    dummy_url = "https://dummy.gcs.com/buckets/b1/objects"
+        expected_bucket_list = [
+            {
+                "kind": "storage#objects",
+                "items": [
+                    {
+                        "kind": "storage#object",
+                        "id": "bucket_1",
+                        "updated": "2011-10-12T00:00:00Z",
+                        "name": "bucket_1",
+                    }
+                ],
+            }
+        ]
+        dummy_url = "https://dummy.gcs.com/buckets/b1/objects"
 
-    expected_response_object = Response(
-        status_code=200,
-        url=dummy_url,
-        json=expected_response,
-        req=Request(method="GET", url=dummy_url),
-    )
+        expected_response_object = Response(
+            status_code=200,
+            url=dummy_url,
+            json=expected_response,
+            req=Request(method="GET", url=dummy_url),
+        )
 
-    # Execute
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            bucket_list = []
-            async for bucket in mocked_gcs_object.fetch_buckets():
-                bucket_list.append(bucket)
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                bucket_list = []
+                async for bucket in source.fetch_buckets():
+                    bucket_list.append(bucket)
 
-    # Assert
-    assert bucket_list == expected_bucket_list
+        assert bucket_list == expected_bucket_list
 
 
 @pytest.mark.asyncio
 async def test_fetch_blobs():
     """Tests the method responsible to yield blobs from Google Cloud Storage bucket."""
 
-    # Setup
-    mocked_gcs_object = get_gcs_source_object()
-    expected_bucket_response = {
-        "kind": "storage#objects",
-        "items": [
-            {
-                "kind": "storage#object",
-                "id": "bucket_1",
-                "updated": "2011-10-12T00:01:00Z",
-                "name": "bucket_1",
-            }
-        ],
-    }
-    dummy_blob_response = {
-        "kind": "storage#objects",
-        "items": [
-            {
-                "kind": "storage#object",
-                "id": "bucket_1/blob_1/123123123",
-                "updated": "2011-10-12T00:01:00Z",
-                "name": "blob_1",
-            }
-        ],
-    }
-    dummy_url = "https://dummy.gcs.com/buckets/b1/objects"
+    async with create_gcs_source() as source:
+        expected_bucket_response = {
+            "kind": "storage#objects",
+            "items": [
+                {
+                    "kind": "storage#object",
+                    "id": "bucket_1",
+                    "updated": "2011-10-12T00:01:00Z",
+                    "name": "bucket_1",
+                }
+            ],
+        }
+        dummy_blob_response = {
+            "kind": "storage#objects",
+            "items": [
+                {
+                    "kind": "storage#object",
+                    "id": "bucket_1/blob_1/123123123",
+                    "updated": "2011-10-12T00:01:00Z",
+                    "name": "blob_1",
+                }
+            ],
+        }
+        dummy_url = "https://dummy.gcs.com/buckets/b1/objects"
 
-    expected_response_object = Response(
-        status_code=200,
-        url=dummy_url,
-        json=dummy_blob_response,
-        req=Request(method="GET", url=dummy_url),
-    )
+        expected_response_object = Response(
+            status_code=200,
+            url=dummy_url,
+            json=dummy_blob_response,
+            req=Request(method="GET", url=dummy_url),
+        )
 
-    # Execute
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            async for blob_result in mocked_gcs_object.fetch_blobs(
-                buckets=expected_bucket_response
-            ):
-                # Assert
-                assert blob_result == dummy_blob_response
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                async for blob_result in source.fetch_blobs(
+                    buckets=expected_bucket_response
+                ):
+                    assert blob_result == dummy_blob_response
 
 
 @pytest.mark.asyncio
 async def test_get_docs():
     """Tests the module responsible to fetch and yield blobs documents from Google Cloud Storage."""
 
-    # Setup
-    mocked_gcs_object = get_gcs_source_object()
-    expected_response = {
-        "kind": "storage#objects",
-        "items": [
-            {
-                "kind": "storage#object",
-                "id": "bucket_1/blob_1/123123123",
-                "updated": "2011-10-12T00:01:00Z",
-                "name": "blob_1",
-            }
-        ],
-    }
-    expected_blob_document = {
-        "_id": "bucket_1/blob_1/123123123",
-        "component_count": None,
-        "content_encoding": None,
-        "content_language": None,
-        "created_at": None,
-        "last_updated": "2011-10-12T00:01:00Z",
-        "metadata": None,
-        "name": "blob_1",
-        "size": None,
-        "storage_class": None,
-        "_timestamp": "2011-10-12T00:01:00Z",
-        "type": None,
-        "url": "https://console.cloud.google.com/storage/browser/_details/None/blob_1;tab=live_object?project=dummy123",
-        "version": None,
-        "bucket_name": None,
-    }
-    dummy_url = "https://dummy.gcs.com/buckets/b1/objects"
+    async with create_gcs_source() as source:
+        expected_response = {
+            "kind": "storage#objects",
+            "items": [
+                {
+                    "kind": "storage#object",
+                    "id": "bucket_1/blob_1/123123123",
+                    "updated": "2011-10-12T00:01:00Z",
+                    "name": "blob_1",
+                }
+            ],
+        }
+        expected_blob_document = {
+            "_id": "bucket_1/blob_1/123123123",
+            "component_count": None,
+            "content_encoding": None,
+            "content_language": None,
+            "created_at": None,
+            "last_updated": "2011-10-12T00:01:00Z",
+            "metadata": None,
+            "name": "blob_1",
+            "size": None,
+            "storage_class": None,
+            "_timestamp": "2011-10-12T00:01:00Z",
+            "type": None,
+            "url": "https://console.cloud.google.com/storage/browser/_details/None/blob_1;tab=live_object?project=dummy123",
+            "version": None,
+            "bucket_name": None,
+        }
+        dummy_url = "https://dummy.gcs.com/buckets/b1/objects"
 
-    expected_response_object = Response(
-        status_code=200,
-        url=dummy_url,
-        json=expected_response,
-        req=Request(method="GET", url=dummy_url),
-    )
+        expected_response_object = Response(
+            status_code=200,
+            url=dummy_url,
+            json=expected_response,
+            req=Request(method="GET", url=dummy_url),
+        )
 
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            async for blob_document in mocked_gcs_object.get_docs():
-                assert blob_document[0] == expected_blob_document
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                async for blob_document in source.get_docs():
+                    assert blob_document[0] == expected_blob_document
 
 
 @pytest.mark.asyncio
@@ -342,228 +297,214 @@ async def test_get_docs_when_no_buckets_present():
     Cloud storage does not have any buckets.
     """
 
-    # Setup
-    mocked_gcs_object = get_gcs_source_object()
-    expected_response = {
-        "kind": "storage#objects",
-    }
-    dummy_url = "https://dummy.gcs.com/buckets/b1/objects"
+    async with create_gcs_source() as source:
+        expected_response = {
+            "kind": "storage#objects",
+        }
+        dummy_url = "https://dummy.gcs.com/buckets/b1/objects"
 
-    expected_response_object = Response(
-        status_code=200,
-        url=dummy_url,
-        json=expected_response,
-        req=Request(method="GET", url=dummy_url),
-    )
+        expected_response_object = Response(
+            status_code=200,
+            url=dummy_url,
+            json=expected_response,
+            req=Request(method="GET", url=dummy_url),
+        )
 
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            async for blob_document in mocked_gcs_object.get_docs():
-                assert blob_document[0] is None
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                async for blob_document in source.get_docs():
+                    assert blob_document[0] is None
 
 
 @pytest.mark.asyncio
 async def test_get_content():
     """Test the module responsible for fetching the content of the file if it is extractable."""
 
-    # Setup
-    mocked_gcs_object = get_gcs_source_object()
-    blob_document = {
-        "id": "bucket_1/blob_1/123123123",
-        "component_count": None,
-        "content_encoding": None,
-        "content_language": None,
-        "created_at": None,
-        "last_updated": "2011-10-12T00:01:00Z",
-        "metadata": None,
-        "name": "blob_1.txt",
-        "size": "15",
-        "storage_class": None,
-        "_timestamp": "2011-10-12T00:01:00Z",
-        "type": None,
-        "url": "https://console.cloud.google.com/storage/browser/_details/bucket_1/blob_1;tab=live_object?project=dummy123",
-        "version": None,
-        "bucket_name": "bucket_1",
-    }
-    expected_blob_document = {
-        "_id": "bucket_1/blob_1/123123123",
-        "_timestamp": "2011-10-12T00:01:00Z",
-        "_attachment": "",
-    }
-    blob_content_response = ""
+    async with create_gcs_source() as source:
+        blob_document = {
+            "id": "bucket_1/blob_1/123123123",
+            "component_count": None,
+            "content_encoding": None,
+            "content_language": None,
+            "created_at": None,
+            "last_updated": "2011-10-12T00:01:00Z",
+            "metadata": None,
+            "name": "blob_1.txt",
+            "size": "15",
+            "storage_class": None,
+            "_timestamp": "2011-10-12T00:01:00Z",
+            "type": None,
+            "url": "https://console.cloud.google.com/storage/browser/_details/bucket_1/blob_1;tab=live_object?project=dummy123",
+            "version": None,
+            "bucket_name": "bucket_1",
+        }
+        expected_blob_document = {
+            "_id": "bucket_1/blob_1/123123123",
+            "_timestamp": "2011-10-12T00:01:00Z",
+            "_attachment": "",
+        }
+        blob_content_response = ""
 
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=blob_content_response
-    ):
-        async with Aiogoogle(
-            service_account_creds=mocked_gcs_object._google_storage_client.service_account_credentials
-        ) as google_client:
-            storage_client = await google_client.discover(
-                api_name=API_NAME, api_version=API_VERSION
-            )
-            storage_client.objects = mock.MagicMock()
-            content = await mocked_gcs_object.get_content(
-                blob=blob_document,
-                doit=True,
-            )
-            assert content == expected_blob_document
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=blob_content_response
+        ):
+            async with Aiogoogle(
+                service_account_creds=source._google_storage_client.service_account_credentials
+            ) as google_client:
+                storage_client = await google_client.discover(
+                    api_name=API_NAME, api_version=API_VERSION
+                )
+                storage_client.objects = mock.MagicMock()
+                content = await source.get_content(
+                    blob=blob_document,
+                    doit=True,
+                )
+                assert content == expected_blob_document
 
 
 @pytest.mark.asyncio
 async def test_get_content_with_upper_extension():
     """Test the module responsible for fetching the content of the file if it is extractable."""
 
-    # Setup
-    mocked_gcs_object = get_gcs_source_object()
-    blob_document = {
-        "id": "bucket_1/blob_1/123123123",
-        "component_count": None,
-        "content_encoding": None,
-        "content_language": None,
-        "created_at": None,
-        "last_updated": "2011-10-12T00:01:00Z",
-        "metadata": None,
-        "name": "blob_1.TXT",
-        "size": "15",
-        "storage_class": None,
-        "_timestamp": "2011-10-12T00:01:00Z",
-        "type": None,
-        "url": "https://console.cloud.google.com/storage/browser/_details/bucket_1/blob_1;tab=live_object?project=dummy123",
-        "version": None,
-        "bucket_name": "bucket_1",
-    }
-    expected_blob_document = {
-        "_id": "bucket_1/blob_1/123123123",
-        "_timestamp": "2011-10-12T00:01:00Z",
-        "_attachment": "",
-    }
-    blob_content_response = ""
+    async with create_gcs_source() as source:
+        blob_document = {
+            "id": "bucket_1/blob_1/123123123",
+            "component_count": None,
+            "content_encoding": None,
+            "content_language": None,
+            "created_at": None,
+            "last_updated": "2011-10-12T00:01:00Z",
+            "metadata": None,
+            "name": "blob_1.TXT",
+            "size": "15",
+            "storage_class": None,
+            "_timestamp": "2011-10-12T00:01:00Z",
+            "type": None,
+            "url": "https://console.cloud.google.com/storage/browser/_details/bucket_1/blob_1;tab=live_object?project=dummy123",
+            "version": None,
+            "bucket_name": "bucket_1",
+        }
+        expected_blob_document = {
+            "_id": "bucket_1/blob_1/123123123",
+            "_timestamp": "2011-10-12T00:01:00Z",
+            "_attachment": "",
+        }
+        blob_content_response = ""
 
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=blob_content_response
-    ):
-        async with Aiogoogle(
-            service_account_creds=mocked_gcs_object._google_storage_client.service_account_credentials
-        ) as google_client:
-            storage_client = await google_client.discover(
-                api_name=API_NAME, api_version=API_VERSION
-            )
-            storage_client.objects = mock.MagicMock()
-            content = await mocked_gcs_object.get_content(
-                blob=blob_document,
-                doit=True,
-            )
-            assert content == expected_blob_document
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=blob_content_response
+        ):
+            async with Aiogoogle(
+                service_account_creds=source._google_storage_client.service_account_credentials
+            ) as google_client:
+                storage_client = await google_client.discover(
+                    api_name=API_NAME, api_version=API_VERSION
+                )
+                storage_client.objects = mock.MagicMock()
+                content = await source.get_content(
+                    blob=blob_document,
+                    doit=True,
+                )
+                assert content == expected_blob_document
 
 
 @pytest.mark.asyncio
 async def test_get_content_when_type_not_supported():
     """Test the module responsible for fetching the content of the file if it is not extractable or doit is not true."""
 
-    # Setup
-    mocked_gcs_object = get_gcs_source_object()
-    blob_document = {
-        "_id": "bucket_1/blob_1/123123123",
-        "component_count": None,
-        "content_encoding": None,
-        "content_language": None,
-        "created_at": None,
-        "last_updated": "2011-10-12T00:01:00Z",
-        "metadata": None,
-        "name": "blob_1.cc",
-        "size": "15",
-        "storage_class": None,
-        "_timestamp": "2011-10-12T00:01:00Z",
-        "type": None,
-        "url": "https://console.cloud.google.com/storage/browser/_details/None/blob_1;tab=live_object?project=dummy123",
-        "version": None,
-        "bucket_name": None,
-    }
+    async with create_gcs_source() as source:
+        blob_document = {
+            "_id": "bucket_1/blob_1/123123123",
+            "component_count": None,
+            "content_encoding": None,
+            "content_language": None,
+            "created_at": None,
+            "last_updated": "2011-10-12T00:01:00Z",
+            "metadata": None,
+            "name": "blob_1.cc",
+            "size": "15",
+            "storage_class": None,
+            "_timestamp": "2011-10-12T00:01:00Z",
+            "type": None,
+            "url": "https://console.cloud.google.com/storage/browser/_details/None/blob_1;tab=live_object?project=dummy123",
+            "version": None,
+            "bucket_name": None,
+        }
 
-    # Execute and Assert
-    async with Aiogoogle(
-        service_account_creds=mocked_gcs_object._google_storage_client.service_account_credentials
-    ) as google_client:
-        storage_client = await google_client.discover(
-            api_name=API_NAME, api_version=API_VERSION
-        )
-        storage_client.objects = mock.MagicMock()
-        content = await mocked_gcs_object.get_content(
-            blob=blob_document,
-            doit=True,
-        )
-        assert content is None
+        async with Aiogoogle(
+            service_account_creds=source._google_storage_client.service_account_credentials
+        ) as google_client:
+            storage_client = await google_client.discover(
+                api_name=API_NAME, api_version=API_VERSION
+            )
+            storage_client.objects = mock.MagicMock()
+            content = await source.get_content(
+                blob=blob_document,
+                doit=True,
+            )
+            assert content is None
 
-        content = await mocked_gcs_object.get_content(
-            blob=blob_document,
-        )
-        assert content is None
+            content = await source.get_content(
+                blob=blob_document,
+            )
+            assert content is None
 
 
 @pytest.mark.asyncio
 async def test_get_content_when_file_size_is_large(catch_stdout):
     """Test the module responsible for fetching the content of the file if it is not extractable or doit is not true."""
 
-    # Setup
-    mocked_gcs_object = get_gcs_source_object()
-    blob_document = {
-        "_id": "bucket_1/blob_1/123123123",
-        "component_count": None,
-        "content_encoding": None,
-        "content_language": None,
-        "created_at": None,
-        "last_updated": "2011-10-12T00:01:00Z",
-        "metadata": None,
-        "name": "blob_1.txt",
-        "size": 10000000000000,
-        "storage_class": None,
-        "_timestamp": "2011-10-12T00:01:00Z",
-        "type": None,
-        "url": "https://console.cloud.google.com/storage/browser/_details/None/blob_1;tab=live_object?project=dummy123",
-        "version": None,
-        "bucket_name": None,
-    }
+    async with create_gcs_source() as source:
+        blob_document = {
+            "_id": "bucket_1/blob_1/123123123",
+            "component_count": None,
+            "content_encoding": None,
+            "content_language": None,
+            "created_at": None,
+            "last_updated": "2011-10-12T00:01:00Z",
+            "metadata": None,
+            "name": "blob_1.txt",
+            "size": 10000000000000,
+            "storage_class": None,
+            "_timestamp": "2011-10-12T00:01:00Z",
+            "type": None,
+            "url": "https://console.cloud.google.com/storage/browser/_details/None/blob_1;tab=live_object?project=dummy123",
+            "version": None,
+            "bucket_name": None,
+        }
 
-    # Execute and Assert
-    async with Aiogoogle(
-        service_account_creds=mocked_gcs_object._google_storage_client.service_account_credentials
-    ) as google_client:
-        storage_client = await google_client.discover(
-            api_name=API_NAME, api_version=API_VERSION
-        )
-        storage_client.objects = mock.MagicMock()
-        content = await mocked_gcs_object.get_content(
-            blob=blob_document,
-            doit=True,
-        )
-        assert content is None
+        async with Aiogoogle(
+            service_account_creds=source._google_storage_client.service_account_credentials
+        ) as google_client:
+            storage_client = await google_client.discover(
+                api_name=API_NAME, api_version=API_VERSION
+            )
+            storage_client.objects = mock.MagicMock()
+            content = await source.get_content(
+                blob=blob_document,
+                doit=True,
+            )
+            assert content is None
 
-        content = await mocked_gcs_object.get_content(
-            blob=blob_document,
-        )
-        assert content is None
+            content = await source.get_content(
+                blob=blob_document,
+            )
+            assert content is None
 
 
 @pytest.mark.asyncio
 async def test_api_call_for_attribute_error(catch_stdout):
     """Tests the api_call method when resource attribute is not present in the getattr."""
 
-    # Setup
-
-    mocked_gcs_object = get_gcs_source_object()
-
-    # Execute
-    with pytest.raises(AttributeError):
-        async for _ in mocked_gcs_object._google_storage_client.api_call(
-            resource="buckets_dummy",
-            method="list",
-            full_response=True,
-            project=mocked_gcs_object._google_storage_client.user_project_id,
-            userProject=mocked_gcs_object._google_storage_client.user_project_id,
-        ):
-            print("Method called successfully....")
+    async with create_gcs_source() as source:
+        with pytest.raises(AttributeError):
+            async for _ in source._google_storage_client.api_call(
+                resource="buckets_dummy",
+                method="list",
+                full_response=True,
+                project=source._google_storage_client.user_project_id,
+                userProject=source._google_storage_client.user_project_id,
+            ):
+                print("Method called successfully....")

--- a/tests/sources/test_google_drive.py
+++ b/tests/sources/test_google_drive.py
@@ -7,6 +7,7 @@
 """
 import asyncio
 import re
+from contextlib import asynccontextmanager
 from unittest import mock
 
 import pytest
@@ -16,34 +17,31 @@ from aiogoogle.models import Request, Response
 
 from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.google_drive import RETRIES, GoogleDriveDataSource
+from tests.sources.support import create_source
 
 SERVICE_ACCOUNT_CREDENTIALS = '{"project_id": "dummy123"}'
 
 MORE_THAN_DEFAULT_FILE_SIZE_LIMIT = 10485760 + 1
 
 
-def get_google_drive_source_object():
-    """Creates the mocked Google Drive source object.
-
-    Returns:
-        GoogleDriveDataSource: Mocked object of the data source class.
-    """
-    configuration = DataSourceConfiguration(
-        {"service_account_credentials": SERVICE_ACCOUNT_CREDENTIALS}
-    )
-    mocked_google_drive_object = GoogleDriveDataSource(configuration=configuration)
-    return mocked_google_drive_object
+@asynccontextmanager
+async def create_gdrive_source():
+    async with create_source(
+        GoogleDriveDataSource,
+        service_account_credentials=SERVICE_ACCOUNT_CREDENTIALS,
+        use_document_level_security=False,
+        google_workspace_admin_email="admin@your-organization.com",
+    ) as source:
+        yield source
 
 
 @pytest.mark.asyncio
 async def test_empty_configuration():
     """Tests the validity of the configurations passed to the Google Drive source class."""
 
-    # Setup
     configuration = DataSourceConfiguration({"service_account_credentials": ""})
     gd_object = GoogleDriveDataSource(configuration=configuration)
 
-    # Execute
     with pytest.raises(
         ConfigurableFieldValueError,
         match="Field validation errors: 'Service_account_credentials' cannot be empty.",
@@ -55,13 +53,11 @@ async def test_empty_configuration():
 async def test_raise_on_invalid_configuration():
     """Test if invalid configuration raises an expected Exception"""
 
-    # Setup
     configuration = DataSourceConfiguration(
         {"service_account_credentials": "{'abc':'bcd','cd'}"}
     )
     gd_object = GoogleDriveDataSource(configuration=configuration)
 
-    # Execute
     with pytest.raises(
         ConfigurableFieldValueError,
         match="Google Drive service account is not a valid JSON",
@@ -73,21 +69,17 @@ async def test_raise_on_invalid_configuration():
 async def test_ping_for_successful_connection():
     """Tests the ping functionality for ensuring connection to Google Drive."""
 
-    # Setup
-
     expected_response = {
         "kind": "drive#about",
     }
-    mocked_gd_object = get_google_drive_source_object()
-    as_service_account_response = asyncio.Future()
-    as_service_account_response.set_result(expected_response)
+    async with create_gdrive_source() as source:
+        as_service_account_response = asyncio.Future()
+        as_service_account_response.set_result(expected_response)
 
-    # Execute
-
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=as_service_account_response
-    ):
-        await mocked_gd_object.ping()
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=as_service_account_response
+        ):
+            await source.ping()
 
 
 @mock.patch("connectors.utils.apply_retry_strategy", mock.AsyncMock())
@@ -95,16 +87,12 @@ async def test_ping_for_successful_connection():
 async def test_ping_for_failed_connection():
     """Tests the ping functionality when connection can not be established to Google Drive."""
 
-    # Setup
-
-    mocked_gd_object = get_google_drive_source_object()
-
-    # Execute
-    with mock.patch.object(
-        Aiogoogle, "discover", side_effect=Exception("Something went wrong")
-    ):
-        with pytest.raises(Exception):
-            await mocked_gd_object.ping()
+    async with create_gdrive_source() as source:
+        with mock.patch.object(
+            Aiogoogle, "discover", side_effect=Exception("Something went wrong")
+        ):
+            with pytest.raises(Exception):
+                await source.ping()
 
 
 @pytest.mark.parametrize(
@@ -149,17 +137,13 @@ async def test_ping_for_failed_connection():
 async def test_prepare_files(files, expected_files):
     """Tests the function which modifies the fetched files and maps the values to keys."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        processed_files = []
 
-    processed_files = []
+        async for file in source.prepare_files(files_page=files[0], paths=dict()):
+            processed_files.append(file)
 
-    # Execute
-    async for file in mocked_gd_object.prepare_files(files_page=files[0], paths=dict()):
-        processed_files.append(file)
-
-    # Assert
-    assert processed_files == expected_files
+        assert processed_files == expected_files
 
 
 @pytest.mark.parametrize(
@@ -294,37 +278,25 @@ async def test_prepare_files(files, expected_files):
 @pytest.mark.asyncio
 async def test_prepare_file(file, expected_file):
     """Test the method that formats the file metadata from Google Drive API"""
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
 
-    dummy_paths = {
-        "folderId4": {
-            "name": "Folder4",
-            "parents": ["driveId3"],
-            "path": "Drive3/Folder4",
+    async with create_gdrive_source() as source:
+        dummy_paths = {
+            "folderId4": {
+                "name": "Folder4",
+                "parents": ["driveId3"],
+                "path": "Drive3/Folder4",
+            }
         }
-    }
 
-    # Execute and Assert
-    assert expected_file == await mocked_gd_object.prepare_file(
-        file=file, paths=dummy_paths
-    )
+        assert expected_file == await source.prepare_file(file=file, paths=dummy_paths)
 
 
 @pytest.mark.asyncio
 async def test_list_drives():
     """Tests the method which lists the shared drives from Google Drive."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    expected_response = {
-        "kind": "drive#driveList",
-        "drives": [
-            {"id": "0ABHLjfsUwpHFUk9PVA", "name": "Test Drive", "kind": "drive#drive"},
-        ],
-    }
-    expected_drives_list = [
-        {
+    async with create_gdrive_source() as source:
+        expected_response = {
             "kind": "drive#driveList",
             "drives": [
                 {
@@ -334,48 +306,44 @@ async def test_list_drives():
                 },
             ],
         }
-    ]
-    dummy_url = "https://www.googleapis.com/drive/v3/drives"
+        expected_drives_list = [
+            {
+                "kind": "drive#driveList",
+                "drives": [
+                    {
+                        "id": "0ABHLjfsUwpHFUk9PVA",
+                        "name": "Test Drive",
+                        "kind": "drive#drive",
+                    },
+                ],
+            }
+        ]
+        dummy_url = "https://www.googleapis.com/drive/v3/drives"
 
-    expected_response_object = Response(
-        status_code=200,
-        url=dummy_url,
-        json=expected_response,
-        req=Request(method="GET", url=dummy_url),
-    )
+        expected_response_object = Response(
+            status_code=200,
+            url=dummy_url,
+            json=expected_response,
+            req=Request(method="GET", url=dummy_url),
+        )
 
-    # Execute
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            drives_list = []
-            async for drive in mocked_gd_object.google_drive_client.list_drives():
-                drives_list.append(drive)
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                drives_list = []
+                async for drive in source.google_drive_client.list_drives():
+                    drives_list.append(drive)
 
-    # Assert
-    assert drives_list == expected_drives_list
+        assert drives_list == expected_drives_list
 
 
 @pytest.mark.asyncio
 async def test_list_folders():
     """Tests the method which lists the folders from Google Drive."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    expected_response = {
-        "kind": "drive#fileList",
-        "files": [
-            {
-                "kind": "drive#file",
-                "mimeType": "application/vnd.google-apps.folder",
-                "id": "1kGzmOTZgherwS9ODxZNC-owji_QZGGRU",
-                "name": "test",
-            }
-        ],
-    }
-    expected_folders_list = [
-        {
+    async with create_gdrive_source() as source:
+        expected_response = {
             "kind": "drive#fileList",
             "files": [
                 {
@@ -386,27 +354,37 @@ async def test_list_folders():
                 }
             ],
         }
-    ]
-    dummy_url = "https://www.googleapis.com/drive/v3/files"
+        expected_folders_list = [
+            {
+                "kind": "drive#fileList",
+                "files": [
+                    {
+                        "kind": "drive#file",
+                        "mimeType": "application/vnd.google-apps.folder",
+                        "id": "1kGzmOTZgherwS9ODxZNC-owji_QZGGRU",
+                        "name": "test",
+                    }
+                ],
+            }
+        ]
+        dummy_url = "https://www.googleapis.com/drive/v3/files"
 
-    expected_response_object = Response(
-        status_code=200,
-        url=dummy_url,
-        json=expected_response,
-        req=Request(method="GET", url=dummy_url),
-    )
+        expected_response_object = Response(
+            status_code=200,
+            url=dummy_url,
+            json=expected_response,
+            req=Request(method="GET", url=dummy_url),
+        )
 
-    # Execute
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            folders_list = []
-            async for folder in mocked_gd_object.google_drive_client.list_folders():
-                folders_list.append(folder)
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                folders_list = []
+                async for folder in source.google_drive_client.list_folders():
+                    folders_list.append(folder)
 
-    # Assert
-    assert folders_list == expected_folders_list
+        assert folders_list == expected_folders_list
 
 
 @pytest.mark.asyncio
@@ -456,38 +434,25 @@ async def test_resolve_paths():
     folders_future = asyncio.Future()
     folders_future.set_result(folders)
 
-    mocked_gd_object = get_google_drive_source_object()
-    mocked_gd_object.google_drive_client.get_all_drives = mock.MagicMock(
-        return_value=drives_future
-    )
-    mocked_gd_object.google_drive_client.get_all_folders = mock.MagicMock(
-        return_value=folders_future
-    )
+    async with create_gdrive_source() as source:
+        source.google_drive_client.get_all_drives = mock.MagicMock(
+            return_value=drives_future
+        )
+        source.google_drive_client.get_all_folders = mock.MagicMock(
+            return_value=folders_future
+        )
 
-    paths = await mocked_gd_object.resolve_paths()
+        paths = await source.resolve_paths()
 
-    assert paths == expected_paths
+        assert paths == expected_paths
 
 
 @pytest.mark.asyncio
 async def test_fetch_files():
     """Tests the method responsible to yield files from Google Drive."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    expected_response = {
-        "kind": "drive#fileList",
-        "files": [
-            {
-                "kind": "drive#file",
-                "mimeType": "text/plain",
-                "id": "id1",
-                "name": "test",
-            }
-        ],
-    }
-    expected_files_list = [
-        {
+    async with create_gdrive_source() as source:
+        expected_response = {
             "kind": "drive#fileList",
             "files": [
                 {
@@ -498,277 +463,273 @@ async def test_fetch_files():
                 }
             ],
         }
-    ]
-    dummy_url = "https://www.googleapis.com/drive/v3/files"
+        expected_files_list = [
+            {
+                "kind": "drive#fileList",
+                "files": [
+                    {
+                        "kind": "drive#file",
+                        "mimeType": "text/plain",
+                        "id": "id1",
+                        "name": "test",
+                    }
+                ],
+            }
+        ]
+        dummy_url = "https://www.googleapis.com/drive/v3/files"
 
-    expected_response_object = Response(
-        status_code=200,
-        url=dummy_url,
-        json=expected_response,
-        req=Request(method="GET", url=dummy_url),
-    )
+        expected_response_object = Response(
+            status_code=200,
+            url=dummy_url,
+            json=expected_response,
+            req=Request(method="GET", url=dummy_url),
+        )
 
-    # Execute
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            files_list = []
-            async for file in mocked_gd_object.google_drive_client.list_folders():
-                files_list.append(file)
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                files_list = []
+                async for file in source.google_drive_client.list_folders():
+                    files_list.append(file)
 
-    # Assert
-    assert files_list == expected_files_list
+        assert files_list == expected_files_list
 
 
 @pytest.mark.asyncio
 async def test_get_docs():
     """Tests the module responsible to fetch and yield files documents from Google Drive."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    expected_response = {
-        "kind": "drive#fileList",
-        "files": [
-            {
-                "kind": "drive#file",
-                "mimeType": "text/plain",
-                "id": "id1",
-                "name": "test.txt",
-                "parents": ["0APU6durKUAiqUk9PVA"],
-                "size": "28",
-                "modifiedTime": "2023-06-28T07:46:28.000Z",
-            }
-        ],
-    }
-    expected_file_document = {
-        "_id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "test.txt",
-        "size": "28",
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "mime_type": "text/plain",
-        "file_extension": None,
-        "url": None,
-        "type": "file",
-    }
-    dummy_url = "https://www.googleapis.com/drive/v3/files"
+    async with create_gdrive_source() as source:
+        expected_response = {
+            "kind": "drive#fileList",
+            "files": [
+                {
+                    "kind": "drive#file",
+                    "mimeType": "text/plain",
+                    "id": "id1",
+                    "name": "test.txt",
+                    "parents": ["0APU6durKUAiqUk9PVA"],
+                    "size": "28",
+                    "modifiedTime": "2023-06-28T07:46:28.000Z",
+                }
+            ],
+        }
+        expected_file_document = {
+            "_id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "test.txt",
+            "size": "28",
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "mime_type": "text/plain",
+            "file_extension": None,
+            "url": None,
+            "type": "file",
+        }
+        dummy_url = "https://www.googleapis.com/drive/v3/files"
 
-    expected_response_object = Response(
-        status_code=200,
-        url=dummy_url,
-        json=expected_response,
-        req=Request(method="GET", url=dummy_url),
-    )
+        expected_response_object = Response(
+            status_code=200,
+            url=dummy_url,
+            json=expected_response,
+            req=Request(method="GET", url=dummy_url),
+        )
 
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            async for file_document in mocked_gd_object.get_docs():
-                assert file_document[0] == expected_file_document
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                async for file_document in source.get_docs():
+                    assert file_document[0] == expected_file_document
 
 
 @pytest.mark.asyncio
 async def test_get_content():
     """Test the module responsible for fetching the content of the file if it is extractable."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "test.txt",
-        "size": 28,
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "mime_type": "text/plain",
-        "file_extension": "txt",
-        "url": None,
-        "type": "file",
-    }
-    expected_file_document = {
-        "_id": "id1",
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "_attachment": "",
-    }
-    file_content_response = ""
+    async with create_gdrive_source() as source:
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "test.txt",
+            "size": 28,
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "mime_type": "text/plain",
+            "file_extension": "txt",
+            "url": None,
+            "type": "file",
+        }
+        expected_file_document = {
+            "_id": "id1",
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "_attachment": "",
+        }
+        file_content_response = ""
 
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=file_content_response
-    ):
-        async with Aiogoogle(
-            service_account_creds=mocked_gd_object.google_drive_client.service_account_credentials
-        ) as google_client:
-            drive_client = await google_client.discover(
-                api_name="drive", api_version="v3"
-            )
-            drive_client.files = mock.MagicMock()
-            content = await mocked_gd_object.get_content(
-                file=file_document,
-                doit=True,
-            )
-            assert content == expected_file_document
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=file_content_response
+        ):
+            async with Aiogoogle(
+                service_account_creds=source.google_drive_client.service_account_credentials
+            ) as google_client:
+                drive_client = await google_client.discover(
+                    api_name="drive", api_version="v3"
+                )
+                drive_client.files = mock.MagicMock()
+                content = await source.get_content(
+                    file=file_document,
+                    doit=True,
+                )
+                assert content == expected_file_document
 
 
 @pytest.mark.asyncio
 async def test_get_content_doit_false():
     """Test the module responsible for fetching the content of the file with `doit` set to False"""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "test.txt",
-        "size": 28,
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "mime_type": "text/plain",
-        "file_extension": "txt",
-        "url": None,
-        "type": "file",
-    }
+    async with create_gdrive_source() as source:
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "test.txt",
+            "size": 28,
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "mime_type": "text/plain",
+            "file_extension": "txt",
+            "url": None,
+            "type": "file",
+        }
 
-    # Execute and Assert
-    content = await mocked_gd_object.get_content(
-        file=file_document,
-        doit=False,
-    )
-    assert content is None
+        content = await source.get_content(
+            file=file_document,
+            doit=False,
+        )
+        assert content is None
 
 
 @pytest.mark.asyncio
 async def test_get_content_google_workspace_called():
     """Test the method responsible for selecting right extraction method depending on MIME type"""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        timestamp = "1234"
 
-    timestamp = "1234"
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "Google docs test",
+            "size": 28,
+            "_timestamp": timestamp,
+            "mime_type": "application/vnd.google-apps.document",
+            "file_extension": None,
+            "url": None,
+            "type": "file",
+        }
+        expected_content = {
+            "_id": "id1",
+            "_timestamp": timestamp,
+            "_attachment": "Test content",
+        }
+        expected_content_future = asyncio.Future()
+        expected_content_future.set_result(expected_content)
 
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "Google docs test",
-        "size": 28,
-        "_timestamp": timestamp,
-        "mime_type": "application/vnd.google-apps.document",
-        "file_extension": None,
-        "url": None,
-        "type": "file",
-    }
-    expected_content = {
-        "_id": "id1",
-        "_timestamp": timestamp,
-        "_attachment": "Test content",
-    }
-    expected_content_future = asyncio.Future()
-    expected_content_future.set_result(expected_content)
+        source.get_google_workspace_content = mock.MagicMock(
+            return_value=expected_content_future
+        )
+        source.get_generic_file_content = mock.MagicMock()
 
-    mocked_gd_object.get_google_workspace_content = mock.MagicMock(
-        return_value=expected_content_future
-    )
-    mocked_gd_object.get_generic_file_content = mock.MagicMock()
-
-    # Execute and Assert
-    await mocked_gd_object.get_content(
-        file=file_document,
-        timestamp=timestamp,
-        doit=True,
-    )
-    mocked_gd_object.get_google_workspace_content.assert_called_once_with(
-        file_document, timestamp=timestamp
-    )
-    mocked_gd_object.get_generic_file_content.assert_not_called()
+        await source.get_content(
+            file=file_document,
+            timestamp=timestamp,
+            doit=True,
+        )
+        source.get_google_workspace_content.assert_called_once_with(
+            file_document, timestamp=timestamp
+        )
+        source.get_generic_file_content.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_get_content_generic_files_called():
     """Test the method responsible for selecting right extraction method depending on MIME type"""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        timestamp = "1234"
 
-    timestamp = "1234"
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "text.txt",
+            "size": 28,
+            "_timestamp": timestamp,
+            "mime_type": "text/plain",
+            "file_extension": "txt",
+            "url": None,
+            "type": "file",
+        }
+        expected_content = {
+            "_id": "id1",
+            "_timestamp": timestamp,
+            "_attachment": "Test content",
+        }
+        expected_content_future = asyncio.Future()
+        expected_content_future.set_result(expected_content)
 
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "text.txt",
-        "size": 28,
-        "_timestamp": timestamp,
-        "mime_type": "text/plain",
-        "file_extension": "txt",
-        "url": None,
-        "type": "file",
-    }
-    expected_content = {
-        "_id": "id1",
-        "_timestamp": timestamp,
-        "_attachment": "Test content",
-    }
-    expected_content_future = asyncio.Future()
-    expected_content_future.set_result(expected_content)
+        source.get_google_workspace_content = mock.MagicMock()
+        source.get_generic_file_content = mock.MagicMock(
+            return_value=expected_content_future
+        )
 
-    mocked_gd_object.get_google_workspace_content = mock.MagicMock()
-    mocked_gd_object.get_generic_file_content = mock.MagicMock(
-        return_value=expected_content_future
-    )
-
-    # Execute and Assert
-    await mocked_gd_object.get_content(
-        file=file_document,
-        timestamp=timestamp,
-        doit=True,
-    )
-    mocked_gd_object.get_google_workspace_content.assert_not_called()
-    mocked_gd_object.get_generic_file_content.assert_called_once_with(
-        file_document, timestamp=timestamp
-    )
+        await source.get_content(
+            file=file_document,
+            timestamp=timestamp,
+            doit=True,
+        )
+        source.get_google_workspace_content.assert_not_called()
+        source.get_generic_file_content.assert_called_once_with(
+            file_document, timestamp=timestamp
+        )
 
 
 @pytest.mark.asyncio
 async def test_get_google_workspace_content():
     """Test the module responsible for fetching the content of the Google Suite document."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "test.txt",
-        "size": 28,
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "mime_type": "application/vnd.google-apps.document",
-        "file_extension": None,
-        "url": None,
-        "type": "file",
-    }
-    expected_file_document = {
-        "_id": "id1",
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "_attachment": "I love unit tests",
-    }
-    file_content_response = ("I love unit tests", 1234)
-    future_file_content_response = asyncio.Future()
-    future_file_content_response.set_result(file_content_response)
+    async with create_gdrive_source() as source:
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "test.txt",
+            "size": 28,
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "mime_type": "application/vnd.google-apps.document",
+            "file_extension": None,
+            "url": None,
+            "type": "file",
+        }
+        expected_file_document = {
+            "_id": "id1",
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "_attachment": "I love unit tests",
+        }
+        file_content_response = ("I love unit tests", 1234)
+        future_file_content_response = asyncio.Future()
+        future_file_content_response.set_result(file_content_response)
 
-    # Execute and Assert
-    mocked_gd_object._download_content = mock.MagicMock(
-        return_value=future_file_content_response
-    )
-    content = await mocked_gd_object.get_content(
-        file=file_document,
-        doit=True,
-    )
-    assert content == expected_file_document
+        source._download_content = mock.MagicMock(
+            return_value=future_file_content_response
+        )
+        content = await source.get_content(
+            file=file_document,
+            doit=True,
+        )
+        assert content == expected_file_document
 
 
 @pytest.mark.asyncio
@@ -776,156 +737,28 @@ async def test_get_google_workspace_content_size_limit():
     """Test the module responsible for fetching the content of the Google Suite document if its size
     is above the limit."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "test.txt",
-        "size": 28,
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "mime_type": "application/vnd.google-apps.document",
-        "file_extension": None,
-        "url": None,
-        "type": "file",
-    }
+    async with create_gdrive_source() as source:
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "test.txt",
+            "size": 28,
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "mime_type": "application/vnd.google-apps.document",
+            "file_extension": None,
+            "url": None,
+            "type": "file",
+        }
 
-    file_content_response = ("I love unit tests", MORE_THAN_DEFAULT_FILE_SIZE_LIMIT)
-    future_file_content_response = asyncio.Future()
-    future_file_content_response.set_result(file_content_response)
+        file_content_response = ("I love unit tests", MORE_THAN_DEFAULT_FILE_SIZE_LIMIT)
+        future_file_content_response = asyncio.Future()
+        future_file_content_response.set_result(file_content_response)
 
-    # Execute and Assert
-    mocked_gd_object._download_content = mock.MagicMock(
-        return_value=future_file_content_response
-    )
-    content = await mocked_gd_object.get_content(
-        file=file_document,
-        doit=True,
-    )
-    assert content is None
-
-
-@pytest.mark.asyncio
-async def test_get_generic_file_content():
-    """Test the module responsible for fetching the content of the file if it is extractable."""
-
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "test.txt",
-        "size": 28,
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "mime_type": "text/plain",
-        "file_extension": "txt",
-        "url": None,
-        "type": "file",
-    }
-    expected_file_document = {
-        "_id": "id1",
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "_attachment": "I love unit tests generic file",
-    }
-    file_content_response = ("I love unit tests generic file", 1234)
-    future_file_content_response = asyncio.Future()
-    future_file_content_response.set_result(file_content_response)
-
-    # Execute and Assert
-    mocked_gd_object._download_content = mock.MagicMock(
-        return_value=future_file_content_response
-    )
-    content = await mocked_gd_object.get_content(
-        file=file_document,
-        doit=True,
-    )
-    assert content == expected_file_document
-
-
-@pytest.mark.asyncio
-async def test_get_generic_file_content_size_limit():
-    """Test the module responsible for fetching the content of the file size is above the limit."""
-
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "test.txt",
-        "size": MORE_THAN_DEFAULT_FILE_SIZE_LIMIT,
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "mime_type": "text/plain",
-        "file_extension": "txt",
-        "url": None,
-        "type": "file",
-    }
-
-    # Execute and Assert
-    mocked_gd_object._download_content = mock.MagicMock()
-    content = await mocked_gd_object.get_content(
-        file=file_document,
-        doit=True,
-    )
-    assert content is None
-
-
-@pytest.mark.asyncio
-async def test_get_generic_file_content_empty_file():
-    """Test the module responsible for fetching the content of the file if the file size is 0."""
-
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "test.txt",
-        "size": 0,
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "mime_type": "text/plain",
-        "file_extension": "txt",
-        "url": None,
-        "type": "file",
-    }
-
-    # Execute and Assert
-    mocked_gd_object._download_content = mock.MagicMock()
-    content = await mocked_gd_object.get_content(
-        file=file_document,
-        doit=True,
-    )
-    assert content is None
-
-
-@pytest.mark.asyncio
-async def test_get_content_when_type_not_supported():
-    """Test the module responsible for fetching the content of the file if it is not extractable."""
-
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-    file_document = {
-        "id": "id1",
-        "created_at": None,
-        "last_updated": "2023-06-28T07:46:28.000Z",
-        "name": "test.xd",
-        "size": 28,
-        "_timestamp": "2023-06-28T07:46:28.000Z",
-        "mime_type": "text/plain",
-        "file_extension": "xd",
-        "url": None,
-        "type": "file",
-    }
-
-    # Execute and Assert
-    async with Aiogoogle(
-        service_account_creds=mocked_gd_object.google_drive_client.service_account_credentials
-    ) as google_client:
-        drive_client = await google_client.discover(api_name="drive", api_version="v3")
-        drive_client.files = mock.MagicMock()
-        content = await mocked_gd_object.get_content(
+        source._download_content = mock.MagicMock(
+            return_value=future_file_content_response
+        )
+        content = await source.get_content(
             file=file_document,
             doit=True,
         )
@@ -933,85 +766,194 @@ async def test_get_content_when_type_not_supported():
 
 
 @pytest.mark.asyncio
+async def test_get_generic_file_content():
+    """Test the module responsible for fetching the content of the file if it is extractable."""
+
+    async with create_gdrive_source() as source:
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "test.txt",
+            "size": 28,
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "mime_type": "text/plain",
+            "file_extension": "txt",
+            "url": None,
+            "type": "file",
+        }
+        expected_file_document = {
+            "_id": "id1",
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "_attachment": "I love unit tests generic file",
+        }
+        file_content_response = ("I love unit tests generic file", 1234)
+        future_file_content_response = asyncio.Future()
+        future_file_content_response.set_result(file_content_response)
+
+        source._download_content = mock.MagicMock(
+            return_value=future_file_content_response
+        )
+        content = await source.get_content(
+            file=file_document,
+            doit=True,
+        )
+        assert content == expected_file_document
+
+
+@pytest.mark.asyncio
+async def test_get_generic_file_content_size_limit():
+    """Test the module responsible for fetching the content of the file size is above the limit."""
+
+    async with create_gdrive_source() as source:
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "test.txt",
+            "size": MORE_THAN_DEFAULT_FILE_SIZE_LIMIT,
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "mime_type": "text/plain",
+            "file_extension": "txt",
+            "url": None,
+            "type": "file",
+        }
+
+        source._download_content = mock.MagicMock()
+        content = await source.get_content(
+            file=file_document,
+            doit=True,
+        )
+        assert content is None
+
+
+@pytest.mark.asyncio
+async def test_get_generic_file_content_empty_file():
+    """Test the module responsible for fetching the content of the file if the file size is 0."""
+
+    async with create_gdrive_source() as source:
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "test.txt",
+            "size": 0,
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "mime_type": "text/plain",
+            "file_extension": "txt",
+            "url": None,
+            "type": "file",
+        }
+
+        source._download_content = mock.MagicMock()
+        content = await source.get_content(
+            file=file_document,
+            doit=True,
+        )
+        assert content is None
+
+
+@pytest.mark.asyncio
+async def test_get_content_when_type_not_supported():
+    """Test the module responsible for fetching the content of the file if it is not extractable."""
+
+    async with create_gdrive_source() as source:
+        file_document = {
+            "id": "id1",
+            "created_at": None,
+            "last_updated": "2023-06-28T07:46:28.000Z",
+            "name": "test.xd",
+            "size": 28,
+            "_timestamp": "2023-06-28T07:46:28.000Z",
+            "mime_type": "text/plain",
+            "file_extension": "xd",
+            "url": None,
+            "type": "file",
+        }
+
+        async with Aiogoogle(
+            service_account_creds=source.google_drive_client.service_account_credentials
+        ) as google_client:
+            drive_client = await google_client.discover(
+                api_name="drive", api_version="v3"
+            )
+            drive_client.files = mock.MagicMock()
+            content = await source.get_content(
+                file=file_document,
+                doit=True,
+            )
+            assert content is None
+
+
+@pytest.mark.asyncio
 @mock.patch("connectors.utils.apply_retry_strategy")
 async def test_api_call_for_attribute_error(mock_apply_retry_strategy):
     """Tests the api_call method when resource attribute is not present in the getattr."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-
-    # Execute
-    with pytest.raises(AttributeError):
-        await mocked_gd_object._google_drive_client.api_call(
-            resource="buckets_dummy", method="list"
-        )
+    async with create_gdrive_source() as source:
+        with pytest.raises(AttributeError):
+            await source._google_drive_client.api_call(
+                resource="buckets_dummy", method="list"
+            )
 
 
 @pytest.mark.asyncio
 @mock.patch("connectors.utils.apply_retry_strategy")
 async def test_api_call_http_error(mock_apply_retry_strategy):
     """Test handling retries for HTTPError exception in api_call() method."""
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-
-    with mock.patch.object(
-        Aiogoogle,
-        "as_service_account",
-        side_effect=HTTPError("Ooops exception", res=mock.MagicMock()),
-    ):
-        with pytest.raises(HTTPError):
-            await mocked_gd_object.ping()
+    async with create_gdrive_source() as source:
+        with mock.patch.object(
+            Aiogoogle,
+            "as_service_account",
+            side_effect=HTTPError("Ooops exception", res=mock.MagicMock()),
+        ):
+            with pytest.raises(HTTPError):
+                await source.ping()
 
 
 @pytest.mark.asyncio
 @mock.patch("connectors.utils.apply_retry_strategy")
 async def test_api_call_other_exception(mock_apply_retry_strategy):
     """Test handling retries for generic Exception in api_call() method."""
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
-
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", side_effect=Exception("other")
-    ):
-        with pytest.raises(Exception):
-            await mocked_gd_object.ping()
+    async with create_gdrive_source() as source:
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", side_effect=Exception("other")
+        ):
+            with pytest.raises(Exception):
+                await source.ping()
 
 
 @pytest.mark.asyncio
 @mock.patch("connectors.utils.apply_retry_strategy")
 async def test_api_call_ping_retries(mock_apply_retry_strategy, mock_responses):
     """Test handling retries for generic Exception in api_call() method."""
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        mock_responses.get(url=re.compile(".*"), status=401)
 
-    mock_responses.get(url=re.compile(".*"), status=401)
+        with pytest.raises(Exception):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                await source.ping()
 
-    with pytest.raises(Exception):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            await mocked_gd_object.ping()
-
-    # Expect retry function to be triggered the expected number of retries,
-    # substract the first call
-    assert mock_apply_retry_strategy.call_count == RETRIES - 1
+        # Expect retry function to be triggered the expected number of retries,
+        # substract the first call
+        assert mock_apply_retry_strategy.call_count == RETRIES - 1
 
 
 @pytest.mark.asyncio
 @mock.patch("connectors.utils.apply_retry_strategy")
 async def test_api_call_list_drives_retries(mock_apply_retry_strategy, mock_responses):
     """Test handling retries for generic Exception in api_call() method."""
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        mock_responses.get(url=re.compile(".*"), status=401)
 
-    mock_responses.get(url=re.compile(".*"), status=401)
+        with pytest.raises(Exception):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                async for _ in source.google_drive_client.list_drives():
+                    continue
 
-    with pytest.raises(Exception):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            async for _ in mocked_gd_object.google_drive_client.list_drives():
-                continue
-
-    # Expect retry function to be triggered the expected number of retries,
-    # substract the first call
-    assert mock_apply_retry_strategy.call_count == RETRIES - 1
+        # Expect retry function to be triggered the expected number of retries,
+        # substract the first call
+        assert mock_apply_retry_strategy.call_count == RETRIES - 1
 
 
 @pytest.mark.parametrize(
@@ -1098,36 +1040,33 @@ async def test_prepare_file_on_shared_drive_with_dls_enabled(
     file, permissions, expected_file
 ):
     """Test the method that formats the file metadata from Google Drive API"""
-    # Setup
 
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        source._dls_enabled = mock.MagicMock(return_value=True)
 
-    mocked_gd_object._dls_enabled = mock.MagicMock(return_value=True)
+        dummy_paths = {
+            "folderId4": {
+                "name": "Folder4",
+                "parents": ["driveId3"],
+                "path": "Drive3/Folder4",
+            },
+            "drive1": {"name": "drive1"},
+        }
 
-    dummy_paths = {
-        "folderId4": {
-            "name": "Folder4",
-            "parents": ["driveId3"],
-            "path": "Drive3/Folder4",
-        },
-        "drive1": {"name": "drive1"},
-    }
+        expected_response_object = Response(
+            status_code=200,
+            url="dummy_url",
+            json={"permissions": permissions},
+            req=Request(method="GET", url="dummy_url"),
+        )
 
-    expected_response_object = Response(
-        status_code=200,
-        url="dummy_url",
-        json={"permissions": permissions},
-        req=Request(method="GET", url="dummy_url"),
-    )
-
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            assert expected_file == await mocked_gd_object.prepare_file(
-                file=file, paths=dummy_paths
-            )
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                assert expected_file == await source.prepare_file(
+                    file=file, paths=dummy_paths
+                )
 
 
 @pytest.mark.parametrize(
@@ -1208,24 +1147,19 @@ async def test_prepare_file_on_shared_drive_with_dls_enabled(
 @pytest.mark.asyncio
 async def test_prepare_file_on_my_drive_with_dls_enabled(file, expected_file):
     """Test the method that formats the file metadata from Google Drive API"""
-    # Setup
 
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        source._dls_enabled = mock.MagicMock(return_value=True)
 
-    mocked_gd_object._dls_enabled = mock.MagicMock(return_value=True)
-
-    dummy_paths = {
-        "folderId4": {
-            "name": "Folder4",
-            "parents": ["driveId3"],
-            "path": "Drive3/Folder4",
+        dummy_paths = {
+            "folderId4": {
+                "name": "Folder4",
+                "parents": ["driveId3"],
+                "path": "Drive3/Folder4",
+            }
         }
-    }
 
-    # Execute and Assert
-    assert expected_file == await mocked_gd_object.prepare_file(
-        file=file, paths=dummy_paths
-    )
+        assert expected_file == await source.prepare_file(file=file, paths=dummy_paths)
 
 
 @pytest.mark.parametrize(
@@ -1295,30 +1229,25 @@ async def test_prepare_file_on_my_drive_with_dls_enabled(file, expected_file):
 @pytest.mark.asyncio
 async def test_prepare_access_control_doc(user, groups, access_control_doc):
     """Test the method that formats the users data from Google Drive API"""
-    # Setup
 
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        source._dls_enabled = mock.MagicMock(return_value=True)
 
-    mocked_gd_object._dls_enabled = mock.MagicMock(return_value=True)
+        expected_response_object = Response(
+            status_code=200,
+            url="dummy_url",
+            json={"groups": groups},
+            req=Request(method="GET", url="dummy_url"),
+        )
 
-    expected_response_object = Response(
-        status_code=200,
-        url="dummy_url",
-        json={"groups": groups},
-        req=Request(method="GET", url="dummy_url"),
-    )
-
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            assert (
-                access_control_doc
-                == await mocked_gd_object.prepare_single_access_control_document(
-                    user=user
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                assert (
+                    access_control_doc
+                    == await source.prepare_single_access_control_document(user=user)
                 )
-            )
 
 
 @pytest.mark.parametrize(
@@ -1396,80 +1325,73 @@ async def test_prepare_access_control_documents(
     users_page, groups, access_control_docs
 ):
     """Test the method that formats the users data from Google Drive API"""
-    # Setup
 
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        source._dls_enabled = mock.MagicMock(return_value=True)
 
-    mocked_gd_object._dls_enabled = mock.MagicMock(return_value=True)
+        expected_response_object = Response(
+            status_code=200,
+            url="dummy_url",
+            json={"groups": groups},
+            req=Request(method="GET", url="dummy_url"),
+        )
 
-    expected_response_object = Response(
-        status_code=200,
-        url="dummy_url",
-        json={"groups": groups},
-        req=Request(method="GET", url="dummy_url"),
-    )
-
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            assert access_control_docs[0] == await anext(
-                mocked_gd_object.prepare_access_control_documents(users_page=users_page)
-            )
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                assert access_control_docs[0] == await anext(
+                    source.prepare_access_control_documents(users_page=users_page)
+                )
 
 
 @pytest.mark.asyncio
 async def test_get_access_control_dls_disabled():
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        source._dls_enabled = mock.MagicMock(return_value=False)
 
-    mocked_gd_object._dls_enabled = mock.MagicMock(return_value=False)
+        acl = []
+        async for access_control in source.get_access_control():
+            acl.append(access_control)
 
-    acl = []
-    async for access_control in mocked_gd_object.get_access_control():
-        acl.append(access_control)
-
-    assert len(acl) == 0
+        assert len(acl) == 0
 
 
 @pytest.mark.asyncio
 async def test_get_access_control_dls_enabled():
     """Tests the module responsible to fetch users data from Google Drive."""
 
-    # Setup
-    mocked_gd_object = get_google_drive_source_object()
+    async with create_gdrive_source() as source:
+        source._dls_enabled = mock.MagicMock(return_value=True)
 
-    mocked_gd_object._dls_enabled = mock.MagicMock(return_value=True)
+        mock_access_control = {
+            "_id": "user1@test.com",
+            "identity": {"name": "User 1", "email": "user1@test.com"},
+            "query": {},
+        }
 
-    mock_access_control = {
-        "_id": "user1@test.com",
-        "identity": {"name": "User 1", "email": "user1@test.com"},
-        "query": {},
-    }
+        source.prepare_single_access_control_document = mock.AsyncMock(
+            return_value=mock_access_control
+        )
+        expected_response = {
+            "users": [
+                {
+                    "id": "user1",
+                    "primaryEmail": "user1@test.com",
+                    "name": {"fullName": "User 1"},
+                }
+            ]
+        }
+        expected_response_object = Response(
+            status_code=200,
+            url="dummy_url",
+            json=expected_response,
+            req=Request(method="GET", url="dummy_url"),
+        )
 
-    mocked_gd_object.prepare_single_access_control_document = mock.AsyncMock(
-        return_value=mock_access_control
-    )
-    expected_response = {
-        "users": [
-            {
-                "id": "user1",
-                "primaryEmail": "user1@test.com",
-                "name": {"fullName": "User 1"},
-            }
-        ]
-    }
-    expected_response_object = Response(
-        status_code=200,
-        url="dummy_url",
-        json=expected_response,
-        req=Request(method="GET", url="dummy_url"),
-    )
-
-    # Execute and Assert
-    with mock.patch.object(
-        Aiogoogle, "as_service_account", return_value=expected_response_object
-    ):
-        with mock.patch.object(ServiceAccountManager, "refresh"):
-            async for access_control in mocked_gd_object.get_access_control():
-                assert access_control == mock_access_control
+        with mock.patch.object(
+            Aiogoogle, "as_service_account", return_value=expected_response_object
+        ):
+            with mock.patch.object(ServiceAccountManager, "refresh"):
+                async for access_control in source.get_access_control():
+                    assert access_control == mock_access_control

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -16,7 +16,7 @@ from aiohttp import StreamReader
 from freezegun import freeze_time
 
 from connectors.protocol import Filter
-from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
+from connectors.source import ConfigurableFieldValueError
 from connectors.sources.jira import JiraClient, JiraDataSource
 from connectors.utils import ssl_context
 from tests.commons import AsyncIterator
@@ -498,7 +498,6 @@ async def test_get_session():
 async def test_close_with_client_session():
     async with create_jira_source() as source:
         source.jira_client._get_session()
-
 
     assert source.jira_client.session is None
 


### PR DESCRIPTION
## Related to https://github.com/elastic/connectors-python/issues/606

Remove `value` field from connector default RCFs, allowing them to be initialised as a type-safe empty value.

- gmail
- google_cloud_storage
- google_drive
- jira
- onedrive

I refactored the `google_cloud_storage` and `google_drive` tests so they would also use `create_source` to generate their test source, bringing them in line with our other connector tests. I didn't update any actual tests, just the way they generate a source.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

## Related PRs

- https://github.com/elastic/connectors-python/pull/1323
- https://github.com/elastic/connectors-python/pull/761
- https://github.com/elastic/connectors-python/pull/1539