### PR TITLE
Forcibly cancel a sync job after waiting for 5 seconds

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -201,7 +201,7 @@ class Sink:
             raise
         except ForceCanceledError:
             self._logger.error(
-                "Sink cannot be stopped after certain period of time, force cancel the task."
+                f"Sink did not stop within {CANCELATION_TIMEOUT} seconds of cancelation, force-canceling the task."
             )
 
     async def _run(self):
@@ -386,10 +386,10 @@ class Extractor:
             raise
         except ForceCanceledError:
             self._logger.error(
-                "Extractor cannot be stopped after certain period of time, force cancel the extractor."
+                f"Extractor did not stop within {CANCELATION_TIMEOUT} seconds of cancelation, force-canceling the task."
             )
         except Exception as e:
-            self._logger.critical("Document fetcher failed", exc_info=True)
+            self._logger.critical("Document extractor failed", exc_info=True)
             await self.put_doc("FETCH_ERROR")
             self.fetch_error = e
 
@@ -758,7 +758,7 @@ class SyncOrchestrator(ESClient):
                 return
 
         self._logger.error(
-            f"Couldn't stop the sync job after {CANCELATION_TIMEOUT} seconds, force canceling."
+            f"Sync job did not stop within {CANCELATION_TIMEOUT} seconds of canceling. Force-canceling."
         )
         self._sink.force_cancel()
         self._extractor.force_cancel()


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5810

This PR makes the changes so that
1. when the connector cancels the sync job, it will wait for (hardcoded) 5 seconds for cancelation to be done
2. If the sync job is not canceled successfully after 5 seconds, it will try to forcibly cancel the sync job, by removing the queue object, so the whole flow from the remote source to Elasticsearch is cut off.
3. The connector then continue to mark the sync job as `canceled`

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)