### PR TITLE
Improve OneDrive Connector Performance

### DIFF
--- a/tests/sources/fixtures/onedrive/connector.json
+++ b/tests/sources/fixtures/onedrive/connector.json
@@ -1,101 +1,118 @@
 {
-    "api_key_id": "xyzIbIgBFjJwEZQV7bda",
-    "configuration": {
-      "tenant_id": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Tenant Id",
-        "sensitive": false,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "00000000-0000-0000-0000-000000000000",
-        "order": 3,
-        "ui_restrictions": []
+  "api_key_id": "xyzIbIgBFjJwEZQV7bda",
+  "configuration": {
+    "tenant_id": {
+      "depends_on": [],
+      "display": "text",
+      "tooltip": null,
+      "default_value": null,
+      "label": "Tenant Id",
+      "sensitive": false,
+      "type": "str",
+      "required": true,
+      "options": [],
+      "validations": [],
+      "value": "00000000-0000-0000-0000-000000000000",
+      "order": 3,
+      "ui_restrictions": []
+    },
+    "client_secret": {
+      "depends_on": [],
+      "display": "text",
+      "tooltip": null,
+      "default_value": null,
+      "label": "Client Secret Value",
+      "sensitive": true,
+      "type": "str",
+      "required": true,
+      "options": [],
+      "validations": [],
+      "value": "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ",
+      "order": 2,
+      "ui_restrictions": []
+    },
+    "client_id": {
+      "depends_on": [],
+      "display": "text",
+      "tooltip": null,
+      "default_value": null,
+      "label": "Client Id",
+      "sensitive": true,
+      "type": "str",
+      "required": true,
+      "options": [],
+      "validations": [],
+      "value": "00000000-0000-0000-0000-000000000000",
+      "order": 1,
+      "ui_restrictions": []
+    },
+    "retry_count": {
+      "default_value": 3,
+      "display": "numeric",
+      "label": "Retries per request",
+      "order": 4,
+      "required": false,
+      "type": "int",
+      "ui_restrictions": ["advanced"],
+      "value": 3
+    },
+    "concurrent_downloads": {
+      "depends_on": [],
+      "display": "numeric",
+      "tooltip": null,
+      "default_value": 15,
+      "label": "Maximum concurrent downloads",
+      "sensitive": false,
+      "type": "int",
+      "required": false,
+      "options": [],
+      "validations": [],
+      "value": 15,
+      "order": 5,
+      "ui_restrictions": [
+        "advanced"
+      ]
+    }
+  },
+  "custom_scheduling": {},
+  "description": null,
+  "error": "Cannot connect to host enterprisesearchasd.microsoft.com:443 ssl:default [nodename nor servname provided, or not known]",
+  "features": {
+    "filtering_advanced_config": false,
+    "filtering_rules": false,
+    "sync_rules": {
+      "advanced": {
+        "enabled": true
       },
-      "client_secret": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Client Secret Value",
-        "sensitive": true,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ",
-        "order": 2,
-        "ui_restrictions": []
-      },
-      "client_id": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Client Id",
-        "sensitive": true,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "00000000-0000-0000-0000-000000000000",
-        "order": 1,
-        "ui_restrictions": []
-      },
-      "retry_count": {
-        "default_value": 3,
-        "display": "numeric",
-        "label": "Retries per request",
-        "order": 4,
-        "required": false,
-        "type": "int",
-        "ui_restrictions": ["advanced"],
-        "value": 3
+      "basic": {
+        "enabled": true
       }
-    },
-    "custom_scheduling": {},
-    "description": null,
-    "error": "Cannot connect to host enterprisesearchasd.microsoft.com:443 ssl:default [nodename nor servname provided, or not known]",
-    "features": {
-      "filtering_advanced_config": false,
-      "filtering_rules": false,
-      "sync_rules": {
-        "advanced": {
-          "enabled": true
-        },
-        "basic": {
-          "enabled": true
-        }
-      }
-    },
-    "index_name": "search-onedrive",
-    "is_native": false,
-    "language": null,
-    "last_seen": "2023-06-02T16:05:43.247794+00:00",
-    "last_sync_error": "Cannot connect to host enterprisesearchasd.microsoft.com:443 ssl:default [nodename nor servname provided, or not known]",
-    "last_sync_scheduled_at": null,
-    "last_sync_status": null,
-    "last_synced": "2023-06-02T16:08:30.745527+00:00",
-    "name": "onedrive-connector",
-    "pipeline": {
-      "extract_binary_content": true,
-      "name": "ent-search-generic-ingestion",
-      "reduce_whitespace": true,
-      "run_ml_inference": true
-    },
-    "scheduling": {
-      "full": {
-        "enabled": true,
-        "interval": "0 * * * * ?"
-      }
-    },
-    "service_type": "onedrive",
-    "status": "connected",
-    "id": "onedrive",
-    "last_indexed_document_count": 0,
-    "last_deleted_document_count": 0
-  }
+    }
+  },
+  "index_name": "search-onedrive",
+  "is_native": false,
+  "language": null,
+  "last_seen": "2023-06-02T16:05:43.247794+00:00",
+  "last_sync_error": "Cannot connect to host enterprisesearchasd.microsoft.com:443 ssl:default [nodename nor servname provided, or not known]",
+  "last_sync_scheduled_at": null,
+  "last_sync_status": null,
+  "last_synced": "2023-06-02T16:08:30.745527+00:00",
+  "name": "onedrive-connector",
+  "pipeline": {
+    "extract_binary_content": true,
+    "name": "ent-search-generic-ingestion",
+    "reduce_whitespace": true,
+    "run_ml_inference": true
+  },
+  "scheduling": {
+    "full": {
+      "enabled": true,
+      "interval": "0 * * * * ?"
+    }
+  },
+  "service_type": "onedrive",
+  "status": "connected",
+  "id": "onedrive",
+  "last_indexed_document_count": 0,
+  "last_deleted_document_count": 0
+}

--- a/tests/sources/fixtures/onedrive/fixture.py
+++ b/tests/sources/fixtures/onedrive/fixture.py
@@ -158,6 +158,9 @@ class DataGenerator:
                 item["folder"] = file["folder"]
             else:
                 item["file"] = file["file"]
+                item[
+                    "@microsoft.graph.downloadUrl"
+                ] = f"{ROOT}/users/{user_id}/drive/items/{file['id']}/content"
 
             results.append(item)
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/1618

With the following change, the execution time is reduced by half 🎉 so it now takes 55 minutes in place of 2 hours to index 51k documents.

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
