### PR TITLE
[8.10] [SPO] individual site lookup RCF (#1653)

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -784,11 +784,19 @@ class Connector(ESDocument):
             doc["service_type"] = configured_service_type
             self.log_debug(f"Populated service type {configured_service_type}")
 
+        simple_config = source_klass.get_simple_configuration()
+        current_config = self.configuration.to_dict()
+        missing_keys = simple_config.keys() - current_config.keys()
         if self.configuration.is_empty():
             # sets the defaults and the flag to NEEDS_CONFIGURATION
-            doc["configuration"] = source_klass.get_simple_configuration()
+            doc["configuration"] = simple_config
             doc["status"] = Status.NEEDS_CONFIGURATION.value
             self.log_debug("Populated configuration")
+        elif missing_keys:
+            doc["configuration"] = self.updated_configuration(
+                missing_keys, current_config, simple_config
+            )
+            # doc["status"] = Status.NEEDS_CONFIGURATION.value # not setting status, because it may be that default values are sufficient
 
         if self.features.features != source_klass.features():
             doc["features"] = source_klass.features()
@@ -804,6 +812,27 @@ class Connector(ESDocument):
             if_primary_term=self._primary_term,
         )
         await self.reload()
+
+    def updated_configuration(
+        self, missing_keys, current_config, simple_default_config
+    ):
+        self.log_warning(
+            f"Detected an existing connector: {self.id} ({self.service_type}) that was previously {Status.CONNECTED.value} but is now missing configuration: {missing_keys}. Values for the new fields will be automatically set. Please review these configuration values as part of your upgrade."
+        )
+        draft_config = {
+            k: simple_default_config[k] for k in missing_keys
+        }  # add missing configs as they exist in the simple default
+
+        # copy any differences (excluding differences in "value") to the draft
+        # the contents of simple_default_config are used unless they are missing
+        for config_name, config_obj in current_config.items():
+            for k, v in config_obj.items():
+                simple_default_value = simple_default_config.get(config_name, {}).get(k)
+                if k != "value" and simple_default_value != v:
+                    draft_config_obj = draft_config.get(config_name, {})
+                    draft_config_obj[k] = simple_default_value or v
+                    draft_config[config_name] = draft_config_obj
+        return draft_config
 
     @with_concurrency_control()
     async def validate_filtering(self, validator):

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1157,7 +1157,7 @@ async def test_connector_prepare():
         "_id": doc_id,
         "_seq_no": seq_no,
         "_primary_term": primary_term,
-        "_source": {},
+        "_source": {"configuration": {}},
     }
     config = {
         "connector_id": doc_id,
@@ -1191,7 +1191,7 @@ async def test_connector_prepare_with_race_condition():
         "_id": doc_id,
         "_seq_no": seq_no,
         "_primary_term": primary_term,
-        "_source": {},
+        "_source": {"configuration": {}},
     }
     config = {
         "connector_id": doc_id,
@@ -1974,3 +1974,75 @@ def test_pipeline_properties(key, value, default_value):
 )
 def test_get_advanced_rules(filtering, expected_advanced_rules):
     assert Filter(filtering).get_advanced_rules() == expected_advanced_rules
+
+
+def test_updated_configuration():
+    current = {
+        "tenant_id": {"label": "Tenant ID", "order": 1, "type": "str", "value": "foo"},
+        "tenant_name": {
+            "label": "Tenant name",
+            "order": 2,
+            "type": "str",
+            "value": "bar",
+        },
+        "client_id": {"label": "Client ID", "order": 3, "type": "str", "value": "baz"},
+        "secret_value": {
+            "label": "Secret value",
+            "order": 4,
+            "sensitive": True,
+            "type": "str",
+            "value": "qux",
+        },
+        "some_toggle": {"label": "toggle", "order": 5, "type": "bool", "value": False},
+    }
+    simple_default = {
+        "tenant_id": {
+            "label": "Tenant Identifier",
+            "order": 1,
+            "type": "str",
+        },
+        "tenant_name": {
+            "label": "Tenant name",
+            "order": 2,
+            "type": "str",
+        },
+        "new_config": {
+            "label": "Config label",
+            "order": 3,
+            "type": "bool",
+            "value": True,
+        },
+        "client_id": {
+            "label": "Client ID",
+            "order": 4,
+            "type": "str",
+        },
+        "secret_value": {
+            "label": "Secret value",
+            "order": 5,
+            "sensitive": True,
+            "type": "str",
+        },
+        "some_toggle": {"label": "toggle", "order": 6, "type": "bool", "value": True},
+    }
+    missing_configs = ["new_config"]
+    connector = Connector(elastic_index=Mock(), doc_source={"_id": "test"})
+    result = connector.updated_configuration(missing_configs, current, simple_default)
+
+    # all keys included where there are changes (excludes 'tenant_name')
+    assert result.keys() == set(
+        ["new_config", "tenant_id", "client_id", "secret_value", "some_toggle"]
+    )
+
+    # order is adjusted
+    assert result["client_id"]["order"] == 4
+    assert result["secret_value"]["order"] == 5
+
+    # so is label
+    assert result["tenant_id"]["label"] == "Tenant Identifier"
+
+    # value is not changed for existing configs
+    assert "value" not in result["some_toggle"].keys()
+
+    # value is set for new configs
+    assert result["new_config"]["value"] is True

--- a/tests/sources/fixtures/sharepoint_online/connector.json
+++ b/tests/sources/fixtures/sharepoint_online/connector.json
@@ -76,6 +76,21 @@
         "order": 5,
         "ui_restrictions": []
       },
+      "enumerate_all_sites": {
+        "depends_on": [],
+        "display": "toggle",
+        "tooltip": "Enumerate all sites?",
+        "default_value": null,
+        "label": "Enumerate all sites?",
+        "sensitive": false,
+        "type": "bool",
+        "required": true,
+        "options": [],
+        "validations": [],
+        "value": true,
+        "order": 6,
+        "ui_restrictions": []
+      },
       "use_text_extraction_service": {
         "depends_on": [],
         "display": "toggle",
@@ -88,7 +103,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 6,
+        "order": 7,
         "ui_restrictions": []
       },
       "use_document_level_security": {
@@ -103,7 +118,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 7,
+        "order": 8,
         "ui_restrictions": []
       },
       "fetch_drive_item_permissions": {
@@ -123,7 +138,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 8,
+        "order": 9,
         "ui_restrictions": []
       },
       "fetch_unique_page_permissions": {
@@ -143,7 +158,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 9,
+        "order": 10,
         "ui_restrictions": []
       },
       "fetch_unique_list_permissions": {
@@ -163,7 +178,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 10,
+        "order": 11,
         "ui_restrictions": []
       },
       "fetch_unique_list_item_permissions": {
@@ -183,7 +198,7 @@
         "options": [],
         "validations": [],
         "value": true,
-        "order": 11,
+        "order": 12,
         "ui_restrictions": []
       }
     },

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -848,7 +848,7 @@ class TestSharepointOnlineClient:
         ]
 
         returned_items = await self._execute_scrolling_method(
-            partial(client.sites, root_site, WILDCARD), patch_scroll, actual_items
+            partial(client.sites, root_site, [WILDCARD]), patch_scroll, actual_items
         )
 
         assert len(returned_items) == len(actual_items)
@@ -872,6 +872,59 @@ class TestSharepointOnlineClient:
         assert len(returned_items) == len(filter_)
         assert actual_items[0] in returned_items
         assert actual_items[2] in returned_items
+
+    @pytest.mark.asyncio
+    async def test_sites_filter_individually(self, client, patch_fetch):
+        root_site = "root"
+        actual_items = [
+            {"name": "First"},
+            {"name": "Third"},
+        ]
+        filter_ = ["First", "Third"]
+        patch_fetch.side_effect = actual_items
+
+        returned_items = []
+        async for site in client.sites(
+            root_site, filter_, enumerate_all_sites=False, fetch_subsites=False
+        ):
+            returned_items.append(site)
+
+        assert len(returned_items) == len(filter_)
+        assert actual_items == returned_items
+
+    @pytest.mark.asyncio
+    async def test_sites_filter_individually_plus_subsites(
+        self, client, patch_fetch, patch_scroll
+    ):
+        root_site = "root"
+        root_item = {
+            "name": "First",
+            "id": "first",
+            "sites": [{"name": "Second"}],
+        }
+        sub_items = [
+            AsyncIterator(
+                [[{"name": "Second", "id": "second", "sites": [{"name": "Third"}]}]]
+            ),
+            AsyncIterator([[{"name": "Third", "id": "third"}]]),
+        ]
+        expected_items = [
+            {"name": "First", "id": "first"},
+            {"name": "Second", "id": "second"},
+            {"name": "Third", "id": "third"},
+        ]
+        filter_ = ["First"]
+        patch_fetch.side_effect = [root_item]
+        patch_scroll.side_effect = sub_items
+
+        returned_items = []
+        async for site in client.sites(
+            root_site, filter_, enumerate_all_sites=False, fetch_subsites=True
+        ):
+            returned_items.append(site)
+
+        assert len(returned_items) == 3
+        assert returned_items == expected_items
 
     @pytest.mark.asyncio
     async def test_site_drives(self, client, patch_scroll):
@@ -1616,7 +1669,7 @@ class TestSharepointOnlineDataSource:
         return [
             {
                 "id": "1",
-                "webUrl": "https://test.sharepoint.com/site-1",
+                "webUrl": "https://test.sharepoint.com/sites/site_1",
                 "name": "site-1",
                 "siteCollection": self.site_collections[0]["siteCollection"],
             }
@@ -2505,6 +2558,40 @@ class TestSharepointOnlineDataSource:
             # Says which site does not exist
             assert e.match(non_existing_site)
             assert e.match(another_non_existing_site)
+
+    @pytest.mark.asyncio
+    async def test_validate_config_with_existing_collection_fetching_all_sites(
+        self, patch_sharepoint_client
+    ):
+        existing_site = "site-1"
+
+        async with create_source(
+            SharepointOnlineDataSource,
+            tenant_id="1",
+            tenant_name="test",
+            client_id="2",
+            secret_value="3",
+            site_collections=[existing_site],
+            enumerate_all_sites=True,
+        ) as source:
+            await source.validate_config()
+
+    @pytest.mark.asyncio
+    async def test_validate_config_with_existing_collection_fetching_individual_sites(
+        self, patch_sharepoint_client
+    ):
+        existing_site = "site_1"
+
+        async with create_source(
+            SharepointOnlineDataSource,
+            tenant_id="1",
+            tenant_name="test",
+            client_id="2",
+            secret_value="3",
+            site_collections=[existing_site],
+            enumerate_all_sites=False,
+        ) as source:
+            await source.validate_config()
 
     @pytest.mark.asyncio
     async def test_get_attachment_content(self, patch_sharepoint_client):


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[SPO] individual site lookup RCF (#1653)](https://github.com/elastic/connectors-python/pull/1653)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)