### PR TITLE
attempt mongo ndjson serialize fix

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from datetime import datetime
 
 import fastjsonschema
-from bson import Decimal128, ObjectId
+from bson import DBRef, Decimal128, ObjectId
 from fastjsonschema import JsonSchemaValueException
 from motor.motor_asyncio import AsyncIOMotorClient
 
@@ -167,6 +167,8 @@ class MongoDataSource(BaseDataSource):
                 value = value.isoformat()
             elif isinstance(value, Decimal128):
                 value = value.to_decimal()
+            elif isinstance(value, DBRef):
+                value = _serialize(value.as_doc().to_dict())
             return value
 
         for key, value in doc.items():

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -350,7 +350,7 @@ class ConcurrentTasks:
         self._task_over.set()
         if task.exception():
             logger.error(
-                f"Exception found for task {task.get_name()}: {task.exception()}"
+                f"Exception found for task {task.get_name()}: {task.exception()}", exc_info=True
             )
         if result_callback is not None:
             result_callback(task.result())

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -350,7 +350,8 @@ class ConcurrentTasks:
         self._task_over.set()
         if task.exception():
             logger.error(
-                f"Exception found for task {task.get_name()}: {task.exception()}", exc_info=True
+                f"Exception found for task {task.get_name()}: {task.exception()}",
+                exc_info=True,
             )
         if result_callback is not None:
             result_callback(task.result())

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -10,6 +10,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from bson import DBRef, ObjectId
 from bson.decimal128 import Decimal128
 
 from connectors.protocol import Filter
@@ -321,3 +322,14 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise():
             collection=configured_collection_name,
         ) as source:
             await source.validate_config()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('raw, output', [
+    ({"ref": DBRef("foo", "bar")}, {"ref": {"$ref":"foo", "$id":"bar"}}),
+    ({"dec": Decimal128("1.25")}, {"dec": 1.25}),
+    ({"id": ObjectId("507f1f77bcf86cd799439011")}, {"id": "507f1f77bcf86cd799439011"})
+])
+async def test_serialize(raw, output):
+    async with create_mongo_source() as source:
+        assert source.serialize(raw) == output

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -325,11 +325,17 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('raw, output', [
-    ({"ref": DBRef("foo", "bar")}, {"ref": {"$ref":"foo", "$id":"bar"}}),
-    ({"dec": Decimal128("1.25")}, {"dec": 1.25}),
-    ({"id": ObjectId("507f1f77bcf86cd799439011")}, {"id": "507f1f77bcf86cd799439011"})
-])
+@pytest.mark.parametrize(
+    "raw, output",
+    [
+        ({"ref": DBRef("foo", "bar")}, {"ref": {"$ref": "foo", "$id": "bar"}}),
+        ({"dec": Decimal128("1.25")}, {"dec": 1.25}),
+        (
+            {"id": ObjectId("507f1f77bcf86cd799439011")},
+            {"id": "507f1f77bcf86cd799439011"},
+        ),
+    ],
+)
 async def test_serialize(raw, output):
     async with create_mongo_source() as source:
         assert source.serialize(raw) == output


### PR DESCRIPTION
## closes https://github.com/elastic/connectors-python/issues/1605

Attempts to handle `DBRef` bson types, to avoid NDJSON serialization errors from the elasticsearch-python client.
Also adds stacktrace logging for when callback coroutines log errors.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes


## Release Note

Fixes a bug where Mongodb records containing BSON `DBRef` fields could not be indexed to Elasticsearch and caused sync failures.
