### PR TITLE
[GMail] Validate subject RCF value

### DIFF
--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -6,7 +6,6 @@
 import asyncio
 import json
 import os
-import re
 from functools import cached_property, partial
 
 import aiofiles
@@ -25,10 +24,12 @@ from connectors.logger import logger
 from connectors.source import BaseDataSource, ConfigurableFieldValueError
 from connectors.sources.google import validate_service_account_json
 from connectors.utils import (
+    EMAIL_REGEX_PATTERN,
     TIKA_SUPPORTED_FILETYPES,
     RetryStrategy,
     convert_to_b64,
     retryable,
+    validate_email_address,
 )
 
 GOOGLE_DRIVE_SERVICE_NAME = "Google Drive"
@@ -58,9 +59,6 @@ GOOGLE_DRIVE_EMULATOR_HOST = os.environ.get("GOOGLE_DRIVE_EMULATOR_HOST")
 RUNNING_FTEST = (
     "RUNNING_FTEST" in os.environ
 )  # Flag to check if a connector is run for ftest or not.
-
-# Regular expression pattern to match a basic email format (no whitespace, valid domain)
-EMAIL_REGEX_PATTERN = r"^\S+@\S+\.\S+$"
 
 
 class RetryableAiohttpSession(AiohttpSession):
@@ -593,7 +591,7 @@ class GoogleDriveDataSource(BaseDataSource):
                     "Google Workspace admin email cannot be empty when Document Level Security is enabled."
                 )
 
-            if not re.fullmatch(EMAIL_REGEX_PATTERN, google_workspace_admin_email):
+            if not validate_email_address(google_workspace_admin_email):
                 raise ConfigurableFieldValueError(
                     "Google Workspace admin email is malformed or contains whitespace characters."
                 )

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,6 +329,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,22 +329,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -10,6 +10,7 @@ import hashlib
 import inspect
 import os
 import platform
+import re
 import shutil
 import ssl
 import subprocess
@@ -36,6 +37,10 @@ DEFAULT_QUEUE_MEM_SIZE = 5
 DEFAULT_CHUNK_MEM_SIZE = 25
 DEFAULT_MAX_CONCURRENCY = 5
 DEFAULT_CONCURRENT_DOWNLOADS = 10
+
+# Regular expression pattern to match a basic email format (no whitespace, valid domain)
+EMAIL_REGEX_PATTERN = r"^\S+@\S+\.\S+$"
+
 TIKA_SUPPORTED_FILETYPES = [
     ".txt",
     ".py",
@@ -902,3 +907,11 @@ def base64url_to_base64(string):
 
     string = string.replace("-", "+")
     return string.replace("_", "/")
+
+
+def validate_email_address(email_address):
+    """Validates an email address against a regular expression.
+    This method does not include any remote check against an SMTP server for example."""
+
+    # non None values indicate a match
+    return re.fullmatch(EMAIL_REGEX_PATTERN, email_address) is not None

--- a/tests/sources/test_gmail.py
+++ b/tests/sources/test_gmail.py
@@ -28,6 +28,8 @@ TIME = "2023-01-24T04:07:19"
 
 CUSTOMER_ID = "customer_id"
 
+SUBJECT = "subject@email_address.com"
+
 DATE = "2023-01-24T04:07:19+00:00"
 
 JSON_CREDENTIALS = {"key": "value"}
@@ -213,6 +215,7 @@ class TestGMailDataSource:
                 "service_account_credentials"
             ).value = valid_json
             source.configuration.get_field("customer_id").value = CUSTOMER_ID
+            source.configuration.get_field("subject").value = SUBJECT
 
             try:
                 await source.validate_config()
@@ -220,11 +223,25 @@ class TestGMailDataSource:
                 raise AssertionError("Should've been a valid config") from None
 
     @pytest.mark.asyncio
-    async def test_validate_config_invalid(self):
+    async def test_validate_config_invalid_service_account_credentials(self):
         async with create_gmail_source() as source:
             source.configuration.get_field(
                 "service_account_credentials"
             ).value = "invalid json"
+
+            with pytest.raises(ConfigurableFieldValueError):
+                await source.validate_config()
+
+    @pytest.mark.asyncio
+    async def test_validate_config_invalid_subject(self):
+        valid_json = '{"project_id": "dummy123"}'
+
+        async with create_gmail_source() as source:
+            source.configuration.get_field(
+                "service_account_credentials"
+            ).value = valid_json
+            source.configuration.get_field("customer_id").value = CUSTOMER_ID
+            source.configuration.get_field("subject").value = "invalid address"
 
             with pytest.raises(ConfigurableFieldValueError):
                 await source.validate_config()

--- a/tests/sources/test_gmail.py
+++ b/tests/sources/test_gmail.py
@@ -32,7 +32,7 @@ SUBJECT = "subject@email_address.com"
 
 DATE = "2023-01-24T04:07:19+00:00"
 
-JSON_CREDENTIALS = {"key": "value"}
+JSON_CREDENTIALS = {"project_id": "dummy123"}
 
 
 def dls_feature_enabled(value):
@@ -52,7 +52,7 @@ async def create_gmail_source(dls_enabled=False, include_spam_and_trash=False):
     async with create_source(
         GMailDataSource,
         service_account_credentials=json.dumps(JSON_CREDENTIALS),
-        subject="subject",
+        subject=SUBJECT,
         customer_id="foo",
         use_document_level_security=dls_enabled,
         include_spam_and_trash=include_spam_and_trash,
@@ -208,15 +208,7 @@ class TestGMailDataSource:
 
     @pytest.mark.asyncio
     async def test_validate_config_valid(self):
-        valid_json = '{"project_id": "dummy123"}'
-
         async with create_gmail_source() as source:
-            source.configuration.get_field(
-                "service_account_credentials"
-            ).value = valid_json
-            source.configuration.get_field("customer_id").value = CUSTOMER_ID
-            source.configuration.get_field("subject").value = SUBJECT
-
             try:
                 await source.validate_config()
             except ConfigurableFieldValueError:
@@ -234,13 +226,7 @@ class TestGMailDataSource:
 
     @pytest.mark.asyncio
     async def test_validate_config_invalid_subject(self):
-        valid_json = '{"project_id": "dummy123"}'
-
         async with create_gmail_source() as source:
-            source.configuration.get_field(
-                "service_account_credentials"
-            ).value = valid_json
-            source.configuration.get_field("customer_id").value = CUSTOMER_ID
             source.configuration.get_field("subject").value = "invalid address"
 
             with pytest.raises(ConfigurableFieldValueError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,6 +50,7 @@ from connectors.utils import (
     ssl_context,
     truncate_id,
     url_encode,
+    validate_email_address,
     validate_index_name,
 )
 
@@ -854,3 +855,18 @@ class TestExtractionService:
 )
 def test_base64url_to_base64(base64url_encoded_value, base64_expected_value):
     assert base64url_to_base64(base64url_encoded_value) == base64_expected_value
+
+
+@pytest.mark.parametrize(
+    "email_address, is_valid",
+    [
+        ("subject@email_address.com", True),
+        ("subject", False),
+        ("@email_address.com", False),
+        ("", False),
+        ("subject @email_address.com", False),
+        ("subject@email_address", False),
+    ],
+)
+def test_validate_email_address(email_address, is_valid):
+    assert validate_email_address(email_address) == is_valid


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/5592

This PR adds an email address validation for the `subject` field in the GMail connector. It also moves common logic for validating an email address into the `utils.py` module to ensure consistent behavior accross connectors (we could swap out that logic later on with a more mature email address validation library, if we need to).

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)