### PR TITLE
catch 400 on list item unique role assignments

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -296,7 +296,7 @@ def retryable_aiohttp_call(retries):
                     async for item in func(*args, **kwargs):
                         yield item
                     break
-                except NotFound:
+                except (NotFound, BadRequestError):
                     raise
                 except Exception:
                     if retry >= retries:

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -94,6 +94,7 @@ class NotFound(Exception):
 
     pass
 
+
 class BadRequestError(Exception):
     """Internal exception class to handle 400's from the API.
 
@@ -101,6 +102,7 @@ class BadRequestError(Exception):
     be translated as empty resutls, and let us return []."""
 
     pass
+
 
 class InternalServerError(Exception):
     """Exception class to indicate that something went wrong on the server side."""
@@ -715,7 +717,9 @@ class SharepointOnlineClient:
         except NotFound:
             return False
         except BadRequestError:
-            self._logger.warning(f"Received error response when retrieving `{list_item_id}` from list: `{site_list_name}` in site: `{site_web_url}`")
+            self._logger.warning(
+                f"Received error response when retrieving `{list_item_id}` from list: `{site_list_name}` in site: `{site_web_url}`"
+            )
             return False
 
     async def site_list_item_role_assignments(

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -629,10 +629,31 @@ class TestMicrosoftAPISession:
         not_found_error.message = "Something went wrong"
 
         mock_responses.get(url, exception=not_found_error)
-        mock_responses.get(url, exception=not_found_error)
-        mock_responses.get(url, exception=not_found_error)
 
         with pytest.raises(NotFound) as e:
+            async with microsoft_api_session._get(url) as _:
+                pass
+
+        assert e is not None
+
+    @pytest.mark.asyncio
+    async def test_call_api_with_400_without_retry_after_header(
+            self,
+            microsoft_api_session,
+            mock_responses,
+            patch_sleep,
+            patch_cancellable_sleeps,
+    ):
+        url = "http://localhost:1234/download-some-sample-file"
+
+        # First throttle, then do not throttle
+        bad_request_error = ClientResponseError(None, None)
+        bad_request_error.status = 400
+        bad_request_error.message = "You did something wrong"
+
+        mock_responses.get(url, exception=bad_request_error)
+
+        with pytest.raises(BadRequestError) as e:
             async with microsoft_api_session._get(url) as _:
                 pass
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -24,6 +24,7 @@ from connectors.sources.sharepoint_online import (
     ACCESS_CONTROL,
     DEFAULT_RETRY_SECONDS,
     WILDCARD,
+    BadRequestError,
     DriveItemsPage,
     GraphAPIToken,
     InternalServerError,
@@ -31,7 +32,6 @@ from connectors.sources.sharepoint_online import (
     MicrosoftAPISession,
     MicrosoftSecurityToken,
     NotFound,
-    BadRequestError,
     PermissionsMissing,
     SharepointOnlineAdvancedRulesValidator,
     SharepointOnlineClient,
@@ -638,11 +638,11 @@ class TestMicrosoftAPISession:
 
     @pytest.mark.asyncio
     async def test_call_api_with_400_without_retry_after_header(
-            self,
-            microsoft_api_session,
-            mock_responses,
-            patch_sleep,
-            patch_cancellable_sleeps,
+        self,
+        microsoft_api_session,
+        mock_responses,
+        patch_sleep,
+        patch_cancellable_sleeps,
     ):
         url = "http://localhost:1234/download-some-sample-file"
 
@@ -1279,10 +1279,9 @@ class TestSharepointOnlineClient:
             site_list_item_role_assignments_url, list_title, list_item_id
         )
 
-
     @pytest.mark.asyncio
     async def test_site_list_item_has_unique_role_assignments_bad_request(
-            self, client, patch_fetch
+        self, client, patch_fetch
     ):
         site_list_item_role_assignments_url = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/roleassignments"
         list_title = "list_title"
@@ -1293,7 +1292,6 @@ class TestSharepointOnlineClient:
         assert not await client.site_list_item_has_unique_role_assignments(
             site_list_item_role_assignments_url, list_title, list_item_id
         )
-
 
     @pytest.mark.asyncio
     async def test_site_list_item_role_assignments(self, client, patch_scroll):

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -31,6 +31,7 @@ from connectors.sources.sharepoint_online import (
     MicrosoftAPISession,
     MicrosoftSecurityToken,
     NotFound,
+    BadRequestError,
     PermissionsMissing,
     SharepointOnlineAdvancedRulesValidator,
     SharepointOnlineClient,
@@ -1256,6 +1257,22 @@ class TestSharepointOnlineClient:
         assert not await client.site_list_item_has_unique_role_assignments(
             site_list_item_role_assignments_url, list_title, list_item_id
         )
+
+
+    @pytest.mark.asyncio
+    async def test_site_list_item_has_unique_role_assignments_bad_request(
+            self, client, patch_fetch
+    ):
+        site_list_item_role_assignments_url = f"https://{self.tenant_name}.sharepoint.com/random/totally/made/up/roleassignments"
+        list_title = "list_title"
+        list_item_id = 1
+
+        patch_fetch.side_effect = BadRequestError()
+
+        assert not await client.site_list_item_has_unique_role_assignments(
+            site_list_item_role_assignments_url, list_title, list_item_id
+        )
+
 
     @pytest.mark.asyncio
     async def test_site_list_item_role_assignments(self, client, patch_scroll):


### PR DESCRIPTION
## Related to https://github.com/elastic/connectors-python/issues/1582

We've had reports of 400 errors when issuing requests like:
```
GET /sites/<site_id>/_api/lists/GetByTitle('<list_title>')/items(41)/HasUniqueRoleAssignments
```

which is odd, since this should be a valid request, as far as we can tell from the docs. 

To prevent this from blocking syncs, we want to simply log a warning when this surfaces, and move on.

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

* a fuller implementation of generic and lenient error handling will be part of https://github.com/elastic/connectors-python/pull/1584

## Release Note

Log (but otherwise ignore) 400 errors that occasionally arise when requesting unique permissions from some Sharepoint Online List Items.
