### PR TITLE
Skip site collection query if * is configured for site collections

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1161,6 +1161,8 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         # Check that we at least have permissions to fetch sites and actual site names are correct
         configured_root_sites = self.configuration["site_collections"]
+        if WILDCARD in configured_root_sites:
+            return
 
         remote_sites = []
 
@@ -1169,9 +1171,6 @@ class SharepointOnlineDataSource(BaseDataSource):
                 site_collection["siteCollection"]["hostname"], [WILDCARD]
             ):
                 remote_sites.append(site["name"])
-
-        if WILDCARD in configured_root_sites:
-            return
 
         missing = [x for x in configured_root_sites if x not in remote_sites]
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2370,6 +2370,7 @@ class TestSharepointOnlineDataSource:
             # Therefore it's important
             patch_sharepoint_client.graph_api_token.get.assert_awaited()
             patch_sharepoint_client.rest_api_token.get.assert_awaited()
+            patch_sharepoint_client.site_collections.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_validate_config_when_invalid_tenant(self, patch_sharepoint_client):


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5740

When * is configured as site collections, skip site name validation, therefore, skip querying site collections.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)