### PR TITLE
[pre-8.10-stable] Replace User Information List usage with role assignments for SPO sites (#1688)

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -17,6 +17,7 @@ import fastjsonschema
 from aiofiles.os import remove
 from aiofiles.tempfile import NamedTemporaryFile
 from aiohttp.client_exceptions import ClientPayloadError, ClientResponseError
+from aiohttp.client_reqrep import RequestInfo
 from fastjsonschema import JsonSchemaValueException
 
 from connectors.es.sink import OP_DELETE, OP_INDEX
@@ -79,6 +80,34 @@ CURSOR_SITE_DRIVE_KEY = "site_drives"
 
 DELTA_NEXT_LINK_KEY = "@odata.nextLink"
 DELTA_LINK_KEY = "@odata.deltaLink"
+
+# See https://github.com/pnp/pnpcore/blob/dev/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/PermissionKind.cs
+# See also: https://learn.microsoft.com/en-us/previous-versions/office/sharepoint-csom/ee536458(v=office.15)
+VIEW_ITEM_MASK = 0x1  # View items in lists, documents in document libraries, and Web discussion comments.
+VIEW_PAGE_MASK = 0x20000  # View pages in a Site.
+
+# See https://github.com/pnp/pnpcore/blob/dev/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/RoleType.cs
+# See also: https://learn.microsoft.com/en-us/dotnet/api/microsoft.sharepoint.client.roletype?view=sharepoint-csom
+READER = 2
+CONTRIBUTOR = 3
+WEB_DESIGNER = 4
+ADMINISTRATOR = 5
+EDITOR = 6
+REVIEWER = 7
+SYSTEM = 0xFF
+# Note the exclusion of NONE(0), GUEST(1), RESTRICTED_READER(8), and RESTRICTED_GUEST(9)
+VIEW_ROLE_TYPES = [
+    READER,
+    CONTRIBUTOR,
+    WEB_DESIGNER,
+    ADMINISTRATOR,
+    EDITOR,
+    REVIEWER,
+    SYSTEM,
+]
+
+# $expand param has a max of 20: see: https://developer.microsoft.com/en-us/graph/known-issues/?search=expand
+SPO_MAX_EXPAND_SIZE = 20
 
 
 class NotFound(Exception):
@@ -332,7 +361,7 @@ class MicrosoftAPISession:
         return await self._get_json(url)
 
     async def post(self, url, payload):
-        self._logger.debug(f"Post to url: {url}")
+        self._logger.debug(f"Post to url: '{url}' with body: {payload}")
         async with self._post(url, payload) as resp:
             return await resp.json()
 
@@ -383,6 +412,8 @@ class MicrosoftAPISession:
             async with self._http_session.post(
                 absolute_url, headers=headers, json=payload
             ) as resp:
+                if absolute_url.endswith("/$batch"):  # response code of $batch lies
+                    await self._check_batch_items_for_errors(absolute_url, resp)
                 yield resp
         except aiohttp.client_exceptions.ClientOSError:
             self._logger.warning(
@@ -393,6 +424,23 @@ class MicrosoftAPISession:
             await self._handle_client_response_error(absolute_url, e, retry_count)
         except ClientPayloadError as e:
             await self._handle_client_payload_error(e, retry_count)
+
+    async def _check_batch_items_for_errors(self, url, batch_resp):
+        body = await batch_resp.json()
+        responses = body.get("responses", [])
+        for response in responses:
+            status = response.get("status", 200)
+            if status != 200:
+                self._logger.warning(f"Batch request item failed with: {response}")
+                headers = response.get("headers", {})
+                req_info = RequestInfo(url=url, method="POST", headers=headers)
+                raise ClientResponseError(
+                    request_info=req_info,
+                    headers=headers,
+                    status=status,
+                    message=response.get("body", {}).get("error", {}).get("message"),
+                    history=(batch_resp),
+                )
 
     @asynccontextmanager
     @retryable_aiohttp_call(retries=DEFAULT_RETRY_COUNT)
@@ -434,7 +482,7 @@ class MicrosoftAPISession:
                 retry_after = int(response_headers["Retry-After"])
             else:
                 self._logger.warning(
-                    f"Response Code from Sharepoint Server is {e.status} but Retry-After header is not found, using default retry time: {DEFAULT_RETRY_SECONDS} seconds"
+                    f"Response Code from Sharepoint Online is {e.status} but Retry-After header is not found, using default retry time: {DEFAULT_RETRY_SECONDS} seconds"
                 )
                 retry_after = DEFAULT_RETRY_SECONDS
 
@@ -550,21 +598,24 @@ class SharepointOnlineClient:
             for site_collection in page:
                 yield site_collection
 
-    async def user_information_list(self, site_id):
-        expand = "fields"
-        url = f"{GRAPH_API_URL}/sites/{site_id}/lists/User Information List/items?expand={expand}"
+    async def site_role_assignments(self, site_web_url):
+        self._validate_sharepoint_rest_url(site_web_url)
+        expand = "Member/users,RoleDefinitionBindings"
+
+        url = f"{site_web_url}/_api/web/roleassignments?$expand={expand}"
 
         try:
-            async for page in self._graph_api_client.scroll(url):
-                for user_information in page:
-                    yield user_information
+            async for page in self._rest_api_client.scroll(url):
+                for role_assignment in page:
+                    yield role_assignment
         except NotFound:
+            self._logger.debug(f"No role assignments found for site: '{site_web_url}'")
             return
 
     async def site_groups_users(self, site_web_url, site_group_id):
         self._validate_sharepoint_rest_url(site_web_url)
 
-        select_ = "Email,Id,UserPrincipalName"
+        select_ = "Email,Id,UserPrincipalName,LoginName,Title"
         url = f"{site_web_url}/_api/web/sitegroups/getbyid({site_group_id})/users?$select={select_}"
 
         try:
@@ -729,16 +780,6 @@ class SharepointOnlineClient:
 
         async for page in self.drive_items_delta(url):
             yield page
-
-    async def drive_item_permissions(self, drive_id, item_id):
-        try:
-            async for page in self._graph_api_client.scroll(
-                f"{GRAPH_API_URL}/drives/{drive_id}/items/{item_id}/permissions"
-            ):
-                for permission in page:
-                    yield permission
-        except NotFound:
-            return
 
     async def drive_items_permissions_batch(self, drive_id, drive_item_ids):
         requests = []
@@ -1058,55 +1099,6 @@ def _postfix_group(group):
     return f"{group} Members"
 
 
-def is_domain_group(user_fields):
-    return user_fields.get(
-        "ContentType"
-    ) == "DomainGroup" and "federateddirectoryclaimprovider" in user_fields.get(
-        "Name", ""
-    )
-
-
-def is_sharepoint_group(user_fields):
-    return user_fields["ContentType"] == "SharePointGroup"
-
-
-def is_person(user_fields):
-    return user_fields["ContentType"] == "Person"
-
-
-def _domain_group_id(user_info_name):
-    """Extracts the domain group id.
-
-    The domain group id can have the following formats:
-    - abc|def|domain-group-id
-    - abc|def|some-prefix/domain-group-id
-
-    Returns:
-        str: domain group id
-
-    """
-    if user_info_name is None or len(user_info_name) == 0:
-        return None
-
-    name_parts = user_info_name.split("|")
-
-    if len(name_parts) <= 2:
-        return None
-
-    domain_group_id = name_parts[2]
-
-    if "/" in domain_group_id:
-        domain_group_id = domain_group_id.split("/")[1]
-
-    if "_" in domain_group_id:
-        domain_group_id = domain_group_id.split("_")[0]
-
-    if len(domain_group_id) == 0:
-        return None
-
-    return domain_group_id
-
-
 async def _emails_and_usernames_of_domain_group(
     domain_group_id, group_identities_generator
 ):
@@ -1352,15 +1344,21 @@ class SharepointOnlineDataSource(BaseDataSource):
         For the given site all groups and its corresponding members and owners (username and/or email) are fetched.
 
         Returns:
-            list: access control list for a given site
-            [
-                "user:spo-user",
-                "email:some.user@spo.com",
-                "group:1234-abcd-id"
-            ]
+            tuple:
+              - list: access control list for a given site
+                [
+                    "user:spo-admin",
+                    "user:spo-user",
+                    "email:some.user@spo.com",
+                    "group:1234-abcd-id"
+                ]
+            - list: subset of the former, applying only to site-admins for this site
+                [
+                  "user":spo-admin"
+                ]
         """
 
-        self._logger.debug(f"Looking at site: {site['id']}")
+        self._logger.debug(f"Looking at site: {site['id']} with url {site['webUrl']}")
         if not self._dls_enabled():
             return [], []
 
@@ -1370,46 +1368,17 @@ class SharepointOnlineDataSource(BaseDataSource):
         access_control = set()
         site_admins_access_control = set()
 
-        async for user_information in self.client.user_information_list(site["id"]):
-            user = user_information["fields"]
+        async for role_assignment in self.client.site_role_assignments(site["webUrl"]):
+            member = role_assignment["Member"]
+            member_access_control = set()
+            member_access_control.update(
+                await self._get_access_control_from_role_assignment(role_assignment)
+            )
 
-            user_access_control = set()
+            if _is_site_admin(member):
+                site_admins_access_control |= member_access_control
 
-            if is_domain_group(user):
-                self._logger.debug(f"It is a domain group with name: {user['Name']}")
-                domain_group_id = _domain_group_id(user["Name"])
-                self._logger.debug(f"Detected domain groupId as: {domain_group_id}")
-
-                if domain_group_id:
-                    user_access_control.add(_prefix_group(domain_group_id))
-
-            if is_person(user):
-                login_name = _get_login_name(user.get("Name"))
-
-                if login_name:
-                    user_access_control.add(_prefix_user(login_name))
-
-                email = user.get("EMail")
-
-                if email:
-                    user_access_control.add(_prefix_email(email))
-
-            if is_sharepoint_group(user):
-                site_group_id = user.get("id")
-                users = await self.site_group_users(site["webUrl"], site_group_id)
-                for site_group_user in users:
-                    site_group_user_name = site_group_user.get("UserPrincipalName")
-                    if site_group_user_name:
-                        user_access_control.add(_prefix_user(site_group_user_name))
-
-                    site_group_user_email = site_group_user.get("Email")
-                    if site_group_user_email:
-                        user_access_control.add(_prefix_email(site_group_user_email))
-
-            if _is_site_admin(user):
-                site_admins_access_control |= user_access_control
-
-            access_control |= user_access_control
+            access_control |= member_access_control
 
         return list(access_control), list(site_admins_access_control)
 
@@ -1501,9 +1470,7 @@ class SharepointOnlineDataSource(BaseDataSource):
         prefixed_groups = set()
 
         expanded_member_groups = user.get("transitiveMemberOf", [])
-        if (
-            len(expanded_member_groups) < 100
-        ):  # $expand param has a max of 100: see: https://learn.microsoft.com/en-us/graph/known-issues#query-parameters
+        if len(expanded_member_groups) < SPO_MAX_EXPAND_SIZE:
             for group in expanded_member_groups:
                 prefixed_groups.add(_prefix_group(group.get("id", None)))
         else:
@@ -1520,7 +1487,9 @@ class SharepointOnlineDataSource(BaseDataSource):
         prefixed_user_id = _prefix_user_id(user.get("id"))
         id_ = email if email else username
 
-        access_control = list({prefixed_mail, prefixed_username}.union(prefixed_groups))
+        access_control = list(
+            {prefixed_mail, prefixed_username, prefixed_user_id}.union(prefixed_groups)
+        )
 
         if "createdDateTime" in user:
             created_at = datetime.strptime(user["createdDateTime"], TIMESTAMP_FORMAT)
@@ -1912,34 +1881,44 @@ class SharepointOnlineDataSource(BaseDataSource):
         if not self.configuration["fetch_drive_item_permissions"]:
             return drive_item
 
-        def _get_id(permissions, identity):
-            if identity not in permissions:
-                return None
+        def _get_id(permissions, label):
+            return permissions.get(label, {}).get("id")
 
-            return permissions.get(identity).get("id")
+        def _get_email(permissions, label):
+            return permissions.get(label, {}).get("email")
 
-        def _get_email(permissions, identity):
-            if identity not in permissions:
-                return None
-
-            return permissions.get(identity).get("email", None)
+        def _get_login_name(permissions, label):
+            identity = permissions.get(label, {})
+            login_name = identity.get("loginName", "")
+            if login_name.startswith("i:0#.f|membership|"):
+                return login_name.split("|")[-1]
 
         drive_item_id = drive_item.get("id")
         access_control = []
 
+        identities = []
         for permission in drive_item_permissions:
             granted_to_v2 = permission.get("grantedToV2")
+            if granted_to_v2:
+                identities.append(granted_to_v2)
+            granted_to_identity_v2 = permission.get("grantedToIdentitiesV2", [])
+            identities.extend(granted_to_identity_v2)
 
-            if not granted_to_v2:
-                self._logger.debug(
-                    f"'grantedToV2' missing for drive item (id: '{drive_item_id}'). Skipping permissions..."
-                )
-                continue
+        if not identities:
+            self._logger.debug(
+                f"'grantedToV2' and 'grantedToIdentitiesV2' missing for drive item (id: '{drive_item_id}'). Skipping permissions..."
+            )
+            self._logger.warning(
+                f"Drive item permissions were: {drive_item_permissions}"
+            )
+            return drive_item
 
-            user_id = _get_id(granted_to_v2, "user")
-            group_id = _get_id(granted_to_v2, "group")
-            site_group_id = _get_id(granted_to_v2, "siteGroup")
-            site_user_email = _get_email(granted_to_v2, "siteUser")
+        for identity in identities:
+            user_id = _get_id(identity, "user")
+            group_id = _get_id(identity, "group")
+            site_group_id = _get_id(identity, "siteGroup")
+            site_user_email = _get_email(identity, "siteUser")
+            site_user_username = _get_login_name(identity, "siteUser")
 
             if user_id:
                 access_control.append(_prefix_user_id(user_id))
@@ -1950,16 +1929,15 @@ class SharepointOnlineDataSource(BaseDataSource):
             if site_user_email:
                 access_control.append(_prefix_email(site_user_email))
 
+            if site_user_username:
+                access_control.append(_prefix_user(site_user_username))
+
             if site_group_id:
                 users = await self.site_group_users(site_web_url, site_group_id)
-                for site_group_user in users:
-                    site_group_user_name = site_group_user.get("UserPrincipalName")
-                    if site_group_user_name:
-                        access_control.append(_prefix_user(site_group_user_name))
-
-                    site_group_user_email = site_group_user.get("Email")
-                    if site_group_user_email:
-                        access_control.append(_prefix_email(site_group_user_email))
+                for site_group_user in users:  # note, 'users' might contain groups.
+                    access_control.extend(
+                        self._access_control_for_member(site_group_user)
+                    )
 
         return self._decorate_with_access_control(drive_item, access_control)
 
@@ -2129,22 +2107,39 @@ class SharepointOnlineDataSource(BaseDataSource):
         If any role is assigned to a user this means at least "read" access.
         """
 
-        def _access_control_for_user(user_):
-            user_access_control = []
+        def _has_limited_access(role_assignment):
+            bindings = role_assignment.get("RoleDefinitionBindings", [])
 
-            user_principal_name = user_.get("UserPrincipalName")
-            login_name = _get_login_name(user_.get("LoginName"))
+            # If there is no permission information, default to restrict access
+            if not bindings:
+                self._logger.debug(
+                    f"No RoleDefinitionBindings found for '{role_assignment.get('odata.id')}'"
+                )
+                return True
 
-            if user_principal_name:
-                user_access_control.append(_prefix_user(user_principal_name))
+            # if any binding grants view access, this role assignment's member has view access
+            for binding in bindings:
+                # full explanation of the bit-math: https://stackoverflow.com/questions/51897160/how-to-parse-getusereffectivepermissions-sharepoint-response-in-java
+                # this approach was confirmed as valid by a Microsoft Sr. Support Escalation Engineer
+                base_permission_low = int(
+                    binding.get("BasePermissions", {}).get("Low", "0")
+                )
+                role_type_kind = binding.get("RoleTypeKind", 0)
+                if (
+                    (base_permission_low & VIEW_ITEM_MASK)
+                    or (base_permission_low & VIEW_PAGE_MASK)
+                    or (role_type_kind in VIEW_ROLE_TYPES)
+                ):
+                    return False
 
-            if login_name:
-                user_access_control.append(_prefix_user(login_name))
+            return (
+                True  # no evidence of view access was found, so assuming limited access
+            )
 
-            return user_access_control
+        if _has_limited_access(role_assignment):
+            return []
 
         access_control = []
-
         identity_type = role_assignment.get("Member", {}).get("odata.type", "")
         is_group = identity_type == "SP.Group"
         is_user = identity_type == "SP.User"
@@ -2153,24 +2148,10 @@ class SharepointOnlineDataSource(BaseDataSource):
             users = role_assignment.get("Member", {}).get("Users", [])
 
             for user in users:
-                access_control.extend(_access_control_for_user(user))
+                access_control.extend(self._access_control_for_member(user))
         elif is_user:
-            user = role_assignment.get("Member", {})
-            login_name = user.get("LoginName")
-
-            # in this context the 'odata.type' being 'SP.User' and the 'LoginName' looking like a group indicates a dynamic group
-            is_dynamic_group = (
-                login_name.startswith("c:0o.c|federateddirectoryclaimprovider|")
-                if login_name
-                else False
-            )
-
-            if is_dynamic_group:
-                self._logger.debug(f"Detected dynamic group '{user.get('Title')}'.")
-                dynamic_group_id = _get_login_name(login_name)
-                access_control.append(_prefix_group(dynamic_group_id))
-            else:
-                access_control = _access_control_for_user(user)
+            member = role_assignment.get("Member", {})
+            access_control.extend(self._access_control_for_member(member))
         else:
             self._logger.debug(
                 f"Skipping unique page permissions for identity type '{identity_type}'."
@@ -2450,3 +2431,38 @@ class SharepointOnlineDataSource(BaseDataSource):
             return True
 
         return False
+
+    def _access_control_for_member(self, member):
+        login_name = member.get("LoginName")
+
+        # 'LoginName' looking like a group indicates a group
+        is_group = (
+            login_name.startswith("c:0o.c|federateddirectoryclaimprovider|")
+            if login_name
+            else False
+        )
+
+        if is_group:
+            self._logger.debug(f"Detected group '{member.get('Title')}'.")
+            dynamic_group_id = _get_login_name(login_name)
+            return [_prefix_group(dynamic_group_id)]
+        else:
+            return self._access_control_for_user(member)
+
+    def _access_control_for_user(self, user):
+        user_access_control = []
+
+        user_principal_name = user.get("UserPrincipalName")
+        login_name = _get_login_name(user.get("LoginName"))
+        email = user.get("Email")
+
+        if user_principal_name:
+            user_access_control.append(_prefix_user(user_principal_name))
+
+        if login_name:
+            user_access_control.append(_prefix_user(login_name))
+
+        if email:
+            user_access_control.append(_prefix_email(email))
+
+        return user_access_control

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -38,8 +38,8 @@ from connectors.sources.sharepoint_online import (
     SharepointOnlineDataSource,
     SharepointRestAPIToken,
     SyncCursorEmpty,
+    ThrottledError,
     TokenFetchFailed,
-    _domain_group_id,
     _emails_and_usernames_of_domain_group,
     _get_login_name,
     _prefix_email,
@@ -47,8 +47,6 @@ from connectors.sources.sharepoint_online import (
     _prefix_identity,
     _prefix_user,
     _prefix_user_id,
-    is_domain_group,
-    is_person,
 )
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
@@ -87,6 +85,8 @@ GROUP_ONE = "Group 1"
 
 GROUP_TWO = "Group 2"
 
+GROUP_TWO_ID = "group-id-2"
+
 USER_ONE_ID = "user-id-1"
 
 USER_ONE_EMAIL = "user1@spo.com"
@@ -103,6 +103,127 @@ NUMBER_OF_DEFAULT_GROUPS = 3
 
 ALLOW_ACCESS_CONTROL_PATCHED = "access_control"
 DEFAULT_GROUPS_PATCHED = ["some default group"]
+
+READ_BINDING = [
+    {
+        "BasePermissions": {"High": "176", "Low": "138612833"},
+        "Description": "Can view pages and list items and download documents.",
+        "Hidden": False,
+        "Id": 1073741826,
+        "Name": "Read",
+        "Order": 128,
+        "RoleTypeKind": 2,
+    }
+]
+
+LIMITED_ACCESS_BINDING = [
+    {
+        "BasePermissions": {"High": "16", "Low": "134283264"},
+        "Description": "Can view specific lists, document libraries, list items, folders, or documents when given permissions.",
+        "Hidden": True,
+        "Id": 1073741825,
+        "Name": "Limited Access",
+        "Order": 160,
+        "RoleTypeKind": 1,
+    }
+]
+
+WEB_ONLY_BINDING = [
+    {
+        "BasePermissions": {"High": "560", "Low": "134221824"},
+        "Description": "Can only view the web when given permissions.",
+        "Hidden": True,
+        "Id": 1073741833,
+        "Name": "Web-Only Limited Access",
+        "Order": 176,
+        "RoleTypeKind": 9,
+    }
+]
+
+SAMPLE_DRIVE_PERMISSIONS = [
+    {
+        "id": "3",
+        "grantedToV2": {
+            "user": {
+                "id": USER_ONE_ID,
+            },
+            "group": {
+                "id": GROUP_ONE_ID,
+            },
+        },
+    },
+    {
+        "id": "4",
+        "grantedToV2": {
+            "user": {
+                "id": USER_ONE_ID,
+            },
+            "group": {
+                "id": GROUP_ONE_ID,
+            },
+        },
+    },
+    {
+        "id": "5",
+        "grantedToV2": {
+            "user": {
+                "id": USER_ONE_ID,
+            },
+            "group": {
+                "id": GROUP_ONE_ID,
+            },
+        },
+    },
+    {
+        "id": "6",
+        "grantedToV2": {
+            "user": {
+                "id": USER_ONE_ID,
+            },
+            "group": {
+                "id": GROUP_ONE_ID,
+            },
+            "siteGroup": {"id": "2", "displayName": "Some site group"},
+        },
+    },
+]
+
+SAMPLE_SITE_GROUP_USERS = [
+    {
+        "UserPrincipalName": SITEGROUP_USER_ONE_ID,
+        "Email": SITEGROUP_USER_ONE_EMAIL,
+    }
+]
+
+BATCH_THROTTLED_RESPONSE = {
+    "responses": [
+        {
+            "id": "014DQHDVKA25ZKRFXRQBDKQS2ZMJ3C442M",
+            "status": 429,
+            "headers": {
+                "Link": '<https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",<https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"',
+                "Deprecation": "Fri, 03 Sep 2021 23:59:59 GMT",
+                "Sunset": "Sun, 01 Oct 2023 23:59:59 GMT",
+                "Retry-After": "28",
+                "Cache-Control": "private",
+                "Content-Type": "application/json",
+            },
+            "body": {
+                "error": {
+                    "code": "activityLimitReached",
+                    "message": "The request has been throttled",
+                    "innerError": {
+                        "code": "throttledRequest",
+                        "innerError": {"code": "quota"},
+                        "date": "2023-09-29T14:31:03",
+                        "request-id": "b4e31937-edce-43cc-a32b-dcf664ddc754",
+                        "client-request-id": "b4e31937-edce-43cc-a32b-dcf664ddc754",
+                    },
+                }
+            },
+        }
+    ]
+}
 
 
 def set_dls_enabled(source, dls_enabled):
@@ -394,6 +515,38 @@ class TestMicrosoftAPISession:
         response = await microsoft_api_session.post(url, payload)
 
         assert response == expected_response
+
+    @pytest.mark.asyncio
+    async def test_post_with_batch_failures(
+        self, microsoft_api_session, mock_responses, patch_cancellable_sleeps
+    ):
+        url = "https://graph.microsoft.com/v1.0/$batch"
+        first_response = BATCH_THROTTLED_RESPONSE
+        second_response = {"responses": [{"key": "value"}]}
+        payload = {"key": "value"}
+
+        mock_responses.post(url, payload=first_response)
+        mock_responses.post(url, payload=second_response)
+
+        response = await microsoft_api_session.post(url, payload)
+
+        assert response == second_response
+
+    @pytest.mark.asyncio
+    async def test_post_with_consecutive_batch_failures(
+        self, microsoft_api_session, mock_responses, patch_cancellable_sleeps
+    ):
+        url = "https://graph.microsoft.com/v1.0/$batch"
+        payload = {"key": "value"}
+
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+
+        with pytest.raises(ThrottledError):
+            await microsoft_api_session.post(url, payload)
 
     @pytest.mark.asyncio
     async def test_fetch_with_retry(
@@ -1264,37 +1417,6 @@ class TestSharepointOnlineClient:
         assert len(returned_items) == 0
 
     @pytest.mark.asyncio
-    async def test_drive_item_permissions(self, client, patch_scroll):
-        drive_id = 1
-        drive_item = {"id": 1}
-
-        permissions = ["permission"]
-        actual_permissions = await self._execute_scrolling_method(
-            client.drive_item_permissions,
-            patch_scroll,
-            permissions,
-            drive_id,
-            drive_item,
-        )
-
-        patch_scroll.return_value = permissions
-
-        assert actual_permissions == permissions
-
-    @pytest.mark.asyncio
-    async def test_drive_item_permissions_not_found(self, client, patch_scroll):
-        drive_id = 1
-        drive_item = {"id": 1}
-
-        patch_scroll.side_effect = NotFound()
-        returned_permissions = []
-
-        async for permission in client.drive_item_permissions(drive_id, drive_item):
-            returned_permissions.append(permission)
-
-        assert len(returned_permissions) == 0
-
-    @pytest.mark.asyncio
     async def test_drive_items_permissions_batch(self, client, patch_post):
         drive_id = 1
         drive_item_ids = [1, 2, 3]
@@ -1333,6 +1455,25 @@ class TestSharepointOnlineClient:
             responses.append(response)
 
         assert len(responses) == 0
+
+    @pytest.mark.asyncio
+    async def test_site_role_assignments(self, client, patch_scroll):
+        site_role_assignments_url = (
+            f"https://{self.tenant_name}.sharepoint.com/sites/test"
+        )
+
+        role_assignments = [{"value": ["role"]}]
+
+        actual_role_assignments = await self._execute_scrolling_method(
+            partial(
+                client.site_role_assignments,
+                site_role_assignments_url,
+            ),
+            patch_scroll,
+            role_assignments,
+        )
+
+        assert actual_role_assignments == role_assignments
 
     @pytest.mark.asyncio
     async def test_site_list_has_unique_role_assignments(self, client, patch_fetch):
@@ -1573,36 +1714,6 @@ class TestSharepointOnlineClient:
         assert len(actual_users_and_groups) == 0
 
     @pytest.mark.asyncio
-    async def test_user_information_lst(self, client, patch_scroll):
-        site_id = "12345"
-        user_info_one = {"name": "some user"}
-        user_info_two = {"name": "some other user"}
-
-        expected_user_infos = [user_info_one, user_info_two]
-
-        actual_user_infos = await self._execute_scrolling_method(
-            partial(client.user_information_list, site_id),
-            patch_scroll,
-            expected_user_infos,
-        )
-
-        assert len(actual_user_infos) == len(expected_user_infos)
-        assert actual_user_infos == expected_user_infos
-
-    @pytest.mark.asyncio
-    async def test_user_information_list_with_not_found_raised(
-        self, client, patch_scroll
-    ):
-        site_id = "12345"
-        patch_scroll.side_effect = NotFound()
-
-        returned_items = []
-        async for user_info in client.user_information_list(site_id):
-            returned_items.append(user_info)
-
-        assert len(returned_items) == 0
-
-    @pytest.mark.asyncio
     async def test_groups_user_transitive_member_of(self, client, patch_scroll):
         user_id = "12345"
         group_one = {"name": "some group"}
@@ -1805,27 +1916,38 @@ class TestSharepointOnlineDataSource:
         return [{"Id": "4", "odata.id": "11", "GUID": "thats-not-a-guid"}]
 
     @property
-    def user_information_list(self):
+    def site_role_assignments(self):
         return [
             {
-                "fields": {
-                    "ContentType": "DomainGroup",
-                    "Name": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_ONE}",
-                }
-            },
-            {
-                "fields": {
-                    "ContentType": "DomainGroup",
-                    "Name": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_TWO}_o",
-                }
-            },
-            {
-                "fields": {
-                    "ContentType": "Person",
-                    "Name": f"i:0#.f|membership|{USER_ONE_EMAIL}",
-                }
-            },
-            {"fields": {"ContentType": "Person", "EMail": USER_TWO_EMAIL}},
+                "Member": {
+                    "odata.type": "SP.Group",
+                    "Users": [
+                        {
+                            "odata.type": "SP.User",
+                            "UserPrincipalName": USER_ONE_EMAIL,
+                        },
+                        {
+                            "odata.type": "SP.User",
+                            "Email": USER_TWO_EMAIL,
+                        },
+                        {
+                            "odata.type": "SP.User",
+                            "LoginName": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_ONE_ID}",
+                            "Title": GROUP_ONE,
+                            "Email": f"{GROUP_ONE}@foobar.onmicrosoft.com",
+                        },
+                        {
+                            "odata.type": "SP.User",
+                            "LoginName": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_TWO_ID}",
+                            "Title": GROUP_TWO,
+                            "Email": f"{GROUP_TWO}@foobar.onmicrosoft.com",
+                        },
+                    ],
+                    "LoginName": "Site Members",
+                    "Title": "Site Members",
+                },
+                "RoleDefinitionBindings": READ_BINDING,
+            }
         ]
 
     @property
@@ -1863,12 +1985,7 @@ class TestSharepointOnlineDataSource:
 
     @property
     def site_group_users(self):
-        return [
-            {
-                "UserPrincipalName": SITEGROUP_USER_ONE_ID,
-                "Email": SITEGROUP_USER_ONE_EMAIL,
-            }
-        ]
+        return SAMPLE_SITE_GROUP_USERS
 
     @property
     def users_and_groups_for_role_assignments(self):
@@ -1922,53 +2039,7 @@ class TestSharepointOnlineDataSource:
 
     @property
     def drive_item_permissions(self):
-        return [
-            {
-                "id": "3",
-                "grantedToV2": {
-                    "user": {
-                        "id": USER_ONE_ID,
-                    },
-                    "group": {
-                        "id": GROUP_ONE_ID,
-                    },
-                },
-            },
-            {
-                "id": "4",
-                "grantedToV2": {
-                    "user": {
-                        "id": USER_ONE_ID,
-                    },
-                    "group": {
-                        "id": GROUP_ONE_ID,
-                    },
-                },
-            },
-            {
-                "id": "5",
-                "grantedToV2": {
-                    "user": {
-                        "id": USER_ONE_ID,
-                    },
-                    "group": {
-                        "id": GROUP_ONE_ID,
-                    },
-                },
-            },
-            {
-                "id": "6",
-                "grantedToV2": {
-                    "user": {
-                        "id": USER_ONE_ID,
-                    },
-                    "group": {
-                        "id": GROUP_ONE_ID,
-                    },
-                    "siteGroup": {"id": "2", "displayName": "Some site group"},
-                },
-            },
-        ]
+        return SAMPLE_DRIVE_PERMISSIONS
 
     @property
     def drive_items_permissions_batch(self):
@@ -1992,12 +2063,11 @@ class TestSharepointOnlineDataSource:
             client.site_collections = AsyncIterator(self.site_collections)
             client.sites = AsyncIterator(self.sites)
             client.site_group_users = AsyncIterator(self.site_group_users)
-            client.user_information_list = AsyncIterator(self.user_information_list)
+            client.site_role_assignments = AsyncIterator(self.site_role_assignments)
             client.group = AsyncMock(return_value=self.group)
             client.group_members = AsyncIterator(self.group_members)
             client.group_owners = AsyncIterator(self.group_owners)
             client.site_users = AsyncIterator(self.site_users)
-            client.drive_item_permissions = AsyncIterator(self.drive_item_permissions)
             client.drive_items_permissions_batch = AsyncIterator(
                 self.drive_items_permissions_batch
             )
@@ -2333,29 +2403,123 @@ class TestSharepointOnlineDataSource:
 
         assert download_result is None
 
+    @pytest.mark.parametrize(
+        "drive_item_permissions, site_group_users, expected_access_control",
+        [
+            (
+                SAMPLE_DRIVE_PERMISSIONS,
+                SAMPLE_SITE_GROUP_USERS,
+                [
+                    "user_id:user-id-1",
+                    "email:sitegroup.user1@spo.com",
+                    "group:group-id-1",
+                    "user:sitegroup.user1",
+                ],
+            ),
+            (
+                # grantedToIdentitiesV2 gets parsed
+                [
+                    {
+                        "grantedToIdentitiesV2": [
+                            {
+                                "user": {
+                                    "displayName": "Generic User",
+                                    "id": "75e1766a-f83d-48f8-aac3-8422f5cea411",
+                                },
+                                "siteUser": {
+                                    "displayName": "Generic User",
+                                    "loginName": "i:0#.f|membership|generic.user@enterprisesearch.onmicrosoft.com",
+                                },
+                            }
+                        ],
+                    }
+                ],
+                [],
+                [
+                    "user:generic.user@enterprisesearch.onmicrosoft.com",
+                    "user_id:75e1766a-f83d-48f8-aac3-8422f5cea411",
+                ],
+            ),
+            (
+                # grantedToIdentitiesV2 parsed alongside grantedToV2
+                [
+                    {
+                        "grantedToIdentitiesV2": [
+                            {
+                                "user": {
+                                    "displayName": "Generic User",
+                                    "id": "75e1766a-f83d-48f8-aac3-8422f5cea411",
+                                },
+                                "siteUser": {
+                                    "displayName": "Generic User",
+                                    "loginName": "i:0#.f|membership|generic.user@enterprisesearch.onmicrosoft.com",
+                                },
+                            }
+                        ],
+                        "grantedToV2": {
+                            "user": {
+                                "displayName": "Enterprise Search",
+                                "email": "demo@enterprisesearch.onmicrosoft.com",
+                                "id": "baa37bda-0dd1-4799-ae22-f3476c2cf58d",
+                            },
+                            "siteUser": {
+                                "displayName": "Enterprise Search",
+                                "email": "demo@enterprisesearch.onmicrosoft.com",
+                                "id": "6",
+                                "loginName": "i:0#.f|membership|demo@enterprisesearch.onmicrosoft.com",
+                            },
+                        },
+                    }
+                ],
+                [],
+                [
+                    "user:generic.user@enterprisesearch.onmicrosoft.com",
+                    "user_id:75e1766a-f83d-48f8-aac3-8422f5cea411",
+                    "email:demo@enterprisesearch.onmicrosoft.com",
+                    "user_id:baa37bda-0dd1-4799-ae22-f3476c2cf58d",
+                    "user:demo@enterprisesearch.onmicrosoft.com",
+                ],
+            ),
+            (
+                # site groups get expanded
+                [
+                    {
+                        "grantedToV2": {"siteGroup": {"id": "3"}},
+                    }
+                ],
+                SAMPLE_SITE_GROUP_USERS,
+                [f"user:{SITEGROUP_USER_ONE_ID}", f"email:{SITEGROUP_USER_ONE_EMAIL}"],
+            ),
+            (
+                # groups of groups
+                [{"grantedToV2": {"siteGroup": {"id": "3"}}}],
+                [
+                    {
+                        "LoginName": "c:0o.c|federateddirectoryclaimprovider|abc123",
+                        "Title": "Nested group",
+                    }
+                ],
+                ["group:abc123"],
+            ),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_with_drive_item_permissions(self, patch_sharepoint_client):
+    async def test_with_drive_item_permissions(
+        self, drive_item_permissions, site_group_users, expected_access_control
+    ):
         source = create_source(SharepointOnlineDataSource)
         set_dls_enabled(source, True)
-        drive_item = {"id": 2}
-        patch_sharepoint_client.drive_item_permissions = AsyncIterator(
-            self.drive_item_permissions
-        )
+        drive_item = {"id": 1}
 
         # mock cache lookup
-        source.site_group_users = AsyncMock(return_value=self.site_group_users)
+        source.site_group_users = AsyncMock(return_value=site_group_users)
 
         drive_item_with_access_control = await source._with_drive_item_permissions(
-            drive_item, self.drive_item_permissions, "dummy_site_web_url"
+            drive_item, drive_item_permissions, "dummy_site_web_url"
         )
         drive_item_access_control = drive_item_with_access_control[ACCESS_CONTROL]
 
-        assert len(drive_item_access_control) == 4
-        assert _prefix_user_id(USER_ONE_ID) in drive_item_access_control
-        assert _prefix_group(GROUP_ONE_ID) in drive_item_access_control
-        # This comes from the sitegroup permission
-        assert _prefix_user(SITEGROUP_USER_ONE_ID) in drive_item_access_control
-        assert _prefix_email(SITEGROUP_USER_ONE_EMAIL) in drive_item_access_control
+        assert set(drive_item_access_control) == set(expected_access_control)
 
     @pytest.mark.asyncio
     async def test_drive_items_batch_with_permissions_when_fetch_drive_item_permissions_enabled(
@@ -2875,14 +3039,13 @@ class TestSharepointOnlineDataSource:
 
         access_control, _ = await source._site_access_control(site)
 
-        two_other_users = 2
+        two_users = 2
         two_groups = 2
 
-        assert len(access_control) == two_groups + two_other_users
+        assert len(access_control) == two_groups + two_users
 
-        assert _prefix_group(GROUP_ONE) in access_control
-        assert _prefix_group(GROUP_TWO) in access_control
-
+        assert _prefix_group(GROUP_ONE_ID) in access_control
+        assert _prefix_group(GROUP_TWO_ID) in access_control
         assert _prefix_user(USER_ONE_EMAIL) in access_control
         assert _prefix_email(USER_TWO_EMAIL) in access_control
 
@@ -3134,23 +3297,6 @@ class TestSharepointOnlineDataSource:
         assert len(user_access_control_docs) == 2
 
     @pytest.mark.parametrize(
-        "user_info_name, expected_domain_group_id",
-        [
-            (None, None),
-            ("", None),
-            ("abc|", None),
-            ("abc|def|", None),
-            ("abc|def|_o", None),
-            (f"abc|def|{DOMAIN_GROUP_ID}", DOMAIN_GROUP_ID),
-            (f"abc|def|{DOMAIN_GROUP_ID}_o", DOMAIN_GROUP_ID),
-            (f"abc|def|ghi/{DOMAIN_GROUP_ID}", DOMAIN_GROUP_ID),
-            (f"abc|def|ghi/{DOMAIN_GROUP_ID}_o", DOMAIN_GROUP_ID),
-        ],
-    )
-    def test_domain_group_id(self, user_info_name, expected_domain_group_id):
-        assert _domain_group_id(user_info_name) == expected_domain_group_id
-
-    @pytest.mark.parametrize(
         "group_identities_generator, expected_emails_and_usernames",
         [
             (AsyncIterator([]), []),
@@ -3224,30 +3370,6 @@ class TestSharepointOnlineDataSource:
 
         assert _prefix_user_id(user_id) == "user_id:user id"
 
-    def test_is_domain_group(self):
-        assert is_domain_group(
-            {
-                "ContentType": "DomainGroup",
-                "Name": "c:0o.c|federateddirectoryclaimprovider|97d055cf-5cdf-4e5e-b383-f01ed3a8844d",
-            }
-        )
-
-    def test_is_not_domain_group(self):
-        assert not is_domain_group({"ContentType": "Person"})
-        assert not is_domain_group({"ContentType": "DomainGroup"})
-        assert not is_domain_group(
-            {
-                "ContentType": "DomainGroup",
-                "Name": "c:0u.c|tenant|67f8dab3bb7a912bc3da51b94b6bc5d23edef0e83056056f1a3929b4e04b8624",
-            }
-        )
-
-    def test_is_person(self):
-        assert is_person({"ContentType": "Person"})
-
-    def test_is_not_person(self):
-        assert not is_person({"ContentType": "DomainGroup"})
-
     @pytest.mark.parametrize(
         "role_assignment, expected_access_control",
         [
@@ -3266,11 +3388,34 @@ class TestSharepointOnlineDataSource:
                                 "odata.type": "SP.User",
                                 "LoginName": f"i:0#.f|membership|{USER_TWO_EMAIL}",
                                 "UserPrincipalName": None,
+                                "Email": USER_TWO_EMAIL,
                             },
                         ],
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
-                [_prefix_user(USER_ONE_EMAIL), _prefix_user(USER_TWO_EMAIL)],
+                [
+                    _prefix_user(USER_ONE_EMAIL),
+                    _prefix_user(USER_TWO_EMAIL),
+                    _prefix_email(USER_TWO_EMAIL),
+                ],
+            ),
+            (
+                # Group of groups (access control: group Id)
+                {
+                    "Member": {
+                        "odata.type": "SP.Group",
+                        "Users": [
+                            {
+                                "odata.type": "SP.User",
+                                "LoginName": "c:0o.c|federateddirectoryclaimprovider|abc123",
+                                "Title": "Nested Group",
+                            }
+                        ],
+                    },
+                    "RoleDefinitionBindings": READ_BINDING,
+                },
+                [_prefix_group("abc123")],
             ),
             (
                 # User (access control: only principal name)
@@ -3280,6 +3425,7 @@ class TestSharepointOnlineDataSource:
                         "LoginName": None,
                         "UserPrincipalName": USER_ONE_EMAIL,
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
                 [_prefix_user(USER_ONE_EMAIL)],
             ),
@@ -3291,6 +3437,7 @@ class TestSharepointOnlineDataSource:
                         "LoginName": f"i:0#.f|membership|{USER_TWO_EMAIL}",
                         "UserPrincipalName": USER_TWO_NAME,
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
                 [_prefix_user(USER_TWO_EMAIL), _prefix_user(USER_TWO_NAME)],
             ),
@@ -3301,6 +3448,7 @@ class TestSharepointOnlineDataSource:
                         "odata.type": "SP.User",
                         "LoginName": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_ONE_ID}",
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
                 [_prefix_group(GROUP_ONE_ID)],
             ),
@@ -3312,8 +3460,141 @@ class TestSharepointOnlineDataSource:
                         "LoginName": None,
                         "UserPrincipalName": USER_ONE_EMAIL,
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
                 [],
+            ),
+            (
+                # User with limited access has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": LIMITED_ACCESS_BINDING,
+                },
+                [],
+            ),
+            (
+                # User with web-only limited access has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": WEB_ONLY_BINDING,
+                },
+                [],
+            ),
+            (
+                # User with mixed access
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": READ_BINDING + LIMITED_ACCESS_BINDING,
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
+            ),
+            (
+                # User with empty mask (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"BasePermissions": {"Low": "0"}}],
+                },
+                [],
+            ),
+            (
+                # User with non-read mask (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"BasePermissions": {"Low": "2"}}],
+                },
+                [],
+            ),
+            (
+                # User with view item mask (custom binding)
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"BasePermissions": {"Low": "1"}}],
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
+            ),
+            (
+                # User with view page mask (custom binding)
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"BasePermissions": {"Low": "131072"}}],
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
+            ),
+            (
+                # User with "None" role type (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 0}],
+                },
+                [],
+            ),
+            (
+                # User with "Guest" role type (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 1}],
+                },
+                [],
+            ),
+            (
+                # User with "Restricted Guest" role type (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 9}],
+                },
+                [],
+            ),
+            (
+                # User with "Reader" role type (custom binding)
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 2}],
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
+            ),
+            (
+                # User with "System" role type (custom binding)
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 255}],
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
             ),
         ],
     )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `pre-8.10-stable`:
 - [Replace User Information List usage with role assignments for SPO sites (#1688)](https://github.com/elastic/connectors-python/pull/1688)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)