### PR TITLE
Revert removed boolean `value` fields

### DIFF
--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -287,6 +287,7 @@ class ConfluenceDataSource(BaseDataSource):
                 "label": "Enable SSL",
                 "order": 8,
                 "type": "bool",
+                "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],
@@ -322,6 +323,7 @@ class ConfluenceDataSource(BaseDataSource):
                 "order": 12,
                 "tooltip": "Document level security ensures identities and permissions set in confluence are maintained in Elasticsearch. This enables you to restrict and personalize read-access users have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
+                "value": True,
             },
         }
 

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -323,7 +323,7 @@ class ConfluenceDataSource(BaseDataSource):
                 "order": 12,
                 "tooltip": "Document level security ensures identities and permissions set in confluence are maintained in Elasticsearch. This enables you to restrict and personalize read-access users have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
-                "value": True,
+                "value": False,
             },
         }
 

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -902,6 +902,7 @@ class GitHubDataSource(BaseDataSource):
                 "label": "Enable SSL",
                 "order": 5,
                 "type": "bool",
+                "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -490,7 +490,7 @@ class GoogleDriveDataSource(BaseDataSource):
                 "order": 2,
                 "tooltip": "Document level security ensures identities and permissions set in Google Drive are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
-                "value": True,
+                "value": False,
             },
             "google_workspace_admin_email": {
                 "depends_on": [{"field": "use_document_level_security", "value": True}],

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -490,6 +490,7 @@ class GoogleDriveDataSource(BaseDataSource):
                 "order": 2,
                 "tooltip": "Document level security ensures identities and permissions set in Google Drive are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
+                "value": True,
             },
             "google_workspace_admin_email": {
                 "depends_on": [{"field": "use_document_level_security", "value": True}],

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -366,7 +366,7 @@ class JiraDataSource(BaseDataSource):
                 "order": 12,
                 "tooltip": "Document level security ensures identities and permissions set in Jira are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
-                "value": True,
+                "value": False,
             },
         }
 

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -330,6 +330,7 @@ class JiraDataSource(BaseDataSource):
                 "label": "Enable SSL",
                 "order": 8,
                 "type": "bool",
+                "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],
@@ -365,6 +366,7 @@ class JiraDataSource(BaseDataSource):
                 "order": 12,
                 "tooltip": "Document level security ensures identities and permissions set in Jira are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
+                "value": True,
             },
         }
 

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -143,6 +143,7 @@ class MongoDataSource(BaseDataSource):
                 "label": "Direct connection",
                 "order": 6,
                 "type": "bool",
+                "value": False,
             },
         }
 

--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -451,6 +451,7 @@ class MSSQLDataSource(BaseDataSource):
                 "label": "Enable SSL verification",
                 "order": 10,
                 "type": "bool",
+                "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],
@@ -463,6 +464,7 @@ class MSSQLDataSource(BaseDataSource):
                 "label": "Validate host",
                 "order": 12,
                 "type": "bool",
+                "value": False,
             },
         }
 

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -388,6 +388,7 @@ class MySqlDataSource(BaseDataSource):
                 "label": "Enable SSL",
                 "order": 7,
                 "type": "bool",
+                "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],

--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -342,6 +342,7 @@ class PostgreSQLDataSource(BaseDataSource):
                 "label": "Enable SSL verification",
                 "order": 9,
                 "type": "bool",
+                "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],


### PR DESCRIPTION
## Related to https://github.com/elastic/connectors-python/issues/606

When removing not-useful `value` fields from connector configurable fields, I mistakenly removed some bool-type values.
Fields with boolean type should always have an initial value.

## Related PRs

- https://github.com/elastic/connectors-python/pull/761
- https://github.com/elastic/connectors-python/pull/1539
- https://github.com/elastic/connectors-python/pull/1540
- https://github.com/elastic/connectors-python/pull/1541