### PR TITLE
Add support for security group prefixes

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1115,6 +1115,7 @@ def _get_login_name(raw_login_name):
     if raw_login_name and (
         raw_login_name.startswith("i:0#.f|membership|")
         or raw_login_name.startswith("c:0o.c|federateddirectoryclaimprovider|")
+        or raw_login_name.startswith("c:0t.c|tenant|")
     ):
         parts = raw_login_name.split("|")
 
@@ -2387,14 +2388,15 @@ class SharepointOnlineDataSource(BaseDataSource):
         # 'LoginName' looking like a group indicates a group
         is_group = (
             login_name.startswith("c:0o.c|federateddirectoryclaimprovider|")
+            or login_name.startswith("c:0t.c|tenant|")
             if login_name
             else False
         )
 
         if is_group:
             self._logger.debug(f"Detected group '{member.get('Title')}'.")
-            dynamic_group_id = _get_login_name(login_name)
-            return [_prefix_group(dynamic_group_id)]
+            group_id = _get_login_name(login_name)
+            return [_prefix_group(group_id)]
         else:
             return self._access_control_for_user(member)
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -3562,6 +3562,7 @@ class TestSharepointOnlineDataSource:
             (f"i:0#.f|membership|{USER_ONE_EMAIL}", USER_ONE_EMAIL),
             (f"membership|{USER_ONE_EMAIL}", None),
             (f"c:0o.c|federateddirectoryclaimprovider|{GROUP_ONE_ID}", GROUP_ONE_ID),
+            (f"c:0t.c|tenant|{GROUP_ONE_ID}", GROUP_ONE_ID),
             (USER_ONE_EMAIL, None),
             ("", None),
             (None, None),


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5958

Ensures that group logins prefixed with `c:0t.c|tenant|` will get picked up

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Fixes a bug where the Sharepoint Online connector did not add ACL entries for Azure Security Groups
