### PR TITLE
[Google Drive/Storage/Gmail] Handle escaped json strings from user input

### DIFF
--- a/connectors/sources/gmail.py
+++ b/connectors/sources/gmail.py
@@ -3,7 +3,6 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import json
 from functools import cached_property
 
 import fastjsonschema
@@ -21,6 +20,7 @@ from connectors.sources.google import (
     GoogleDirectoryClient,
     MessageFields,
     UserFields,
+    load_service_account_json,
     validate_service_account_json,
 )
 from connectors.utils import (
@@ -205,8 +205,8 @@ class GMailDataSource(BaseDataSource):
 
     @cached_property
     def _service_account_credentials(self):
-        service_account_credentials = json.loads(
-            self.configuration["service_account_credentials"]
+        service_account_credentials = load_service_account_json(
+            self.configuration["service_account_credentials"], "GMail"
         )
         return service_account_credentials
 

--- a/connectors/sources/google.py
+++ b/connectors/sources/google.py
@@ -38,6 +38,46 @@ class MessageFields(Enum):
     FULL_MESSAGE = "raw"
 
 
+def load_service_account_json(service_account_credentials_json, google_service):
+    """
+    Load and parse a Google service account JSON configuration.
+
+    Args:
+        service_account_credentials_json (str): A JSON string containing
+            service account credentials.
+        google_service (str): The name of the Google service being configured (e.g., "Google Cloud").
+
+    Returns:
+        dict: A dictionary representing the parsed JSON credentials.
+
+    Raises:
+        ConfigurableFieldValueError: If the provided JSON is invalid or cannot be loaded.
+    """
+
+    def _load_json(json_string):
+        try:
+            json_credentials = json.loads(json_string)
+        except ValueError as e:
+            raise ConfigurableFieldValueError(
+                f"{google_service} service account is not a valid JSON. Exception: {e}"
+            ) from e
+
+        return json_credentials
+
+    json_credentials = _load_json(service_account_credentials_json)
+
+    if isinstance(json_credentials, dict):
+        return json_credentials
+    elif isinstance(json_credentials, str):
+        # Handle case of escaped json string from the user input,
+        # in that case we need to call json.loads() twice
+        return _load_json(json_credentials)
+    else:
+        raise ConfigurableFieldValueError(
+            f"{google_service} service account is not a valid JSON."
+        )
+
+
 def validate_service_account_json(service_account_credentials, google_service):
     """Validates whether service account JSON is a valid JSON string and
     checks for unexpected keys.
@@ -46,12 +86,9 @@ def validate_service_account_json(service_account_credentials, google_service):
         ConfigurableFieldValueError: The service account json is invalid.
     """
 
-    try:
-        json_credentials = json.loads(service_account_credentials)
-    except ValueError as e:
-        raise ConfigurableFieldValueError(
-            f"{google_service} service account is not a valid JSON. Exception: {e}"
-        ) from e
+    json_credentials = load_service_account_json(
+        service_account_credentials, google_service
+    )
 
     for key in json_credentials.keys():
         if key not in SERVICE_ACCOUNT_JSON_ALLOWED_KEYS:

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -4,7 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
-import json
 import os
 from functools import cached_property, partial
 
@@ -22,7 +21,10 @@ from connectors.access_control import (
 )
 from connectors.logger import logger
 from connectors.source import BaseDataSource, ConfigurableFieldValueError
-from connectors.sources.google import validate_service_account_json
+from connectors.sources.google import (
+    load_service_account_json,
+    validate_service_account_json,
+)
 from connectors.utils import (
     EMAIL_REGEX_PATTERN,
     TIKA_SUPPORTED_FILETYPES,
@@ -33,6 +35,7 @@ from connectors.utils import (
 )
 
 GOOGLE_DRIVE_SERVICE_NAME = "Google Drive"
+GOOGLE_ADMIN_DIRECTORY_SERVICE_NAME = "Google Admin Directory"
 
 RETRIES = 3
 RETRY_INTERVAL = 2
@@ -525,7 +528,9 @@ class GoogleDriveDataSource(BaseDataSource):
             service_account_credentials, GOOGLE_DRIVE_SERVICE_NAME
         )
 
-        json_credentials = json.loads(service_account_credentials)
+        json_credentials = load_service_account_json(
+            service_account_credentials, GOOGLE_DRIVE_SERVICE_NAME
+        )
 
         return GoogleDriveClient(json_credentials=json_credentials)
 
@@ -539,12 +544,14 @@ class GoogleDriveDataSource(BaseDataSource):
         service_account_credentials = self.configuration["service_account_credentials"]
 
         validate_service_account_json(
-            service_account_credentials, "Google Admin Directory"
+            service_account_credentials, GOOGLE_ADMIN_DIRECTORY_SERVICE_NAME
         )
 
         self._validate_google_workspace_admin_email()
 
-        json_credentials = json.loads(service_account_credentials)
+        json_credentials = load_service_account_json(
+            service_account_credentials, GOOGLE_ADMIN_DIRECTORY_SERVICE_NAME
+        )
 
         return GoogleAdminDirectoryClient(
             json_credentials=json_credentials,

--- a/tests/sources/fixtures/description.txt
+++ b/tests/sources/fixtures/description.txt
@@ -1,0 +1,1 @@
+Running an e2e test for google_drive with a medium corpus.

--- a/tests/sources/test_google.py
+++ b/tests/sources/test_google.py
@@ -13,6 +13,7 @@ from connectors.sources.google import (
     GMailClient,
     GoogleDirectoryClient,
     GoogleServiceAccountClient,
+    load_service_account_json,
     remove_universe_domain,
     validate_service_account_json,
 )
@@ -66,6 +67,35 @@ def test_validate_service_account_json_when_invalid():
     with pytest.raises(ConfigurableFieldValueError):
         validate_service_account_json(
             invalid_service_account_credentials, "some google service"
+        )
+
+
+def test_load_service_account_json_valid_unescaped():
+    valid_unescaped_service_account_credentials = '{"project_id": "dummy123"}'
+
+    json_credentials = load_service_account_json(
+        valid_unescaped_service_account_credentials, "some google service"
+    )
+
+    assert isinstance(json_credentials, dict)
+
+
+def test_load_service_account_json_valid_escaped():
+    valid_unescaped_service_account_credentials = '"{\\"project_id\\": \\"dummy123\\"}"'
+
+    json_credentials = load_service_account_json(
+        valid_unescaped_service_account_credentials, "some google service"
+    )
+
+    assert isinstance(json_credentials, dict)
+
+
+def test_load_service_account_json_not_valid():
+    valid_unescaped_service_account_credentials = "xd"
+
+    with pytest.raises(ConfigurableFieldValueError):
+        load_service_account_json(
+            valid_unescaped_service_account_credentials, "some google service"
         )
 
 

--- a/tests/sources/test_google_cloud_storage.py
+++ b/tests/sources/test_google_cloud_storage.py
@@ -56,7 +56,7 @@ async def test_raise_on_invalid_configuration():
 
     with pytest.raises(
         ConfigurableFieldValueError,
-        match="Google Cloud service account is not a valid JSON",
+        match="Google Cloud Storage service account is not a valid JSON",
     ):
         await gcs_object.validate_config()
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5676

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

`json.loads()` doesn't work with escaped JSON strings out of the box. This change adds additional logic that handles valid escaped json strings by essentially calling `json.loads` twice. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
