### PR TITLE
Navarone/5857 expand extraction service 1

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -16,6 +16,7 @@ from pydoc import locate
 
 from bson import Decimal128
 
+from connectors.content_extraction import ContentExtraction
 from connectors.filtering.validation import (
     BasicRuleAgainstSchemaValidator,
     BasicRuleNoMatchAllRegexValidator,
@@ -385,6 +386,13 @@ class BaseDataSource:
         self._features = None
         # A dictionary, the structure of which is connector dependent, to indicate a point where the sync is at
         self._sync_cursor = None
+
+        if self.configuration.get("use_text_extraction_service"):
+            self.extraction_service = ContentExtraction()
+            self.download_dir = self.extraction_service.get_volume_dir()
+        else:
+            self.extraction_service = None
+            self.download_dir = None
 
     def __str__(self):
         return f"Datasource `{self.__class__.name}`"

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -24,7 +24,6 @@ from connectors.access_control import (
     es_access_control_query,
     prefix_identity,
 )
-from connectors.content_extraction import ContentExtraction
 from connectors.es.sink import OP_DELETE, OP_INDEX
 from connectors.filtering.validation import (
     AdvancedRulesValidator,
@@ -1146,14 +1145,6 @@ class SharepointOnlineDataSource(BaseDataSource):
         super().__init__(configuration=configuration)
 
         self._client = None
-
-        if self.configuration["use_text_extraction_service"]:
-            self.extraction_service = ContentExtraction()
-            self.download_dir = self.extraction_service.get_volume_dir()
-        else:
-            self.extraction_service = None
-            self.download_dir = None
-
         self.site_group_cache = {}
 
     def _set_internal_logger(self):
@@ -2352,7 +2343,7 @@ class SharepointOnlineDataSource(BaseDataSource):
         attachment = None
         body = None
         source_file_name = ""
-        file_extension = os.path.splitext(original_filename)[-1]
+        file_extension = os.path.splitext(original_filename)[-1].lower()
 
         try:
             async with NamedTemporaryFile(

--- a/tests/sources/fixtures/azure_blob_storage/connector.json
+++ b/tests/sources/fixtures/azure_blob_storage/connector.json
@@ -70,7 +70,7 @@
                         "type": "bool",
                         "ui_restrictions": [],
                         "validations": [],
-                        "value": false,
+                        "value": false
                 }
         },
         "filtering": [

--- a/tests/sources/fixtures/azure_blob_storage/connector.json
+++ b/tests/sources/fixtures/azure_blob_storage/connector.json
@@ -56,6 +56,21 @@
                                 {"type": "less_than", "constraint": 101}
                         ],
                         "value": null
+                },
+                "use_text_extraction_service": {
+                        "default_value": null,
+                        "depends_on": [],
+                        "display": "toggle",
+                        "label": "Use text extraction service",
+                        "options": [],
+                        "order": 6,
+                        "required": true,
+                        "sensitive": false,
+                        "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+                        "type": "bool",
+                        "ui_restrictions": [],
+                        "validations": [],
+                        "value": false,
                 }
         },
         "filtering": [

--- a/tests/sources/test_azure_blob_storage.py
+++ b/tests/sources/test_azure_blob_storage.py
@@ -53,7 +53,7 @@ async def test_ping_for_successful_connection():
     with patch.object(
         BlobServiceClient, "get_account_information", return_value=mock_response
     ):
-        async with create_source(AzureBlobStorageDataSource) as source:
+        async with create_abs_source() as source:
             # Execute
             await source.ping()
 
@@ -63,7 +63,7 @@ async def test_ping_for_failed_connection():
     """Test ping method of AzureBlobStorageDataSource class with negative case"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         with patch.object(
             BlobServiceClient,
             "get_account_information",
@@ -79,7 +79,7 @@ async def test_prepare_blob_doc():
     """Test prepare_blob_doc method of AzureBlobStorageDataSource Class"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         document = {
             "container": "container1",
             "name": "blob1",
@@ -119,7 +119,7 @@ async def test_get_container():
     """Test get_container method of AzureBlobStorageDataSource Class"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         source.connection_string = source._configure_connection_string()
         mock_repsonse = AsyncIterator(
             [
@@ -152,7 +152,7 @@ async def test_get_blob():
     """Test get_blob method of AzureBlobStorageDataSource Class"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         source.connection_string = source._configure_connection_string()
         mock_response = AsyncIterator(
             [
@@ -201,7 +201,7 @@ async def test_get_doc():
     """Test get_doc method of AzureBlobStorageDataSource Class"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         source.get_container = Mock(
             return_value=AsyncIterator(
                 [
@@ -268,7 +268,7 @@ async def test_get_content():
     """Test get_content method of AzureBlobStorageDataSource Class"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         source.connection_string = source._configure_connection_string()
 
         class DownloadBlobMock:
@@ -309,7 +309,7 @@ async def test_get_content_with_upper_extension():
     """Test get_content method of AzureBlobStorageDataSource Class"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         source.connection_string = source._configure_connection_string()
 
         class DownloadBlobMock:
@@ -352,7 +352,7 @@ async def test_get_content_when_doit_false():
     """Test get_content method when doit is false."""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         mock_response = {
             "type": "blob",
             "id": "container1/blob1",
@@ -380,7 +380,7 @@ async def test_get_content_when_file_size_0b():
     """Test get_content method when the file size is 0b"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         mock_response = {
             "type": "blob",
             "id": "container1/blob1",
@@ -408,7 +408,7 @@ async def test_get_content_when_size_limit_exceeded():
     """Test get_content method when the file size is 10MB"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         mock_response = {
             "type": "blob",
             "id": "container1/blob1",
@@ -436,7 +436,7 @@ async def test_get_content_when_type_not_supported():
     """Test get_content method when the file type is not supported"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         mock_response = {
             "type": "blob",
             "id": "container1/blob1",
@@ -464,7 +464,7 @@ async def test_validate_config_no_account_name():
     """Test configure connection string method of AzureBlobStorageDataSource class"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         source.configuration.get_field("account_name").value = ""
 
         with pytest.raises(ConfigurableFieldValueError):
@@ -477,7 +477,7 @@ async def test_tweak_bulk_options():
     """Test tweak_bulk_options method of BaseDataSource class"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         options = {}
         options["concurrent_downloads"] = 10
 
@@ -503,7 +503,7 @@ async def test_get_content_when_blob_tier_archive():
     """Test get_content method when the blob tier is archive"""
 
     # Setup
-    async with create_source(AzureBlobStorageDataSource) as source:
+    async with create_abs_source() as source:
         mock_response = {
             "type": "blob",
             "id": "container1/blob1",


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/5857

- Adds the data extraction service functionality to Azure Blob Storage connectors.
- Moves ContentExtraction initializing logic to BaseDataSource so other connectors can easily have extraction service added

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

