### PR TITLE
Stop nightlies for 8.7 and 8.8

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -86,14 +86,6 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors-python"
       schedules:
-        Daily 8_7:
-          branch: '8.7'
-          cronline: '@daily'
-          message: "Runs daily `8.7` e2e test"
-        Daily 8_8:
-          branch: '8.8'
-          cronline: '@daily'
-          message: "Runs daily `8.8` e2e test"
         Daily 8_9:
           branch: '8.9'
           cronline: '@daily'
@@ -184,14 +176,6 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors-python"
       schedules:
-        Daily 8_7:
-          branch: '8.7'
-          cronline: '@daily'
-          message: "Runs daily `8.7` e2e aarch64 test"
-        Daily 8_8:
-          branch: '8.8'
-          cronline: '@daily'
-          message: "Runs daily `8.8` e2e aarch64 test"
         Daily 8_9:
           branch: '8.9'
           cronline: '@daily'


### PR DESCRIPTION
Minor change - we still run nightly tests for 8.7 and 8.8 branches, but we don't push anything into them. 

Removing nightlies for them - does not make sense to keep running them.