### PR TITLE
[Utils] Support synchronous functions in retryable decorator

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,6 +329,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -375,7 +375,7 @@ class CustomGeneratorException(Exception):
 
 @pytest.mark.fail_slow(1)
 @pytest.mark.asyncio
-async def test_exponential_backoff_retry_async_generator():
+async def test_exponential_backoff_retry_asyncgen_function():
     mock_gen = Mock()
     num_retries = 10
 
@@ -406,6 +406,42 @@ async def test_exponential_backoff_retry_async_generator():
     # would fail, if retried once (retry_interval = 5 seconds). Explicit time boundary for this test: 1 second
     items = []
     async for item in does_not_raise_async_generator():
+        items.append(item)
+
+    assert items == [1, 1, 1]
+
+
+@pytest.mark.fail_slow(1)
+def test_exponential_backoff_retry_sync_function():
+    mock_func = Mock()
+    num_retries = 10
+
+    @retryable(
+        retries=num_retries,
+        interval=0,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    def raises_function():
+        for _ in range(3):
+            mock_func()
+            raise CustomException()
+
+    with pytest.raises(CustomException):
+        for _ in raises_function():
+            pass
+
+    # retried 10 times
+    assert mock_func.call_count == num_retries
+
+    # would lead to roughly ~ 50 seconds of retrying
+    @retryable(retries=10, interval=5, strategy=RetryStrategy.LINEAR_BACKOFF)
+    def does_not_raise_function():
+        for _ in range(3):
+            yield 1
+
+    # would fail, if retried once (retry_interval = 5 seconds). Explicit time boundary for this test: 1 second
+    items = []
+    for item in does_not_raise_function():
         items.append(item)
 
     assert items == [1, 1, 1]
@@ -446,7 +482,7 @@ async def test_exponential_backoff_retry():
     [CustomGeneratorException, [CustomGeneratorException, RuntimeError]],
 )
 @pytest.mark.asyncio
-async def test_skipped_exceptions_retry_async_generator(skipped_exceptions):
+async def test_skipped_exceptions_retry_asyncgen_function(skipped_exceptions):
     mock_gen = Mock()
     num_retries = 10
 
@@ -471,7 +507,7 @@ async def test_skipped_exceptions_retry_async_generator(skipped_exceptions):
     "skipped_exceptions", [CustomException, [CustomException, RuntimeError]]
 )
 @pytest.mark.asyncio
-async def test_skipped_exceptions_retry(skipped_exceptions):
+async def test_skipped_exceptions_retry_coroutine_function(skipped_exceptions):
     mock_func = Mock()
     num_retries = 10
 
@@ -486,7 +522,28 @@ async def test_skipped_exceptions_retry(skipped_exceptions):
     with pytest.raises(CustomException):
         await raises()
 
-        # retried 10 times
+        assert mock_func.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "skipped_exceptions", [CustomException, [CustomException, RuntimeError]]
+)
+@pytest.mark.asyncio
+async def test_skipped_exceptions_retry_sync_function(skipped_exceptions):
+    mock_func = Mock()
+    num_retries = 10
+
+    @retryable(
+        retries=num_retries,
+        skipped_exceptions=skipped_exceptions,
+    )
+    def raises():
+        mock_func()
+        raise CustomException()
+
+    with pytest.raises(CustomException):
+        await raises()
+
         assert mock_func.call_count == 1
 
 


### PR DESCRIPTION
## Related to https://github.com/elastic/connectors-python/pull/1578

This PR adds synchronous function support to the `@retryable` decorator. This is needed to remove the dependency on the `retry` library in this PR: https://github.com/elastic/connectors-python/pull/1578. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)