### PR TITLE
[pre-8.10-stable] [SPO] individual site lookup RCF (#1653)

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -780,11 +780,19 @@ class Connector(ESDocument):
             doc["service_type"] = configured_service_type
             self.log_debug(f"Populated service type {configured_service_type}")
 
+        simple_config = source_klass.get_simple_configuration()
+        current_config = self.configuration.to_dict()
+        missing_keys = simple_config.keys() - current_config.keys()
         if self.configuration.is_empty():
             # sets the defaults and the flag to NEEDS_CONFIGURATION
-            doc["configuration"] = source_klass.get_simple_configuration()
+            doc["configuration"] = simple_config
             doc["status"] = Status.NEEDS_CONFIGURATION.value
             self.log_debug("Populated configuration")
+        elif missing_keys:
+            doc["configuration"] = self.updated_configuration(
+                missing_keys, current_config, simple_config
+            )
+            # doc["status"] = Status.NEEDS_CONFIGURATION.value # not setting status, because it may be that default values are sufficient
 
         if self.features.features != source_klass.features():
             doc["features"] = source_klass.features()
@@ -800,6 +808,27 @@ class Connector(ESDocument):
             if_primary_term=self._primary_term,
         )
         await self.reload()
+
+    def updated_configuration(
+        self, missing_keys, current_config, simple_default_config
+    ):
+        self.log_warning(
+            f"Detected an existing connector: {self.id} ({self.service_type}) that was previously {Status.CONNECTED.value} but is now missing configuration: {missing_keys}. Values for the new fields will be automatically set. Please review these configuration values as part of your upgrade."
+        )
+        draft_config = {
+            k: simple_default_config[k] for k in missing_keys
+        }  # add missing configs as they exist in the simple default
+
+        # copy any differences (excluding differences in "value") to the draft
+        # the contents of simple_default_config are used unless they are missing
+        for config_name, config_obj in current_config.items():
+            for k, v in config_obj.items():
+                simple_default_value = simple_default_config.get(config_name, {}).get(k)
+                if k != "value" and simple_default_value != v:
+                    draft_config_obj = draft_config.get(config_name, {})
+                    draft_config_obj[k] = simple_default_value or v
+                    draft_config[config_name] = draft_config_obj
+        return draft_config
 
     @with_concurrency_control()
     async def validate_filtering(self, validator):

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -623,20 +623,82 @@ class SharepointOnlineClient:
         except NotFound:
             return
 
-    async def sites(self, parent_site_id, allowed_root_sites):
-        select = ""
+    async def sites(
+        self,
+        sharepoint_host,
+        allowed_root_sites,
+        enumerate_all_sites=True,
+        fetch_subsites=False,
+    ):
+        if allowed_root_sites == [WILDCARD] or enumerate_all_sites:
+            self._logger.debug(f"Looking up all sites to fetch: {allowed_root_sites}")
+            async for site in self._all_sites(sharepoint_host, allowed_root_sites):
+                yield site
+        else:
+            self._logger.debug(f"Looking up individual sites: {allowed_root_sites}")
+            for allowed_site in allowed_root_sites:
+                try:
+                    if fetch_subsites:
+                        async for site in self._fetch_site_and_subsites_by_path(
+                            sharepoint_host, allowed_site
+                        ):
+                            yield site
+                    else:
+                        yield await self._fetch_site(sharepoint_host, allowed_site)
 
+                except NotFound:
+                    self._logger.warning(
+                        f"Could not look up site '{allowed_site}' by relative path in parent site: {sharepoint_host}"
+                    )
+
+    async def _all_sites(self, sharepoint_host, allowed_root_sites):
+        select = ""
         async for page in self._graph_api_client.scroll(
-            f"{GRAPH_API_URL}/sites/{parent_site_id}/sites?search=*&$select={select}"
+            f"{GRAPH_API_URL}/sites/{sharepoint_host}/sites?search=*&$select={select}"
         ):
             for site in page:
                 # Filter out site collections that are not needed
-                if (
-                    WILDCARD not in allowed_root_sites
-                    and site["name"] not in allowed_root_sites
-                ):
+                if [WILDCARD] != allowed_root_sites and site[
+                    "name"
+                ] not in allowed_root_sites:
                     continue
+                yield site
 
+    async def _fetch_site_and_subsites_by_path(self, sharepoint_host, allowed_site):
+        self._logger.debug(
+            f"Requesting site '{allowed_site}' and subsites by relative path in host: {sharepoint_host}"
+        )
+        site_with_subsites = await self._graph_api_client.fetch(
+            f"{GRAPH_API_URL}/sites/{sharepoint_host}:/sites/{allowed_site}?expand=sites"
+        )
+        async for site in self._recurse_sites(site_with_subsites):
+            yield site
+
+    async def _fetch_site(self, sharepoint_host, allowed_site):
+        self._logger.debug(
+            f"Requesting site '{allowed_site}' by relative path in parent site: {sharepoint_host}"
+        )
+        return await self._graph_api_client.fetch(
+            f"{GRAPH_API_URL}/sites/{sharepoint_host}:/sites/{allowed_site}"
+        )
+
+    async def _scroll_subsites_by_parent_id(self, parent_site_id):
+        self._logger.debug(f"Scrolling subsites of {parent_site_id}")
+        async for page in self._graph_api_client.scroll(
+            f"{GRAPH_API_URL}/sites/{parent_site_id}/sites?expand=sites"
+        ):
+            for site in page:
+                async for subsite in self._recurse_sites(site):  # pyright: ignore
+                    yield subsite
+
+    async def _recurse_sites(self, site_with_subsites):
+        subsites = site_with_subsites.pop("sites", [])
+        site_with_subsites.pop("sites@odata.context", None)  # remove unnecesary field
+        yield site_with_subsites
+        if subsites:
+            async for site in self._scroll_subsites_by_parent_id(
+                site_with_subsites["id"]
+            ):
                 yield site
 
     async def site_drives(self, site_id):
@@ -1151,10 +1213,27 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "type": "list",
                 "value": "",
             },
+            "enumerate_all_sites": {
+                "display": "toggle",
+                "label": "Enumerate all sites?",
+                "tooltip": 'Whether sites should be fetched by name from "all sites". If disabled, each configured site will be fetched with an individual request.',
+                "order": 6,
+                "type": "bool",
+                "value": True,
+            },
+            "fetch_subsites": {
+                "display": "toggle",
+                "label": "Fetch sub-sites of configured sites?",
+                "tooltip": "Whether subsites of the configured site(s) should be automatically fetched.",
+                "order": 7,
+                "type": "bool",
+                "value": True,
+                "depends_on": [{"field": "enumerate_all_sites", "value": False}],
+            },
             "use_text_extraction_service": {
                 "display": "toggle",
                 "label": "Use text extraction service",
-                "order": 6,
+                "order": 8,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
                 "value": False,
@@ -1162,7 +1241,7 @@ class SharepointOnlineDataSource(BaseDataSource):
             "use_document_level_security": {
                 "display": "toggle",
                 "label": "Enable document level security",
-                "order": 7,
+                "order": 9,
                 "tooltip": "Document level security ensures identities and permissions set in Sharepoint Online are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
                 "value": False,
@@ -1171,7 +1250,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "depends_on": [{"field": "use_document_level_security", "value": True}],
                 "display": "toggle",
                 "label": "Fetch drive item permissions",
-                "order": 8,
+                "order": 10,
                 "tooltip": "Enable this option to fetch drive item specific permissions. This setting can increase sync time.",
                 "type": "bool",
                 "value": True,
@@ -1180,7 +1259,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "depends_on": [{"field": "use_document_level_security", "value": True}],
                 "display": "toggle",
                 "label": "Fetch unique page permissions",
-                "order": 9,
+                "order": 11,
                 "tooltip": "Enable this option to fetch unique page permissions. This setting can increase sync time. If this setting is disabled a page will inherit permissions from its parent site.",
                 "type": "bool",
                 "value": True,
@@ -1189,7 +1268,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "depends_on": [{"field": "use_document_level_security", "value": True}],
                 "display": "toggle",
                 "label": "Fetch unique list permissions",
-                "order": 10,
+                "order": 12,
                 "tooltip": "Enable this option to fetch unique list permissions. This setting can increase sync time. If this setting is disabled a list will inherit permissions from its parent site.",
                 "type": "bool",
                 "value": True,
@@ -1198,7 +1277,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "depends_on": [{"field": "use_document_level_security", "value": True}],
                 "display": "toggle",
                 "label": "Fetch unique list item permissions",
-                "order": 11,
+                "order": 13,
                 "tooltip": "Enable this option to fetch unique list item permissions. This setting can increase sync time. If this setting is disabled a list item will inherit permissions from its parent site.",
                 "type": "bool",
                 "value": True,
@@ -1232,20 +1311,32 @@ class SharepointOnlineDataSource(BaseDataSource):
         if WILDCARD in configured_root_sites:
             return
 
-        remote_sites = []
+        retrieved_sites = []
 
         async for site_collection in self.client.site_collections():
             async for site in self.client.sites(
-                site_collection["siteCollection"]["hostname"], [WILDCARD]
+                site_collection["siteCollection"]["hostname"],
+                configured_root_sites,
+                self.configuration["enumerate_all_sites"],
             ):
-                remote_sites.append(site["name"])
+                if self.configuration["enumerate_all_sites"]:
+                    retrieved_sites.append(site["name"])
+                else:
+                    retrieved_sites.append(self._site_path_from_web_url(site["webUrl"]))
 
-        missing = [x for x in configured_root_sites if x not in remote_sites]
+        missing = [x for x in configured_root_sites if x not in retrieved_sites]
 
         if missing:
             raise Exception(
-                f"The specified SharePoint sites [{', '.join(missing)}] could not be retrieved during sync. Examples of sites available on the tenant:[{', '.join(remote_sites[:5])}]."
+                f"The specified SharePoint sites [{', '.join(missing)}] could not be retrieved during sync. Examples of sites available on the tenant:[{', '.join(retrieved_sites[:5])}]."
             )
+
+    def _site_path_from_web_url(self, web_url):
+        url_parts = web_url.split("/sites/")
+        site_path_parts = url_parts[1:]
+        return "/sites/".join(
+            site_path_parts
+        )  # just in case there was a /sites/ in the site path
 
     def _decorate_with_access_control(self, document, access_control):
         if self._dls_enabled():
@@ -1759,6 +1850,8 @@ class SharepointOnlineDataSource(BaseDataSource):
         async for site in self.client.sites(
             hostname,
             collections,
+            enumerate_all_sites=self.configuration["enumerate_all_sites"],
+            fetch_subsites=self.configuration["fetch_subsites"],
         ):  # TODO: simplify and eliminate root call
             site["_id"] = site["id"]
             site["object_type"] = "site"

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1157,7 +1157,7 @@ async def test_connector_prepare():
         "_id": doc_id,
         "_seq_no": seq_no,
         "_primary_term": primary_term,
-        "_source": {},
+        "_source": {"configuration": {}},
     }
     config = {
         "connector_id": doc_id,
@@ -1191,7 +1191,7 @@ async def test_connector_prepare_with_race_condition():
         "_id": doc_id,
         "_seq_no": seq_no,
         "_primary_term": primary_term,
-        "_source": {},
+        "_source": {"configuration": {}},
     }
     config = {
         "connector_id": doc_id,
@@ -1959,3 +1959,75 @@ def test_pipeline_properties(key, value, default_value):
 )
 def test_get_advanced_rules(filtering, expected_advanced_rules):
     assert Filter(filtering).get_advanced_rules() == expected_advanced_rules
+
+
+def test_updated_configuration():
+    current = {
+        "tenant_id": {"label": "Tenant ID", "order": 1, "type": "str", "value": "foo"},
+        "tenant_name": {
+            "label": "Tenant name",
+            "order": 2,
+            "type": "str",
+            "value": "bar",
+        },
+        "client_id": {"label": "Client ID", "order": 3, "type": "str", "value": "baz"},
+        "secret_value": {
+            "label": "Secret value",
+            "order": 4,
+            "sensitive": True,
+            "type": "str",
+            "value": "qux",
+        },
+        "some_toggle": {"label": "toggle", "order": 5, "type": "bool", "value": False},
+    }
+    simple_default = {
+        "tenant_id": {
+            "label": "Tenant Identifier",
+            "order": 1,
+            "type": "str",
+        },
+        "tenant_name": {
+            "label": "Tenant name",
+            "order": 2,
+            "type": "str",
+        },
+        "new_config": {
+            "label": "Config label",
+            "order": 3,
+            "type": "bool",
+            "value": True,
+        },
+        "client_id": {
+            "label": "Client ID",
+            "order": 4,
+            "type": "str",
+        },
+        "secret_value": {
+            "label": "Secret value",
+            "order": 5,
+            "sensitive": True,
+            "type": "str",
+        },
+        "some_toggle": {"label": "toggle", "order": 6, "type": "bool", "value": True},
+    }
+    missing_configs = ["new_config"]
+    connector = Connector(elastic_index=Mock(), doc_source={"_id": "test"})
+    result = connector.updated_configuration(missing_configs, current, simple_default)
+
+    # all keys included where there are changes (excludes 'tenant_name')
+    assert result.keys() == set(
+        ["new_config", "tenant_id", "client_id", "secret_value", "some_toggle"]
+    )
+
+    # order is adjusted
+    assert result["client_id"]["order"] == 4
+    assert result["secret_value"]["order"] == 5
+
+    # so is label
+    assert result["tenant_id"]["label"] == "Tenant Identifier"
+
+    # value is not changed for existing configs
+    assert "value" not in result["some_toggle"].keys()
+
+    # value is set for new configs
+    assert result["new_config"]["value"] is True

--- a/tests/sources/fixtures/sharepoint_online/connector.json
+++ b/tests/sources/fixtures/sharepoint_online/connector.json
@@ -76,6 +76,21 @@
         "order": 5,
         "ui_restrictions": []
       },
+      "enumerate_all_sites": {
+        "depends_on": [],
+        "display": "toggle",
+        "tooltip": "Enumerate all sites?",
+        "default_value": null,
+        "label": "Enumerate all sites?",
+        "sensitive": false,
+        "type": "bool",
+        "required": true,
+        "options": [],
+        "validations": [],
+        "value": true,
+        "order": 6,
+        "ui_restrictions": []
+      },
       "use_text_extraction_service": {
         "depends_on": [],
         "display": "toggle",
@@ -88,7 +103,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 6,
+        "order": 7,
         "ui_restrictions": []
       },
       "use_document_level_security": {
@@ -103,7 +118,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 7,
+        "order": 8,
         "ui_restrictions": []
       },
       "fetch_drive_item_permissions": {
@@ -123,7 +138,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 8,
+        "order": 9,
         "ui_restrictions": []
       },
       "fetch_unique_page_permissions": {
@@ -143,7 +158,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 9,
+        "order": 10,
         "ui_restrictions": []
       },
       "fetch_unique_list_permissions": {
@@ -163,7 +178,7 @@
         "options": [],
         "validations": [],
         "value": false,
-        "order": 10,
+        "order": 11,
         "ui_restrictions": []
       },
       "fetch_unique_list_item_permissions": {
@@ -183,7 +198,7 @@
         "options": [],
         "validations": [],
         "value": true,
-        "order": 11,
+        "order": 12,
         "ui_restrictions": []
       }
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `pre-8.10-stable`:
 - [[SPO] individual site lookup RCF (#1653)](https://github.com/elastic/connectors-python/pull/1653)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)