### PR TITLE
Make test_mem_queue less flaky

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -185,8 +185,8 @@ async def test_mem_queue():
         await queue.get()  # removes the 2kb
         assert not queue.full()
 
-    await asyncio.gather(remove_data(), add_data())
-    assert when[1] - when[0] > 0.1
+    await asyncio.gather(add_data(), remove_data())
+    assert when[1] - when[0] < queue.refresh_timeout
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -151,6 +151,10 @@ async def test_mem_queue_race():
 
 @pytest.mark.asyncio
 async def test_mem_queue():
+    # Initial timeout is really small so that the test is fast.
+    # The part of the test before timeout increase will take at least refresh_timeout
+    # seconds to execute, so if timeout is 60 seconds, then it'll take 60+ seconds.
+    # Thus we make timeout small and increase it later
     queue = MemQueue(maxmemsize=1024, refresh_interval=0, refresh_timeout=0.15)
     await queue.put("small stuff")
 
@@ -163,6 +167,8 @@ async def test_mem_queue():
         while True:
             await queue.put("x" * 100)
 
+    # We increase the timeout to not be so flaky
+    queue.refresh_timeout = 2
     when = []
 
     async def add_data():


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1277

Several things:

1. Initial timeout is a little too small as sometimes event loop hicks up and takes more than 0.1 second to remove something from the queue (which is weird). I increase timeout to 2 seconds after we've made queue full
2. Last assert is flaky by design - there are no good guarantees about it since we don't run both add_data and remove_data immediately - they're ran on event loop, so if something slows down, then one function can start later than the other (add_data will start with a lag of 0.05 second and will fail the test, for example). I've changed this assert to just check, that the data is added into the queue within refresh_timeout

All in all this test is hard to make non-flaky and might make sense to break it into individual tests.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)