### PR TITLE
[FTest] Separate Kibana fake logger from framework logger

### DIFF
--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -15,7 +15,7 @@ import elasticsearch
 from connectors.config import load_config
 from connectors.es.settings import DEFAULT_LANGUAGE, Mappings, Settings
 from connectors.es.sink import SyncOrchestrator
-from connectors.logger import logger, set_logger
+from connectors.logger import set_extra_logger
 from connectors.source import get_source_klass
 from connectors.utils import validate_index_name
 
@@ -88,6 +88,9 @@ DEFAULT_PIPELINE = {
         }
     ],
 }
+
+logger = logging.getLogger("kibana-fake")
+set_extra_logger(logger, log_level=logging.DEBUG, prefix="KBN-FAKE")
 
 
 async def prepare(service_type, index_name, config, connector_definition=None):
@@ -330,7 +333,6 @@ def main(args=None):
     if not os.path.exists(config_file):
         raise IOError(f"config file at '{config_file}' does not exist")
 
-    set_logger(args.debug and logging.DEBUG or logging.INFO)
     config = load_config(config_file)
     connector_definition = None
     if (

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,6 +329,22 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+    )
+    async def get_last_update_time(self, table):
+        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
+            await cursor.execute(self.queries.table_last_update_time(table))
+
+            result = await cursor.fetchone()
+
+            if result is not None:
+                return result[0]
+
+            return None
+
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -329,22 +329,6 @@ def generate_id(tables, row, primary_key_columns):
         f"{'_'.join([str(pk_value) for pk in primary_key_columns if (pk_value := row.get(pk)) is not None])}"
     )
 
-    @retryable(
-        retries=RETRIES,
-        interval=RETRY_INTERVAL,
-        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
-    )
-    async def get_last_update_time(self, table):
-        async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(self.queries.table_last_update_time(table))
-
-            result = await cursor.fetchone()
-
-            if result is not None:
-                return result[0]
-
-            return None
-
 
 class MySqlDataSource(BaseDataSource):
     """MySQL"""

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -66,7 +66,6 @@ def test_main(patch_logger, mock_responses):
         )
         == 0
     )
-    patch_logger.assert_present("Done")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related to https://github.com/elastic/connectors-python/pull/1577

Currently the kibana fake used implicitly the framework logger, which lead to the following log messages:

`[FMWK][17:03:04][INFO] Prepare .elastic-connectors-v1 document`.

Considering that we want to refactor and improve ftests a lot in the future I think it's useful to separate the kibana fake logger for better debugability/traceability as it's conceptually not part of the framework, but a separate entity updating some elasticsearch indices. It's also only used during ftests.

The new log messages would look like:

`[KBN-FAKE][17:03:04][INFO] Prepare .elastic-connectors-v1 document`.

Now it's more clear, which different entities do what during an ftest.
I've also removed the logger assertion, which is a bad practice. I think it's more useful to assert on the actual client calls and not rely on log messages. (needs a bigger refactoring -> separate PR)

(We should probably in general rethink, if a "kibana-fake" is a useful thing or if it should be named differently and also behave differently, but one step after the other).

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)