### PR TITLE
Handle aiohttp.ClientPayloadError

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -16,7 +16,7 @@ import aiohttp
 import fastjsonschema
 from aiofiles.os import remove
 from aiofiles.tempfile import NamedTemporaryFile
-from aiohttp.client_exceptions import ClientResponseError
+from aiohttp.client_exceptions import ClientPayloadError, ClientResponseError
 from fastjsonschema import JsonSchemaValueException
 
 from connectors.access_control import (
@@ -394,6 +394,8 @@ class MicrosoftAPISession:
             raise
         except ClientResponseError as e:
             await self._handle_client_response_error(absolute_url, e, retry_count)
+        except ClientPayloadError as e:
+            await self._handle_client_payload_error(e, retry_count)
 
     @asynccontextmanager
     @retryable_aiohttp_call(retries=DEFAULT_RETRY_COUNT)
@@ -415,6 +417,17 @@ class MicrosoftAPISession:
             raise
         except ClientResponseError as e:
             await self._handle_client_response_error(absolute_url, e, retry_count)
+        except ClientPayloadError as e:
+            await self._handle_client_payload_error(e, retry_count)
+
+    async def _handle_client_payload_error(self, e, retry_count):
+        await self._sleeps.sleep(
+            self._compute_retry_after(
+                DEFAULT_RETRY_SECONDS, retry_count, DEFAULT_BACKOFF_MULTIPLIER
+            )
+        )
+
+        raise e
 
     async def _handle_client_response_error(self, absolute_url, e, retry_count):
         if e.status == 429 or e.status == 503:

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -562,33 +562,6 @@ class TestMicrosoftAPISession:
         patch_cancellable_sleeps.assert_awaited_with(retry_after)
 
     @pytest.mark.asyncio
-    async def test_call_api_with_404_with_retry_after_header(
-        self,
-        microsoft_api_session,
-        mock_responses,
-        patch_sleep,
-        patch_cancellable_sleeps,
-    ):
-        url = "http://localhost:1234/download-some-sample-file"
-        payload = {"hello": "world"}
-        retry_after = 25
-
-        # First throttle, then do not throttle
-        first_request_error = ClientResponseError(None, None)
-        first_request_error.status = 404
-        first_request_error.message = "Something went wrong"
-        first_request_error.headers = {"Retry-After": str(retry_after)}
-
-        mock_responses.get(url, exception=first_request_error)
-        mock_responses.get(url, payload=payload)
-
-        with pytest.raises(NotFound) as e:
-            async with microsoft_api_session._get(url) as _:
-                pass
-
-        assert e is not None
-
-    @pytest.mark.asyncio
     async def test_call_api_with_429_without_retry_after(
         self,
         microsoft_api_session,

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -15,7 +15,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 import aiohttp
 import pytest
 import pytest_asyncio
-from aiohttp.client_exceptions import (ClientResponseError, ClientPayloadError)
+from aiohttp.client_exceptions import ClientPayloadError, ClientResponseError
 
 from connectors.logger import logger
 from connectors.protocol import Features
@@ -25,7 +25,6 @@ from connectors.sources.sharepoint_online import (
     DEFAULT_BACKOFF_MULTIPLIER,
     DEFAULT_RETRY_SECONDS,
     WILDCARD,
-    DEFAULT_RETRY_SECONDS,
     BadRequestError,
     DriveItemsPage,
     GraphAPIToken,
@@ -561,7 +560,6 @@ class TestMicrosoftAPISession:
             assert actual_payload == payload
 
         patch_cancellable_sleeps.assert_awaited_with(retry_after)
-
 
     @pytest.mark.asyncio
     async def test_call_api_with_404_with_retry_after_header(


### PR DESCRIPTION
There are 2 exceptions reported (see the stacktrace): 

1. https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientPayloadError
2. RuntimeError: generator didn't stop after athrow()

The first can occur when the HTTP connection is lost. In its turn, the second issue arises because we don't let the async context manager finish its job. This leads to GeneratorExit which can't be caught by except Exception.

This PR will add a handler to catch `ClientPayloadError` and retry the requestion. `DEFAULT_RETRY_SECONDS` will be used in retries because the response payload can't be parsed. 

<details><summary>Original stack trace</summary>

```
[FMWK][17:57:53][DEBUG] [Sync Job id: ExTKlYoBw3jntSQT8Xn7, connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Fetching url: https://graph.microsoft.com/v1.0/sites/retailstarbucks1com.sharepoint.com,8cf7065d-af86-4ece-9df3-9c7faf57f801,c388935f-df6f-4be6-9792-05175814bcfb/lists/b3eb1c07-b1b3-41f7-ab0c-fbc120762063/items?$select=createdDateTime%2cid%2clastModifiedDateTime%2cweburl%2ccreatedBy%2clastModifiedBy%2ccontentType&$expand=fields(%24select%3dTitle%2cLink%2cAttachments%2cLinkTitle%2cLinkFilename%2cDescription%2cConversation)&$skiptoken=UGFnZWQ9VFJVRSZwX1NvcnRCZWhhdmlvcj0wJnBfSUQ9MjAwMw
[FMWK][17:57:53][DEBUG] [Sync Job id: ExTKlYoBw3jntSQT8Xn7, connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Calling Sharepoint Endpoint: https://graph.microsoft.com/v1.0/sites/retailstarbucks1com.sharepoint.com,8cf7065d-af86-4ece-9df3-9c7faf57f801,c388935f-df6f-4be6-9792-05175814bcfb/lists/b3eb1c07-b1b3-41f7-ab0c-fbc120762063/items?$select=createdDateTime%2cid%2clastModifiedDateTime%2cweburl%2ccreatedBy%2clastModifiedBy%2ccontentType&$expand=fields(%24select%3dTitle%2cLink%2cAttachments%2cLinkTitle%2cLinkFilename%2cDescription%2cConversation)&$skiptoken=UGFnZWQ9VFJVRSZwX1NvcnRCZWhhdmlvcj0wJnBfSUQ9MjAwMw
[FMWK][17:58:14][DEBUG] Polling every 30 seconds for Job Scheduling Service
[FMWK][17:58:14][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Sending heartbeat
[FMWK][17:58:14][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Status is Status.CONNECTED
[FMWK][17:58:14][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Filtering is in state valid, skipping...
[FMWK][17:58:14][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'access_control' sync scheduling is disabled
[FMWK][17:58:14][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'incremental' sync scheduling is disabled
[FMWK][17:58:14][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'full' sync scheduling is disabled
[FMWK][17:58:44][DEBUG] Polling every 30 seconds for Job Scheduling Service
[FMWK][17:58:44][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Status is Status.CONNECTED
[FMWK][17:58:44][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Filtering is in state valid, skipping...
[FMWK][17:58:44][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'access_control' sync scheduling is disabled
[FMWK][17:58:44][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'incremental' sync scheduling is disabled
[FMWK][17:58:44][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'full' sync scheduling is disabled
[FMWK][17:59:14][DEBUG] Polling every 30 seconds for Job Scheduling Service
[FMWK][17:59:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Status is Status.CONNECTED
[FMWK][17:59:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Filtering is in state valid, skipping...
[FMWK][17:59:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'access_control' sync scheduling is disabled
[FMWK][17:59:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'incremental' sync scheduling is disabled
[FMWK][17:59:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'full' sync scheduling is disabled
^[[B[FMWK][17:59:45][DEBUG] Polling every 30 seconds for Job Scheduling Service
[FMWK][17:59:45][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Status is Status.CONNECTED
[FMWK][17:59:45][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Filtering is in state valid, skipping...
[FMWK][17:59:45][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'access_control' sync scheduling is disabled
[FMWK][17:59:45][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'incremental' sync scheduling is disabled
[FMWK][17:59:45][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'full' sync scheduling is disabled
[FMWK][18:00:15][DEBUG] Polling every 30 seconds for Job Scheduling Service
[FMWK][18:00:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Status is Status.CONNECTED
[FMWK][18:00:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Filtering is in state valid, skipping...
[FMWK][18:00:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'access_control' sync scheduling is disabled
[FMWK][18:00:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'incremental' sync scheduling is disabled
[FMWK][18:00:15][DEBUG] [Connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] 'full' sync scheduling is disabled
[FMWK][18:00:37][DEBUG] [Sync Job id: ExTKlYoBw3jntSQT8Xn7, connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] Calling Sharepoint Endpoint: https://graph.microsoft.com/v1.0/sites/retailstarbucks1com.sharepoint.com,8cf7065d-af86-4ece-9df3-9c7faf57f801,c388935f-df6f-4be6-9792-05175814bcfb/lists/b3eb1c07-b1b3-41f7-ab0c-fbc120762063/items?$select=createdDateTime%2cid%2clastModifiedDateTime%2cweburl%2ccreatedBy%2clastModifiedBy%2ccontentType&$expand=fields(%24select%3dTitle%2cLink%2cAttachments%2cLinkTitle%2cLinkFilename%2cDescription%2cConversation)&$skiptoken=UGFnZWQ9VFJVRSZwX1NvcnRCZWhhdmlvcj0wJnBfSUQ9MjAwMw
[FMWK][18:00:38][DEBUG] [get_doc call] 35357-_decorate_with_metrics_span took 165.33971571922302 seconds.
[FMWK][18:00:38][CRITICAL] [Sync Job id: ExTKlYoBw3jntSQT8Xn7, connector id: 2BSTj4oBw3jntSQTwXiF, index name: search-spo] The document fetcher failed
Traceback (most recent call last):
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/sources/sharepoint_online.py", line 296, in wrapped
    yield item
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/sources/sharepoint_online.py", line 372, in _get_json
    return await resp.json()
  File "/Users/seanstory/Desktop/Dev/connectors-python/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 1099, in json
    await self.read()
  File "/Users/seanstory/Desktop/Dev/connectors-python/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 1037, in read
    self._body = await self.content.read()
  File "/Users/seanstory/Desktop/Dev/connectors-python/lib/python3.10/site-packages/aiohttp/streams.py", line 375, in read
    block = await self.readany()
  File "/Users/seanstory/Desktop/Dev/connectors-python/lib/python3.10/site-packages/aiohttp/streams.py", line 397, in readany
    await self._wait("readany")
  File "/Users/seanstory/Desktop/Dev/connectors-python/lib/python3.10/site-packages/aiohttp/streams.py", line 304, in _wait
    await waiter
aiohttp.client_exceptions.ClientPayloadError: Response payload is not completed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/es/sink.py", line 387, in get_docs
    async for count, doc in aenumerate(generator):
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/utils.py", line 689, in aenumerate
    async for elem in asequence:
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/logger.py", line 134, in __anext__
    return await self.gen.__anext__()
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/es/sink.py", line 360, in _decorate_with_metrics_span
    async for doc in generator:
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/sync_job_runner.py", line 310, in prepare_docs
    async for doc, lazy_download, operation in self.generator():
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/sync_job_runner.py", line 342, in generator
    async for doc, lazy_download in self.data_provider.get_docs(
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/sources/sharepoint_online.py", line 1549, in get_docs
    async for list_item, download_func in self.site_list_items(
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/sources/sharepoint_online.py", line 1779, in site_list_items
    async for list_item in self.client.site_list_items(site_id, site_list_id):
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/sources/sharepoint_online.py", line 747, in site_list_items
    async for page in self._graph_api_client.scroll(
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/sources/sharepoint_online.py", line 347, in scroll
    graph_data = await self._get_json(scroll_url)
  File "/Users/seanstory/Desktop/Dev/connectors-python/connectors/sources/sharepoint_online.py", line 371, in _get_json
    async with self._get(absolute_url) as resp:
  File "/opt/homebrew/Cellar/python@3.10/3.10.11/Frameworks/Python.framework/Versions/3.10/lib/python3.10/contextlib.py", line 249, in __aexit__
    raise RuntimeError("generator didn't stop after athrow()")
RuntimeError: generator didn't stop after athrow()
```

</details>



## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
