### PR TITLE
Fix slack time range error

### DIFF
--- a/connectors/sources/slack.py
+++ b/connectors/sources/slack.py
@@ -261,9 +261,8 @@ class SlackDataSource(BaseDataSource):
             yield message, None
 
     async def channels_and_messages(self):
-        delta = timedelta(days=self.n_days_to_fetch)
-        past_unix_timestamp = time.mktime((datetime.utcnow() - delta).timetuple())
-        current_unix_timestamp = time.mktime(datetime.utcnow().timetuple())
+        current_unix_timestamp = time.time()
+        past_unix_timestamp = current_unix_timestamp - self.n_days_to_fetch * 24 * 3600
         async for channel in self.slack_client.list_channels(
             not self.auto_join_channels
         ):

--- a/connectors/sources/slack.py
+++ b/connectors/sources/slack.py
@@ -7,7 +7,7 @@
 import re
 import time
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import aiohttp
 from aiohttp.client_exceptions import ClientResponseError


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5684

The slack connector will sync messages of past n days (n is configurable), and the time range was incorrect built which cased the latest messages are not synced. This PR fix the bug.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)