### PR TITLE
Make test_next_run deterministic

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,9 +52,8 @@ from connectors.utils import (
 )
 
 
-@freeze_time("2023-01-18 17:18:56.814003", tick=True)
 def test_next_run():
-    now = datetime.utcnow()
+    now = datetime(2023, 1, 18, 17, 18, 56, 814)
     # can run within two minutes
     assert (
         next_run("1 * * * * *", now).isoformat(" ", "seconds") == "2023-01-18 17:19:01"


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1210

Since test_next_run is now deterministic, then `test_next_run` can be deterministic too - therefore instead of freezing time and calling `datetime.utcnow` we create datetime statically and pass it into `next_run` method.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)