### PR TITLE
[8.10] [SPO] Remove site_group_id and site_user_id (#1467)

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -510,16 +510,6 @@ class SharepointOnlineClient:
             for site_collection in page:
                 yield site_collection
 
-    async def site_group(self, site_web_url, group_principal_id):
-        self._validate_sharepoint_rest_url(site_web_url)
-
-        url = f"{site_web_url}/_api/web/sitegroups/getbyid({group_principal_id})"
-
-        try:
-            return await self._rest_api_client.fetch(url)
-        except NotFound:
-            return {}
-
     async def user_information_list(self, site_id):
         expand = "fields"
         url = f"{GRAPH_API_URL}/sites/{site_id}/lists/User Information List/items?expand={expand}"
@@ -934,16 +924,8 @@ def _prefix_group(group):
     return _prefix_identity("group", group)
 
 
-def _prefix_site_group(site_group):
-    return _prefix_identity("site_group", site_group)
-
-
 def _prefix_user(user):
     return _prefix_identity("user", user)
-
-
-def _prefix_site_user_id(site_user_id):
-    return _prefix_identity("site_user_id", site_user_id)
 
 
 def _prefix_user_id(user_id):
@@ -1748,20 +1730,12 @@ class SharepointOnlineDataSource(BaseDataSource):
 
             user_id = _get_id(granted_to_v2, "user")
             group_id = _get_id(granted_to_v2, "group")
-            site_group_id = _get_id(granted_to_v2, "siteGroup")
-            site_user_id = _get_id(granted_to_v2, "siteUser")
 
             if user_id:
                 access_control.append(_prefix_user_id(user_id))
 
             if group_id:
                 access_control.append(_prefix_group(group_id))
-
-            if site_group_id:
-                access_control.append(_prefix_site_group(site_group_id))
-
-            if site_user_id:
-                access_control.append(_prefix_site_user_id(site_user_id))
 
         return self._decorate_with_access_control(drive_item, access_control)
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -43,8 +43,6 @@ from connectors.sources.sharepoint_online import (
     _prefix_email,
     _prefix_group,
     _prefix_identity,
-    _prefix_site_group,
-    _prefix_site_user_id,
     _prefix_user,
     _prefix_user_id,
     is_domain_group,
@@ -87,13 +85,7 @@ GROUP_ONE = "Group 1"
 
 GROUP_TWO = "Group 2"
 
-SITE_GROUP_ONE_ID = "site-group-id-1"
-
-SITE_GROUP_ONE = "site-group-1"
-
 USER_ONE_ID = "user-id-1"
-
-SITE_USER_ONE_ID = "site-user-id-1"
 
 USER_ONE_EMAIL = "user1@spo.com"
 
@@ -1071,29 +1063,6 @@ class TestSharepointOnlineClient:
         assert http_call_result == actual_result
 
     @pytest.mark.asyncio
-    async def test_site_group(self, client, patch_fetch):
-        site_groups_url = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/sitegroups"
-        group_principal_id = "1"
-        group = {"id": group_principal_id}
-
-        patch_fetch.return_value = group
-
-        actual_group = await client.site_group(site_groups_url, group_principal_id)
-
-        assert actual_group == group
-
-    @pytest.mark.asyncio
-    async def test_site_group_not_found(self, client, patch_fetch):
-        site_groups_url = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/sitegroups"
-        group_principal_id = "1"
-
-        patch_fetch.side_effect = NotFound()
-
-        site_group = await client.site_group(site_groups_url, group_principal_id)
-
-        assert len(site_group) == 0
-
-    @pytest.mark.asyncio
     async def test_site_users(self, client, patch_scroll):
         site_users_url = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/siteusers"
         users = ["user1", "user2"]
@@ -1687,10 +1656,6 @@ class TestSharepointOnlineDataSource:
         return {"id": GROUP_ONE_ID}
 
     @property
-    def site_groups(self):
-        return [{"Title": GROUP_ONE}, {"Title": GROUP_TWO}, {}, {"Title": None}]
-
-    @property
     def site_users(self):
         return [
             {"UserPrincipalName": USER_ONE_EMAIL},
@@ -1762,13 +1727,9 @@ class TestSharepointOnlineDataSource:
                     "user": {
                         "id": USER_ONE_ID,
                     },
-                    "siteUser": {
-                        "id": SITE_USER_ONE_ID,
-                    },
                     "group": {
                         "id": GROUP_ONE_ID,
                     },
-                    "siteGroup": {"id": SITE_GROUP_ONE_ID},
                 },
             },
             {
@@ -1777,13 +1738,9 @@ class TestSharepointOnlineDataSource:
                     "user": {
                         "id": USER_ONE_ID,
                     },
-                    "siteUser": {
-                        "id": SITE_USER_ONE_ID,
-                    },
                     "group": {
                         "id": GROUP_ONE_ID,
                     },
-                    "siteGroup": {"id": SITE_GROUP_ONE_ID},
                 },
             },
             {
@@ -1792,13 +1749,9 @@ class TestSharepointOnlineDataSource:
                     "user": {
                         "id": USER_ONE_ID,
                     },
-                    "siteUser": {
-                        "id": SITE_USER_ONE_ID,
-                    },
                     "group": {
                         "id": GROUP_ONE_ID,
                     },
-                    "siteGroup": {"id": SITE_GROUP_ONE_ID},
                 },
             },
             {
@@ -1807,13 +1760,9 @@ class TestSharepointOnlineDataSource:
                     "user": {
                         "id": USER_ONE_ID,
                     },
-                    "siteUser": {
-                        "id": SITE_USER_ONE_ID,
-                    },
                     "group": {
                         "id": GROUP_ONE_ID,
                     },
-                    "siteGroup": {"id": SITE_GROUP_ONE_ID},
                 },
             },
         ]
@@ -1839,7 +1788,6 @@ class TestSharepointOnlineDataSource:
             client = new_mock.return_value
             client.site_collections = AsyncIterator(self.site_collections)
             client.sites = AsyncIterator(self.sites)
-            client.site_group = AsyncIterator(self.site_groups)
             client.user_information_list = AsyncIterator(self.user_information_list)
             client.group = AsyncMock(return_value=self.group)
             client.group_members = AsyncIterator(self.group_members)
@@ -2000,8 +1948,6 @@ class TestSharepointOnlineDataSource:
 
             expected_drive_item_access_control = [
                 _prefix_user_id(USER_ONE_ID),
-                _prefix_site_group(SITE_GROUP_ONE_ID),
-                _prefix_site_user_id(SITE_USER_ONE_ID),
                 _prefix_group(GROUP_ONE_ID),
                 *expected_access_control,
             ]
@@ -2200,11 +2146,9 @@ class TestSharepointOnlineDataSource:
             )
             drive_item_access_control = drive_item_with_access_control[ACCESS_CONTROL]
 
-            assert len(drive_item_access_control) == 4
+            assert len(drive_item_access_control) == 2
             assert _prefix_user_id(USER_ONE_ID) in drive_item_access_control
             assert _prefix_group(GROUP_ONE_ID) in drive_item_access_control
-            assert _prefix_site_user_id(SITE_USER_ONE_ID) in drive_item_access_control
-            assert _prefix_site_group(SITE_GROUP_ONE_ID) in drive_item_access_control
 
     @pytest.mark.asyncio
     async def test_drive_items_batch_with_permissions_when_fetch_drive_item_permissions_enabled(
@@ -2297,8 +2241,6 @@ class TestSharepointOnlineDataSource:
 
             expected_drive_item_access_control = [
                 _prefix_user_id(USER_ONE_ID),
-                _prefix_site_group(SITE_GROUP_ONE_ID),
-                _prefix_site_user_id(SITE_USER_ONE_ID),
                 _prefix_group(GROUP_ONE_ID),
             ]
 
@@ -3056,16 +2998,6 @@ class TestSharepointOnlineDataSource:
         email = "email"
 
         assert _prefix_email(email) == "email:email"
-
-    def test_prefix_site_group(self):
-        site_group = "site group"
-
-        assert _prefix_site_group(site_group) == "site_group:site group"
-
-    def test_prefix_site_user_id(self):
-        site_user_id = "site user id"
-
-        assert _prefix_site_user_id(site_user_id) == "site_user_id:site user id"
 
     def test_prefix_user_id(self):
         user_id = "user id"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[SPO] Remove site_group_id and site_user_id (#1467)](https://github.com/elastic/connectors-python/pull/1467)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)