### PR TITLE
[FTest] Use logger instead of print

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,6 +329,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,22 +329,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -40,7 +40,7 @@ def wait_for_es(url="http://localhost:9200", user="elastic", password="changeme"
         return session.get(url, auth=basic).json()
     except Exception as e:
         # we're going to display some docker info here
-        logger.error(f"Failed to reach out Elasticsearch {repr(e)}")
+        logger.error(f"Failed to reach out to Elasticsearch {repr(e)}")
         os.system("docker ps -a")
         os.system("docker logs es01")
         raise

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -96,7 +96,9 @@ def _monitor_service(pid):
 
             if len(response["hits"]["hits"]) == 0:
                 if time.time() - start > index_present_timeout:
-                    raise Exception(f"{CONNECTORS_INDEX} not present after {index_present_timeout} seconds.")
+                    raise Exception(
+                        f"{CONNECTORS_INDEX} not present after {index_present_timeout} seconds."
+                    )
 
                 logger.info(f"{CONNECTORS_INDEX} not present, waiting...")
                 time.sleep(1)
@@ -114,7 +116,9 @@ def _monitor_service(pid):
             lapsed = time.time() - start
             if last_synced != new_last_synced or lapsed > sync_job_timeout:
                 if lapsed > sync_job_timeout:
-                    logger.error(f"Took too long to complete the sync job (over {sync_job_timeout} minutes), give up!")
+                    logger.error(
+                        f"Took too long to complete the sync job (over {sync_job_timeout} minutes), give up!"
+                    )
                 break
             time.sleep(1)
     except Exception as e:


### PR DESCRIPTION
## Follow-up for https://github.com/elastic/connectors-python/pull/1577

This PR makes use of the newly introduced ftest logger. The print statements related to `DATA_SIZE` are not changed as they're used to set an environment variable through the caller script `ftest.sh`. 

Also improved some variables and log messages containing more accurate information about timeouts.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)