### PR TITLE
[8.10] Forcibly cancel a sync job after waiting for 5 seconds (#1683)

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -52,6 +52,7 @@ OP_INDEX = "index"
 OP_UPSERT = "update"
 OP_DELETE = "delete"
 TIMESTAMP_FIELD = "_timestamp"
+CANCELATION_TIMEOUT = 5
 
 
 def get_mb_size(ob):
@@ -60,6 +61,10 @@ def get_mb_size(ob):
 
 
 class UnsupportedJobType(Exception):
+    pass
+
+
+class ForceCanceledError(Exception):
     pass
 
 
@@ -103,6 +108,7 @@ class Sink:
         self.indexed_document_volume = 0
         self.deleted_document_count = 0
         self._logger = logger_ or logger
+        self._canceled = False
 
     def _bulk_op(self, doc, operation=OP_INDEX):
         doc_id = doc["_id"]
@@ -168,12 +174,25 @@ class Sink:
             f"Sink stats - no. of docs indexed: {self.indexed_document_count}, volume of docs indexed: {round(self.indexed_document_volume)} bytes, no. of docs deleted: {self.deleted_document_count}"
         )
 
+    def force_cancel(self):
+        self._canceled = True
+
+    async def fetch_doc(self):
+        if self._canceled:
+            raise ForceCanceledError
+
+        return await self.queue.get()
+
     async def run(self):
         try:
             await self._run()
         except asyncio.CancelledError:
             self._logger.info("Task is canceled, stop Sink...")
             raise
+        except ForceCanceledError:
+            self._logger.error(
+                f"Sink did not stop within {CANCELATION_TIMEOUT} seconds of cancelation, force-canceling the task."
+            )
 
     async def _run(self):
         """Creates batches of bulk calls given a queue of items.
@@ -193,7 +212,7 @@ class Sink:
         overhead_size = None
 
         while True:
-            doc_size, doc = await self.queue.get()
+            doc_size, doc = await self.fetch_doc()
             if doc in ("END_DOCS", "FETCH_ERROR"):
                 break
             operation = doc["_op_type"]
@@ -284,6 +303,7 @@ class Extractor:
         self.display_every = display_every
         self.concurrent_downloads = concurrent_downloads
         self._logger = logger_ or logger
+        self._canceled = False
 
     async def _get_existing_ids(self):
         """Returns an iterator on the `id` and `_timestamp` fields of all documents in an index.
@@ -322,7 +342,7 @@ class Extractor:
 
         doc.pop("_original_filename", None)
 
-        await self.queue.put(
+        await self.put_doc(
             {
                 "_op_type": operation,
                 "_index": self.index,
@@ -330,6 +350,15 @@ class Extractor:
                 "doc": doc,
             }
         )
+
+    def force_cancel(self):
+        self._canceled = True
+
+    async def put_doc(self, doc):
+        if self._canceled:
+            raise ForceCanceledError
+
+        await self.queue.put(doc)
 
     async def run(self, generator, job_type):
         try:
@@ -345,6 +374,14 @@ class Extractor:
         except asyncio.CancelledError:
             self._logger.info("Task is canceled, stop Extractor...")
             raise
+        except ForceCanceledError:
+            self._logger.error(
+                f"Extractor did not stop within {CANCELATION_TIMEOUT} seconds of cancelation, force-canceling the task."
+            )
+        except Exception as e:
+            self._logger.critical("Document extractor failed", exc_info=True)
+            await self.put_doc("FETCH_ERROR")
+            self.fetch_error = e
 
     @tracer.start_as_current_span("get_doc call", slow_log=1.0)
     async def _decorate_with_metrics_span(self, generator):
@@ -423,7 +460,7 @@ class Extractor:
 
                 else:
                     # we can push into the queue right away
-                    await self.queue.put(
+                    await self.put_doc(
                         {
                             "_op_type": operation,
                             "_index": self.index,
@@ -433,17 +470,12 @@ class Extractor:
                     )
 
                 await asyncio.sleep(0)
-        except Exception as e:
-            self._logger.critical("Document fetcher failed", exc_info=True)
-            await self.queue.put("FETCH_ERROR")
-            self.fetch_error = e
-            return
         finally:
             # wait for all downloads to be finished
             await lazy_downloads.join()
 
         await self.enqueue_docs_to_delete(existing_ids)
-        await self.queue.put("END_DOCS")
+        await self.put_doc("END_DOCS")
 
     async def get_docs_incrementally(self, generator):
         """Iterate on a generator of documents to fill a queue of bulk operations for the `Sink` to consume.
@@ -501,19 +533,14 @@ class Extractor:
                     }
                     if operation in (OP_INDEX, OP_UPSERT):
                         item["doc"] = doc
-                    await self.queue.put(item)
+                    await self.put_doc(item)
 
                 await asyncio.sleep(0)
-        except Exception as e:
-            self._logger.critical("The document fetcher failed", exc_info=True)
-            await self.queue.put("FETCH_ERROR")
-            self.fetch_error = e
-            return
         finally:
             # wait for all downloads to be finished
             await lazy_downloads.join()
 
-        await self.queue.put("END_DOCS")
+        await self.put_doc("END_DOCS")
 
     async def get_access_control_docs(self, generator):
         """Iterate on a generator of access control documents to fill a queue with bulk operations for the `Sink` to consume.
@@ -536,60 +563,53 @@ class Extractor:
             )
 
         count = 0
-        try:
-            async for doc in generator:
-                doc, _, _ = doc
-                count += 1
-                if count % self.display_every == 0:
-                    self._log_progress()
+        async for doc in generator:
+            doc, _, _ = doc
+            count += 1
+            if count % self.display_every == 0:
+                self._log_progress()
 
-                doc_id = doc["id"] = doc.pop("_id")
-                doc_exists = doc_id in existing_ids
+            doc_id = doc["id"] = doc.pop("_id")
+            doc_exists = doc_id in existing_ids
 
-                if doc_exists:
-                    last_update_timestamp = existing_ids.pop(doc_id)
-                    doc_not_updated = (
-                        TIMESTAMP_FIELD in doc
-                        and last_update_timestamp == doc[TIMESTAMP_FIELD]
-                    )
-
-                    if doc_not_updated:
-                        continue
-
-                    self.total_docs_updated += 1
-
-                    operation = OP_UPSERT
-                else:
-                    self.total_docs_created += 1
-
-                    if TIMESTAMP_FIELD not in doc:
-                        doc[TIMESTAMP_FIELD] = iso_utc()
-
-                    operation = OP_INDEX
-
-                await self.queue.put(
-                    {
-                        "_op_type": operation,
-                        "_index": self.index,
-                        "_id": doc_id,
-                        "doc": doc,
-                    }
+            if doc_exists:
+                last_update_timestamp = existing_ids.pop(doc_id)
+                doc_not_updated = (
+                    TIMESTAMP_FIELD in doc
+                    and last_update_timestamp == doc[TIMESTAMP_FIELD]
                 )
 
-                await asyncio.sleep(0)
-        except Exception as e:
-            self._logger.critical("The document fetcher failed", exc_info=True)
-            await self.queue.put("FETCH_ERROR")
-            self.fetch_error = e
-            return
+                if doc_not_updated:
+                    continue
+
+                self.total_docs_updated += 1
+
+                operation = OP_UPSERT
+            else:
+                self.total_docs_created += 1
+
+                if TIMESTAMP_FIELD not in doc:
+                    doc[TIMESTAMP_FIELD] = iso_utc()
+
+                operation = OP_INDEX
+
+            await self.put_doc(
+                {
+                    "_op_type": operation,
+                    "_index": self.index,
+                    "_id": doc_id,
+                    "doc": doc,
+                }
+            )
+            await asyncio.sleep(0)
 
         await self.enqueue_docs_to_delete(existing_ids)
-        await self.queue.put("END_DOCS")
+        await self.put_doc("END_DOCS")
 
     async def enqueue_docs_to_delete(self, existing_ids):
         self._logger.debug(f"Delete {len(existing_ids)} docs from index '{self.index}'")
         for doc_id in existing_ids.keys():
-            await self.queue.put(
+            await self.put_doc(
                 {
                     "_op_type": OP_DELETE,
                     "_index": self.index,
@@ -684,19 +704,33 @@ class SyncOrchestrator(ESClient):
             return False
         return True
 
+    def _sink_task_running(self):
+        return self._sink_task is not None and not self._sink_task.done()
+
+    def _extractor_task_running(self):
+        return self._extractor_task is not None and not self._extractor_task.done()
+
     async def cancel(self):
-        if self._extractor_task is not None and not self._extractor_task.done():
-            self._extractor_task.cancel()
-            try:
-                await self._extractor_task
-            except asyncio.CancelledError:
-                self._logger.info("Extractor is stopped.")
-        if self._sink_task is not None and not self._sink_task.done():
+        if self._sink_task_running():
             self._sink_task.cancel()
-            try:
-                await self._sink_task
-            except asyncio.CancelledError:
-                self._logger.info("Sink is stopped.")
+        if self._extractor_task_running():
+            self._extractor_task.cancel()
+
+        cancelation_timeout = CANCELATION_TIMEOUT
+        while cancelation_timeout > 0:
+            await asyncio.sleep(1)
+            cancelation_timeout -= 1
+            if not self._sink_task_running() and not self._extractor_task_running():
+                self._logger.info(
+                    "Both Extractor and Sink tasks are successfully stopped."
+                )
+                return
+
+        self._logger.error(
+            f"Sync job did not stop within {CANCELATION_TIMEOUT} seconds of canceling. Force-canceling."
+        )
+        self._sink.force_cancel()
+        self._extractor.force_cancel()
 
     def ingestion_stats(self):
         stats = {}

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -5,6 +5,7 @@
 #
 import asyncio
 import datetime
+import itertools
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import ANY, Mock, call
@@ -17,6 +18,7 @@ from connectors.es.sink import (
     ContentIndexNameInvalid,
     Extractor,
     IndexMissing,
+    ForceCanceledError,
     Sink,
     SyncOrchestrator,
 )
@@ -1037,6 +1039,27 @@ def test_bulk_populate_stats(res, expected_result):
     assert sink.deleted_document_count == expected_result["deleted_document_count"]
 
 
+@pytest.mark.asyncio
+async def test_batch_bulk_with_retry():
+    client = Mock()
+    sink = Sink(
+        client=client,
+        queue=None,
+        chunk_size=0,
+        pipeline={"name": "pipeline"},
+        chunk_mem_size=0,
+        max_concurrency=0,
+        max_retries=3,
+    )
+
+    with mock.patch.object(asyncio, "sleep"):
+        # first call raises exception, and the second call succeeds
+        client.bulk = AsyncMock(side_effect=[Exception(), {"items": []}])
+        await sink._batch_bulk([], {OP_INDEX: {}, OP_UPSERT: {}, OP_DELETE: {}})
+
+        assert client.bulk.await_count == 2
+
+
 @pytest.mark.parametrize(
     "extractor_task, extractor_task_done, sink_task, sink_task_done, expected_result",
     [
@@ -1068,3 +1091,132 @@ async def test_elastic_server_done(
     assert es.done() == expected_result
 
     await es.close()
+
+
+@pytest.mark.asyncio
+async def test_extractor_put_doc():
+    doc = {"id": 123}
+    queue = Mock()
+    queue.put = AsyncMock()
+    extractor = Extractor(
+        None,
+        queue,
+        INDEX,
+    )
+
+    await extractor.put_doc(doc)
+    queue.put.assert_awaited_once_with(doc)
+
+
+@pytest.mark.asyncio
+async def test_force_canceled_extractor_put_doc():
+    doc = {"id": 123}
+    queue = Mock()
+    queue.put = AsyncMock()
+    extractor = Extractor(
+        None,
+        queue,
+        INDEX,
+    )
+
+    extractor.force_cancel()
+    with pytest.raises(ForceCanceledError):
+        await extractor.put_doc(doc)
+        queue.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sink_fetch_doc():
+    expected_doc = {"id": 123}
+    queue = Mock()
+    queue.get = AsyncMock(return_value=expected_doc)
+    sink = Sink(
+        None,
+        queue,
+        chunk_size=0,
+        pipeline={"name": "pipeline"},
+        chunk_mem_size=0,
+        max_concurrency=0,
+        max_retries=3,
+    )
+
+    doc = await sink.fetch_doc()
+    queue.get.assert_awaited_once()
+    assert doc == expected_doc
+
+
+@pytest.mark.asyncio
+async def test_force_canceled_sink_fetch_doc():
+    expected_doc = {"id": 123}
+    queue = Mock()
+    queue.get = AsyncMock(return_value=expected_doc)
+    sink = Sink(
+        None,
+        queue,
+        chunk_size=0,
+        pipeline={"name": "pipeline"},
+        chunk_mem_size=0,
+        max_concurrency=0,
+        max_retries=3,
+    )
+
+    sink.force_cancel()
+    with pytest.raises(ForceCanceledError):
+        await sink.fetch_doc()
+        queue.get.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "extractor_task_done, sink_task_done, force_cancel",
+    [
+        (
+            itertools.chain([False, False, False], itertools.repeat(True)),
+            itertools.chain([False, False], itertools.repeat(True)),
+            False,
+        ),
+        (
+            itertools.chain([False, False, False], itertools.repeat(True)),
+            itertools.repeat(False),
+            True,
+        ),
+        (
+            itertools.repeat(False),
+            itertools.chain([False, False], itertools.repeat(True)),
+            True,
+        ),
+        (
+            itertools.repeat(False),
+            itertools.repeat(False),
+            True,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_cancel_sync(extractor_task_done, sink_task_done, force_cancel):
+    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
+    es = SyncOrchestrator(config)
+    es._extractor = Mock()
+    es._extractor.force_cancel = Mock()
+
+    es._sink = Mock()
+    es._sink.force_cancel = Mock()
+
+    es._extractor_task = Mock()
+    es._extractor_task.cancel = Mock()
+    es._extractor_task.done = Mock(side_effect=extractor_task_done)
+
+    es._sink_task = Mock()
+    es._sink_task.cancel = Mock()
+    es._sink_task.done = Mock(side_effect=sink_task_done)
+
+    with mock.patch.object(asyncio, "sleep"):
+        await es.cancel()
+        es._extractor_task.cancel.assert_called_once()
+        es._sink_task.cancel.assert_called_once()
+
+        if force_cancel:
+            es._extractor.force_cancel.assert_called_once()
+            es._sink.force_cancel.assert_called_once()
+        else:
+            es._extractor.force_cancel.assert_not_called()
+            es._sink.force_cancel.assert_not_called()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Forcibly cancel a sync job after waiting for 5 seconds (#1683)](https://github.com/elastic/connectors-python/pull/1683)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)