### PR TITLE
Pass retry_count to the retry handler

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -287,7 +287,6 @@ class SharepointRestAPIToken(MicrosoftSecurityToken):
             return access_token, expires_in
 
 
-
 def retryable_aiohttp_call(retries):
     # TODO: improve utils.retryable to allow custom logic
     # that can help choose what to retry
@@ -429,7 +428,9 @@ class MicrosoftAPISession:
                 )
                 retry_after = DEFAULT_RETRY_SECONDS
 
-            retry_seconds = self._compute_retry_after(retry_after, retry_count, DEFAULT_BACKOFF_MULTIPLIER)
+            retry_seconds = self._compute_retry_after(
+                retry_after, retry_count, DEFAULT_BACKOFF_MULTIPLIER
+            )
 
             self._logger.warning(
                 f"Rate Limited by Sharepoint: a new attempt will be performed in {retry_seconds} seconds (retry-after header: {retry_after}, retry_count: {retry_count}, backoff: {DEFAULT_BACKOFF_MULTIPLIER})"
@@ -460,6 +461,7 @@ class MicrosoftAPISession:
             return retry_after
         else:
             return retry_after * retry_count * backoff
+
 
 class SharepointOnlineClient:
     def __init__(self, tenant_id, tenant_name, client_id, client_secret):

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -66,9 +66,10 @@ else:
     GRAPH_API_AUTH_URL = "https://login.microsoftonline.com"
     REST_API_AUTH_URL = "https://accounts.accesscontrol.windows.net"
 
-DEFAULT_RETRY_COUNT = 3
+DEFAULT_RETRY_COUNT = 5
 DEFAULT_RETRY_SECONDS = 30
 DEFAULT_PARALLEL_CONNECTION_COUNT = 10
+DEFAULT_BACKOFF_MULTIPLIER = 5
 FILE_WRITE_CHUNK_SIZE = 1024 * 64  # 64KB default SSD page size
 MAX_DOCUMENT_SIZE = 10485760
 WILDCARD = "*"
@@ -113,7 +114,10 @@ class InternalServerError(Exception):
 class ThrottledError(Exception):
     """Internal exception class to indicate that request was throttled by the API"""
 
-    pass
+    # def __init__(self, retry_seconds, message='Microsoft Graph API throttling error'):
+    #     self.message = message
+    #     self.retry_seconds = retry_seconds
+    #     super().__init__(self.message)
 
 
 class InvalidSharepointTenant(Exception):
@@ -286,6 +290,7 @@ class SharepointRestAPIToken(MicrosoftSecurityToken):
             return access_token, expires_in
 
 
+
 def retryable_aiohttp_call(retries):
     # TODO: improve utils.retryable to allow custom logic
     # that can help choose what to retry
@@ -295,7 +300,7 @@ def retryable_aiohttp_call(retries):
             retry = 1
             while retry <= retries:
                 try:
-                    async for item in func(*args, **kwargs):
+                    async for item in func(*args, **kwargs, retry_count=retry):
                         yield item
                     break
                 except (NotFound, BadRequestError):
@@ -376,7 +381,7 @@ class MicrosoftAPISession:
 
     @asynccontextmanager
     @retryable_aiohttp_call(retries=DEFAULT_RETRY_COUNT)
-    async def _post(self, absolute_url, payload=None):
+    async def _post(self, absolute_url, payload=None, retry_count=0):
         try:
             token = await self._api_token.get()
             headers = {"authorization": f"Bearer {token}"}
@@ -392,11 +397,12 @@ class MicrosoftAPISession:
             )
             raise
         except ClientResponseError as e:
-            await self._handle_client_response_error(absolute_url, e)
+            import pdb; pdb.set_trace();
+            await self._handle_client_response_error(absolute_url, e, retry_count)
 
     @asynccontextmanager
     @retryable_aiohttp_call(retries=DEFAULT_RETRY_COUNT)
-    async def _get(self, absolute_url):
+    async def _get(self, absolute_url, retry_count=0):
         try:
             token = await self._api_token.get()
             headers = {"authorization": f"Bearer {token}"}
@@ -413,20 +419,24 @@ class MicrosoftAPISession:
             )
             raise
         except ClientResponseError as e:
-            await self._handle_client_response_error(absolute_url, e)
+            await self._handle_client_response_error(absolute_url, e, retry_count)
 
-    async def _handle_client_response_error(self, absolute_url, e):
+    async def _handle_client_response_error(self, absolute_url, e, retry_count):
         if e.status == 429 or e.status == 503:
             response_headers = e.headers or {}
+
             if "Retry-After" in response_headers:
-                retry_seconds = int(response_headers["Retry-After"])
+                retry_after = int(response_headers["Retry-After"])
             else:
                 self._logger.warning(
                     f"Response Code from Sharepoint Server is {e.status} but Retry-After header is not found, using default retry time: {DEFAULT_RETRY_SECONDS} seconds"
                 )
-                retry_seconds = DEFAULT_RETRY_SECONDS
-            self._logger.debug(
-                f"Rate Limited by Sharepoint: retry in {retry_seconds} seconds"
+                retry_after = DEFAULT_RETRY_SECONDS
+
+            retry_seconds = self._compute_retry_after(retry_after, retry_count, DEFAULT_BACKOFF_MULTIPLIER)
+
+            self._logger.warning(
+                f"Rate Limited by Sharepoint: a new attempt will be performed in {retry_seconds} seconds (retry-after header: {retry_after}, retry_count: {retry_count}, backoff: {DEFAULT_BACKOFF_MULTIPLIER})"
             )
 
             await self._sleeps.sleep(retry_seconds)
@@ -447,6 +457,13 @@ class MicrosoftAPISession:
         else:
             raise
 
+    def _compute_retry_after(self, retry_after, retry_count, backoff):
+        # wait what Sharepoint API asked after the first failure
+        # apply backoff if API is still not available
+        if retry_count <= 1:
+            return retry_after
+        else:
+            return retry_after * retry_count * backoff
 
 class SharepointOnlineClient:
     def __init__(self, tenant_id, tenant_name, client_id, client_secret):

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -397,7 +397,6 @@ class MicrosoftAPISession:
             )
             raise
         except ClientResponseError as e:
-            import pdb; pdb.set_trace();
             await self._handle_client_response_error(absolute_url, e, retry_count)
 
     @asynccontextmanager

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -114,6 +114,8 @@ class InternalServerError(Exception):
 class ThrottledError(Exception):
     """Internal exception class to indicate that request was throttled by the API"""
 
+    pass
+
 
 class InvalidSharepointTenant(Exception):
     """Exception class to notify that tenant name is invalid or does not match tenant id provided"""

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -114,11 +114,6 @@ class InternalServerError(Exception):
 class ThrottledError(Exception):
     """Internal exception class to indicate that request was throttled by the API"""
 
-    # def __init__(self, retry_seconds, message='Microsoft Graph API throttling error'):
-    #     self.message = message
-    #     self.retry_seconds = retry_seconds
-    #     super().__init__(self.message)
-
 
 class InvalidSharepointTenant(Exception):
     """Exception class to notify that tenant name is invalid or does not match tenant id provided"""
@@ -457,8 +452,8 @@ class MicrosoftAPISession:
             raise
 
     def _compute_retry_after(self, retry_after, retry_count, backoff):
-        # wait what Sharepoint API asked after the first failure
-        # apply backoff if API is still not available
+        # Wait for what Sharepoint API asks after the first failure.
+        # Apply backoff if API is still not available.
         if retry_count <= 1:
             return retry_after
         else:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -352,7 +352,6 @@ class ConcurrentTasks:
             logger.error(
                 f"Exception found for task {task.get_name()}: {task.exception()}"
             )
-            raise task.exception()
         if result_callback is not None:
             result_callback(task.result())
         # global callback

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -352,6 +352,7 @@ class ConcurrentTasks:
             logger.error(
                 f"Exception found for task {task.get_name()}: {task.exception()}"
             )
+            raise task.exception()
         if result_callback is not None:
             result_callback(task.result())
         # global callback

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -662,13 +662,10 @@ class TestMicrosoftAPISession:
         not_found_error.message = "Something went wrong"
 
         mock_responses.get(url, exception=not_found_error)
-<<<<<<< HEAD
-=======
         mock_responses.get(url, exception=not_found_error)
         mock_responses.get(url, exception=not_found_error)
         mock_responses.get(url, exception=not_found_error)
         mock_responses.get(url, exception=not_found_error)
->>>>>>> 37d0f863 (Fix tests and add more)
 
         with pytest.raises(NotFound) as e:
             async with microsoft_api_session._get(url) as _:

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -22,8 +22,8 @@ from connectors.protocol import Features
 from connectors.source import ConfigurableFieldValueError
 from connectors.sources.sharepoint_online import (
     ACCESS_CONTROL,
-    DEFAULT_RETRY_SECONDS,
     DEFAULT_BACKOFF_MULTIPLIER,
+    DEFAULT_RETRY_SECONDS,
     WILDCARD,
     BadRequestError,
     DriveItemsPage,
@@ -573,14 +573,13 @@ class TestMicrosoftAPISession:
         url = "http://localhost:1234/download-some-sample-file"
         payload = {"hello": "world"}
 
-
         # First throttle, then do not throttle
         first_request_error = ClientResponseError(None, None)
         first_request_error.status = 429
         first_request_error.message = "Something went wrong"
 
         retry_count = 3
-        for i in range(retry_count):
+        for _i in range(retry_count):
             mock_responses.get(url, exception=first_request_error)
 
         mock_responses.get(url, payload=payload)
@@ -589,7 +588,9 @@ class TestMicrosoftAPISession:
             actual_payload = await response.json()
             assert actual_payload == payload
 
-        patch_cancellable_sleeps.assert_awaited_with(DEFAULT_RETRY_SECONDS * DEFAULT_BACKOFF_MULTIPLIER * retry_count)
+        patch_cancellable_sleeps.assert_awaited_with(
+            DEFAULT_RETRY_SECONDS * DEFAULT_BACKOFF_MULTIPLIER * retry_count
+        )
 
     @pytest.mark.asyncio
     async def test_call_api_with_403(

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -23,6 +23,7 @@ from connectors.source import ConfigurableFieldValueError
 from connectors.sources.sharepoint_online import (
     ACCESS_CONTROL,
     DEFAULT_RETRY_SECONDS,
+    DEFAULT_BACKOFF_MULTIPLIER,
     WILDCARD,
     BadRequestError,
     DriveItemsPage,
@@ -562,6 +563,35 @@ class TestMicrosoftAPISession:
         patch_cancellable_sleeps.assert_awaited_with(DEFAULT_RETRY_SECONDS)
 
     @pytest.mark.asyncio
+    async def test_call_api_with_429_with_retry_after_and_backoff(
+        self,
+        microsoft_api_session,
+        mock_responses,
+        patch_sleep,
+        patch_cancellable_sleeps,
+    ):
+        url = "http://localhost:1234/download-some-sample-file"
+        payload = {"hello": "world"}
+
+
+        # First throttle, then do not throttle
+        first_request_error = ClientResponseError(None, None)
+        first_request_error.status = 429
+        first_request_error.message = "Something went wrong"
+
+        retry_count = 3
+        for i in range(retry_count):
+            mock_responses.get(url, exception=first_request_error)
+
+        mock_responses.get(url, payload=payload)
+
+        async with microsoft_api_session._get(url) as response:
+            actual_payload = await response.json()
+            assert actual_payload == payload
+
+        patch_cancellable_sleeps.assert_awaited_with(DEFAULT_RETRY_SECONDS * DEFAULT_BACKOFF_MULTIPLIER * retry_count)
+
+    @pytest.mark.asyncio
     async def test_call_api_with_403(
         self,
         microsoft_api_session,
@@ -576,6 +606,8 @@ class TestMicrosoftAPISession:
         unauthorized_error.status = 403
         unauthorized_error.message = "Something went wrong"
 
+        mock_responses.get(url, exception=unauthorized_error)
+        mock_responses.get(url, exception=unauthorized_error)
         mock_responses.get(url, exception=unauthorized_error)
         mock_responses.get(url, exception=unauthorized_error)
         mock_responses.get(url, exception=unauthorized_error)
@@ -629,6 +661,13 @@ class TestMicrosoftAPISession:
         not_found_error.message = "Something went wrong"
 
         mock_responses.get(url, exception=not_found_error)
+<<<<<<< HEAD
+=======
+        mock_responses.get(url, exception=not_found_error)
+        mock_responses.get(url, exception=not_found_error)
+        mock_responses.get(url, exception=not_found_error)
+        mock_responses.get(url, exception=not_found_error)
+>>>>>>> 37d0f863 (Fix tests and add more)
 
         with pytest.raises(NotFound) as e:
             async with microsoft_api_session._get(url) as _:
@@ -676,6 +715,8 @@ class TestMicrosoftAPISession:
         not_found_error.status = 420
         not_found_error.message = error_message
 
+        mock_responses.get(url, exception=not_found_error)
+        mock_responses.get(url, exception=not_found_error)
         mock_responses.get(url, exception=not_found_error)
         mock_responses.get(url, exception=not_found_error)
         mock_responses.get(url, exception=not_found_error)


### PR DESCRIPTION
### Closes https://github.com/elastic/enterprise-search-team/issues/5733

This PR adds a linear backoff multiplier to the Sharepoint connector. Customers might experience throttling issues when connectors respect the `Retry-After` header.  

Also, this PR will change `DEFAULT_RETRY_COUNT` to 5 and `DEFAULT_BACKOFF_MULTIPLIER` to 5. These numbers are tested for the lowest Sharepoint tier.

Follow-up: 
* To make the retryable solution more consistent (handling retries based on the response error codes) a refactoring is required. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)