### PR TITLE
[Bugfix] Throw DocumentNotFoundError if index doesnt exist when looking for doc by id

### DIFF
--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -217,18 +217,18 @@ class ESIndex(ESClient):
         return self._create_object(resp_body)
 
     async def fetch_response_by_id(self, doc_id):
-        if not self.serverless:
-            await self._retrier.execute_with_retry(
-                partial(self.client.indices.refresh, index=self.index_name)
-            )
-
         try:
+            if not self.serverless:
+                await self._retrier.execute_with_retry(
+                    partial(self.client.indices.refresh, index=self.index_name)
+                )
+
             resp = await self._retrier.execute_with_retry(
                 partial(self.client.get, index=self.index_name, id=doc_id)
             )
         except ApiError as e:
-            logger.critical(f"The server returned {e.status_code}")
-            logger.critical(e.body, exc_info=True)
+            logger.error(f"The server returned {e.status_code}")
+            logger.error(e.body, exc_info=True)
             if e.status_code == 404:
                 msg = f"Couldn't find document in {self.index_name} by id {doc_id}"
                 raise DocumentNotFoundError(msg) from e


### PR DESCRIPTION
## Changes

`NotFoundError` -> `DocumentNotFoundError` (consistent with the rest of framework)

The index refresh operation should be wrapped in a `try/catch` block. Otherwise, if we’re searching for a document in an index that doesn’t exist yet, it throws a `NotFoundError` instead of a `DocumentNotFoundError`. In my opinion, if the document doesn’t exist because the underlying index is missing, we should still return a `DocumentNotFoundError`. This also simplifies the caller logic, as we only need to handle a single exception type.

Update logs from `critical` to `error`. In my opinion, the `critical` log level should be reserved for cases that cause the entire framework to fail. In most, if not all, of these cases, we either retry or have some graceful handling, so it’s appropriate to log them at just the `error` level.