### PR TITLE
[SPO] Do not use retry-after as multiplier

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -472,7 +472,7 @@ class MicrosoftAPISession:
         if retry_count <= 1:
             return retry_after
         else:
-            return retry_after * retry_count * backoff
+            return retry_after + retry_count * backoff
 
 
 class SharepointOnlineClient:

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -619,7 +619,7 @@ class TestMicrosoftAPISession:
             assert actual_payload == payload
 
         patch_cancellable_sleeps.assert_awaited_with(
-            DEFAULT_RETRY_SECONDS * DEFAULT_BACKOFF_MULTIPLIER * retry_count
+            DEFAULT_RETRY_SECONDS + DEFAULT_BACKOFF_MULTIPLIER * retry_count
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
`retry-after` header can change if the request is throttled more than once. Therefore, the waiting time can be very long

```
[FMWK][10:41:34][WARNING] [Connector id: M9XHqYoBDc5CccrnbkG-, index name: search-test, Sync job id: 8CBW4YoBQesD0dyuubIq] Rate Limited by Sharepoint: a new attempt will be performed in 540 seconds (retry-after header: 54, retry_count: 2, backoff: 5)
```

This PR will change the waiting time computing logic to `retry-after + retry-count * backoff`

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
