### PR TITLE
[pre-8.10-stable] Fix mongodb tests by removing mocking of _get_socket + patching admin ping call (#1514)

### DIFF
--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -167,17 +167,9 @@ async def test_ping_when_called_then_does_not_raise(*args):
     admin_mock = Mock()
     command_mock = AsyncMock()
     admin_mock.command = command_mock
-    async with create_source(
-        MongoDataSource,
-        host="mongodb://127.0.0.1:27021",
-        database="db",
-        collection="col",
-        direct_connection=True,
-        user="foo",
-        password="password",
-    ) as source:
-        source.client.admin = admin_mock
-        await source.ping()
+    source = create_connector()
+    source.client.admin = admin_mock
+    await source.ping()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `pre-8.10-stable`:
 - [Fix mongodb tests by removing mocking of _get_socket + patching admin ping call (#1514)](https://github.com/elastic/connectors-python/pull/1514)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)