### PR TITLE
[GMail] Consider RCF configuration value in dls_enabled check

### DIFF
--- a/connectors/sources/gmail.py
+++ b/connectors/sources/gmail.py
@@ -208,10 +208,11 @@ class GMailDataSource(BaseDataSource):
                 raise
 
     def _dls_enabled(self):
-        if self._features is None:
-            return False
-
-        return self._features.document_level_security_enabled()
+        return (
+            self._features is not None
+            and self._features.document_level_security_enabled()
+            and self.configuration["use_document_level_security"]
+        )
 
     def access_control_query(self, access_control):
         return es_access_control_query(access_control)

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,6 +329,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,22 +329,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5727

This PR ensures that the GMail connector considers the `use_document_level_security` RCF value inside `_dls_enabled`. This fixes a bug, where the `_allow_access_control` was present even if the RCF value was `False`.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)