### PR TITLE
[8.10] Replace User Information List usage with role assignments for SPO sites (#1688)

### DIFF
--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -38,8 +38,8 @@ from connectors.sources.sharepoint_online import (
     SharepointOnlineDataSource,
     SharepointRestAPIToken,
     SyncCursorEmpty,
+    ThrottledError,
     TokenFetchFailed,
-    _domain_group_id,
     _emails_and_usernames_of_domain_group,
     _get_login_name,
     _prefix_email,
@@ -47,8 +47,6 @@ from connectors.sources.sharepoint_online import (
     _prefix_identity,
     _prefix_user,
     _prefix_user_id,
-    is_domain_group,
-    is_person,
 )
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
@@ -87,6 +85,8 @@ GROUP_ONE = "Group 1"
 
 GROUP_TWO = "Group 2"
 
+GROUP_TWO_ID = "group-id-2"
+
 USER_ONE_ID = "user-id-1"
 
 USER_ONE_EMAIL = "user1@spo.com"
@@ -103,6 +103,127 @@ NUMBER_OF_DEFAULT_GROUPS = 3
 
 ALLOW_ACCESS_CONTROL_PATCHED = "access_control"
 DEFAULT_GROUPS_PATCHED = ["some default group"]
+
+READ_BINDING = [
+    {
+        "BasePermissions": {"High": "176", "Low": "138612833"},
+        "Description": "Can view pages and list items and download documents.",
+        "Hidden": False,
+        "Id": 1073741826,
+        "Name": "Read",
+        "Order": 128,
+        "RoleTypeKind": 2,
+    }
+]
+
+LIMITED_ACCESS_BINDING = [
+    {
+        "BasePermissions": {"High": "16", "Low": "134283264"},
+        "Description": "Can view specific lists, document libraries, list items, folders, or documents when given permissions.",
+        "Hidden": True,
+        "Id": 1073741825,
+        "Name": "Limited Access",
+        "Order": 160,
+        "RoleTypeKind": 1,
+    }
+]
+
+WEB_ONLY_BINDING = [
+    {
+        "BasePermissions": {"High": "560", "Low": "134221824"},
+        "Description": "Can only view the web when given permissions.",
+        "Hidden": True,
+        "Id": 1073741833,
+        "Name": "Web-Only Limited Access",
+        "Order": 176,
+        "RoleTypeKind": 9,
+    }
+]
+
+SAMPLE_DRIVE_PERMISSIONS = [
+    {
+        "id": "3",
+        "grantedToV2": {
+            "user": {
+                "id": USER_ONE_ID,
+            },
+            "group": {
+                "id": GROUP_ONE_ID,
+            },
+        },
+    },
+    {
+        "id": "4",
+        "grantedToV2": {
+            "user": {
+                "id": USER_ONE_ID,
+            },
+            "group": {
+                "id": GROUP_ONE_ID,
+            },
+        },
+    },
+    {
+        "id": "5",
+        "grantedToV2": {
+            "user": {
+                "id": USER_ONE_ID,
+            },
+            "group": {
+                "id": GROUP_ONE_ID,
+            },
+        },
+    },
+    {
+        "id": "6",
+        "grantedToV2": {
+            "user": {
+                "id": USER_ONE_ID,
+            },
+            "group": {
+                "id": GROUP_ONE_ID,
+            },
+            "siteGroup": {"id": "2", "displayName": "Some site group"},
+        },
+    },
+]
+
+SAMPLE_SITE_GROUP_USERS = [
+    {
+        "UserPrincipalName": SITEGROUP_USER_ONE_ID,
+        "Email": SITEGROUP_USER_ONE_EMAIL,
+    }
+]
+
+BATCH_THROTTLED_RESPONSE = {
+    "responses": [
+        {
+            "id": "014DQHDVKA25ZKRFXRQBDKQS2ZMJ3C442M",
+            "status": 429,
+            "headers": {
+                "Link": '<https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",<https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"',
+                "Deprecation": "Fri, 03 Sep 2021 23:59:59 GMT",
+                "Sunset": "Sun, 01 Oct 2023 23:59:59 GMT",
+                "Retry-After": "28",
+                "Cache-Control": "private",
+                "Content-Type": "application/json",
+            },
+            "body": {
+                "error": {
+                    "code": "activityLimitReached",
+                    "message": "The request has been throttled",
+                    "innerError": {
+                        "code": "throttledRequest",
+                        "innerError": {"code": "quota"},
+                        "date": "2023-09-29T14:31:03",
+                        "request-id": "b4e31937-edce-43cc-a32b-dcf664ddc754",
+                        "client-request-id": "b4e31937-edce-43cc-a32b-dcf664ddc754",
+                    },
+                }
+            },
+        }
+    ]
+}
 
 
 def set_dls_enabled(source, dls_enabled):
@@ -394,6 +515,38 @@ class TestMicrosoftAPISession:
         response = await microsoft_api_session.post(url, payload)
 
         assert response == expected_response
+
+    @pytest.mark.asyncio
+    async def test_post_with_batch_failures(
+        self, microsoft_api_session, mock_responses, patch_cancellable_sleeps
+    ):
+        url = "https://graph.microsoft.com/v1.0/$batch"
+        first_response = BATCH_THROTTLED_RESPONSE
+        second_response = {"responses": [{"key": "value"}]}
+        payload = {"key": "value"}
+
+        mock_responses.post(url, payload=first_response)
+        mock_responses.post(url, payload=second_response)
+
+        response = await microsoft_api_session.post(url, payload)
+
+        assert response == second_response
+
+    @pytest.mark.asyncio
+    async def test_post_with_consecutive_batch_failures(
+        self, microsoft_api_session, mock_responses, patch_cancellable_sleeps
+    ):
+        url = "https://graph.microsoft.com/v1.0/$batch"
+        payload = {"key": "value"}
+
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+        mock_responses.post(url, payload=BATCH_THROTTLED_RESPONSE)
+
+        with pytest.raises(ThrottledError):
+            await microsoft_api_session.post(url, payload)
 
     @pytest.mark.asyncio
     async def test_fetch_with_retry(
@@ -1240,37 +1393,6 @@ class TestSharepointOnlineClient:
         assert len(returned_items) == 0
 
     @pytest.mark.asyncio
-    async def test_drive_item_permissions(self, client, patch_scroll):
-        drive_id = 1
-        drive_item = {"id": 1}
-
-        permissions = ["permission"]
-        actual_permissions = await self._execute_scrolling_method(
-            client.drive_item_permissions,
-            patch_scroll,
-            permissions,
-            drive_id,
-            drive_item,
-        )
-
-        patch_scroll.return_value = permissions
-
-        assert actual_permissions == permissions
-
-    @pytest.mark.asyncio
-    async def test_drive_item_permissions_not_found(self, client, patch_scroll):
-        drive_id = 1
-        drive_item = {"id": 1}
-
-        patch_scroll.side_effect = NotFound()
-        returned_permissions = []
-
-        async for permission in client.drive_item_permissions(drive_id, drive_item):
-            returned_permissions.append(permission)
-
-        assert len(returned_permissions) == 0
-
-    @pytest.mark.asyncio
     async def test_drive_items_permissions_batch(self, client, patch_post):
         drive_id = 1
         drive_item_ids = [1, 2, 3]
@@ -1309,6 +1431,25 @@ class TestSharepointOnlineClient:
             responses.append(response)
 
         assert len(responses) == 0
+
+    @pytest.mark.asyncio
+    async def test_site_role_assignments(self, client, patch_scroll):
+        site_role_assignments_url = (
+            f"https://{self.tenant_name}.sharepoint.com/sites/test"
+        )
+
+        role_assignments = [{"value": ["role"]}]
+
+        actual_role_assignments = await self._execute_scrolling_method(
+            partial(
+                client.site_role_assignments,
+                site_role_assignments_url,
+            ),
+            patch_scroll,
+            role_assignments,
+        )
+
+        assert actual_role_assignments == role_assignments
 
     @pytest.mark.asyncio
     async def test_site_list_has_unique_role_assignments(self, client, patch_fetch):
@@ -1549,36 +1690,6 @@ class TestSharepointOnlineClient:
         assert len(actual_users_and_groups) == 0
 
     @pytest.mark.asyncio
-    async def test_user_information_lst(self, client, patch_scroll):
-        site_id = "12345"
-        user_info_one = {"name": "some user"}
-        user_info_two = {"name": "some other user"}
-
-        expected_user_infos = [user_info_one, user_info_two]
-
-        actual_user_infos = await self._execute_scrolling_method(
-            partial(client.user_information_list, site_id),
-            patch_scroll,
-            expected_user_infos,
-        )
-
-        assert len(actual_user_infos) == len(expected_user_infos)
-        assert actual_user_infos == expected_user_infos
-
-    @pytest.mark.asyncio
-    async def test_user_information_list_with_not_found_raised(
-        self, client, patch_scroll
-    ):
-        site_id = "12345"
-        patch_scroll.side_effect = NotFound()
-
-        returned_items = []
-        async for user_info in client.user_information_list(site_id):
-            returned_items.append(user_info)
-
-        assert len(returned_items) == 0
-
-    @pytest.mark.asyncio
     async def test_groups_user_transitive_member_of(self, client, patch_scroll):
         user_id = "12345"
         group_one = {"name": "some group"}
@@ -1781,27 +1892,38 @@ class TestSharepointOnlineDataSource:
         return [{"Id": "4", "odata.id": "11", "GUID": "thats-not-a-guid"}]
 
     @property
-    def user_information_list(self):
+    def site_role_assignments(self):
         return [
             {
-                "fields": {
-                    "ContentType": "DomainGroup",
-                    "Name": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_ONE}",
-                }
-            },
-            {
-                "fields": {
-                    "ContentType": "DomainGroup",
-                    "Name": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_TWO}_o",
-                }
-            },
-            {
-                "fields": {
-                    "ContentType": "Person",
-                    "Name": f"i:0#.f|membership|{USER_ONE_EMAIL}",
-                }
-            },
-            {"fields": {"ContentType": "Person", "EMail": USER_TWO_EMAIL}},
+                "Member": {
+                    "odata.type": "SP.Group",
+                    "Users": [
+                        {
+                            "odata.type": "SP.User",
+                            "UserPrincipalName": USER_ONE_EMAIL,
+                        },
+                        {
+                            "odata.type": "SP.User",
+                            "Email": USER_TWO_EMAIL,
+                        },
+                        {
+                            "odata.type": "SP.User",
+                            "LoginName": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_ONE_ID}",
+                            "Title": GROUP_ONE,
+                            "Email": f"{GROUP_ONE}@foobar.onmicrosoft.com",
+                        },
+                        {
+                            "odata.type": "SP.User",
+                            "LoginName": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_TWO_ID}",
+                            "Title": GROUP_TWO,
+                            "Email": f"{GROUP_TWO}@foobar.onmicrosoft.com",
+                        },
+                    ],
+                    "LoginName": "Site Members",
+                    "Title": "Site Members",
+                },
+                "RoleDefinitionBindings": READ_BINDING,
+            }
         ]
 
     @property
@@ -1839,12 +1961,7 @@ class TestSharepointOnlineDataSource:
 
     @property
     def site_group_users(self):
-        return [
-            {
-                "UserPrincipalName": SITEGROUP_USER_ONE_ID,
-                "Email": SITEGROUP_USER_ONE_EMAIL,
-            }
-        ]
+        return SAMPLE_SITE_GROUP_USERS
 
     @property
     def users_and_groups_for_role_assignments(self):
@@ -1898,53 +2015,7 @@ class TestSharepointOnlineDataSource:
 
     @property
     def drive_item_permissions(self):
-        return [
-            {
-                "id": "3",
-                "grantedToV2": {
-                    "user": {
-                        "id": USER_ONE_ID,
-                    },
-                    "group": {
-                        "id": GROUP_ONE_ID,
-                    },
-                },
-            },
-            {
-                "id": "4",
-                "grantedToV2": {
-                    "user": {
-                        "id": USER_ONE_ID,
-                    },
-                    "group": {
-                        "id": GROUP_ONE_ID,
-                    },
-                },
-            },
-            {
-                "id": "5",
-                "grantedToV2": {
-                    "user": {
-                        "id": USER_ONE_ID,
-                    },
-                    "group": {
-                        "id": GROUP_ONE_ID,
-                    },
-                },
-            },
-            {
-                "id": "6",
-                "grantedToV2": {
-                    "user": {
-                        "id": USER_ONE_ID,
-                    },
-                    "group": {
-                        "id": GROUP_ONE_ID,
-                    },
-                    "siteGroup": {"id": "2", "displayName": "Some site group"},
-                },
-            },
-        ]
+        return SAMPLE_DRIVE_PERMISSIONS
 
     @property
     def drive_items_permissions_batch(self):
@@ -1968,12 +2039,11 @@ class TestSharepointOnlineDataSource:
             client.site_collections = AsyncIterator(self.site_collections)
             client.sites = AsyncIterator(self.sites)
             client.site_group_users = AsyncIterator(self.site_group_users)
-            client.user_information_list = AsyncIterator(self.user_information_list)
+            client.site_role_assignments = AsyncIterator(self.site_role_assignments)
             client.group = AsyncMock(return_value=self.group)
             client.group_members = AsyncIterator(self.group_members)
             client.group_owners = AsyncIterator(self.group_owners)
             client.site_users = AsyncIterator(self.site_users)
-            client.drive_item_permissions = AsyncIterator(self.drive_item_permissions)
             client.drive_items_permissions_batch = AsyncIterator(
                 self.drive_items_permissions_batch
             )
@@ -2314,29 +2384,123 @@ class TestSharepointOnlineDataSource:
 
             assert download_result is None
 
+    @pytest.mark.parametrize(
+        "drive_item_permissions, site_group_users, expected_access_control",
+        [
+            (
+                SAMPLE_DRIVE_PERMISSIONS,
+                SAMPLE_SITE_GROUP_USERS,
+                [
+                    "user_id:user-id-1",
+                    "email:sitegroup.user1@spo.com",
+                    "group:group-id-1",
+                    "user:sitegroup.user1",
+                ],
+            ),
+            (
+                # grantedToIdentitiesV2 gets parsed
+                [
+                    {
+                        "grantedToIdentitiesV2": [
+                            {
+                                "user": {
+                                    "displayName": "Generic User",
+                                    "id": "75e1766a-f83d-48f8-aac3-8422f5cea411",
+                                },
+                                "siteUser": {
+                                    "displayName": "Generic User",
+                                    "loginName": "i:0#.f|membership|generic.user@enterprisesearch.onmicrosoft.com",
+                                },
+                            }
+                        ],
+                    }
+                ],
+                [],
+                [
+                    "user:generic.user@enterprisesearch.onmicrosoft.com",
+                    "user_id:75e1766a-f83d-48f8-aac3-8422f5cea411",
+                ],
+            ),
+            (
+                # grantedToIdentitiesV2 parsed alongside grantedToV2
+                [
+                    {
+                        "grantedToIdentitiesV2": [
+                            {
+                                "user": {
+                                    "displayName": "Generic User",
+                                    "id": "75e1766a-f83d-48f8-aac3-8422f5cea411",
+                                },
+                                "siteUser": {
+                                    "displayName": "Generic User",
+                                    "loginName": "i:0#.f|membership|generic.user@enterprisesearch.onmicrosoft.com",
+                                },
+                            }
+                        ],
+                        "grantedToV2": {
+                            "user": {
+                                "displayName": "Enterprise Search",
+                                "email": "demo@enterprisesearch.onmicrosoft.com",
+                                "id": "baa37bda-0dd1-4799-ae22-f3476c2cf58d",
+                            },
+                            "siteUser": {
+                                "displayName": "Enterprise Search",
+                                "email": "demo@enterprisesearch.onmicrosoft.com",
+                                "id": "6",
+                                "loginName": "i:0#.f|membership|demo@enterprisesearch.onmicrosoft.com",
+                            },
+                        },
+                    }
+                ],
+                [],
+                [
+                    "user:generic.user@enterprisesearch.onmicrosoft.com",
+                    "user_id:75e1766a-f83d-48f8-aac3-8422f5cea411",
+                    "email:demo@enterprisesearch.onmicrosoft.com",
+                    "user_id:baa37bda-0dd1-4799-ae22-f3476c2cf58d",
+                    "user:demo@enterprisesearch.onmicrosoft.com",
+                ],
+            ),
+            (
+                # site groups get expanded
+                [
+                    {
+                        "grantedToV2": {"siteGroup": {"id": "3"}},
+                    }
+                ],
+                SAMPLE_SITE_GROUP_USERS,
+                [f"user:{SITEGROUP_USER_ONE_ID}", f"email:{SITEGROUP_USER_ONE_EMAIL}"],
+            ),
+            (
+                # groups of groups
+                [{"grantedToV2": {"siteGroup": {"id": "3"}}}],
+                [
+                    {
+                        "LoginName": "c:0o.c|federateddirectoryclaimprovider|abc123",
+                        "Title": "Nested group",
+                    }
+                ],
+                ["group:abc123"],
+            ),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_with_drive_item_permissions(self, patch_sharepoint_client):
+    async def test_with_drive_item_permissions(
+        self, drive_item_permissions, site_group_users, expected_access_control
+    ):
         async with create_source(SharepointOnlineDataSource) as source:
             set_dls_enabled(source, True)
-            drive_item = {"id": 2}
-            patch_sharepoint_client.drive_item_permissions = AsyncIterator(
-                self.drive_item_permissions
-            )
+            drive_item = {"id": 1}
 
             # mock cache lookup
-            source.site_group_users = AsyncMock(return_value=self.site_group_users)
+            source.site_group_users = AsyncMock(return_value=site_group_users)
 
             drive_item_with_access_control = await source._with_drive_item_permissions(
-                drive_item, self.drive_item_permissions, "dummy_site_web_url"
+                drive_item, drive_item_permissions, "dummy_site_web_url"
             )
             drive_item_access_control = drive_item_with_access_control[ACCESS_CONTROL]
 
-            assert len(drive_item_access_control) == 4
-            assert _prefix_user_id(USER_ONE_ID) in drive_item_access_control
-            assert _prefix_group(GROUP_ONE_ID) in drive_item_access_control
-            # This comes from the sitegroup permission
-            assert _prefix_user(SITEGROUP_USER_ONE_ID) in drive_item_access_control
-            assert _prefix_email(SITEGROUP_USER_ONE_EMAIL) in drive_item_access_control
+            assert set(drive_item_access_control) == set(expected_access_control)
 
     @pytest.mark.asyncio
     async def test_drive_items_batch_with_permissions_when_fetch_drive_item_permissions_enabled(
@@ -2870,13 +3034,13 @@ class TestSharepointOnlineDataSource:
 
             access_control, _ = await source._site_access_control(site)
 
-            two_other_users = 2
+            two_users = 2
             two_groups = 2
 
-            assert len(access_control) == two_groups + two_other_users
+            assert len(access_control) == two_groups + two_users
 
-            assert _prefix_group(GROUP_ONE) in access_control
-            assert _prefix_group(GROUP_TWO) in access_control
+            assert _prefix_group(GROUP_ONE_ID) in access_control
+            assert _prefix_group(GROUP_TWO_ID) in access_control
 
             assert _prefix_user(USER_ONE_EMAIL) in access_control
             assert _prefix_email(USER_TWO_EMAIL) in access_control
@@ -3136,23 +3300,6 @@ class TestSharepointOnlineDataSource:
             assert len(user_access_control_docs) == 2
 
     @pytest.mark.parametrize(
-        "user_info_name, expected_domain_group_id",
-        [
-            (None, None),
-            ("", None),
-            ("abc|", None),
-            ("abc|def|", None),
-            ("abc|def|_o", None),
-            (f"abc|def|{DOMAIN_GROUP_ID}", DOMAIN_GROUP_ID),
-            (f"abc|def|{DOMAIN_GROUP_ID}_o", DOMAIN_GROUP_ID),
-            (f"abc|def|ghi/{DOMAIN_GROUP_ID}", DOMAIN_GROUP_ID),
-            (f"abc|def|ghi/{DOMAIN_GROUP_ID}_o", DOMAIN_GROUP_ID),
-        ],
-    )
-    def test_domain_group_id(self, user_info_name, expected_domain_group_id):
-        assert _domain_group_id(user_info_name) == expected_domain_group_id
-
-    @pytest.mark.parametrize(
         "group_identities_generator, expected_emails_and_usernames",
         [
             (AsyncIterator([]), []),
@@ -3226,30 +3373,6 @@ class TestSharepointOnlineDataSource:
 
         assert _prefix_user_id(user_id) == "user_id:user id"
 
-    def test_is_domain_group(self):
-        assert is_domain_group(
-            {
-                "ContentType": "DomainGroup",
-                "Name": "c:0o.c|federateddirectoryclaimprovider|97d055cf-5cdf-4e5e-b383-f01ed3a8844d",
-            }
-        )
-
-    def test_is_not_domain_group(self):
-        assert not is_domain_group({"ContentType": "Person"})
-        assert not is_domain_group({"ContentType": "DomainGroup"})
-        assert not is_domain_group(
-            {
-                "ContentType": "DomainGroup",
-                "Name": "c:0u.c|tenant|67f8dab3bb7a912bc3da51b94b6bc5d23edef0e83056056f1a3929b4e04b8624",
-            }
-        )
-
-    def test_is_person(self):
-        assert is_person({"ContentType": "Person"})
-
-    def test_is_not_person(self):
-        assert not is_person({"ContentType": "DomainGroup"})
-
     @pytest.mark.parametrize(
         "role_assignment, expected_access_control",
         [
@@ -3268,11 +3391,34 @@ class TestSharepointOnlineDataSource:
                                 "odata.type": "SP.User",
                                 "LoginName": f"i:0#.f|membership|{USER_TWO_EMAIL}",
                                 "UserPrincipalName": None,
+                                "Email": USER_TWO_EMAIL,
                             },
                         ],
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
-                [_prefix_user(USER_ONE_EMAIL), _prefix_user(USER_TWO_EMAIL)],
+                [
+                    _prefix_user(USER_ONE_EMAIL),
+                    _prefix_user(USER_TWO_EMAIL),
+                    _prefix_email(USER_TWO_EMAIL),
+                ],
+            ),
+            (
+                # Group of groups (access control: group Id)
+                {
+                    "Member": {
+                        "odata.type": "SP.Group",
+                        "Users": [
+                            {
+                                "odata.type": "SP.User",
+                                "LoginName": "c:0o.c|federateddirectoryclaimprovider|abc123",
+                                "Title": "Nested Group",
+                            }
+                        ],
+                    },
+                    "RoleDefinitionBindings": READ_BINDING,
+                },
+                [_prefix_group("abc123")],
             ),
             (
                 # User (access control: only principal name)
@@ -3282,6 +3428,7 @@ class TestSharepointOnlineDataSource:
                         "LoginName": None,
                         "UserPrincipalName": USER_ONE_EMAIL,
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
                 [_prefix_user(USER_ONE_EMAIL)],
             ),
@@ -3293,6 +3440,7 @@ class TestSharepointOnlineDataSource:
                         "LoginName": f"i:0#.f|membership|{USER_TWO_EMAIL}",
                         "UserPrincipalName": USER_TWO_NAME,
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
                 [_prefix_user(USER_TWO_EMAIL), _prefix_user(USER_TWO_NAME)],
             ),
@@ -3303,6 +3451,7 @@ class TestSharepointOnlineDataSource:
                         "odata.type": "SP.User",
                         "LoginName": f"c:0o.c|federateddirectoryclaimprovider|{GROUP_ONE_ID}",
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
                 [_prefix_group(GROUP_ONE_ID)],
             ),
@@ -3314,8 +3463,141 @@ class TestSharepointOnlineDataSource:
                         "LoginName": None,
                         "UserPrincipalName": USER_ONE_EMAIL,
                     },
+                    "RoleDefinitionBindings": READ_BINDING,
                 },
                 [],
+            ),
+            (
+                # User with limited access has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": LIMITED_ACCESS_BINDING,
+                },
+                [],
+            ),
+            (
+                # User with web-only limited access has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": WEB_ONLY_BINDING,
+                },
+                [],
+            ),
+            (
+                # User with mixed access
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": READ_BINDING + LIMITED_ACCESS_BINDING,
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
+            ),
+            (
+                # User with empty mask (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"BasePermissions": {"Low": "0"}}],
+                },
+                [],
+            ),
+            (
+                # User with non-read mask (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"BasePermissions": {"Low": "2"}}],
+                },
+                [],
+            ),
+            (
+                # User with view item mask (custom binding)
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"BasePermissions": {"Low": "1"}}],
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
+            ),
+            (
+                # User with view page mask (custom binding)
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"BasePermissions": {"Low": "131072"}}],
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
+            ),
+            (
+                # User with "None" role type (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 0}],
+                },
+                [],
+            ),
+            (
+                # User with "Guest" role type (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 1}],
+                },
+                [],
+            ),
+            (
+                # User with "Restricted Guest" role type (custom binding) has no ACLs
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 9}],
+                },
+                [],
+            ),
+            (
+                # User with "Reader" role type (custom binding)
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 2}],
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
+            ),
+            (
+                # User with "System" role type (custom binding)
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_ONE_EMAIL,
+                    },
+                    "RoleDefinitionBindings": [{"RoleTypeKind": 255}],
+                },
+                [_prefix_user(USER_ONE_EMAIL)],
             ),
         ],
     )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Replace User Information List usage with role assignments for SPO sites (#1688)](https://github.com/elastic/connectors-python/pull/1688)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)