### PR TITLE
[8.10] [DOCS] Update README.md (#1537)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,52 @@
 # Elastic Python connectors
 
-![logo](logo-enterprise-search.png)
+<img width="250" alt="search-icon" src="https://github.com/elastic/connectors-python/assets/32779855/2f594d89-7369-4c49-994a-1d67eefce436">
 
-The home of Elastic connector service and connectors written in Python. This repository contains the framework for customizing Elastic connectors, or writing your own connectors for advanced use cases.
+## Connectors
 
-**The connector will be operated by an administrative user from within Kibana.**
+This repository contains the source code for all Elastic connectors, developed by the Search team at Elastic.
+Use connectors to sync data from popular data sources to Elasticsearch.
 
-See the [official end-user documentation](https://www.elastic.co/guide/en/enterprise-search/current/build-connector.html).
+These connectors are available as:
+- [**Connector clients**](https://www.elastic.co/guide/en/enterprise-search/current/build-connector.html) to be self-managed on your own infrastructure
+- [**Native connectors**](https://www.elastic.co/guide/en/enterprise-search/current/native-connectors.html) using our fully managed service on Elastic Cloud
 
-## Guides
+ℹ️ For an overview of the steps involved in deploying connector clients refer to [**Connector clients**](https://www.elastic.co/guide/en/enterprise-search/current/build-connector.html).
+You can get started quickly with Docker, using [these instructions](docs/DOCKER.md).
+We also have an end-to-end tutorial using the [PostgreSQL connector client](https://www.elastic.co/guide/en/enterprise-search/current/postgresql-connector-client-tutorial.html).
+
+### Connector documentation
+
+The main documentation for _using_ connectors lives in the Search solution's docs.
+Here are the main pages:
+
+- [Connectors overview](https://www.elastic.co/guide/en/enterprise-search/current/connectors.html)
+- [Connector clients](https://www.elastic.co/guide/en/enterprise-search/current/build-connector.html)
+- [Native connectors](https://www.elastic.co/guide/en/enterprise-search/current/native-connectors.html)
+
+You'll also find the individual references for each connector there.
+For everything to do with _developing_ connectors, you'll find that here in this repo.
+
+## Connector service code
+
+In addition to the source code for individual connectors, this repo also contains the connector service code, which is used for tasks like running connectors, and managing scheduling, syncs, and cleanup.
+This is shared code that is not used by individual connectors, but helps to coordinate and run a deployed instance/process.
+
+## Python connector framework
+
+This repo is also the home of the Elastic Python connector framework. This framework enables developers to build Elastic-supported connector clients.
+The framework implements common functionalities out of the box, so developers can focus on the logic specific to integrating their chosen data source.
+
+The framework ensures compatibility, makes it easier for our team to review PRs, and help out in the development process. When you build using our framework, we provide a pathway for the connector to be officially supported by Elastic.
+
+### Framework use cases
+
+The framework serves two distinct, but related use cases:
+
+- Customizing an existing Elastic connector client
+- Building a new connector client
+
+### Guides for using the framework
 
 - [Code of Conduct](https://www.elastic.co/community/codeofconduct)
 - [Getting Support](docs/SUPPORT.md)
@@ -21,17 +59,3 @@ See the [official end-user documentation](https://www.elastic.co/guide/en/enterp
 - [Configuration](docs/CONFIG.md)
 - [Contribution guide](docs/CONTRIBUTING.md)
 - [Upgrading](docs/UPGRADING.md)
-
-### Advanced sync rules
-
-- [MySQL](docs/sync-rules/MYSQL.md)
-- [JIRA](docs/sync-rules/JIRA.md)
-- [CONFLUENCE](docs/sync-rules/CONFLUENCE.md)
-- [SERVICENOW](docs/sync-rules/SERVICENOW.md)
-- [GITHUB](docs/sync-rules/GITHUB.md)
-- [NETWORK_DRIVE](docs/sync-rules/NETWORK_DRIVE.md)
-
-### Document level security
-
-- [JIRA](docs/document-level-security/JIRA.md)
-- [CONFLUENCE](docs/document-level-security/CONFLUENCE.md)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[DOCS] Update README.md (#1537)](https://github.com/elastic/connectors-python/pull/1537)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)