### PR TITLE
[8.10] Pass retry_count to the retry handler (#1601)

### DIFF
--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -21,6 +21,7 @@ from connectors.protocol import Features
 from connectors.source import ConfigurableFieldValueError
 from connectors.sources.sharepoint_online import (
     ACCESS_CONTROL,
+    DEFAULT_BACKOFF_MULTIPLIER,
     DEFAULT_RETRY_SECONDS,
     WILDCARD,
     BadRequestError,
@@ -546,6 +547,36 @@ class TestMicrosoftAPISession:
         patch_cancellable_sleeps.assert_awaited_with(DEFAULT_RETRY_SECONDS)
 
     @pytest.mark.asyncio
+    async def test_call_api_with_429_with_retry_after_and_backoff(
+        self,
+        microsoft_api_session,
+        mock_responses,
+        patch_sleep,
+        patch_cancellable_sleeps,
+    ):
+        url = "http://localhost:1234/download-some-sample-file"
+        payload = {"hello": "world"}
+
+        # First throttle, then do not throttle
+        first_request_error = ClientResponseError(None, None)
+        first_request_error.status = 429
+        first_request_error.message = "Something went wrong"
+
+        retry_count = 3
+        for _i in range(retry_count):
+            mock_responses.get(url, exception=first_request_error)
+
+        mock_responses.get(url, payload=payload)
+
+        async with microsoft_api_session._get(url) as response:
+            actual_payload = await response.json()
+            assert actual_payload == payload
+
+        patch_cancellable_sleeps.assert_awaited_with(
+            DEFAULT_RETRY_SECONDS * DEFAULT_BACKOFF_MULTIPLIER * retry_count
+        )
+
+    @pytest.mark.asyncio
     async def test_call_api_with_403(
         self,
         microsoft_api_session,
@@ -560,6 +591,8 @@ class TestMicrosoftAPISession:
         unauthorized_error.status = 403
         unauthorized_error.message = "Something went wrong"
 
+        mock_responses.get(url, exception=unauthorized_error)
+        mock_responses.get(url, exception=unauthorized_error)
         mock_responses.get(url, exception=unauthorized_error)
         mock_responses.get(url, exception=unauthorized_error)
         mock_responses.get(url, exception=unauthorized_error)
@@ -613,6 +646,10 @@ class TestMicrosoftAPISession:
         not_found_error.message = "Something went wrong"
 
         mock_responses.get(url, exception=not_found_error)
+        mock_responses.get(url, exception=not_found_error)
+        mock_responses.get(url, exception=not_found_error)
+        mock_responses.get(url, exception=not_found_error)
+        mock_responses.get(url, exception=not_found_error)
 
         with pytest.raises(NotFound) as e:
             async with microsoft_api_session._get(url) as _:
@@ -660,6 +697,8 @@ class TestMicrosoftAPISession:
         not_found_error.status = 420
         not_found_error.message = error_message
 
+        mock_responses.get(url, exception=not_found_error)
+        mock_responses.get(url, exception=not_found_error)
         mock_responses.get(url, exception=not_found_error)
         mock_responses.get(url, exception=not_found_error)
         mock_responses.get(url, exception=not_found_error)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Pass retry_count to the retry handler (#1601)](https://github.com/elastic/connectors-python/pull/1601)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)