### PR TITLE
Add ui restrictions for all extraction RCFs

### DIFF
--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -100,6 +100,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
                 "order": 6,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -324,6 +324,7 @@ class ConfluenceDataSource(BaseDataSource):
                 "order": 13,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/dropbox.py
+++ b/connectors/sources/dropbox.py
@@ -591,6 +591,7 @@ class DropboxDataSource(BaseDataSource):
                 "order": 7,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -920,6 +920,7 @@ class GitHubDataSource(BaseDataSource):
                 "order": 8,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/google_cloud_storage.py
+++ b/connectors/sources/google_cloud_storage.py
@@ -231,6 +231,7 @@ class GoogleCloudStorageDataSource(BaseDataSource):
                 "order": 3,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/google_drive.py
+++ b/connectors/sources/google_drive.py
@@ -513,6 +513,7 @@ class GoogleDriveDataSource(BaseDataSource):
                 "order": 5,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -398,6 +398,7 @@ class JiraDataSource(BaseDataSource):
                 "order": 13,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/onedrive.py
+++ b/connectors/sources/onedrive.py
@@ -449,6 +449,7 @@ class OneDriveDataSource(BaseDataSource):
                 "order": 7,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -768,6 +768,7 @@ class OutlookDataSource(BaseDataSource):
                 "order": 7,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -327,6 +327,7 @@ class S3DataSource(BaseDataSource):
                 "order": 8,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -1340,6 +1340,7 @@ class SalesforceDataSource(BaseDataSource):
                 "order": 7,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/servicenow.py
+++ b/connectors/sources/servicenow.py
@@ -469,6 +469,7 @@ class ServiceNowDataSource(BaseDataSource):
                 "order": 7,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1218,6 +1218,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                 "order": 8,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
             "use_document_level_security": {

--- a/connectors/sources/sharepoint_server.py
+++ b/connectors/sources/sharepoint_server.py
@@ -526,6 +526,7 @@ class SharepointServerDataSource(BaseDataSource):
                 "order": 8,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }

--- a/connectors/sources/zoom.py
+++ b/connectors/sources/zoom.py
@@ -357,6 +357,7 @@ class ZoomDataSource(BaseDataSource):
                 "order": 6,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
+                "ui_restrictions": ["advanced"],
                 "value": False,
             },
         }


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/5855

Add missing UI restrictions for all connectors with `use_text_extraction_service` RCF.