### PR TITLE
Update NOTICE.txt to include link to certifi source

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,2 +1,4 @@
-connectors-py
+Elastic Python connectors
 Copyright 2022 Elasticsearch B.V.
+
+The software uses 3rd-party library certifi, transitively, which is under Mozilla Public License 2.0 (MPL 2.0). The source code to this library is https://github.com/certifi/python-certifi.


### PR DESCRIPTION
Connector service uses a transitive library [certifi](https://pypi.org/project/certifi/), which is under Mozilla Public License 2.0 (MPL 2.0). MPL 2.0 is in yellow list:
>Incorporation of **unmodified** source or binaries into Elastic products is permitted, provided that the product's NOTICE file links to a URL providing the MPL-covered source code

This PR adds the link to certifi source in NOTICE.txt

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)