### PR TITLE
Expand extraction service to more connectors #3

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -724,7 +724,12 @@ class BaseDataSource:
         return True
 
     async def download_and_extract_file(
-        self, doc, source_filename, file_extension, download_func, return_doc_if_failed=False
+        self,
+        doc,
+        source_filename,
+        file_extension,
+        download_func,
+        return_doc_if_failed=False,
     ):
         """
         Performs all the steps required for handling binary content:

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -760,7 +760,8 @@ class BaseDataSource:
             return doc
         except Exception as e:
             self._logger.warning(
-                f"File download and extraction or conversion for file {source_filename} failed: {e}", exc_info=True
+                f"File download and extraction or conversion for file {source_filename} failed: {e}",
+                exc_info=True,
             )
             if return_doc_if_failed:
                 return doc

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -693,6 +693,11 @@ class BaseDataSource:
         return get_file_extension(filename)
 
     def can_file_be_downloaded(self, file_extension, filename, file_size):
+        return self.is_valid_file_type(
+            file_extension, filename
+        ) and self.is_file_size_within_limit(file_size, filename)
+
+    def is_valid_file_type(self, file_extension, filename):
         if file_extension == "":
             self._logger.debug(
                 f"Files without extension are not supported, skipping {filename}."
@@ -705,6 +710,9 @@ class BaseDataSource:
             )
             return False
 
+        return True
+
+    def is_file_size_within_limit(self, file_size, filename):
         if file_size > FILE_SIZE_LIMIT and not self.configuration.get(
             "use_text_extraction_service"
         ):

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -760,7 +760,7 @@ class BaseDataSource:
             return doc
         except Exception as e:
             self._logger.warning(
-                f"File download and extraction or conversion for file {source_filename} failed: {e}"
+                f"File download and extraction or conversion for file {source_filename} failed: {e}", exc_info=True
             )
             if return_doc_if_failed:
                 return doc

--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -178,14 +178,12 @@ class AzureBlobStorageDataSource(BaseDataSource):
             return
 
         document = {"_id": blob["id"], "_timestamp": blob["_timestamp"]}
-        document = await self.download_and_extract_file(
+        return await self.download_and_extract_file(
             document,
             filename,
             file_extension,
             partial(self.blob_download_func, filename, blob["container"]),
         )
-
-        return document
 
     async def blob_download_func(self, blob_name, container_name):
         async with BlobClient.from_connection_string(

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -653,7 +653,7 @@ class ConfluenceDataSource(BaseDataSource):
             return
 
         document = {"_id": attachment["_id"], "_timestamp": attachment["_timestamp"]}
-        document = await self.download_and_extract_file(
+        return await self.download_and_extract_file(
             document,
             filename,
             file_extension,
@@ -665,8 +665,6 @@ class ConfluenceDataSource(BaseDataSource):
                 ),
             ),
         )
-
-        return document
 
     async def _attachment_coro(self, document, access_control):
         """Coroutine to add attachments to Queue and download content

--- a/connectors/sources/dropbox.py
+++ b/connectors/sources/dropbox.py
@@ -667,6 +667,7 @@ class DropboxDataSource(BaseDataSource):
             )
             return
 
+        self._logger.debug(f"Downloading {filename}")
         document = {
             "_id": attachment["id"],
             "_timestamp": attachment["server_modified"],

--- a/connectors/sources/dropbox.py
+++ b/connectors/sources/dropbox.py
@@ -667,7 +667,6 @@ class DropboxDataSource(BaseDataSource):
             )
             return
 
-        self._logger.debug(f"Downloading {filename}")
         document = {
             "_id": attachment["id"],
             "_timestamp": attachment["server_modified"],

--- a/connectors/sources/dropbox.py
+++ b/connectors/sources/dropbox.py
@@ -671,7 +671,7 @@ class DropboxDataSource(BaseDataSource):
             "_id": attachment["id"],
             "_timestamp": attachment["server_modified"],
         }
-        document = await self.download_and_extract_file(
+        return await self.download_and_extract_file(
             document,
             filename,
             file_extension,
@@ -680,8 +680,6 @@ class DropboxDataSource(BaseDataSource):
                 download_func,
             ),
         )
-
-        return document
 
     def download_func(self, is_shared, attachment, filename):
         if is_shared:

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -10,9 +10,6 @@ import os
 import urllib.parse
 from functools import cached_property, partial
 
-import aiofiles
-from aiofiles.os import remove
-from aiofiles.tempfile import NamedTemporaryFile
 from aiogoogle import Aiogoogle
 from aiogoogle.auth.creds import ServiceAccountCreds
 
@@ -22,7 +19,7 @@ from connectors.sources.google import (
     load_service_account_json,
     validate_service_account_json,
 )
-from connectors.utils import TIKA_SUPPORTED_FILETYPES, convert_to_b64, get_pem_format
+from connectors.utils import get_pem_format
 
 CLOUD_STORAGE_READ_ONLY_SCOPE = "https://www.googleapis.com/auth/devstorage.read_only"
 CLOUD_STORAGE_BASE_URL = "https://console.cloud.google.com/storage/browser/_details/"

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -229,6 +229,14 @@ class GoogleCloudStorageDataSource(BaseDataSource):
                 "type": "int",
                 "ui_restrictions": ["advanced"],
             },
+            "use_text_extraction_service": {
+                "display": "toggle",
+                "label": "Use text extraction service",
+                "order": 3,
+                "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+                "type": "bool",
+                "value": False,
+            },
         }
 
     async def validate_config(self):
@@ -370,50 +378,40 @@ class GoogleCloudStorageDataSource(BaseDataSource):
         Returns:
             dictionary: Content document with id, timestamp & text
         """
-        blob_size = int(blob["size"])
-        if not (doit and blob_size):
+        file_size = int(blob["size"])
+        if not (doit and file_size):
             return
 
-        blob_name = blob["name"]
-        if (os.path.splitext(blob_name)[-1]).lower() not in TIKA_SUPPORTED_FILETYPES:
-            self._logger.debug(f"{blob_name} can't be extracted")
+        filename = blob["name"]
+        file_extension = self.get_file_extension(filename)
+        if not self.can_file_be_downloaded(file_extension, filename, file_size):
             return
 
-        if blob_size > DEFAULT_FILE_SIZE_LIMIT:
-            self._logger.warning(
-                f"File size {blob_size} of file {blob_name} is larger than {DEFAULT_FILE_SIZE_LIMIT} bytes. Discarding the file content"
-            )
-            return
-        self._logger.debug(f"Downloading {blob_name}")
         document = {
             "_id": blob["id"],
             "_timestamp": blob["_timestamp"],
         }
-        source_file_name = ""
-        async with NamedTemporaryFile(mode="wb", delete=False) as async_buffer:
+
+        # gcs has a unique download method so we can't utilize
+        # the generic download_and_extract_file func
+        async with self.create_temp_file(file_extension) as async_buffer:
             await anext(
                 self._google_storage_client.api_call(
                     resource="objects",
                     method="get",
                     bucket=blob["bucket_name"],
-                    object=blob_name,
+                    object=filename,
                     alt="media",
                     userProject=self._google_storage_client.user_project_id,
                     pipe_to=async_buffer,
                 )
             )
-            source_file_name = async_buffer.name
+            await async_buffer.close()
 
-        self._logger.debug(f"Calling convert_to_b64 for file : {blob_name}")
-        await asyncio.to_thread(
-            convert_to_b64,
-            source=source_file_name,
-        )
-        async with aiofiles.open(file=source_file_name, mode="r") as target_file:
-            # base64 on macOS will add a EOL, so we strip() here
-            document["_attachment"] = (await target_file.read()).strip()
-        await remove(str(source_file_name))
-        self._logger.debug(f"Downloaded {blob_name} for {blob_size} bytes ")
+            document = await self.handle_file_content_extraction(
+                document, filename, async_buffer.name
+            )
+
         return document
 
     async def get_docs(self, filtering=None):

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -7,9 +7,6 @@ import asyncio
 import os
 from functools import cached_property, partial
 
-import aiofiles
-from aiofiles.os import remove, stat
-from aiofiles.tempfile import NamedTemporaryFile
 from aiogoogle import Aiogoogle, HTTPError
 from aiogoogle.auth.creds import ServiceAccountCreds
 from aiogoogle.sessions.aiohttp_session import AiohttpSession
@@ -27,9 +24,7 @@ from connectors.sources.google import (
 )
 from connectors.utils import (
     EMAIL_REGEX_PATTERN,
-    TIKA_SUPPORTED_FILETYPES,
     RetryStrategy,
-    convert_to_b64,
     retryable,
     validate_email_address,
 )
@@ -39,7 +34,6 @@ GOOGLE_ADMIN_DIRECTORY_SERVICE_NAME = "Google Admin Directory"
 
 RETRIES = 3
 RETRY_INTERVAL = 2
-FILE_SIZE_LIMIT = 10485760  # ~ 10 Megabytes
 
 GOOGLE_API_MAX_CONCURRENCY = 25  # Max open connections to Google API
 
@@ -513,6 +507,14 @@ class GoogleDriveDataSource(BaseDataSource):
                 "ui_restrictions": ["advanced"],
                 "validations": [{"type": "greater_than", "constraint": 0}],
             },
+            "use_text_extraction_service": {
+                "display": "toggle",
+                "label": "Use text extraction service",
+                "order": 5,
+                "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+                "type": "bool",
+                "value": False,
+            },
         }
 
     @cached_property
@@ -778,43 +780,23 @@ class GoogleDriveDataSource(BaseDataSource):
             attachment, file_size (tuple): base64 encoded contnet of the file and size in bytes of the attachment
         """
 
-        temp_file_name = ""
         file_name = file["name"]
-        attachment, file_size = None, 0
+        file_extension = self.get_file_extension(file_name)
+        attachment, body, file_size = None, None, 0
 
-        self._logger.debug(f"Downloading {file_name}")
-
-        try:
-            async with NamedTemporaryFile(mode="wb", delete=False) as async_buffer:
-                await download_func(
-                    pipe_to=async_buffer,
-                )
-
-                temp_file_name = async_buffer.name
-
-            await asyncio.to_thread(
-                convert_to_b64,
-                source=temp_file_name,
+        async with self.create_temp_file(file_extension) as async_buffer:
+            await download_func(
+                pipe_to=async_buffer,
             )
+            await async_buffer.close()
 
-            file_stat = await stat(temp_file_name)
-            file_size = file_stat.st_size
-
-            async with aiofiles.open(file=temp_file_name, mode="r") as target_file:
-                attachment = (await target_file.read()).strip()
-
-            self._logger.debug(
-                f"Downloaded {file_name} with the size of {file_size} bytes "
+            doc = await self.handle_file_content_extraction(
+                {}, file_name, async_buffer.name
             )
-        except Exception as e:
-            self._logger.error(
-                f"Exception encountered when processing file: {file_name}. Exception: {e}"
-            )
-        finally:
-            if temp_file_name:
-                await remove(str(temp_file_name))
+            attachment = doc.get("_attachment")
+            body = doc.get("body")
 
-        return attachment, file_size
+        return attachment, body, file_size
 
     async def get_google_workspace_content(self, file, timestamp=None):
         """Exports Google Workspace documents to an allowed file type and extracts its text content.
@@ -837,8 +819,7 @@ class GoogleDriveDataSource(BaseDataSource):
             "_id": file_id,
             "_timestamp": file["_timestamp"],
         }
-
-        attachment, file_size = await self._download_content(
+        attachment, body, file_size = await self._download_content(
             file=file,
             download_func=partial(
                 self.google_drive_client.api_call,
@@ -854,13 +835,14 @@ class GoogleDriveDataSource(BaseDataSource):
         #    into text/plain format. We usually we end up with tiny .txt files.
         # 2. Google will ofter report the Google Workspace shared documents to have size 0
         #    as they don't count against user's storage quota.
-        if file_size > FILE_SIZE_LIMIT:
-            self._logger.warning(
-                f"File size {file_size} of file {file_name} is larger than {FILE_SIZE_LIMIT} bytes. Discarding the file content"
-            )
+        if not self.is_file_size_within_limit(file_size, file_name):
             return
 
-        document["_attachment"] = attachment
+        if attachment:
+            document["_attachment"] = attachment
+        elif body:
+            document["body"] = body
+
         return document
 
     async def get_generic_file_content(self, file, timestamp=None):
@@ -885,22 +867,14 @@ class GoogleDriveDataSource(BaseDataSource):
             f".{file['file_extension']}",
         )
 
-        if file_extension not in TIKA_SUPPORTED_FILETYPES:
-            self._logger.debug(f"{file_name} can't be extracted")
-            return
-
-        if file_size > FILE_SIZE_LIMIT:
-            self._logger.warning(
-                f"File size {file_size} of file {file_name} is larger than {FILE_SIZE_LIMIT} bytes. Discarding the file content"
-            )
+        if not self.can_file_be_downloaded(file_extension, file_name, file_size):
             return
 
         document = {
             "_id": file_id,
             "_timestamp": file["_timestamp"],
         }
-
-        attachment, _ = await self._download_content(
+        attachment, body, _ = await self._download_content(
             file=file,
             download_func=partial(
                 self.google_drive_client.api_call,
@@ -912,7 +886,11 @@ class GoogleDriveDataSource(BaseDataSource):
             ),
         )
 
-        document["_attachment"] = attachment
+        if attachment:
+            document["_attachment"] = attachment
+        elif body:
+            document["body"] = body
+
         return document
 
     async def get_content(self, file, timestamp=None, doit=None):

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -838,9 +838,9 @@ class GoogleDriveDataSource(BaseDataSource):
         if not self.is_file_size_within_limit(file_size, file_name):
             return
 
-        if attachment:
+        if attachment is not None:
             document["_attachment"] = attachment
-        elif body:
+        elif body is not None:
             document["body"] = body
 
         return document
@@ -886,9 +886,9 @@ class GoogleDriveDataSource(BaseDataSource):
             ),
         )
 
-        if attachment:
+        if attachment is not None:
             document["_attachment"] = attachment
-        elif body:
+        elif body is not None:
             document["body"] = body
 
         return document

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -645,7 +645,7 @@ class JiraDataSource(BaseDataSource):
             "_id": f"{issue_key}-{attachment['id']}",
             "_timestamp": attachment["created"],
         }
-        document = await self.download_and_extract_file(
+        return await self.download_and_extract_file(
             document,
             filename,
             file_extension,
@@ -659,7 +659,6 @@ class JiraDataSource(BaseDataSource):
                 ),
             ),
         )
-        return document
 
     async def ping(self):
         """Verify the connection with Jira"""

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -250,6 +250,8 @@ class S3DataSource(BaseDataSource):
             await s3_client.download_fileobj(
                 Bucket=bucket, Key=filename, Fileobj=async_buffer
             )
+            await async_buffer.close()
+
             document = await self.handle_file_content_extraction(
                 document, filename, async_buffer.name
             )

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -6,7 +6,7 @@
 """Salesforce source module responsible to fetch documents from Salesforce."""
 import asyncio
 import os
-from functools import cached_property
+from functools import cached_property, partial
 from itertools import groupby
 
 import aiofiles
@@ -293,14 +293,14 @@ class SalesforceClient:
 
         return all_case_feeds
 
-    async def download_content_documents(self, content_documents):
-        for content_document in content_documents:
-            content_version = content_document.get("LatestPublishedVersion", {}) or {}
-            download_url = content_version.get("VersionDataUrl")
-            if download_url:
-                content_document["_attachment"] = await self._download(download_url)
-
-            yield content_document
+    # async def download_content_documents(self, content_documents):
+    #     for content_document in content_documents:
+    #         content_version = content_document.get("LatestPublishedVersion", {}) or {}
+    #         download_url = content_version.get("VersionDataUrl")
+    #         if download_url:
+    #             content_document["_attachment"] = await self._download(download_url)
+    #
+    #         yield content_document
 
     async def queryable_sobjects(self):
         """Cached async property"""
@@ -483,6 +483,10 @@ class SalesforceClient:
             headers=headers,
             params=params,
         )
+
+    async def _download(self, url):
+        response = await self._get(url)
+        yield response
 
     async def _handle_client_response_error(self, response_body, e):
         exception_details = f"status: {e.status}, message: {e.message}"
@@ -1201,7 +1205,6 @@ class SalesforceDocMapper:
 
         return {
             "_id": content_document.get("Id"),
-            "_attachment": content_document.get("_attachment"),
             "content_size": content_document.get("ContentSize"),
             "created_at": content_document.get("CreatedDate"),
             "created_by": created_by.get("Name"),
@@ -1374,6 +1377,14 @@ class SalesforceDataSource(BaseDataSource):
                 "tooltip": "The client secret for your OAuth2-enabled connected app. Also called 'consumer secret'",
                 "type": "str",
             },
+            "use_text_extraction_service": {
+                "display": "toggle",
+                "label": "Use text extraction service",
+                "order": 7,
+                "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+                "type": "bool",
+                "value": False,
+            },
         }
 
     async def validate_config(self):
@@ -1420,10 +1431,37 @@ class SalesforceDataSource(BaseDataSource):
 
         # Note: this could possibly be done on the fly if memory becomes an issue
         content_docs = self._combine_duplicate_content_docs(content_docs)
-        async for content_doc in self.salesforce_client.download_content_documents(
-            content_docs
-        ):
-            yield self.doc_mapper.map_content_document(content_doc), None
+        for content_doc in content_docs:
+            download_url = (content_doc.get("LatestPublishedVersion", {}) or {}).get("VersionDataUrl")
+            if not download_url:
+                self._logger.debug(f"No download URL found for {content_doc.get('title')}, skipping.")
+                continue
+
+            doc = self.doc_mapper.map_content_document(content_doc)
+            doc = await self.get_content(doc, download_url)
+
+            yield doc, None
+
+    async def get_content(self, doc, download_url):
+        file_size = doc["content_size"]
+        filename = doc["title"]
+        file_extension = self.get_file_extension(filename)
+        if not self.can_file_be_downloaded(file_extension, filename, file_size):
+            return
+
+        return await self.download_and_extract_file(
+            doc,
+            filename,
+            file_extension,
+            partial(
+                self.generic_chunked_download_func,
+                partial(
+                    self.salesforce_client._download,
+                    download_url,
+                ),
+            ),
+            return_doc_if_failed=True, # we still ingest on download failure for Salesforce
+        )
 
     def _parse_content_documents(self, record):
         content_docs = []

--- a/connectors/sources/servicenow.py
+++ b/connectors/sources/servicenow.py
@@ -4,7 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """ServiceNow source module responsible to fetch documents from ServiceNow."""
-import asyncio
 import base64
 import json
 import os
@@ -13,12 +12,9 @@ from enum import Enum
 from functools import cached_property, partial
 from urllib.parse import urlencode
 
-import aiofiles
 import aiohttp
 import dateutil.parser as parser
 import fastjsonschema
-from aiofiles.os import remove
-from aiofiles.tempfile import NamedTemporaryFile
 
 from connectors.filtering.validation import (
     AdvancedRulesValidator,
@@ -27,12 +23,10 @@ from connectors.filtering.validation import (
 from connectors.logger import logger
 from connectors.source import BaseDataSource, ConfigurableFieldValueError
 from connectors.utils import (
-    TIKA_SUPPORTED_FILETYPES,
     CancellableSleeps,
     ConcurrentTasks,
     MemQueue,
     RetryStrategy,
-    convert_to_b64,
     iso_utc,
     retryable,
 )
@@ -278,6 +272,10 @@ class ServiceNowClient:
             url=url, params=params, json=actions
         )
 
+    async def download_func(self, url):
+        response = await self._api_call(url, {}, {}, "get")
+        yield response
+
     async def filter_services(self, configured_service):
         """Filter services based on service mappings.
 
@@ -317,78 +315,6 @@ class ServiceNowClient:
                 f"Error while filtering services. Exception: {exception}."
             )
             raise
-
-    async def fetch_attachment_content(self, metadata, timestamp=None, doit=False):
-        """Fetch attachment content via metadata.
-
-        Args:
-            metadata (dict): Attachment metadata.
-            timestamp (timestamp, None): Attachment last modified timestamp. Defaults to None.
-            doit (bool, False): Whether to get content or not. Defaults to False.
-
-        Returns:
-            dict: Document with id, timestamp & content.
-        """
-
-        attachment_size = int(metadata["size_bytes"])
-        if not (doit and attachment_size > 0):
-            return
-
-        attachment_name = metadata["file_name"]
-        attachment_extension = os.path.splitext(attachment_name)[-1]
-        if attachment_extension == "":
-            self._logger.warning(
-                f"Files without extension are not supported by TIKA, skipping {attachment_name}."
-            )
-            return
-        elif attachment_extension.lower() not in TIKA_SUPPORTED_FILETYPES:
-            self._logger.warning(
-                f"Files with the extension {attachment_extension} are not supported by TIKA, skipping {attachment_name}."
-            )
-            return
-
-        if attachment_size > FILE_SIZE_LIMIT:
-            self._logger.warning(
-                f"File size {attachment_size} of file {attachment_name} is larger than {FILE_SIZE_LIMIT} bytes. Discarding file content."
-            )
-            return
-
-        document = {"_id": metadata["id"], "_timestamp": metadata["_timestamp"]}
-
-        temp_filename = ""
-        async with NamedTemporaryFile(mode="wb", delete=False) as async_buffer:
-            temp_filename = str(async_buffer.name)
-
-            try:
-                response = await self._api_call(
-                    url=ENDPOINTS["DOWNLOAD"].format(sys_id=metadata["id"]),
-                    params={},
-                    actions={},
-                    method="get",
-                )
-                async for data in response.content.iter_chunked(CHUNK_SIZE):
-                    await async_buffer.write(data)
-
-            except Exception as exception:
-                self._logger.warning(
-                    f"Skipping content for {attachment_name}. Exception: {exception}."
-                )
-                return
-
-        self._logger.debug(f"Calling convert_to_b64 for file : {attachment_name}.")
-        await asyncio.to_thread(convert_to_b64, source=temp_filename)
-
-        async with aiofiles.open(file=temp_filename, mode="r") as async_buffer:
-            document["_attachment"] = (await async_buffer.read()).strip()
-
-        try:
-            await remove(temp_filename)
-        except Exception as exception:
-            self._logger.warning(
-                f"Error while deleting the file: {temp_filename} from disk. Error: {exception}"
-            )
-
-        return document
 
     async def ping(self):
         await self.get_table_length(table_name="sys_db_object")
@@ -539,6 +465,14 @@ class ServiceNowDataSource(BaseDataSource):
                 "type": "int",
                 "ui_restrictions": ["advanced"],
             },
+            "use_text_extraction_service": {
+                "display": "toggle",
+                "label": "Use text extraction service",
+                "order": 7,
+                "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+                "type": "bool",
+                "value": False,
+            },
         }
 
     async def _remote_validation(self):
@@ -614,7 +548,7 @@ class ServiceNowDataSource(BaseDataSource):
                         (  # pyright: ignore
                             serialized_attachment_metadata,
                             partial(
-                                self.servicenow_client.fetch_attachment_content,
+                                self.get_content,
                                 serialized_attachment_metadata,
                             ),
                         )
@@ -769,3 +703,27 @@ class ServiceNowDataSource(BaseDataSource):
             yield item
 
         await self.fetchers.join()
+
+    async def get_content(self, metadata, timestamp=None, doit=False):
+        file_size = int(metadata["size_bytes"])
+        if not (doit and file_size > 0):
+            return
+
+        filename = metadata["file_name"]
+        file_extension = self.get_file_extension(filename)
+        if not self.can_file_be_downloaded(file_extension, filename, file_size):
+            return
+
+        document = {"_id": metadata["id"], "_timestamp": metadata["_timestamp"]}
+        return await self.download_and_extract_file(
+            document,
+            filename,
+            file_extension,
+            partial(
+                self.generic_chunked_download_func,
+                partial(
+                    self.servicenow_client.download_func,
+                    ENDPOINTS["DOWNLOAD"].format(sys_id=metadata["id"]),
+                ),
+            ),
+        )

--- a/tests/sources/fixtures/google_cloud_storage/connector.json
+++ b/tests/sources/fixtures/google_cloud_storage/connector.json
@@ -37,6 +37,21 @@
       "ui_restrictions": [
         "advanced"
       ]
+    },
+    "use_text_extraction_service": {
+      "default_value": null,
+      "depends_on": [],
+      "display": "toggle",
+      "label": "Use text extraction service",
+      "options": [],
+      "order": 7,
+      "required": true,
+      "sensitive": false,
+      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+      "type": "bool",
+      "ui_restrictions": [],
+      "validations": [],
+      "value": false
     }
   },
   "custom_scheduling": {},

--- a/tests/sources/fixtures/google_drive/connector.json
+++ b/tests/sources/fixtures/google_drive/connector.json
@@ -77,6 +77,21 @@
       "ui_restrictions": [
         "advanced"
       ]
+    },
+      "use_text_extraction_service": {
+      "default_value": null,
+      "depends_on": [],
+      "display": "toggle",
+      "label": "Use text extraction service",
+      "options": [],
+      "order": 7,
+      "required": true,
+      "sensitive": false,
+      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+      "type": "bool",
+      "ui_restrictions": [],
+      "validations": [],
+      "value": false
     }
   },
   "custom_scheduling": {},

--- a/tests/sources/fixtures/onedrive/connector.json
+++ b/tests/sources/fixtures/onedrive/connector.json
@@ -87,6 +87,21 @@
       "value": false,
       "order": 6,
       "ui_restrictions": []
+    },
+    "use_text_extraction_service": {
+      "default_value": null,
+      "depends_on": [],
+      "display": "toggle",
+      "label": "Use text extraction service",
+      "options": [],
+      "order": 7,
+      "required": true,
+      "sensitive": false,
+      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+      "type": "bool",
+      "ui_restrictions": [],
+      "validations": [],
+      "value": false
     }
   },
   "custom_scheduling": {},

--- a/tests/sources/fixtures/salesforce/connector.json
+++ b/tests/sources/fixtures/salesforce/connector.json
@@ -15,6 +15,21 @@
       "label": "Domain",
       "type": "str",
       "value": "fake.sandbox"
+    },
+    "use_text_extraction_service": {
+      "default_value": null,
+      "depends_on": [],
+      "display": "toggle",
+      "label": "Use text extraction service",
+      "options": [],
+      "order": 7,
+      "required": true,
+      "sensitive": false,
+      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+      "type": "bool",
+      "ui_restrictions": [],
+      "validations": [],
+      "value": false
     }
   },
   "custom_scheduling": {},

--- a/tests/sources/fixtures/servicenow/connector.json
+++ b/tests/sources/fixtures/servicenow/connector.json
@@ -94,6 +94,21 @@
       "value": "some_test_user",
       "order": 2,
       "ui_restrictions": []
+    },
+    "use_text_extraction_service": {
+      "default_value": null,
+      "depends_on": [],
+      "display": "toggle",
+      "label": "Use text extraction service",
+      "options": [],
+      "order": 7,
+      "required": true,
+      "sensitive": false,
+      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+      "type": "bool",
+      "ui_restrictions": [],
+      "validations": [],
+      "value": false
     }
   },
   "custom_scheduling": {},

--- a/tests/sources/test_google_cloud_storage.py
+++ b/tests/sources/test_google_cloud_storage.py
@@ -422,6 +422,7 @@ async def test_get_content_with_text_extraction_enabled_adds_body():
                     )
                     assert content == expected_blob_document
 
+
 @pytest.mark.asyncio
 async def test_get_content_with_upper_extension():
     """Test the module responsible for fetching the content of the file if it is extractable."""

--- a/tests/sources/test_google_cloud_storage.py
+++ b/tests/sources/test_google_cloud_storage.py
@@ -8,6 +8,7 @@
 import asyncio
 from contextlib import asynccontextmanager
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 from aiogoogle import Aiogoogle
@@ -24,11 +25,12 @@ API_VERSION = "v1"
 
 
 @asynccontextmanager
-async def create_gcs_source():
+async def create_gcs_source(use_text_extraction_service=False):
     async with create_source(
         GoogleCloudStorageDataSource,
         service_account_credentials=SERVICE_ACCOUNT_CREDENTIALS,
         retry_count=0,
+        use_text_extraction_service=use_text_extraction_service,
     ) as source:
         yield source
 
@@ -363,6 +365,62 @@ async def test_get_content():
                 )
                 assert content == expected_blob_document
 
+
+@pytest.mark.asyncio
+@patch(
+    "connectors.content_extraction.ContentExtraction._check_configured",
+    lambda *_: True,
+)
+async def test_get_content_with_text_extraction_enabled_adds_body():
+    """Test the module responsible for fetching the content of the file if it is extractable."""
+
+    with patch(
+        "connectors.content_extraction.ContentExtraction.extract_text",
+        return_value="file content",
+    ), patch(
+        "connectors.content_extraction.ContentExtraction.get_extraction_config",
+        return_value={"host": "http://localhost:8090"},
+    ):
+        async with create_gcs_source(use_text_extraction_service=True) as source:
+            blob_document = {
+                "id": "bucket_1/blob_1/123123123",
+                "component_count": None,
+                "content_encoding": None,
+                "content_language": None,
+                "created_at": None,
+                "last_updated": "2011-10-12T00:01:00Z",
+                "metadata": None,
+                "name": "blob_1.txt",
+                "size": "15",
+                "storage_class": None,
+                "_timestamp": "2011-10-12T00:01:00Z",
+                "type": None,
+                "url": "https://console.cloud.google.com/storage/browser/_details/bucket_1/blob_1;tab=live_object?project=dummy123",
+                "version": None,
+                "bucket_name": "bucket_1",
+            }
+            expected_blob_document = {
+                "_id": "bucket_1/blob_1/123123123",
+                "_timestamp": "2011-10-12T00:01:00Z",
+                "body": "file content",
+            }
+            blob_content_response = ""
+
+            with mock.patch.object(
+                Aiogoogle, "as_service_account", return_value=blob_content_response
+            ):
+                async with Aiogoogle(
+                    service_account_creds=source._google_storage_client.service_account_credentials
+                ) as google_client:
+                    storage_client = await google_client.discover(
+                        api_name=API_NAME, api_version=API_VERSION
+                    )
+                    storage_client.objects = mock.MagicMock()
+                    content = await source.get_content(
+                        blob=blob_document,
+                        doit=True,
+                    )
+                    assert content == expected_blob_document
 
 @pytest.mark.asyncio
 async def test_get_content_with_upper_extension():

--- a/tests/sources/test_onedrive.py
+++ b/tests/sources/test_onedrive.py
@@ -730,7 +730,9 @@ async def test_get_content_with_extraction_service():
     ):
         async with create_onedrive_source(use_text_extraction_service=True) as source:
             with patch.object(AccessToken, "get", return_value="abc"):
-                with patch("aiohttp.ClientSession.get", return_value=get_stream_reader()):
+                with patch(
+                    "aiohttp.ClientSession.get", return_value=get_stream_reader()
+                ):
                     with patch(
                         "aiohttp.StreamReader.iter_chunked",
                         return_value=AsyncIterator([bytes(RESPONSE_CONTENT, "utf-8")]),
@@ -741,6 +743,7 @@ async def test_get_content_with_extraction_service():
                             doit=True,
                         )
                         assert response == EXPECTED_CONTENT_EXTRACTED
+
 
 @patch.object(OneDriveClient, "list_users", return_value=AsyncIterator(EXPECTED_USERS))
 @patch.object(

--- a/tests/sources/test_onedrive.py
+++ b/tests/sources/test_onedrive.py
@@ -4,6 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 """Tests the OneDrive source class methods"""
+from contextlib import asynccontextmanager
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -288,6 +289,11 @@ EXPECTED_CONTENT = {
     "_timestamp": "2023-05-01T09:10:21Z",
     "_attachment": "IyBUaGlzIGlzIHRoZSBkdW1teSBmaWxl",
 }
+EXPECTED_CONTENT_EXTRACTED = {
+    "_id": "01DABHRNUACUYC4OM3GJG2NVHDI2ABGP4E",
+    "_timestamp": "2023-05-01T09:10:21Z",
+    "body": RESPONSE_CONTENT,
+}
 
 EXPECTED_FILES_FOLDERS = {}
 
@@ -423,6 +429,18 @@ def test_get_configuration():
     assert config["client_id"] == ""
 
 
+@asynccontextmanager
+async def create_onedrive_source(use_text_extraction_service=False):
+    async with create_source(
+        OneDriveDataSource,
+        client_id="foo",
+        client_secret="bar",
+        tenant_id="faa",
+        use_text_extraction_service=use_text_extraction_service,
+    ) as source:
+        yield source
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "extras",
@@ -446,7 +464,7 @@ async def test_validate_configuration_with_invalid_dependency_fields_raises_erro
 
 @pytest.mark.asyncio
 async def test_close_with_client_session():
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         source.client.access_token = "dummy"
 
         await source.close()
@@ -456,7 +474,7 @@ async def test_close_with_client_session():
 
 @pytest.mark.asyncio
 async def test_set_access_token():
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         mock_token = {"access_token": "msgraphtoken", "expires_in": "1234555"}
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(
@@ -471,7 +489,7 @@ async def test_set_access_token():
 
 @pytest.mark.asyncio
 async def test_ping_for_successful_connection():
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         DUMMY_RESPONSE = {}
         source.client.get = AsyncIterator([[DUMMY_RESPONSE]])
 
@@ -481,7 +499,7 @@ async def test_ping_for_successful_connection():
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession.get")
 async def test_ping_for_failed_connection_exception(mock_get):
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         with patch.object(
             OneDriveClient, "get", side_effect=Exception("Something went wrong")
         ):
@@ -559,7 +577,7 @@ async def test_get_with_429_status():
     payload = {"value": "Test rate limit"}
 
     retried_response.__aenter__ = AsyncMock(return_value=JSONAsyncMock(payload))
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         with patch.object(AccessToken, "get", return_value="abc"):
             with patch(
                 "aiohttp.ClientSession.get",
@@ -585,7 +603,7 @@ async def test_get_with_429_status_without_retry_after_header():
 
     retried_response.__aenter__ = AsyncMock(return_value=JSONAsyncMock(payload))
     with patch("connectors.sources.onedrive.DEFAULT_RETRY_SECONDS", 0.3):
-        async with create_source(OneDriveDataSource) as source:
+        async with create_onedrive_source() as source:
             with patch.object(AccessToken, "get", return_value="abc"):
                 with patch(
                     "aiohttp.ClientSession.get",
@@ -604,7 +622,7 @@ async def test_get_with_404_status():
     error = ClientResponseError(None, None)
     error.status = 404
 
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         with patch.object(AccessToken, "get", return_value="abc"):
             with patch(
                 "aiohttp.ClientSession.get",
@@ -623,7 +641,7 @@ async def test_get_with_500_status():
     error = ClientResponseError(None, None)
     error.status = 500
 
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         with patch.object(AccessToken, "get", return_value="abc"):
             with patch(
                 "aiohttp.ClientSession.get",
@@ -638,7 +656,7 @@ async def test_get_with_500_status():
 
 @pytest.mark.asyncio
 async def test_get_owned_files():
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(
             return_value=JSONAsyncMock(RESPONSE_FILES)
@@ -659,7 +677,7 @@ async def test_get_owned_files():
 
 @pytest.mark.asyncio
 async def test_list_users():
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         response = []
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(
@@ -686,7 +704,7 @@ async def test_list_users():
 async def test_get_content_when_is_downloadable_is_true(
     file, download_url, expected_content
 ):
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         with patch.object(AccessToken, "get", return_value="abc"):
             with patch("aiohttp.ClientSession.get", return_value=get_stream_reader()):
                 with patch(
@@ -700,6 +718,29 @@ async def test_get_content_when_is_downloadable_is_true(
                     )
                     assert response == expected_content
 
+
+@pytest.mark.asyncio
+async def test_get_content_with_extraction_service():
+    with patch(
+        "connectors.content_extraction.ContentExtraction.extract_text",
+        return_value=RESPONSE_CONTENT,
+    ), patch(
+        "connectors.content_extraction.ContentExtraction.get_extraction_config",
+        return_value={"host": "http://localhost:8090"},
+    ):
+        async with create_onedrive_source(use_text_extraction_service=True) as source:
+            with patch.object(AccessToken, "get", return_value="abc"):
+                with patch("aiohttp.ClientSession.get", return_value=get_stream_reader()):
+                    with patch(
+                        "aiohttp.StreamReader.iter_chunked",
+                        return_value=AsyncIterator([bytes(RESPONSE_CONTENT, "utf-8")]),
+                    ):
+                        response = await source.get_content(
+                            file=MOCK_ATTACHMENT,
+                            download_url="https://content1",
+                            doit=True,
+                        )
+                        assert response == EXPECTED_CONTENT_EXTRACTED
 
 @patch.object(OneDriveClient, "list_users", return_value=AsyncIterator(EXPECTED_USERS))
 @patch.object(
@@ -726,7 +767,7 @@ async def test_get_content_when_is_downloadable_is_true(
 )
 @pytest.mark.asyncio
 async def test_get_docs(users_patch, files_patch):
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         expected_responses = [*EXPECTED_USER1_FILES, *EXPECTED_USER2_FILES]
         source.get_content = AsyncMock(return_value=EXPECTED_CONTENT)
 
@@ -835,7 +876,7 @@ async def test_get_docs(users_patch, files_patch):
 )
 @pytest.mark.asyncio
 async def test_advanced_rules_validation(advanced_rules, expected_validation_result):
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         validation_result = await OneDriveAdvancedRulesValidator(source).validate(
             advanced_rules
         )
@@ -866,7 +907,7 @@ async def test_advanced_rules_validation(advanced_rules, expected_validation_res
 )
 @pytest.mark.asyncio
 async def test_get_docs_with_advanced_rules(filtering):
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         with patch.object(AccessToken, "get", return_value="abc"):
             with patch.object(
                 OneDriveClient, "list_users", return_value=AsyncIterator(EXPECTED_USERS)
@@ -898,7 +939,7 @@ async def test_get_docs_with_advanced_rules(filtering):
 
 @pytest.mark.asyncio
 async def test_get_access_control_dls_disabled():
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         source._dls_enabled = MagicMock(return_value=False)
 
         acl = []
@@ -925,7 +966,7 @@ async def test_get_access_control_dls_enabled():
         ],
     ]
 
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         source._dls_enabled = MagicMock(return_value=True)
 
         with patch.object(AccessToken, "get", return_value="abc"):
@@ -967,7 +1008,7 @@ async def test_get_access_control_dls_enabled():
 )
 @pytest.mark.asyncio
 async def test_get_docs_without_dls_enabled(users_patch, files_patch):
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         source._dls_enabled = MagicMock(return_value=False)
 
         expected_responses = [*EXPECTED_USER1_FILES, *EXPECTED_USER2_FILES]
@@ -1020,7 +1061,7 @@ async def test_get_docs_without_dls_enabled(users_patch, files_patch):
 )
 @pytest.mark.asyncio
 async def test_get_docs_with_dls_enabled(users_patch, files_patch, permissions_patch):
-    async with create_source(OneDriveDataSource) as source:
+    async with create_onedrive_source() as source:
         source._dls_enabled = MagicMock(return_value=True)
 
         expected_responses = [

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -422,7 +422,9 @@ CACHED_SOBJECTS = {
 
 
 @asynccontextmanager
-async def create_salesforce_source(use_text_extraction_service=False, mock_token=True, mock_queryables=True):
+async def create_salesforce_source(
+    use_text_extraction_service=False, mock_token=True, mock_queryables=True
+):
     async with create_source(
         SalesforceDataSource,
         domain=TEST_DOMAIN,

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -8,6 +8,7 @@ import re
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from unittest import TestCase, mock
+from unittest.mock import patch
 
 import pytest
 from aiohttp.client_exceptions import ClientConnectionError
@@ -421,12 +422,13 @@ CACHED_SOBJECTS = {
 
 
 @asynccontextmanager
-async def create_salesforce_source(mock_token=True, mock_queryables=True):
+async def create_salesforce_source(use_text_extraction_service=False, mock_token=True, mock_queryables=True):
     async with create_source(
         SalesforceDataSource,
         domain=TEST_DOMAIN,
         client_id=TEST_CLIENT_ID,
         client_secret=TEST_CLIENT_SECRET,
+        use_text_extraction_service=use_text_extraction_service,
     ) as source:
         if mock_token is True:
             source.salesforce_client.api_token.token = mock.AsyncMock(
@@ -1041,12 +1043,13 @@ async def test_get_all_with_content_docs_when_success(
             "url": f"{TEST_BASE_URL}/content_document_id",
             "version_number": "2",
             "version_url": f"{TEST_BASE_URL}/content_version_id",
-            "_attachment": expected_attachment,
         }
+        if expected_attachment is not None:
+            expected_doc["_attachment"] = expected_attachment
 
         mock_responses.get(
             f"{TEST_FILE_DOWNLOAD_URL}/sfc/servlet.shepherd/version/download/download_id",
-            status=response_body,
+            status=response_status,
             body=response_body,
         )
         mock_responses.get(
@@ -1059,6 +1062,60 @@ async def test_get_all_with_content_docs_when_success(
                 content_document_records.append(record)
 
         TestCase().assertCountEqual(content_document_records, [expected_doc])
+
+
+@pytest.mark.asyncio
+async def test_get_all_with_content_docs_and_extraction_service(mock_responses):
+    with patch(
+        "connectors.content_extraction.ContentExtraction.extract_text",
+        return_value="chunk1",
+    ), patch(
+        "connectors.content_extraction.ContentExtraction.get_extraction_config",
+        return_value={"host": "http://localhost:8090"},
+    ):
+        async with create_salesforce_source(use_text_extraction_service=True) as source:
+            expected_doc = {
+                "_id": "content_document_id",
+                "content_size": 1000,
+                "created_at": "",
+                "created_by": "Frodo",
+                "created_by_email": "frodo@tlotr.com",
+                "body": "chunk1",
+                "description": "A file about a ring.",
+                "file_extension": "txt",
+                "last_updated": "",
+                "linked_ids": [
+                    "account_id",
+                    "campaign_id",
+                    "case_id",
+                    "contact_id",
+                    "lead_id",
+                    "opportunity_id",
+                ],  # contains every SObject that is connected to this doc
+                "owner": "Frodo",
+                "owner_email": "frodo@tlotr.com",
+                "title": "the_ring.txt",
+                "type": "content_document",
+                "url": f"{TEST_BASE_URL}/content_document_id",
+                "version_number": "2",
+                "version_url": f"{TEST_BASE_URL}/content_version_id",
+            }
+
+            mock_responses.get(
+                f"{TEST_FILE_DOWNLOAD_URL}/sfc/servlet.shepherd/version/download/download_id",
+                status=200,
+                body=b"chunk1",
+            )
+            mock_responses.get(
+                TEST_QUERY_MATCH_URL, repeat=True, callback=salesforce_query_callback
+            )
+
+            content_document_records = []
+            async for record, _ in source.get_docs():
+                if record["type"] == "content_document":
+                    content_document_records.append(record)
+
+            TestCase().assertCountEqual(content_document_records, [expected_doc])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/5857

- Expand extraction service to more connectors:
  - Google Cloud Storage
  - Google Drive
  - Onedrive
  - Salesforce
  - Servicenow

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

## Related Pull Requests

- https://github.com/elastic/connectors-python/pull/1685
- https://github.com/elastic/connectors-python/pull/1693