### PR TITLE
[pre-8.10-stable] Skip site collection query if * is configured for site collections (#1595)

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1170,6 +1170,8 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         # Check that we at least have permissions to fetch sites and actual site names are correct
         configured_root_sites = self.configuration["site_collections"]
+        if WILDCARD in configured_root_sites:
+            return
 
         remote_sites = []
 
@@ -1178,9 +1180,6 @@ class SharepointOnlineDataSource(BaseDataSource):
                 site_collection["siteCollection"]["hostname"], [WILDCARD]
             ):
                 remote_sites.append(site["name"])
-
-        if WILDCARD in configured_root_sites:
-            return
 
         missing = [x for x in configured_root_sites if x not in remote_sites]
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2369,6 +2369,7 @@ class TestSharepointOnlineDataSource:
         # Therefore it's important
         patch_sharepoint_client.graph_api_token.get.assert_awaited()
         patch_sharepoint_client.rest_api_token.get.assert_awaited()
+        patch_sharepoint_client.site_collections.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_validate_config_when_invalid_tenant(self, patch_sharepoint_client):


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `pre-8.10-stable`:
 - [Skip site collection query if * is configured for site collections (#1595)](https://github.com/elastic/connectors-python/pull/1595)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)