### PR TITLE
Add retryable to bulk api call

### DIFF
--- a/connectors/config.py
+++ b/connectors/config.py
@@ -59,6 +59,7 @@ def _default_config():
                 "max_concurrency": 5,
                 "chunk_max_mem_size": 5,
                 "concurrent_downloads": 10,
+                "max_retries": 3,
             },
             "retry_on_timeout": True,
             "request_timeout": 120,

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -37,6 +37,7 @@ DEFAULT_QUEUE_MEM_SIZE = 5
 DEFAULT_CHUNK_MEM_SIZE = 25
 DEFAULT_MAX_CONCURRENCY = 5
 DEFAULT_CONCURRENT_DOWNLOADS = 10
+DEFAULT_BULK_MAX_RETRIES = 3
 
 # Regular expression pattern to match a basic email format (no whitespace, valid domain)
 EMAIL_REGEX_PATTERN = r"^\S+@\S+\.\S+$"

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -7,12 +7,15 @@ import asyncio
 import datetime
 from copy import deepcopy
 from unittest import mock
-from unittest.mock import ANY, Mock, call
+from unittest.mock import ANY, AsyncMock, Mock, call
 
 import pytest
 
 from connectors.es.settings import TEXT_FIELD_MAPPING
 from connectors.es.sink import (
+    OP_DELETE,
+    OP_INDEX,
+    OP_UPSERT,
     AsyncBulkRunningError,
     ContentIndexNameInvalid,
     Extractor,
@@ -1029,12 +1032,32 @@ def test_bulk_populate_stats(res, expected_result):
         pipeline=None,
         chunk_mem_size=0,
         max_concurrency=0,
+        max_retries=3,
     )
     sink._populate_stats(deepcopy(STATS), res)
 
     assert sink.indexed_document_count == expected_result["indexed_document_count"]
     assert sink.indexed_document_volume == expected_result["indexed_document_volume"]
     assert sink.deleted_document_count == expected_result["deleted_document_count"]
+
+
+async def test_batch_bulk():
+    client = Mock()
+    sink = Sink(
+        client=client,
+        queue=None,
+        chunk_size=0,
+        pipeline={"name": "pipeline"},
+        chunk_mem_size=0,
+        max_concurrency=0,
+        max_retries=3,
+    )
+
+    with mock.patch.object(asyncio, "sleep"):
+        client.bulk = AsyncMock(side_effect=[Exception(), {"items": []}])
+        await sink._batch_bulk([], {OP_INDEX: {}, OP_UPSERT: {}, OP_DELETE: {}})
+
+        assert client.bulk.await_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -1041,7 +1041,7 @@ def test_bulk_populate_stats(res, expected_result):
     assert sink.deleted_document_count == expected_result["deleted_document_count"]
 
 
-async def test_batch_bulk():
+async def test_batch_bulk_with_retry():
     client = Mock()
     sink = Sink(
         client=client,
@@ -1054,6 +1054,7 @@ async def test_batch_bulk():
     )
 
     with mock.patch.object(asyncio, "sleep"):
+        # first call raises exception, and the second call succeeds
         client.bulk = AsyncMock(side_effect=[Exception(), {"items": []}])
         await sink._batch_bulk([], {OP_INDEX: {}, OP_UPSERT: {}, OP_DELETE: {}})
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5191

This PR adds a configurable max number of tries to bulk API calls.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)