### PR TITLE
Increase the number of retries, and ensure a minimum wait time on 429s

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -66,7 +66,7 @@ else:
     GRAPH_API_AUTH_URL = "https://login.microsoftonline.com"
     REST_API_AUTH_URL = "https://accounts.accesscontrol.windows.net"
 
-DEFAULT_RETRY_COUNT = 3
+DEFAULT_RETRY_COUNT = 10
 DEFAULT_RETRY_SECONDS = 30
 DEFAULT_PARALLEL_CONNECTION_COUNT = 10
 FILE_WRITE_CHUNK_SIZE = 1024 * 64  # 64KB default SSD page size
@@ -424,6 +424,8 @@ class MicrosoftAPISession:
                 self._logger.warning(
                     f"Response Code from Sharepoint Server is {e.status} but Retry-After header is not found, using default retry time: {DEFAULT_RETRY_SECONDS} seconds"
                 )
+                retry_seconds = DEFAULT_RETRY_SECONDS
+            if retry_seconds < DEFAULT_RETRY_SECONDS:
                 retry_seconds = DEFAULT_RETRY_SECONDS
             self._logger.debug(
                 f"Rate Limited by Sharepoint: retry in {retry_seconds} seconds"


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/5733

While @vidok has been working on a more comprehensive improvement, I found that these tweaks got me past any rate limit issues. Dmitrii, I'm happy to just close this if your PR covers these pieces, or  if not, maybe we can add these to your PR?

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference



## Release Note

Increases the maximum number of retries the Sharepoint Online connector will attempt. This helps prevent syncs from failing when Sharepoint Online is heavily rate-limiting your Azure App.
