### PR TITLE
[pre-8.10-stable] Truncate branches and leafs in incremental sync (#1731)

### DIFF
--- a/connectors/source.py
+++ b/connectors/source.py
@@ -22,7 +22,9 @@ from connectors.filtering.validation import (
     FilteringValidator,
 )
 from connectors.logger import logger
-from connectors.utils import hash_id
+from connectors.utils import epoch_timestamp_zulu, hash_id
+
+CURSOR_SYNC_TIMESTAMP = "cursor_timestamp"
 
 DEFAULT_CONFIGURATION = {
     "default_value": None,
@@ -639,6 +641,17 @@ class BaseDataSource:
         NOTE modifying license key logic violates the Elastic License 2.0 that this code is licensed under
         """
         return False
+
+    def last_sync_time(self):
+        default_time = epoch_timestamp_zulu()
+        if not self._sync_cursor:
+            return default_time
+        return self._sync_cursor.get(CURSOR_SYNC_TIMESTAMP, default_time)
+
+    def update_sync_timestamp_cursor(self, timestamp):
+        if self._sync_cursor is None:
+            self._sync_cursor = {}
+        self._sync_cursor[CURSOR_SYNC_TIMESTAMP] = timestamp
 
 
 @cache

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -26,7 +26,7 @@ from connectors.filtering.validation import (
     SyncRuleValidationResult,
 )
 from connectors.logger import logger
-from connectors.source import BaseDataSource
+from connectors.source import CURSOR_SYNC_TIMESTAMP, BaseDataSource
 from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     CacheWithTimeout,
@@ -35,6 +35,7 @@ from connectors.utils import (
     convert_to_b64,
     html_to_text,
     iso_utc,
+    iso_zulu,
     iterable_batches_generator,
     retryable,
     url_encode,
@@ -1714,6 +1715,7 @@ class SharepointOnlineDataSource(BaseDataSource):
 
     async def get_docs_incrementally(self, sync_cursor, filtering=None):
         self._sync_cursor = sync_cursor
+        timestamp = iso_zulu()
 
         if not self._sync_cursor:
             raise SyncCursorEmpty(
@@ -1732,6 +1734,7 @@ class SharepointOnlineDataSource(BaseDataSource):
             async for site in self.sites(
                 site_collection["siteCollection"]["hostname"],
                 self.configuration["site_collections"],
+                check_timestamp=True,
             ):
                 (
                     site_access_control,
@@ -1742,7 +1745,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                     site, site_access_control
                 ), None, OP_INDEX
 
-                async for site_drive in self.site_drives(site):
+                async for site_drive in self.site_drives(site, check_timestamp=True):
                     yield self._decorate_with_access_control(
                         site_drive, site_access_control
                     ), None, OP_INDEX
@@ -1782,7 +1785,9 @@ class SharepointOnlineDataSource(BaseDataSource):
                         )
 
                 # Sync site list and site list items
-                async for site_list in self.site_lists(site, site_access_control):
+                async for site_list in self.site_lists(
+                    site, site_access_control, check_timestamp=True
+                ):
                     # Always include site admins in site list access controls
                     site_list = self._decorate_with_access_control(
                         site_list, site_admin_access_control
@@ -1794,6 +1799,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                         site_list_id=site_list["id"],
                         site_list_name=site_list["name"],
                         site_access_control=site_access_control,
+                        check_timestamp=True,
                     ):
                         # Always include site admins in list item access controls
                         list_item = self._decorate_with_access_control(
@@ -1802,12 +1808,16 @@ class SharepointOnlineDataSource(BaseDataSource):
                         yield list_item, download_func, OP_INDEX
 
                 # Sync site pages
-                async for site_page in self.site_pages(site, site_access_control):
+                async for site_page in self.site_pages(
+                    site, site_access_control, check_timestamp=True
+                ):
                     # Always include site admins in site page access controls
                     site_page = self._decorate_with_access_control(
                         site_page, site_admin_access_control
                     )
                     yield site_page, None, OP_INDEX
+
+        self.update_sync_timestamp_cursor(timestamp)
 
     async def site_collections(self):
         async for site_collection in self.client.site_collections():
@@ -1816,24 +1826,32 @@ class SharepointOnlineDataSource(BaseDataSource):
 
             yield site_collection
 
-    async def sites(self, hostname, collections):
+    async def sites(self, hostname, collections, check_timestamp=False):
         async for site in self.client.sites(
             hostname,
             collections,
             enumerate_all_sites=self.configuration["enumerate_all_sites"],
             fetch_subsites=self.configuration["fetch_subsites"],
         ):  # TODO: simplify and eliminate root call
-            site["_id"] = site["id"]
-            site["object_type"] = "site"
+            if not check_timestamp or (
+                check_timestamp
+                and site["lastModifiedDateTime"] >= self.last_sync_time()
+            ):
+                site["_id"] = site["id"]
+                site["object_type"] = "site"
 
-            yield site
+                yield site
 
-    async def site_drives(self, site):
+    async def site_drives(self, site, check_timestamp=False):
         async for site_drive in self.client.site_drives(site["id"]):
-            site_drive["_id"] = site_drive["id"]
-            site_drive["object_type"] = "site_drive"
+            if not check_timestamp or (
+                check_timestamp
+                and site_drive["lastModifiedDateTime"] >= self.last_sync_time()
+            ):
+                site_drive["_id"] = site_drive["id"]
+                site_drive["object_type"] = "site_drive"
 
-            yield site_drive
+                yield site_drive
 
     async def _with_drive_item_permissions(
         self, drive_item, drive_item_permissions, site_web_url
@@ -1952,148 +1970,161 @@ class SharepointOnlineDataSource(BaseDataSource):
                 yield drive_item, self.download_function(drive_item, max_drive_item_age)
 
     async def site_list_items(
-        self, site, site_list_id, site_list_name, site_access_control
+        self,
+        site,
+        site_list_id,
+        site_list_name,
+        site_access_control,
+        check_timestamp=False,
     ):
         site_id = site.get("id")
         site_web_url = site.get("webUrl")
         site_collection = site.get("siteCollection", {}).get("hostname")
         async for list_item in self.client.site_list_items(site_id, site_list_id):
-            # List Item IDs are unique within list.
-            # Therefore we mix in site_list id to it to make sure they are
-            # globally unique.
-            # Also we need to remember original ID because when a document
-            # is yielded, its "id" field is overwritten with content of "_id" field
-            list_item_natural_id = list_item["id"]
-            list_item["_id"] = f"{site_list_id}-{list_item['id']}"
-            list_item["object_type"] = "list_item"
-
-            content_type = list_item["contentType"]["name"]
-
-            if content_type in [
-                "Web Template Extensions",
-                "Client Side Component Manifests",
-            ]:  # TODO: make it more flexible. For now I ignore them cause they 404 all the time
-                continue
-
-            has_unique_role_assignments = False
-
-            if (
-                self._dls_enabled()
-                and self.configuration["fetch_unique_list_item_permissions"]
+            if not check_timestamp or (
+                check_timestamp
+                and list_item["lastModifiedDateTime"] >= self.last_sync_time()
             ):
-                has_unique_role_assignments = (
-                    await self.client.site_list_item_has_unique_role_assignments(
-                        site_web_url, site_list_name, list_item_natural_id
-                    )
-                )
+                # List Item IDs are unique within list.
+                # Therefore we mix in site_list id to it to make sure they are
+                # globally unique.
+                # Also we need to remember original ID because when a document
+                # is yielded, its "id" field is overwritten with content of "_id" field
+                list_item_natural_id = list_item["id"]
+                list_item["_id"] = f"{site_list_id}-{list_item['id']}"
+                list_item["object_type"] = "list_item"
 
-                if has_unique_role_assignments:
-                    self._logger.debug(
-                        f"Fetching unique permissions for list item with id '{list_item_natural_id}'. Ignoring parent site permissions."
-                    )
+                content_type = list_item["contentType"]["name"]
 
-                    list_item_access_control = []
+                if content_type in [
+                    "Web Template Extensions",
+                    "Client Side Component Manifests",
+                ]:  # TODO: make it more flexible. For now I ignore them cause they 404 all the time
+                    continue
 
-                    async for role_assignment in self.client.site_list_item_role_assignments(
-                        site_web_url, site_list_name, list_item_natural_id
-                    ):
-                        list_item_access_control.extend(
-                            await self._get_access_control_from_role_assignment(
-                                role_assignment
-                            )
-                        )
+                has_unique_role_assignments = False
 
-                    list_item = self._decorate_with_access_control(
-                        list_item, list_item_access_control
-                    )
-
-            if not has_unique_role_assignments:
-                list_item = self._decorate_with_access_control(
-                    list_item, site_access_control
-                )
-
-            if "Attachments" in list_item["fields"]:
-                async for list_item_attachment in self.client.site_list_item_attachments(
-                    site_web_url, site_list_name, list_item_natural_id
+                if (
+                    self._dls_enabled()
+                    and self.configuration["fetch_unique_list_item_permissions"]
                 ):
-                    list_item_attachment["_id"] = list_item_attachment["odata.id"]
-                    list_item_attachment["object_type"] = "list_item_attachment"
-                    list_item_attachment["_timestamp"] = list_item[
-                        "lastModifiedDateTime"
-                    ]
-                    list_item_attachment[
-                        "_original_filename"
-                    ] = list_item_attachment.get("FileName", "")
-                    if (
-                        "ServerRelativePath" in list_item_attachment
-                        and "DecodedUrl"
-                        in list_item_attachment.get("ServerRelativePath", {})
-                    ):
-                        list_item_attachment[
-                            "webUrl"
-                        ] = f"https://{site_collection}{list_item_attachment['ServerRelativePath']['DecodedUrl']}"
-                    else:
+                    has_unique_role_assignments = (
+                        await self.client.site_list_item_has_unique_role_assignments(
+                            site_web_url, site_list_name, list_item_natural_id
+                        )
+                    )
+
+                    if has_unique_role_assignments:
                         self._logger.debug(
-                            f"Unable to populate webUrl for list item attachment {list_item_attachment['_id']}"
+                            f"Fetching unique permissions for list item with id '{list_item_natural_id}'. Ignoring parent site permissions."
                         )
 
-                    if self._dls_enabled():
-                        list_item_attachment[ACCESS_CONTROL] = list_item.get(
-                            ACCESS_CONTROL, []
-                        )
+                        list_item_access_control = []
 
-                    attachment_download_func = partial(
-                        self.get_attachment_content, list_item_attachment
-                    )
-                    yield list_item_attachment, attachment_download_func
-
-            yield list_item, None
-
-    async def site_lists(self, site, site_access_control):
-        async for site_list in self.client.site_lists(site["id"]):
-            site_list["_id"] = site_list["id"]
-            site_list["object_type"] = "site_list"
-            site_url = site["webUrl"]
-            site_list_name = site_list["name"]
-
-            has_unique_role_assignments = False
-
-            if (
-                self._dls_enabled()
-                and self.configuration["fetch_unique_list_permissions"]
-            ):
-                has_unique_role_assignments = (
-                    await self.client.site_list_has_unique_role_assignments(
-                        site_url, site_list_name
-                    )
-                )
-
-                if has_unique_role_assignments:
-                    self._logger.debug(
-                        f"Fetching unique list permissions for list with id '{site_list['_id']}'. Ignoring parent site permissions."
-                    )
-
-                    site_list_access_control = []
-
-                    async for role_assignment in self.client.site_list_role_assignments(
-                        site_url, site_list_name
-                    ):
-                        site_list_access_control.extend(
-                            await self._get_access_control_from_role_assignment(
-                                role_assignment
+                        async for role_assignment in self.client.site_list_item_role_assignments(
+                            site_web_url, site_list_name, list_item_natural_id
+                        ):
+                            list_item_access_control.extend(
+                                await self._get_access_control_from_role_assignment(
+                                    role_assignment
+                                )
                             )
+
+                        list_item = self._decorate_with_access_control(
+                            list_item, list_item_access_control
                         )
 
-                    site_list = self._decorate_with_access_control(
-                        site_list, site_list_access_control
+                if not has_unique_role_assignments:
+                    list_item = self._decorate_with_access_control(
+                        list_item, site_access_control
                     )
 
-            if not has_unique_role_assignments:
-                site_list = self._decorate_with_access_control(
-                    site_list, site_access_control
-                )
+                if "Attachments" in list_item["fields"]:
+                    async for list_item_attachment in self.client.site_list_item_attachments(
+                        site_web_url, site_list_name, list_item_natural_id
+                    ):
+                        list_item_attachment["_id"] = list_item_attachment["odata.id"]
+                        list_item_attachment["object_type"] = "list_item_attachment"
+                        list_item_attachment["_timestamp"] = list_item[
+                            "lastModifiedDateTime"
+                        ]
+                        list_item_attachment[
+                            "_original_filename"
+                        ] = list_item_attachment.get("FileName", "")
+                        if (
+                            "ServerRelativePath" in list_item_attachment
+                            and "DecodedUrl"
+                            in list_item_attachment.get("ServerRelativePath", {})
+                        ):
+                            list_item_attachment[
+                                "webUrl"
+                            ] = f"https://{site_collection}{list_item_attachment['ServerRelativePath']['DecodedUrl']}"
+                        else:
+                            self._logger.debug(
+                                f"Unable to populate webUrl for list item attachment {list_item_attachment['_id']}"
+                            )
 
-            yield site_list
+                        if self._dls_enabled():
+                            list_item_attachment[ACCESS_CONTROL] = list_item.get(
+                                ACCESS_CONTROL, []
+                            )
+
+                        attachment_download_func = partial(
+                            self.get_attachment_content, list_item_attachment
+                        )
+                        yield list_item_attachment, attachment_download_func
+
+                yield list_item, None
+
+    async def site_lists(self, site, site_access_control, check_timestamp=False):
+        async for site_list in self.client.site_lists(site["id"]):
+            if not check_timestamp or (
+                check_timestamp
+                and site_list["lastModifiedDateTime"] >= self.last_sync_time()
+            ):
+                site_list["_id"] = site_list["id"]
+                site_list["object_type"] = "site_list"
+                site_url = site["webUrl"]
+                site_list_name = site_list["name"]
+
+                has_unique_role_assignments = False
+
+                if (
+                    self._dls_enabled()
+                    and self.configuration["fetch_unique_list_permissions"]
+                ):
+                    has_unique_role_assignments = (
+                        await self.client.site_list_has_unique_role_assignments(
+                            site_url, site_list_name
+                        )
+                    )
+
+                    if has_unique_role_assignments:
+                        self._logger.debug(
+                            f"Fetching unique list permissions for list with id '{site_list['_id']}'. Ignoring parent site permissions."
+                        )
+
+                        site_list_access_control = []
+
+                        async for role_assignment in self.client.site_list_role_assignments(
+                            site_url, site_list_name
+                        ):
+                            site_list_access_control.extend(
+                                await self._get_access_control_from_role_assignment(
+                                    role_assignment
+                                )
+                            )
+
+                        site_list = self._decorate_with_access_control(
+                            site_list, site_list_access_control
+                        )
+
+                if not has_unique_role_assignments:
+                    site_list = self._decorate_with_access_control(
+                        site_list, site_access_control
+                    )
+
+                yield site_list
 
     async def _get_access_control_from_role_assignment(self, role_assignment):
         """Extracts access control from a role assignment.
@@ -2160,68 +2191,78 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         return access_control
 
-    async def site_pages(self, site, site_access_control):
+    async def site_pages(self, site, site_access_control, check_timestamp=False):
         site_id = site["id"]
         url = site["webUrl"]
         async for site_page in self.client.site_pages(url):
-            # site page object has multiple ids:
-            # - Id - not globally unique, just an increment, e.g. 1, 2, 3, 4
-            # - GUID - not globally unique, though it's a real guid
-            # - odata.id - not even sure what this id is
-            # Therefore, we generate id combining unique site id with site page id that is unique within this site
-            # Careful with format - changing other ids can overlap with this one if they follow the format of:
-            # {site_id}-{some_name_or_string_id}-{autoincremented_id}
-            site_page["_id"] = f"{site_id}-site_page-{site_page['Id']}"
-            site_page["object_type"] = "site_page"
-
-            has_unique_role_assignments = False
-
-            # ignore parent site permissions and use unique per page permissions ("unique permissions" means breaking the inheritance to the parent site)
-            if (
-                self._dls_enabled()
-                and self.configuration["fetch_unique_page_permissions"]
+            if not check_timestamp or (
+                check_timestamp and site_page["Modified"] >= self.last_sync_time()
             ):
-                has_unique_role_assignments = (
-                    await self.client.site_page_has_unique_role_assignments(
-                        url, site_page["Id"]
+                # site page object has multiple ids:
+                # - Id - not globally unique, just an increment, e.g. 1, 2, 3, 4
+                # - GUID - not globally unique, though it's a real guid
+                # - odata.id - not even sure what this id is
+                # Therefore, we generate id combining unique site id with site page id that is unique within this site
+                # Careful with format - changing other ids can overlap with this one if they follow the format of:
+                # {site_id}-{some_name_or_string_id}-{autoincremented_id}
+                site_page["_id"] = f"{site_id}-site_page-{site_page['Id']}"
+                site_page["object_type"] = "site_page"
+
+                has_unique_role_assignments = False
+
+                # ignore parent site permissions and use unique per page permissions ("unique permissions" means breaking the inheritance to the parent site)
+                if (
+                    self._dls_enabled()
+                    and self.configuration["fetch_unique_page_permissions"]
+                ):
+                    has_unique_role_assignments = (
+                        await self.client.site_page_has_unique_role_assignments(
+                            url, site_page["Id"]
+                        )
                     )
-                )
 
-                if has_unique_role_assignments:
-                    self._logger.debug(
-                        f"Fetching unique page permissions for page with id '{site_page['_id']}'. Ignoring parent site permissions."
-                    )
-
-                    page_access_control = []
-
-                    async for role_assignment in self.client.site_page_role_assignments(
-                        url, site_page["Id"]
-                    ):
-                        page_access_control.extend(
-                            await self._get_access_control_from_role_assignment(
-                                role_assignment
-                            )
+                    if has_unique_role_assignments:
+                        self._logger.debug(
+                            f"Fetching unique page permissions for page with id '{site_page['_id']}'. Ignoring parent site permissions."
                         )
 
+                        page_access_control = []
+
+                        async for role_assignment in self.client.site_page_role_assignments(
+                            url, site_page["Id"]
+                        ):
+                            page_access_control.extend(
+                                await self._get_access_control_from_role_assignment(
+                                    role_assignment
+                                )
+                            )
+
+                        site_page = self._decorate_with_access_control(
+                            site_page, page_access_control
+                        )
+
+                # set parent site access control
+                if not has_unique_role_assignments:
                     site_page = self._decorate_with_access_control(
-                        site_page, page_access_control
+                        site_page, site_access_control
                     )
 
-            # set parent site access control
-            if not has_unique_role_assignments:
-                site_page = self._decorate_with_access_control(
-                    site_page, site_access_control
-                )
+                for html_field in [
+                    "LayoutWebpartsContent",
+                    "CanvasContent1",
+                    "WikiField",
+                ]:
+                    if html_field in site_page:
+                        site_page[html_field] = html_to_text(site_page[html_field])
 
-            for html_field in ["LayoutWebpartsContent", "CanvasContent1", "WikiField"]:
-                if html_field in site_page:
-                    site_page[html_field] = html_to_text(site_page[html_field])
-
-            yield site_page
+                yield site_page
 
     def init_sync_cursor(self):
         if not self._sync_cursor:
-            self._sync_cursor = {CURSOR_SITE_DRIVE_KEY: {}}
+            self._sync_cursor = {
+                CURSOR_SITE_DRIVE_KEY: {},
+                CURSOR_SYNC_TIMESTAMP: iso_zulu(),
+            }
 
         return self._sync_cursor
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -17,6 +17,7 @@ import time
 import urllib.parse
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from time import strftime
 
 import aiofiles
 import aiohttp
@@ -70,11 +71,23 @@ TIKA_SUPPORTED_FILETYPES = [
     ".vsdm",
 ]
 
+ISO_ZULU_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
 
 def iso_utc(when=None):
     if when is None:
         when = datetime.now(timezone.utc)
     return when.isoformat()
+
+
+def iso_zulu():
+    """Returns the current time in ISO Zulu format"""
+    return datetime.now(timezone.utc).strftime(ISO_ZULU_TIMESTAMP_FORMAT)
+
+
+def epoch_timestamp_zulu():
+    """Returns the timestamp of the start of the epoch, in ISO Zulu format"""
+    return strftime(ISO_ZULU_TIMESTAMP_FORMAT, time.gmtime(0))
 
 
 def next_run(quartz_definition):

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -15,6 +15,7 @@ import aiohttp
 import pytest
 import pytest_asyncio
 from aiohttp.client_exceptions import ClientPayloadError, ClientResponseError
+from freezegun import freeze_time
 
 from connectors.logger import logger
 from connectors.protocol import Features
@@ -48,6 +49,7 @@ from connectors.sources.sharepoint_online import (
     _prefix_user,
     _prefix_user_id,
 )
+from connectors.utils import iso_utc
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
 
@@ -1824,12 +1826,26 @@ class TestSharepointOnlineAdvancedRulesValidator:
 
 class TestSharepointOnlineDataSource:
     @property
-    def month_ago(self):
-        return datetime.now(timezone.utc) - timedelta(days=30)
+    def today(self):
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     @property
     def day_ago(self):
-        return datetime.now(timezone.utc) - timedelta(days=1)
+        return (datetime.now(timezone.utc) - timedelta(days=1)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+    @property
+    def month_ago(self):
+        return (datetime.now(timezone.utc) - timedelta(days=30)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+    @property
+    def two_months_ago(selfself):
+        return (datetime.now(timezone.utc) - timedelta(days=60)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
 
     @property
     def site_collections(self):
@@ -1837,6 +1853,7 @@ class TestSharepointOnlineDataSource:
             {
                 "siteCollection": {"hostname": "test.sharepoint.com"},
                 "webUrl": "https://test.sharepoint.com",
+                "lastModifiedDateTime": self.day_ago,
             }
         ]
 
@@ -1848,12 +1865,13 @@ class TestSharepointOnlineDataSource:
                 "webUrl": "https://test.sharepoint.com/sites/site_1",
                 "name": "site-1",
                 "siteCollection": self.site_collections[0]["siteCollection"],
+                "lastModifiedDateTime": self.day_ago,
             }
         ]
 
     @property
     def site_drives(self):
-        return [{"id": "2"}]
+        return [{"id": "2", "lastModifiedDateTime": self.day_ago}]
 
     @property
     def drive_items(self):
@@ -1877,7 +1895,13 @@ class TestSharepointOnlineDataSource:
 
     @property
     def site_lists(self):
-        return [{"id": SITE_LIST_ONE_ID, "name": SITE_LIST_ONE_NAME}]
+        return [
+            {
+                "id": SITE_LIST_ONE_ID,
+                "name": SITE_LIST_ONE_NAME,
+                "lastModifiedDateTime": self.day_ago,
+            }
+        ]
 
     @property
     def site_list_has_unique_role_assignments(self):
@@ -1896,11 +1920,13 @@ class TestSharepointOnlineDataSource:
                 "id": "7",
                 "contentType": {"name": "Web Template Extensions"},
                 "fields": {},
+                "lastModifiedDateTime": self.day_ago,
             },  # Will be ignored!!!
             {
                 "id": "8",
                 "contentType": {"name": "Something without attachments"},
                 "fields": {},
+                "lastModifiedDateTime": self.two_months_ago,
             },
         ]
 
@@ -1913,7 +1939,14 @@ class TestSharepointOnlineDataSource:
 
     @property
     def site_pages(self):
-        return [{"Id": "4", "odata.id": "11", "GUID": "thats-not-a-guid"}]
+        return [
+            {
+                "Id": "4",
+                "odata.id": "11",
+                "GUID": "thats-not-a-guid",
+                "Modified": "2023-10-04T08:58:33Z",
+            }
+        ]
 
     @property
     def site_role_assignments(self):
@@ -2165,6 +2198,7 @@ class TestSharepointOnlineDataSource:
         "connectors.sources.sharepoint_online.ACCESS_CONTROL",
         ALLOW_ACCESS_CONTROL_PATCHED,
     )
+    @freeze_time(iso_utc())
     async def test_get_docs_with_access_control(self, patch_sharepoint_client):
         group = "group"
         email = "email"
@@ -2275,6 +2309,8 @@ class TestSharepointOnlineDataSource:
             ]
         )
 
+        assert source.sync_cursor()["cursor_timestamp"] == self.today
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize("sync_cursor", [None, {}])
     async def test_get_docs_incrementally_with_empty_cursor(
@@ -2289,6 +2325,7 @@ class TestSharepointOnlineDataSource:
                 pass
 
     @pytest.mark.asyncio
+    @freeze_time(iso_utc())
     async def test_get_docs_incrementally(self, patch_sharepoint_client):
         source = create_source(SharepointOnlineDataSource)
         source._site_access_control = AsyncMock(return_value=([], []))
@@ -2296,7 +2333,7 @@ class TestSharepointOnlineDataSource:
         # mock cache lookup
         source.site_group_users = AsyncMock(return_value=self.site_group_users)
 
-        sync_cursor = {"site_drives": {}}
+        sync_cursor = {"site_drives": {}, "cursor_timestamp": self.month_ago}
         for site_drive in self.site_drives:
             sync_cursor["site_drives"][
                 site_drive["id"]
@@ -2327,10 +2364,11 @@ class TestSharepointOnlineDataSource:
                 len(self.site_drives),
                 len(self.site_pages),
                 len(self.site_lists),
-                len(self.site_list_items),
+                len(self.site_list_items) - 1,  # one is too old
                 len(self.site_list_item_attachments),
             ]
         )
+        assert sync_cursor["cursor_timestamp"] == self.today  # cursor was updated
 
         assert (operations["delete"]) == deleted
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `pre-8.10-stable`:
 - [Truncate branches and leafs in incremental sync (#1731)](https://github.com/elastic/connectors-python/pull/1731)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)