### PR TITLE
fetch site admins separate from role assignments

### DIFF
--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2010,7 +2010,7 @@ class TestSharepointOnlineDataSource:
             },
             {
                 "LoginName": "c:0t.c|tenant|78b2fb13-4ef2-4132-96c6-84c1a58e2bdf",
-            }
+            },
         ]
 
     @property

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2002,6 +2002,18 @@ class TestSharepointOnlineDataSource:
         ]
 
     @property
+    def site_admins(self):
+        return [
+            {
+                "LoginName": "c:0o.c|federateddirectoryclaimprovider|97d055cf-5cdf-4e5e-b383-f01ed3a8844d_o",
+                "Email": "Sean'sTeamSite@enterprisesearch.onmicrosoft.com",
+            },
+            {
+                "LoginName": "c:0t.c|tenant|78b2fb13-4ef2-4132-96c6-84c1a58e2bdf",
+            }
+        ]
+
+    @property
     def group_members(self):
         return [
             {
@@ -2115,6 +2127,7 @@ class TestSharepointOnlineDataSource:
             client.sites = AsyncIterator(self.sites)
             client.site_group_users = AsyncIterator(self.site_group_users)
             client.site_role_assignments = AsyncIterator(self.site_role_assignments)
+            client.site_admins = AsyncIterator(self.site_admins)
             client.group = AsyncMock(return_value=self.group)
             client.group_members = AsyncIterator(self.group_members)
             client.group_owners = AsyncIterator(self.group_owners)


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1715

This fetches site collection admins with a `GET /_api/web/SiteUsers?$filter=isSiteAdmin eq true`, and appends the results to the ACLS fetched from role assignments that had `isSiteAdmin: true`. This ensures that _all_ the site admins, not just the ones in the site's "Owners" group, get stored and granted access through DLS.

Additionally, this PR ensures that `_o`-suffixed group IDS get expanded into the _owners_ of the group. This happens when a site's "members" includes a group, that group's owners automatically get added to the site's "owners" group.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
  - needs confirmation from stakeholders that it does or does not need backporting.



## Release Note

Ensures that all Site Collection Administrators are present in Site, Site Page, Site List, Site List Item, and Drive Item access control lists for Document Level Security on the Sharepoint Online connector.
