### PR TITLE
Ensure indices are created on startup

### DIFF
--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -10,7 +10,7 @@ import time
 from enum import Enum
 
 from elastic_transport.client_utils import url_to_node_config
-from elasticsearch import ApiError, AsyncElasticsearch, ConflictError, NotFoundError
+from elasticsearch import ApiError, AsyncElasticsearch, ConflictError
 from elasticsearch import ConnectionError as ElasticConnectionError
 
 from connectors import __version__
@@ -171,8 +171,10 @@ class ESClient:
         for index in indices:
             logger.debug(f"Checking index {index}")
             if not await self.client.indices.exists(index=index):
-                await self.client.index(index=index, document={}, id='.connectors-create-doc')
-                await self.client.delete(index=index, id='.connectors-create-doc')
+                await self.client.index(
+                    index=index, document={}, id=".connectors-create-doc"
+                )
+                await self.client.delete(index=index, id=".connectors-create-doc")
                 logger.debug(f"Created index {index}")
 
     async def delete_indices(self, indices):

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -225,7 +225,11 @@ async def prepare(service_type, index_name, config, connector_definition=None):
         }
 
         logger.info(f"Prepare {CONNECTORS_INDEX} document")
-        await es.client.index(index=CONNECTORS_INDEX, id=config["connectors"][0]["connector_id"], document=doc)
+        await es.client.index(
+            index=CONNECTORS_INDEX,
+            id=config["connectors"][0]["connector_id"],
+            document=doc,
+        )
 
         logger.info(f"Prepare {index_name}")
         mappings = Mappings.default_text_fields_mappings(

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -89,77 +89,6 @@ DEFAULT_PIPELINE = {
     ],
 }
 
-# This should be updated when ftest starts to hate on it for any reason
-# Later we won't need it at all
-JOB_INDEX_MAPPINGS = {
-    "dynamic": "false",
-    "_meta": {"version": 1},
-    "properties": {
-        "cancelation_requested_at": {"type": "date"},
-        "canceled_at": {"type": "date"},
-        "completed_at": {"type": "date"},
-        "connector": {
-            "properties": {
-                "configuration": {"type": "object"},
-                "filtering": {
-                    "properties": {
-                        "advanced_snippet": {
-                            "properties": {
-                                "created_at": {"type": "date"},
-                                "updated_at": {"type": "date"},
-                                "value": {"type": "object"},
-                            }
-                        },
-                        "domain": {"type": "keyword"},
-                        "rules": {
-                            "properties": {
-                                "created_at": {"type": "date"},
-                                "field": {"type": "keyword"},
-                                "id": {"type": "keyword"},
-                                "order": {"type": "short"},
-                                "policy": {"type": "keyword"},
-                                "rule": {"type": "keyword"},
-                                "updated_at": {"type": "date"},
-                                "value": {"type": "keyword"},
-                            }
-                        },
-                        "warnings": {
-                            "properties": {
-                                "ids": {"type": "keyword"},
-                                "messages": {"type": "text"},
-                            }
-                        },
-                    }
-                },
-                "id": {"type": "keyword"},
-                "index_name": {"type": "keyword"},
-                "language": {"type": "keyword"},
-                "pipeline": {
-                    "properties": {
-                        "extract_binary_content": {"type": "boolean"},
-                        "name": {"type": "keyword"},
-                        "reduce_whitespace": {"type": "boolean"},
-                        "run_ml_inference": {"type": "boolean"},
-                    }
-                },
-                "service_type": {"type": "keyword"},
-            }
-        },
-        "created_at": {"type": "date"},
-        "deleted_document_count": {"type": "integer"},
-        "error": {"type": "keyword"},
-        "indexed_document_count": {"type": "integer"},
-        "indexed_document_volume": {"type": "integer"},
-        "last_seen": {"type": "date"},
-        "metadata": {"type": "object"},
-        "started_at": {"type": "date"},
-        "status": {"type": "keyword"},
-        "total_document_count": {"type": "integer"},
-        "trigger_method": {"type": "keyword"},
-        "worker_hostname": {"type": "keyword"},
-    },
-}
-
 
 async def prepare(service_type, index_name, config, connector_definition=None):
     klass = get_source_klass(config["sources"][service_type])
@@ -295,16 +224,8 @@ async def prepare(service_type, index_name, config, connector_definition=None):
             "is_native": False,
         }
 
-        logger.info(f"Prepare {CONNECTORS_INDEX}")
-        await upsert_index(
-            es,
-            CONNECTORS_INDEX,
-            docs=[doc],
-            doc_ids=[config["connectors"][0]["connector_id"]],
-        )
-
-        logger.info(f"Prepare {JOBS_INDEX}")
-        await upsert_index(es, JOBS_INDEX, docs=[], mappings=JOB_INDEX_MAPPINGS)
+        logger.info(f"Prepare {CONNECTORS_INDEX} document")
+        await es.client.index(index=CONNECTORS_INDEX, id=config["connectors"][0]["connector_id"], document=doc)
 
         logger.info(f"Prepare {index_name}")
         mappings = Mappings.default_text_fields_mappings(

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -19,8 +19,8 @@ from connectors.logger import logger, set_logger
 from connectors.source import get_source_klass
 from connectors.utils import validate_index_name
 
-CONNECTORS_INDEX = ".elastic-connectors"
-JOBS_INDEX = ".elastic-connectors-sync-jobs"
+CONNECTORS_INDEX = ".elastic-connectors-v1"
+JOBS_INDEX = ".elastic-connectors-sync-jobs-v1"
 DEFAULT_CONFIG = os.path.join(os.path.dirname(__file__), "..", "config.yml")
 DEFAULT_FILTERING = [
     {

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -8,7 +8,7 @@ import aiohttp
 
 from connectors.es import ESClient
 from connectors.logger import logger
-from connectors.protocol import CONNECTORS_INDEX, JOBS_INDEX
+from connectors.protocol import CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX
 from connectors.utils import CancellableSleeps
 
 
@@ -92,10 +92,12 @@ class PreflightCheck:
         while self.running:
             try:
                 # Checking the indices/pipeline in the loop to be less strict about the boot ordering
-                # Using concrete write index to create these to ensure ES-installed template takes
+                # Using concrete write index to create these to ensure ES-installed template processes
+                # The templates are installed here: https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
+                # and located here: https://github.com/elastic/elasticsearch/tree/main/x-pack/plugin/core/template-resources/src/main/resources/entsearch/connector
 
                 await self.es_client.ensure_exists(
-                    indices=[CONNECTORS_INDEX + "-v1", JOBS_INDEX + "-v1"]
+                    indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
                 )
                 return True
             except Exception as e:

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -95,7 +95,7 @@ class PreflightCheck:
                 # Using concrete write index to create these to ensure ES-installed template takes
 
                 await self.es_client.ensure_exists(
-                    indices=[CONNECTORS_INDEX + '-v1', JOBS_INDEX +'-v1']
+                    indices=[CONNECTORS_INDEX + "-v1", JOBS_INDEX + "-v1"]
                 )
                 return True
             except Exception as e:

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -92,8 +92,10 @@ class PreflightCheck:
         while self.running:
             try:
                 # Checking the indices/pipeline in the loop to be less strict about the boot ordering
-                await self.es_client.check_exists(
-                    indices=[CONNECTORS_INDEX, JOBS_INDEX]
+                # Using concrete write index to create these to ensure ES-installed template takes
+
+                await self.es_client.ensure_exists(
+                    indices=[CONNECTORS_INDEX + '-v1', JOBS_INDEX +'-v1']
                 )
                 return True
             except Exception as e:

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -42,6 +42,8 @@ from connectors.utils import (
 __all__ = [
     "CONNECTORS_INDEX",
     "JOBS_INDEX",
+    "CONCRETE_CONNECTORS_INDEX",
+    "CONCRETE_JOBS_INDEX",
     "ConnectorIndex",
     "Filter",
     "SyncJobIndex",
@@ -65,6 +67,8 @@ __all__ = [
 
 CONNECTORS_INDEX = ".elastic-connectors"
 JOBS_INDEX = ".elastic-connectors-sync-jobs"
+CONCRETE_CONNECTORS_INDEX = CONNECTORS_INDEX + "-v1"
+CONCRETE_JOBS_INDEX = JOBS_INDEX + "-v1"
 
 JOB_NOT_FOUND_ERROR = "Couldn't find the job"
 UNKNOWN_ERROR = "unknown error"

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,6 +5,7 @@ aioresponses==0.7.4
 pytest==7.4.0
 pytest-cov==4.1.0
 pytest-asyncio==0.21.1
+pytest-mock==3.11.1
 pytest-randomly==3.13.0
 git+https://github.com/elastic/perf8#egg=perf8
 freezegun==1.2.2

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -40,12 +40,10 @@ def mock_index_creation(index, mock_responses, hidden=True):
 def test_main(patch_logger, mock_responses):
     headers = {"X-Elastic-Product": "Elasticsearch"}
 
-    mock_index_creation(".elastic-connectors", mock_responses)
     mock_responses.put(
-        "http://nowhere.com:9200/.elastic-connectors/_doc/1",
+        "http://nowhere.com:9200/.elastic-connectors-v1/_doc/1",
         headers=headers,
     )
-    mock_index_creation(".elastic-connectors-sync-jobs", mock_responses)
     mock_index_creation("data", mock_responses, hidden=False)
     mock_responses.get(
         "http://nowhere.com:9200/_ingest/pipeline/ent-search-generic-ingestion",

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -40,13 +40,15 @@ def mock_index_exists(mock_responses, index, exist=True, repeat=False):
     status = 200 if exist else 404
     mock_responses.head(f"{host}/{index}", status=status, repeat=repeat)
 
-def mock_index(mock_responses, index, id, repeat=False):
-    status = 200
-    mock_responses.put(f"{host}/{index}/_doc/{id}", status=status, repeat=repeat)
 
-def mock_delete(mock_responses, index, id, repeat=False):
+def mock_index(mock_responses, index, doc_id, repeat=False):
     status = 200
-    mock_responses.delete(f"{host}/{index}/_doc/{id}", status=status, repeat=repeat)
+    mock_responses.put(f"{host}/{index}/_doc/{doc_id}", status=status, repeat=repeat)
+
+
+def mock_delete(mock_responses, index, doc_id, repeat=False):
+    status = 200
+    mock_responses.delete(f"{host}/{index}/_doc/{doc_id}", status=status, repeat=repeat)
 
 
 @pytest.mark.asyncio
@@ -56,52 +58,55 @@ async def test_es_unavailable(mock_responses):
     result = await preflight.run()
     assert result is False
 
+
 @pytest.mark.asyncio
 async def test_connectors_index_missing(mocker, mock_responses):
-    id = ".connectors-create-doc"
+    doc_id = ".connectors-create-doc"
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, exist=False)
     mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=True)
-    mock_index(mock_responses, CONCRETE_CONNECTORS_INDEX, id)
-    mock_delete(mock_responses, CONCRETE_CONNECTORS_INDEX, id)
+    mock_index(mock_responses, CONCRETE_CONNECTORS_INDEX, doc_id)
+    mock_delete(mock_responses, CONCRETE_CONNECTORS_INDEX, doc_id)
     preflight = PreflightCheck(config)
-    spy = mocker.spy(preflight.es_client.client, 'index')
-    deleteSpy = mocker.spy(preflight.es_client.client, 'delete')
+    spy = mocker.spy(preflight.es_client.client, "index")
+    delete_spy = mocker.spy(preflight.es_client.client, "delete")
     await preflight.run()
-    spy.assert_called_with(index=CONCRETE_CONNECTORS_INDEX, document={}, id=id)
-    deleteSpy.assert_called_with(index=CONCRETE_CONNECTORS_INDEX, id=id)
+    spy.assert_called_with(index=CONCRETE_CONNECTORS_INDEX, document={}, id=doc_id)
+    delete_spy.assert_called_with(index=CONCRETE_CONNECTORS_INDEX, id=doc_id)
+
 
 @pytest.mark.asyncio
 async def test_jobs_index_missing(mocker, mock_responses):
-    id = ".connectors-create-doc"
+    doc_id = ".connectors-create-doc"
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, exist=True)
     mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=False)
-    mock_index(mock_responses, CONCRETE_JOBS_INDEX, id)
-    mock_delete(mock_responses, CONCRETE_JOBS_INDEX, id)
+    mock_index(mock_responses, CONCRETE_JOBS_INDEX, doc_id)
+    mock_delete(mock_responses, CONCRETE_JOBS_INDEX, doc_id)
     preflight = PreflightCheck(config)
-    spy = mocker.spy(preflight.es_client.client, 'index')
-    deleteSpy = mocker.spy(preflight.es_client.client, 'delete')
+    spy = mocker.spy(preflight.es_client.client, "index")
+    delete_spy = mocker.spy(preflight.es_client.client, "delete")
     await preflight.run()
-    spy.assert_called_with(index=CONCRETE_JOBS_INDEX, document={}, id=id)
-    deleteSpy.assert_called_with(index=CONCRETE_JOBS_INDEX, id=id)
+    spy.assert_called_with(index=CONCRETE_JOBS_INDEX, document={}, id=doc_id)
+    delete_spy.assert_called_with(index=CONCRETE_JOBS_INDEX, id=doc_id)
+
 
 @pytest.mark.asyncio
 async def test_both_indices_missing(mocker, mock_responses):
-    id = ".connectors-create-doc"
+    doc_id = ".connectors-create-doc"
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, exist=False)
     mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=False)
-    mock_index(mock_responses, CONCRETE_CONNECTORS_INDEX, id)
-    mock_index(mock_responses, CONCRETE_JOBS_INDEX, id)
-    mock_delete(mock_responses, CONCRETE_CONNECTORS_INDEX, id)
-    mock_delete(mock_responses, CONCRETE_JOBS_INDEX, id)
+    mock_index(mock_responses, CONCRETE_CONNECTORS_INDEX, doc_id)
+    mock_index(mock_responses, CONCRETE_JOBS_INDEX, doc_id)
+    mock_delete(mock_responses, CONCRETE_CONNECTORS_INDEX, doc_id)
+    mock_delete(mock_responses, CONCRETE_JOBS_INDEX, doc_id)
     preflight = PreflightCheck(config)
-    spy = mocker.spy(preflight.es_client.client, 'index')
-    deleteSpy = mocker.spy(preflight.es_client.client, 'delete')
+    spy = mocker.spy(preflight.es_client.client, "index")
+    delete_spy = mocker.spy(preflight.es_client.client, "delete")
     await preflight.run()
     assert spy.call_count == 2
-    assert deleteSpy.call_count == 2
+    assert delete_spy.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from connectors.preflight_check import PreflightCheck
-from connectors.protocol import CONNECTORS_INDEX, JOBS_INDEX
+from connectors.protocol import CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX
 
 headers = {"X-Elastic-Product": "Elasticsearch"}
 host = "http://localhost:9200"
@@ -40,6 +40,14 @@ def mock_index_exists(mock_responses, index, exist=True, repeat=False):
     status = 200 if exist else 404
     mock_responses.head(f"{host}/{index}", status=status, repeat=repeat)
 
+def mock_index(mock_responses, index, id, repeat=False):
+    status = 200
+    mock_responses.put(f"{host}/{index}/_doc/{id}", status=status, repeat=repeat)
+
+def mock_delete(mock_responses, index, id, repeat=False):
+    status = 200
+    mock_responses.delete(f"{host}/{index}/_doc/{id}", status=status, repeat=repeat)
+
 
 @pytest.mark.asyncio
 async def test_es_unavailable(mock_responses):
@@ -48,22 +56,59 @@ async def test_es_unavailable(mock_responses):
     result = await preflight.run()
     assert result is False
 
+@pytest.mark.asyncio
+async def test_connectors_index_missing(mocker, mock_responses):
+    id = ".connectors-create-doc"
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, exist=False)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=True)
+    mock_index(mock_responses, CONCRETE_CONNECTORS_INDEX, id)
+    mock_delete(mock_responses, CONCRETE_CONNECTORS_INDEX, id)
+    preflight = PreflightCheck(config)
+    spy = mocker.spy(preflight.es_client.client, 'index')
+    deleteSpy = mocker.spy(preflight.es_client.client, 'delete')
+    await preflight.run()
+    spy.assert_called_with(index=CONCRETE_CONNECTORS_INDEX, document={}, id=id)
+    deleteSpy.assert_called_with(index=CONCRETE_CONNECTORS_INDEX, id=id)
 
 @pytest.mark.asyncio
-async def test_both_indices_missing(mock_responses):
+async def test_jobs_index_missing(mocker, mock_responses):
+    id = ".connectors-create-doc"
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=False)
-    mock_index_exists(mock_responses, JOBS_INDEX, exist=False)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, exist=True)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=False)
+    mock_index(mock_responses, CONCRETE_JOBS_INDEX, id)
+    mock_delete(mock_responses, CONCRETE_JOBS_INDEX, id)
     preflight = PreflightCheck(config)
-    result = await preflight.run()
-    assert result is False
+    spy = mocker.spy(preflight.es_client.client, 'index')
+    deleteSpy = mocker.spy(preflight.es_client.client, 'delete')
+    await preflight.run()
+    spy.assert_called_with(index=CONCRETE_JOBS_INDEX, document={}, id=id)
+    deleteSpy.assert_called_with(index=CONCRETE_JOBS_INDEX, id=id)
+
+@pytest.mark.asyncio
+async def test_both_indices_missing(mocker, mock_responses):
+    id = ".connectors-create-doc"
+    mock_es_info(mock_responses)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, exist=False)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=False)
+    mock_index(mock_responses, CONCRETE_CONNECTORS_INDEX, id)
+    mock_index(mock_responses, CONCRETE_JOBS_INDEX, id)
+    mock_delete(mock_responses, CONCRETE_CONNECTORS_INDEX, id)
+    mock_delete(mock_responses, CONCRETE_JOBS_INDEX, id)
+    preflight = PreflightCheck(config)
+    spy = mocker.spy(preflight.es_client.client, 'index')
+    deleteSpy = mocker.spy(preflight.es_client.client, 'delete')
+    await preflight.run()
+    assert spy.call_count == 2
+    assert deleteSpy.call_count == 2
 
 
 @pytest.mark.asyncio
 async def test_pass(mock_responses):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     preflight = PreflightCheck(config)
     result = await preflight.run()
     assert result is True
@@ -73,8 +118,8 @@ async def test_pass(mock_responses):
 async def test_es_transient_error(mock_responses):
     mock_es_info(mock_responses, healthy=False)
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     preflight = PreflightCheck(config)
     result = await preflight.run()
     assert result is True
@@ -83,10 +128,10 @@ async def test_es_transient_error(mock_responses):
 @pytest.mark.asyncio
 async def test_index_exist_transient_error(mock_responses):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=False)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX, repeat=True)
-    mock_index_exists(mock_responses, JOBS_INDEX, exist=False)
-    mock_index_exists(mock_responses, JOBS_INDEX, repeat=True)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, exist=False)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, repeat=True)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=False)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, repeat=True)
     preflight = PreflightCheck(config)
     result = await preflight.run()
     assert result is True
@@ -96,8 +141,8 @@ async def test_index_exist_transient_error(mock_responses):
 @patch("connectors.preflight_check.logger")
 async def test_native_config_is_warned(patched_logger, mock_responses):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     local_config = deepcopy(config)
     local_config["native_service_types"] = ["foo", "bar"]
     del local_config["connectors"]
@@ -119,8 +164,8 @@ async def test_native_config_is_warned(patched_logger, mock_responses):
 @patch("connectors.preflight_check.logger")
 async def test_native_config_is_forced(patched_logger, mock_responses):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     local_config = deepcopy(config)
     local_config["native_service_types"] = ["foo", "bar"]
     local_config["_force_allow_native"] = True
@@ -134,8 +179,8 @@ async def test_native_config_is_forced(patched_logger, mock_responses):
 @patch("connectors.preflight_check.logger")
 async def test_client_config(patched_logger, mock_responses):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     local_config = deepcopy(config)
     local_config["connectors"][0]["connector_id"] = "foo"
     local_config["connectors"][0]["service_type"] = "bar"
@@ -149,8 +194,8 @@ async def test_client_config(patched_logger, mock_responses):
 @patch("connectors.preflight_check.logger")
 async def test_unmodified_default_config(patched_logger, mock_responses):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     local_config = deepcopy(config)
     local_config["connectors"][0]["connector_id"] = "changeme"
     local_config["connectors"][0]["service_type"] = "changeme"
@@ -166,8 +211,8 @@ async def test_unmodified_default_config(patched_logger, mock_responses):
 @patch("connectors.preflight_check.logger")
 async def test_missing_mode_config(patched_logger, mock_responses):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     local_config = deepcopy(config)
     del local_config["connectors"]
     preflight = PreflightCheck(local_config)
@@ -182,8 +227,8 @@ async def test_extraction_service_enabled_and_found_writes_info_log(
     patched_logger, mock_responses
 ):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     local_config = deepcopy(config)
     local_config["extraction_service"] = {"host": "http://localhost:8090"}
     preflight = PreflightCheck(local_config)
@@ -206,8 +251,8 @@ async def test_extraction_service_enabled_but_missing_logs_warning(
     patched_logger, mock_responses
 ):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     local_config = deepcopy(config)
     local_config["extraction_service"] = {"host": "http://localhost:8090"}
     preflight = PreflightCheck(local_config)
@@ -230,8 +275,8 @@ async def test_extraction_service_enabled_but_missing_logs_critical(
     patched_logger, mock_responses
 ):
     mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX)
-    mock_index_exists(mock_responses, JOBS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX)
     local_config = deepcopy(config)
     local_config["extraction_service"] = {"host": "http://localhost:8090"}
     preflight = PreflightCheck(local_config)

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -50,26 +50,6 @@ async def test_es_unavailable(mock_responses):
 
 
 @pytest.mark.asyncio
-async def test_connector_index_missing(mock_responses):
-    mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=False)
-    mock_index_exists(mock_responses, JOBS_INDEX, exist=True)
-    preflight = PreflightCheck(config)
-    result = await preflight.run()
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_job_index_missing(mock_responses):
-    mock_es_info(mock_responses)
-    mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=True)
-    mock_index_exists(mock_responses, JOBS_INDEX, exist=False)
-    preflight = PreflightCheck(config)
-    result = await preflight.run()
-    assert result is False
-
-
-@pytest.mark.asyncio
 async def test_both_indices_missing(mock_responses):
     mock_es_info(mock_responses)
     mock_index_exists(mock_responses, CONNECTORS_INDEX, exist=False)


### PR DESCRIPTION
This ensures the system indices are created by the connector on startup if not already present. 

**Release Note**
Connectors now create the connectors indices by indexing an empty document to trigger the Elasticsearch-installed index template.