### PR TITLE
[SPO] individual site lookup RCF

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -830,10 +830,7 @@ class Connector(ESDocument):
                 simple_default_value = simple_default_config.get(config_name, {}).get(k)
                 if k != "value" and simple_default_value != v:
                     draft_config_obj = draft_config.get(config_name, {})
-                    if simple_default_value is None:
-                        draft_config_obj[k] = v
-                    else:
-                        draft_config_obj[k] = simple_default_value
+                    draft_config_obj[k] = simple_default_value or v
                     draft_config[config_name] = draft_config_obj
         return draft_config
 

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -793,7 +793,7 @@ class Connector(ESDocument):
             doc["status"] = Status.NEEDS_CONFIGURATION.value
             self.log_debug("Populated configuration")
         elif missing_keys:
-            doc["configuration"] = self._updated_configuration(
+            doc["configuration"] = self.updated_configuration(
                 missing_keys, current_config, simple_config
             )
             # doc["status"] = Status.NEEDS_CONFIGURATION.value # not setting status, because it may be that default values are sufficient

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1200,7 +1200,10 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "value": 3,
                 "order": 8,
                 "validations": [{"type": "greater_than", "constraint": 0}],
-                "depends_on": [{"field": "fetch_subsites", "value": True}, {"field": "enumerate_all_sites", "value": False}],
+                "depends_on": [
+                    {"field": "fetch_subsites", "value": True},
+                    {"field": "enumerate_all_sites", "value": False},
+                ],
             },
             "use_text_extraction_service": {
                 "display": "toggle",

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -685,13 +685,13 @@ class SharepointOnlineClient:
             f"{GRAPH_API_URL}/sites/{sharepoint_host}:/sites/{allowed_site}"
         )
 
-    async def _fetch_subsites_by_parent_id(self, parent_site_id):
+    async def _scroll_subsites_by_parent_id(self, parent_site_id):
         self._logger.debug(f"Scrolling subsites of {parent_site_id}")
         async for page in self._graph_api_client.scroll(
             f"{GRAPH_API_URL}/sites/{parent_site_id}/sites?expand=sites"
         ):
             for site in page:
-                async for subsite in self._recurse_sites(site):
+                async for subsite in self._recurse_sites(site):  # pyright: ignore
                     yield subsite
 
     async def _recurse_sites(self, site_with_subsites):
@@ -699,7 +699,7 @@ class SharepointOnlineClient:
         site_with_subsites.pop("sites@odata.context", None)  # remove unnecesary field
         yield site_with_subsites
         if subsites:
-            async for site in self._fetch_subsites_by_parent_id(
+            async for site in self._scroll_subsites_by_parent_id(
                 site_with_subsites["id"]
             ):
                 yield site

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -694,7 +694,7 @@ class SharepointOnlineClient:
         site_with_subsites.pop("sites@odata.context", None)  # remove unnecesary field
         yield site_with_subsites
         for site in subsites:
-            async for item in self._recurse_sites(site):
+            async for item in self._recurse_sites(site):  # pyright: ignore
                 yield item
 
     def _subsite_expansion_str(self, depth):

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1208,7 +1208,9 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         async for site_collection in self.client.site_collections():
             async for site in self.client.sites(
-                site_collection["siteCollection"]["hostname"], configured_root_sites
+                site_collection["siteCollection"]["hostname"],
+                configured_root_sites,
+                self.configuration["enumerate_all_sites"],
             ):
                 retrieved_sites.append(self._site_path_from_web_url(site["webUrl"]))
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1200,7 +1200,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "value": 3,
                 "order": 8,
                 "validations": [{"type": "greater_than", "constraint": 0}],
-                "depends_on": [{"field": "fetch_subsites", "value": True}],
+                "depends_on": [{"field": "fetch_subsites", "value": True}, {"field": "enumerate_all_sites", "value": False}],
             },
             "use_text_extraction_service": {
                 "display": "toggle",
@@ -1291,7 +1291,10 @@ class SharepointOnlineDataSource(BaseDataSource):
                 configured_root_sites,
                 self.configuration["enumerate_all_sites"],
             ):
-                retrieved_sites.append(self._site_path_from_web_url(site["webUrl"]))
+                if self.configuration["enumerate_all_sites"]:
+                    retrieved_sites.append(site["name"])
+                else:
+                    retrieved_sites.append(self._site_path_from_web_url(site["webUrl"]))
 
         missing = [x for x in configured_root_sites if x not in retrieved_sites]
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -593,18 +593,21 @@ class SharepointOnlineClient:
     async def sites(self, parent_site_id, allowed_root_sites):
         select = ""
 
-        async for page in self._graph_api_client.scroll(
-            f"{GRAPH_API_URL}/sites/{parent_site_id}/sites?search=*&$select={select}"
-        ):
-            for site in page:
-                # Filter out site collections that are not needed
-                if (
-                    WILDCARD not in allowed_root_sites
-                    and site["name"] not in allowed_root_sites
-                ):
-                    continue
-
-                yield site
+        if allowed_root_sites == [WILDCARD]:
+            async for page in self._graph_api_client.scroll(
+                f"{GRAPH_API_URL}/sites/{parent_site_id}/sites?search=*&$select={select}" # TODO: why search?
+            ):
+                for site in page:
+                    yield site
+        else:
+            self._logger.debug(f"Looking up sites: {allowed_root_sites}")
+            for allowed_site in allowed_root_sites:
+                try:
+                    self._logger.debug(f"Requesting site '{allowed_site}' by relative path in parent site: {parent_site_id}")
+                    site = await self._graph_api_client.fetch(f"{GRAPH_API_URL}/sites/{parent_site_id}:/sites/{allowed_site}")
+                    yield site
+                except NotFound as e:
+                    self._logger.warning(f"Could not look up site '{allowed_site}' by relative path in parent site: {parent_site_id}")
 
     async def site_drives(self, site_id):
         select = "createdDateTime,description,id,lastModifiedDateTime,name,webUrl,driveType,createdBy,lastModifiedBy,owner"
@@ -1185,7 +1188,7 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         async for site_collection in self.client.site_collections():
             async for site in self.client.sites(
-                site_collection["siteCollection"]["hostname"], [WILDCARD]
+                site_collection["siteCollection"]["hostname"], configured_root_sites
             ):
                 remote_sites.append(site["name"])
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -600,8 +600,8 @@ class SharepointOnlineClient:
                 for site in page:
                     # Filter out site collections that are not needed
                     if (
-                            WILDCARD not in allowed_root_sites
-                            and site["name"] not in allowed_root_sites
+                        WILDCARD not in allowed_root_sites
+                        and site["name"] not in allowed_root_sites
                     ):
                         continue
                     yield site
@@ -609,11 +609,17 @@ class SharepointOnlineClient:
             self._logger.debug(f"Looking up sites: {allowed_root_sites} individually")
             for allowed_site in allowed_root_sites:
                 try:
-                    self._logger.debug(f"Requesting site '{allowed_site}' by relative path in parent site: {parent_site_id}")
-                    site = await self._graph_api_client.fetch(f"{GRAPH_API_URL}/sites/{parent_site_id}:/sites/{allowed_site}")
+                    self._logger.debug(
+                        f"Requesting site '{allowed_site}' by relative path in parent site: {parent_site_id}"
+                    )
+                    site = await self._graph_api_client.fetch(
+                        f"{GRAPH_API_URL}/sites/{parent_site_id}:/sites/{allowed_site}"
+                    )
                     yield site
-                except NotFound as e:
-                    self._logger.warning(f"Could not look up site '{allowed_site}' by relative path in parent site: {parent_site_id}")
+                except NotFound:
+                    self._logger.warning(
+                        f"Could not look up site '{allowed_site}' by relative path in parent site: {parent_site_id}"
+                    )
 
     async def site_drives(self, site_id):
         select = "createdDateTime,description,id,lastModifiedDateTime,name,webUrl,driveType,createdBy,lastModifiedBy,owner"
@@ -1112,10 +1118,10 @@ class SharepointOnlineDataSource(BaseDataSource):
             "enumerate_all_sites": {
                 "display": "toggle",
                 "lavel": "Enumerate all sites?",
-                "tooltip": "Whether sites should be fetched by name from \"all sites\". If disabled, each configured site will be fetched with an individual request.",
+                "tooltip": 'Whether sites should be fetched by name from "all sites". If disabled, each configured site will be fetched with an individual request.',
                 "order": 6,
                 "type": "bool",
-                "value": True
+                "value": True,
             },
             "use_text_extraction_service": {
                 "display": "toggle",
@@ -1204,7 +1210,7 @@ class SharepointOnlineDataSource(BaseDataSource):
             async for site in self.client.sites(
                 site_collection["siteCollection"]["hostname"], configured_root_sites
             ):
-                retrieved_sites.append(self._site_path_from_web_url(site['webUrl']))
+                retrieved_sites.append(self._site_path_from_web_url(site["webUrl"]))
 
         missing = [x for x in configured_root_sites if x not in retrieved_sites]
 
@@ -1214,9 +1220,11 @@ class SharepointOnlineDataSource(BaseDataSource):
             )
 
     def _site_path_from_web_url(self, web_url):
-        url_parts = web_url.split('/sites/')
+        url_parts = web_url.split("/sites/")
         site_path_parts = url_parts[1:]
-        return '/sites/'.join(site_path_parts) # just in case there was a /sites/ in the site path
+        return "/sites/".join(
+            site_path_parts
+        )  # just in case there was a /sites/ in the site path
 
     def _decorate_with_access_control(self, document, access_control):
         if self._dls_enabled():
@@ -1648,7 +1656,7 @@ class SharepointOnlineDataSource(BaseDataSource):
         async for site in self.client.sites(
             hostname,
             collections,
-            enumerate_all_sites=self.configuration['enumerate_all_sites']
+            enumerate_all_sites=self.configuration["enumerate_all_sites"],
         ):  # TODO: simplify and eliminate root call
             site["_id"] = site["id"]
             site["object_type"] = "site"

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1157,7 +1157,7 @@ async def test_connector_prepare():
         "_id": doc_id,
         "_seq_no": seq_no,
         "_primary_term": primary_term,
-        "_source": {},
+        "_source": {"configuration": {}},
     }
     config = {
         "connector_id": doc_id,
@@ -1191,7 +1191,7 @@ async def test_connector_prepare_with_race_condition():
         "_id": doc_id,
         "_seq_no": seq_no,
         "_primary_term": primary_term,
-        "_source": {},
+        "_source": {"configuration": {}},
     }
     config = {
         "connector_id": doc_id,

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1974,3 +1974,75 @@ def test_pipeline_properties(key, value, default_value):
 )
 def test_get_advanced_rules(filtering, expected_advanced_rules):
     assert Filter(filtering).get_advanced_rules() == expected_advanced_rules
+
+
+def test_updated_configuration():
+    current = {
+        "tenant_id": {"label": "Tenant ID", "order": 1, "type": "str", "value": "foo"},
+        "tenant_name": {
+            "label": "Tenant name",
+            "order": 2,
+            "type": "str",
+            "value": "bar",
+        },
+        "client_id": {"label": "Client ID", "order": 3, "type": "str", "value": "baz"},
+        "secret_value": {
+            "label": "Secret value",
+            "order": 4,
+            "sensitive": True,
+            "type": "str",
+            "value": "qux",
+        },
+        "some_toggle": {"label": "toggle", "order": 5, "type": "bool", "value": False},
+    }
+    simple_default = {
+        "tenant_id": {
+            "label": "Tenant Identifier",
+            "order": 1,
+            "type": "str",
+        },
+        "tenant_name": {
+            "label": "Tenant name",
+            "order": 2,
+            "type": "str",
+        },
+        "new_config": {
+            "label": "Config label",
+            "order": 3,
+            "type": "bool",
+            "value": True,
+        },
+        "client_id": {
+            "label": "Client ID",
+            "order": 4,
+            "type": "str",
+        },
+        "secret_value": {
+            "label": "Secret value",
+            "order": 5,
+            "sensitive": True,
+            "type": "str",
+        },
+        "some_toggle": {"label": "toggle", "order": 6, "type": "bool", "value": True},
+    }
+    missing_configs = ["new_config"]
+    connector = Connector(elastic_index=Mock(), doc_source={"_id": "test"})
+    result = connector.updated_configuration(missing_configs, current, simple_default)
+
+    # all keys included where there are changes (excludes 'tenant_name')
+    assert result.keys() == set(
+        ["new_config", "tenant_id", "client_id", "secret_value", "some_toggle"]
+    )
+
+    # order is adjusted
+    assert result["client_id"]["order"] == 4
+    assert result["secret_value"]["order"] == 5
+
+    # so is label
+    assert result["tenant_id"]["label"] == "Tenant Identifier"
+
+    # value is not changed for existing configs
+    assert "value" not in result["some_toggle"].keys()
+
+    # value is set for new configs
+    assert result["new_config"]["value"] is True

--- a/tests/sources/fixtures/sharepoint_online/connector.json
+++ b/tests/sources/fixtures/sharepoint_online/connector.json
@@ -76,6 +76,21 @@
         "order": 5,
         "ui_restrictions": []
       },
+      "enumerate_all_sites": {
+        "depends_on": [],
+        "display": "toggle",
+        "tooltip": "Enumerate all sites?",
+        "default_value": null,
+        "label": "Enumerate all sites?",
+        "sensitive": false,
+        "type": "bool",
+        "required": true,
+        "options": [],
+        "validations": [],
+        "value": trie,
+        "order": 6,
+        "ui_restrictions": []
+      },
       "use_text_extraction_service": {
         "depends_on": [],
         "display": "toggle",
@@ -88,7 +103,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 6,
+        "order": 7,
         "ui_restrictions": []
       },
       "use_document_level_security": {
@@ -103,7 +118,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 7,
+        "order": 8,
         "ui_restrictions": []
       },
       "fetch_drive_item_permissions": {
@@ -123,7 +138,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 8,
+        "order": 9,
         "ui_restrictions": []
       },
       "fetch_unique_page_permissions": {
@@ -143,7 +158,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 9,
+        "order": 10,
         "ui_restrictions": []
       },
       "fetch_unique_list_permissions": {
@@ -163,7 +178,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 10,
+        "order": 11,
         "ui_restrictions": []
       },
       "fetch_unique_list_item_permissions": {
@@ -183,7 +198,7 @@
         "options": [],
         "validations": [],
         "value": true,
-        "order": 11,
+        "order": 12,
         "ui_restrictions": []
       }
     },

--- a/tests/sources/fixtures/sharepoint_online/connector.json
+++ b/tests/sources/fixtures/sharepoint_online/connector.json
@@ -87,7 +87,7 @@
         "required": true,
         "options": [],
         "validations": [],
-        "value": trie,
+        "value": true,
         "order": 6,
         "ui_restrictions": []
       },

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2615,13 +2615,24 @@ class TestSharepointOnlineDataSource:
             assert e.match(another_non_existing_site)
 
     @pytest.mark.asyncio
+    async def test_validate_config_with_existing_collection_fetching_all_sites(
+        self, patch_sharepoint_client
+    ):
+        existing_site = "site-1"
+
+        async with create_spo_source(
+            site_collections=[existing_site], enumerate_all_sites=True
+        ) as source:
+            await source.validate_config()
+
+    @pytest.mark.asyncio
     async def test_validate_config_with_existing_collection_fetching_individual_sites(
         self, patch_sharepoint_client
     ):
         existing_site = "site_1"
 
         async with create_spo_source(
-            site_collections=[existing_site], enumerate_all_sites=True
+            site_collections=[existing_site], enumerate_all_sites=False
         ) as source:
             await source.validate_config()
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -832,7 +832,26 @@ class TestSharepointOnlineClient:
         assert returned_items == actual_items
 
     @pytest.mark.asyncio
-    async def test_sites_filter(self, client, patch_fetch):
+    async def test_sites_filter(self, client, patch_scroll):
+        root_site = "root"
+        actual_items = [
+            {"name": "First"},
+            {"name": "Second"},
+            {"name": "Third"},
+            {"name": "Fourth"},
+        ]
+        filter_ = ["First", "Third"]
+
+        returned_items = await self._execute_scrolling_method(
+            partial(client.sites, root_site, filter_), patch_scroll, actual_items
+        )
+
+        assert len(returned_items) == len(filter_)
+        assert actual_items[0] in returned_items
+        assert actual_items[2] in returned_items
+
+    @pytest.mark.asyncio
+    async def test_sites_filter_individually(self, client, patch_fetch):
         root_site = "root"
         actual_items = [
             {"name": "First"},
@@ -843,7 +862,7 @@ class TestSharepointOnlineClient:
 
 
         returned_items = []
-        async for site in client.sites(root_site, filter_):
+        async for site in client.sites(root_site, filter_, enumerate_all_sites=False):
             returned_items.append(site)
 
         assert len(returned_items) == len(filter_)

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -825,30 +825,29 @@ class TestSharepointOnlineClient:
         ]
 
         returned_items = await self._execute_scrolling_method(
-            partial(client.sites, root_site, WILDCARD), patch_scroll, actual_items
+            partial(client.sites, root_site, [WILDCARD]), patch_scroll, actual_items
         )
 
         assert len(returned_items) == len(actual_items)
         assert returned_items == actual_items
 
     @pytest.mark.asyncio
-    async def test_sites_filter(self, client, patch_scroll):
+    async def test_sites_filter(self, client, patch_fetch):
         root_site = "root"
         actual_items = [
             {"name": "First"},
-            {"name": "Second"},
             {"name": "Third"},
-            {"name": "Fourth"},
         ]
         filter_ = ["First", "Third"]
+        patch_fetch.side_effect = actual_items
 
-        returned_items = await self._execute_scrolling_method(
-            partial(client.sites, root_site, filter_), patch_scroll, actual_items
-        )
+
+        returned_items = []
+        async for site in client.sites(root_site, filter_):
+            returned_items.append(site)
 
         assert len(returned_items) == len(filter_)
-        assert actual_items[0] in returned_items
-        assert actual_items[2] in returned_items
+        assert actual_items == returned_items
 
     @pytest.mark.asyncio
     async def test_site_drives(self, client, patch_scroll):

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -902,11 +902,42 @@ class TestSharepointOnlineClient:
         patch_fetch.side_effect = actual_items
 
         returned_items = []
-        async for site in client.sites(root_site, filter_, enumerate_all_sites=False):
+        async for site in client.sites(
+            root_site, filter_, enumerate_all_sites=False, fetch_subsites=False
+        ):
             returned_items.append(site)
 
         assert len(returned_items) == len(filter_)
         assert actual_items == returned_items
+
+    @pytest.mark.asyncio
+    async def test_sites_filter_individually_plus_subsites(self, client, patch_fetch):
+        root_site = "root"
+        actual_items = [
+            {
+                "name": "First",
+                "sites": [{"name": "Second", "sites": [{"name": "Third"}]}],
+            },
+            {"name": "Fourth", "sites": [{"name": "Fifth", "sites": []}]},
+        ]
+        expected_items = [
+            {"name": "First"},
+            {"name": "Second"},
+            {"name": "Third"},
+            {"name": "Fourth"},
+            {"name": "Fifth"},
+        ]
+        filter_ = ["First", "Fourth"]
+        patch_fetch.side_effect = actual_items
+
+        returned_items = []
+        async for site in client.sites(
+            root_site, filter_, enumerate_all_sites=False, fetch_subsites=True
+        ):
+            returned_items.append(site)
+
+        assert len(returned_items) == 5
+        assert returned_items == expected_items
 
     @pytest.mark.asyncio
     async def test_site_drives(self, client, patch_scroll):

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -108,6 +108,7 @@ async def create_spo_source(
     use_text_extraction_service=False,
     fetch_drive_item_permissions=True,
     fetch_unique_list_permissions=True,
+    enumerate_all_sites=False,
 ):
     async with create_source(
         SharepointOnlineDataSource,
@@ -120,6 +121,7 @@ async def create_spo_source(
         use_text_extraction_service=use_text_extraction_service,
         fetch_drive_item_permissions=fetch_drive_item_permissions,
         fetch_unique_list_permissions=fetch_unique_list_permissions,
+        enumerate_all_sites=enumerate_all_sites,
     ) as source:
         source.set_features(
             Features(
@@ -1610,7 +1612,7 @@ class TestSharepointOnlineDataSource:
         return [
             {
                 "id": "1",
-                "webUrl": "https://test.sharepoint.com/site-1",
+                "webUrl": "https://test.sharepoint.com/sites/site_1",
                 "name": "site-1",
                 "siteCollection": self.site_collections[0]["siteCollection"],
             }
@@ -2457,6 +2459,17 @@ class TestSharepointOnlineDataSource:
             # Says which site does not exist
             assert e.match(non_existing_site)
             assert e.match(another_non_existing_site)
+
+    @pytest.mark.asyncio
+    async def test_validate_config_with_existing_collection_fetching_individual_sites(
+        self, patch_sharepoint_client
+    ):
+        existing_site = "site_1"
+
+        async with create_spo_source(
+            site_collections=[existing_site], enumerate_all_sites=True
+        ) as source:
+            await source.validate_config()
 
     @pytest.mark.asyncio
     async def test_get_attachment_content(self, patch_sharepoint_client):

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -860,7 +860,6 @@ class TestSharepointOnlineClient:
         filter_ = ["First", "Third"]
         patch_fetch.side_effect = actual_items
 
-
         returned_items = []
         async for site in client.sites(root_site, filter_, enumerate_all_sites=False):
             returned_items.append(site)


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1648

Sites are currently looked up by name, out of the paginated results of enumerating all sites. This is efficient when large numbers of sites should be synced relative to the total number of sites. However, if a tenant has many sites, but only a small number are configured for syncing, it may be more efficient to look up just the individually configured sites.

This PR adds an RCF to allow the user to pick which strategy to use, and implements looking up sites based on their path.

Additionally, this PR modifies the `validate_config` logic to check sites not by their `"name"` but by the path they use in their URL. This is more reliable and easier for customers to reason about. 

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference


## Related Pull Requests

* original POC: https://github.com/elastic/connectors-python/pull/1639/commits

## Release Note

Adds the ability for the Sharepoint Online connector to fetch sites individually, rather than by paging through all sites. This can be advantageous when syncing a relatively small number of sites.
