### PR TITLE
Abstract download file extraction and conversion

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -6,14 +6,19 @@
 """ Helpers to build sources + FQN-based Registry
 """
 
+import asyncio
 import importlib
 import re
+from contextlib import asynccontextmanager
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
 from functools import cache
 from pydoc import locate
 
+import aiofiles
+from aiofiles.os import remove
+from aiofiles.tempfile import NamedTemporaryFile
 from bson import Decimal128
 
 from connectors.content_extraction import ContentExtraction
@@ -24,7 +29,10 @@ from connectors.filtering.validation import (
     FilteringValidator,
 )
 from connectors.logger import logger
-from connectors.utils import hash_id
+from connectors.utils import convert_to_b64, hash_id
+
+CHUNK_SIZE = 1024
+FILE_SIZE_LIMIT = 10485760  # ~10 Megabytes
 
 DEFAULT_CONFIGURATION = {
     "default_value": None,
@@ -675,6 +683,93 @@ class BaseDataSource:
         NOTE modifying license key logic violates the Elastic License 2.0 that this code is licensed under
         """
         return False
+
+    async def download_and_extract_file(
+        self, doc, source_filename, file_extension, download_func
+    ):
+        # 1 create tempfile
+        async with self.create_temp_file(file_extension) as async_buffer:
+            temp_filename = async_buffer.name
+
+            # 2 download to tempfile
+            await self.download_to_temp_file(
+                temp_filename,
+                source_filename,
+                async_buffer,
+                download_func,
+            )
+
+            # 3 extract or convert content
+            doc = await self.handle_file_content_extraction(
+                doc, source_filename, temp_filename
+            )
+
+        return doc
+
+    @asynccontextmanager
+    async def create_temp_file(self, file_extension):
+        temp_filename = ""
+        try:
+            async with NamedTemporaryFile(
+                mode="wb", delete=False, suffix=file_extension, dir=self.download_dir
+            ) as async_buffer:
+                temp_filename = async_buffer.name
+                yield async_buffer
+        finally:
+            await async_buffer.close()
+            await self.remove_temp_file(temp_filename)
+
+    async def download_to_temp_file(
+        self, temp_filename, source_filename, async_buffer, chunked_download_func
+    ):
+        self._logger.debug(f"Download beginning for file: {source_filename}.")
+        async for data in chunked_download_func():
+            await async_buffer.write(data)
+
+        self._logger.debug(f"Download completed for file: {source_filename}.")
+        # close tempfile here so file content is accessible within async context
+        await async_buffer.close()
+
+    async def generic_chunked_download_func(self, download_func):
+        """
+        This provides a wrapper for chunked download funcs that
+        use `response.content.iterchunked`.
+        This should not be used for downloads that use other methods.
+        """
+        async for response in download_func():
+            async for data in response.content.iter_chunked(CHUNK_SIZE):
+                yield data
+
+    async def handle_file_content_extraction(self, doc, source_filename, temp_filename):
+        """
+        Determines if file content should be extracted locally,
+        or converted to b64 for pipeline extraction.
+
+        Returns the `doc` arg with a new field:
+            - `body` if local content extraction was used
+            - `_attachment` if pipeline extraction will be used
+        """
+        if self.configuration.get("use_text_extraction_service"):
+            if self.extraction_service._check_configured():
+                doc["body"] = await self.extraction_service.extract_text(
+                    temp_filename, source_filename
+                )
+        else:
+            self._logger.debug(f"Calling convert_to_b64 for file : {source_filename}")
+            await asyncio.to_thread(convert_to_b64, source=temp_filename)
+            async with aiofiles.open(file=temp_filename, mode="r") as async_buffer:
+                # base64 on macOS will add a EOL, so we strip() here
+                doc["_attachment"] = (await async_buffer.read()).strip()
+
+        return doc
+
+    async def remove_temp_file(self, temp_filename):
+        try:
+            await remove(temp_filename)
+        except Exception as e:
+            self._logger.warning(
+                f"Could not remove downloaded temp file: {temp_filename}. Error: {e}"
+            )
 
 
 @cache

--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -4,17 +4,13 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """Azure Blob Storage source module responsible to fetch documents from Azure Blob Storage"""
-import asyncio
 import os
 from functools import partial
 
-import aiofiles
-from aiofiles.os import remove
-from aiofiles.tempfile import NamedTemporaryFile
 from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
 
 from connectors.source import BaseDataSource
-from connectors.utils import TIKA_SUPPORTED_FILETYPES, convert_to_b64
+from connectors.utils import TIKA_SUPPORTED_FILETYPES
 
 BLOB_SCHEMA = {
     "title": "name",
@@ -107,6 +103,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
                 "order": 6,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["self-managed"],
                 "value": False,
             },
         }
@@ -191,44 +188,25 @@ class AzureBlobStorageDataSource(BaseDataSource):
             return
 
         document = {"_id": blob["id"], "_timestamp": blob["_timestamp"]}
+        document = await self.download_and_extract_file(
+            document,
+            blob_name,
+            file_extension,
+            partial(self.blob_download_func, blob_name, blob["container"]),
+        )
 
+        return document
+
+    async def blob_download_func(self, blob_name, container_name):
         async with BlobClient.from_connection_string(
             conn_str=self.connection_string,
-            container_name=blob["container"],
+            container_name=container_name,
             blob_name=blob_name,
             retry_total=self.retry_count,
         ) as blob_client:
             data = await blob_client.download_blob()
-            temp_filename = ""
-
-            try:
-                async with NamedTemporaryFile(
-                    mode="wb",
-                    suffix=file_extension,
-                    delete=False,
-                    dir=self.download_dir,
-                ) as async_buffer:
-                    temp_filename = async_buffer.name
-                    async for content in data.chunks():
-                        await async_buffer.write(content)
-
-                if self.configuration["use_text_extraction_service"]:
-                    if self.extraction_service._check_configured():
-                        document["body"] = await self.extraction_service.extract_text(
-                            temp_filename, blob_name
-                        )
-                else:
-                    self._logger.debug(f"Calling convert_to_b64 for file : {blob_name}")
-                    await asyncio.to_thread(convert_to_b64, source=temp_filename)
-                    async with aiofiles.open(
-                        file=temp_filename, mode="r"
-                    ) as async_buffer:
-                        # base64 on macOS will add a EOL, so we strip() here
-                        document["_attachment"] = (await async_buffer.read()).strip()
-            finally:
-                await remove(str(temp_filename))
-
-        return document
+            async for content in data.chunks():
+                yield content
 
     async def get_container(self):
         """Get containers from Azure Blob Storage via azure base client


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/5857

This PR moves the logic for downloading files to temp files, and their extraction/conversion to b64 to BaseDataSource.
The new tool is very generic, so it can be easily added to other connectors in future PRs.
If this is approved, I will also generalise/abstract the file size and file extension check.

This PR uses two connectors as examples for how this tool would be used:

1. Confluence

This is a "standard" download and extraction case. The download func uses `response.content.iter_chunked`, which is the same pattern that most connectors use. This download func is now abstracted onto the `BaseDataSource` class as `generic_chunked_download_func`.

1. Azure Blob Storage

ABS has an irregular download method (it uses a library and has its own chunking method). As a result, its download func can't be abstracted. Instead the download func is defined in the ABS connector and is passed as a partial arg.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
