### PR TITLE
Include missing lxml library - beautifulsoup attempted to use it, but did not since library is not there

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -23,3 +23,4 @@ dropbox==11.36.2
 beautifulsoup4==4.12.2
 gidgethub==5.2.1
 wcmatch==8.4.1
+lxml==4.9.3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -672,7 +672,10 @@ def test_html_to_text_without_html():
 def test_html_to_text_with_weird_html():
     invalid_html = "<div/>just</div> text"
 
-    assert html_to_text(invalid_html) == "just\n text"
+    text = html_to_text(invalid_html)
+
+    assert "just" in text
+    assert "text" in text
 
 
 def batch_size(value):


### PR DESCRIPTION
Small change - our `html_to_text` uses the following code:

```python
    return BeautifulSoup(html, "lxml").get_text(separator="\n")
```

It does not properly work because `lxml` is not installed locally.

Once it's installed, the format of parsed html changes slightly (only line breaks are affected as it seems), so test is changed too.