### PR TITLE
[8.12] Remove automatically deleting indices for orphaned jobs (#2038)

### DIFF
--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -69,9 +69,6 @@ class JobCleanUpService(BaseService):
                 logger.debug("No orphaned jobs found, skipping cleaning")
                 return
 
-            # delete content indices in case they are re-created by sync job
-            if len(content_indices) > 0:
-                await self.sync_job_index.delete_indices(indices=list(content_indices))
             result = await self.sync_job_index.delete_jobs(job_ids=job_ids)
             if len(result["failures"]) > 0:
                 logger.error(f"Error found when deleting jobs: {result['failures']}")

--- a/tests/services/test_job_cleanup.py
+++ b/tests/services/test_job_cleanup.py
@@ -47,7 +47,6 @@ def mock_sync_job(sync_job_id="1", connector_id="1", index_name="index_name"):
 
 @pytest.mark.asyncio
 @patch("connectors.protocol.SyncJobIndex.delete_jobs")
-@patch("connectors.protocol.SyncJobIndex.delete_indices")
 @patch("connectors.protocol.SyncJobIndex.idle_jobs")
 @patch("connectors.protocol.SyncJobIndex.orphaned_jobs")
 @patch("connectors.protocol.ConnectorIndex.fetch_by_id")
@@ -59,7 +58,6 @@ async def test_cleanup_jobs(
     connector_fetch_by_id,
     orphaned_jobs,
     idle_jobs,
-    delete_indices,
     delete_jobs,
 ):
     existing_index_name = "foo"
@@ -77,7 +75,6 @@ async def test_cleanup_jobs(
 
     await create_and_run_service(JobCleanUpService, config=CONFIG, stop_after=0.1)
 
-    delete_indices.assert_called_with(indices=[to_be_deleted_index_name])
     delete_jobs.assert_called_with(job_ids=[sync_job.id, another_sync_job.id])
     sync_job.fail.assert_called_with(IDLE_JOB_ERROR)
     connector.sync_done.assert_called_with(job=sync_job)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [Remove automatically deleting indices for orphaned jobs (#2038)](https://github.com/elastic/connectors/pull/2038)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)