### PR TITLE
Add support for DatetimeMS in MongoDB

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from tempfile import NamedTemporaryFile
 
 import fastjsonschema
-from bson import OLD_UUID_SUBTYPE, Binary, DBRef, Decimal128, ObjectId
+from bson import OLD_UUID_SUBTYPE, Binary, CodecOptions, DBRef, DatetimeConversion, DatetimeMS, Decimal128, ObjectId
 from bson.binary import UUID_SUBTYPE
 from fastjsonschema import JsonSchemaValueException
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -177,6 +177,8 @@ class MongoDataSource(BaseDataSource):
         try:
             client_params = {}
 
+            client_params["datetime_conversion"] = DatetimeConversion.DATETIME_AUTO
+
             if self.configuration["direct_connection"]:
                 client_params["directConnection"] = True
 
@@ -242,6 +244,8 @@ class MongoDataSource(BaseDataSource):
                 value = value.to_decimal()
             elif isinstance(value, DBRef):
                 value = _serialize(value.as_doc().to_dict())
+            elif isinstance(value, DatetimeMS):
+                value = value._value
             elif isinstance(value, Binary):
                 # UUID_SUBTYPE is guaranteed to properly be serialized cross-platform and cross-driver
                 if value.subtype == UUID_SUBTYPE:

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -11,7 +11,15 @@ from datetime import datetime
 from tempfile import NamedTemporaryFile
 
 import fastjsonschema
-from bson import OLD_UUID_SUBTYPE, Binary, CodecOptions, DBRef, DatetimeConversion, DatetimeMS, Decimal128, ObjectId
+from bson import (
+    OLD_UUID_SUBTYPE,
+    Binary,
+    DatetimeConversion,
+    DatetimeMS,
+    DBRef,
+    Decimal128,
+    ObjectId,
+)
 from bson.binary import UUID_SUBTYPE
 from fastjsonschema import JsonSchemaValueException
 from motor.motor_asyncio import AsyncIOMotorClient

--- a/tests/sources/fixtures/mongodb/fixture.py
+++ b/tests/sources/fixtures/mongodb/fixture.py
@@ -17,7 +17,7 @@ NUMBER_OF_RECORDS_TO_DELETE = 50
 
 fake = Faker()
 client = MongoClient(
-    "mongodb://admin:justtesting@127.0.0.1:27021?uuidRepresentation=standard"
+    "mongodb://admin:justtesting@127.0.0.1:27021?uuidRepresentation=standard", datetime_conversion=bson.DatetimeConversion.DATETIME_AUTO
 )
 
 
@@ -31,6 +31,9 @@ async def load():
             "time": fake.time(),
             "comment": fake.sentence(),
             "unique_id": uuid4(),
+            "some_large_datetime": bson.DatetimeMS(2**62),
+            "some_small_datetime": bson.DatetimeMS(-(2**62)),
+            "some_zero_datetime": bson.DatetimeMS(0),
         }
 
     record_number = _SIZES[DATA_SIZE] + NUMBER_OF_RECORDS_TO_DELETE

--- a/tests/sources/fixtures/mongodb/fixture.py
+++ b/tests/sources/fixtures/mongodb/fixture.py
@@ -17,7 +17,8 @@ NUMBER_OF_RECORDS_TO_DELETE = 50
 
 fake = Faker()
 client = MongoClient(
-    "mongodb://admin:justtesting@127.0.0.1:27021?uuidRepresentation=standard", datetime_conversion=bson.DatetimeConversion.DATETIME_AUTO
+    "mongodb://admin:justtesting@127.0.0.1:27021?uuidRepresentation=standard",
+    datetime_conversion=bson.DatetimeConversion.DATETIME_AUTO,
 )
 
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3444

This PR adds support for `datetime` values that cannot be handled by python.

Before this change instances of `datetime` that are outside of `[datetime.min; datetime.max]` range will raise an error:

```
year 643385 is out of range (Consider Using CodecOptions(datetime_conversion=DATETIME_AUTO) or MongoClient(datetime_conversion='DATETIME_AUTO')). See: https://pymongo.readthedocs.io/en/stable/examples/datetimes.html#handling-out-of-range-datetimes
```

This PR makes use of `DatetimeConversion.DATETIME_AUTO` conversion setting.

In practice it will mean that:

- `datetime` objects that can be Python datetimes will be parsed as such and sent to Elasticsearch as datetimes
- If driver cannot parse the object as Python `datetime` it will be serlaised as a `long`

This, though, can be problematic due to internal Elasticsearch type conversion (something that is already a problem with MongoDB connector to some extent):

Elasticsearch allows conversion of  `long` to `datetime`, but does not allow the opposite.

Demonstration:

```
PUT connector-mongodb-f1e8/_doc/zdO8fZcBkReHFeyYyxGV
{
    "address": """3821 Jennifer Key
Victoriaville, MD 12105""",
    "birthdate": "1976-11-08",
    "unique_id": "46292e6c-5227-4715-879c-1932ccae9062",
    "some_small_datetime": -4611686018427388000, # this field is a long
    "some_zero_datetime": "1970-01-01T00:00:00", # this field is a datetime
    "name": "Earl Phillips",
    "comment": "Four tax per.",
    "id": "6851474d557891815b63f1e3",
    "time": "12:23:15",
    "some_large_datetime": 4611686018427388000,
    "fun_field": 4611686018427388000
}

OK

{
    "address": """3821 Jennifer Key
Victoriaville, MD 12105""",
    "birthdate": "1976-11-08",
    "unique_id": "46292e6c-5227-4715-879c-1932ccae9062",
    "some_small_datetime": -4611686018427388000, # this field is a long
    "some_zero_datetime": -4611686018427388000, # this field is a datetime
    "name": "Earl Phillips",
    "comment": "Four tax per.",
    "id": "6851474d557891815b63f1e3",
    "time": "12:23:15",
    "some_large_datetime": 4611686018427388000,
    "fun_field": 4611686018427388000
}

OK


{
    "address": """3821 Jennifer Key
Victoriaville, MD 12105""",
    "birthdate": "1976-11-08",
    "unique_id": "46292e6c-5227-4715-879c-1932ccae9062",
    "some_small_datetime": "1970-01-01T00:00:00", # this field is a long
    "some_zero_datetime": -4611686018427388000, # this field is a datetime
    "name": "Earl Phillips",
    "comment": "Four tax per.",
    "id": "6851474d557891815b63f1e3",
    "time": "12:23:15",
    "some_large_datetime": 4611686018427388000,
    "fun_field": 4611686018427388000
}

[1:175] failed to parse field [some_small_datetime] of type [long] in document with id 'zdO8fZcBkReHFeyYyxGV'. Preview of field's value: '1970-01-01T00:00:00'
```

In practice it means that if a field in MongoDB collection contains both valid and invalid datetimes (from python's perspective) then the ingestion might fail depending on order of insertion, because the mapping are dynamic.

For example, if first record will contain an out-of-range datetime, then the field will be inferred as `long`, and next time a in-range datetime is met the ingestion will fail, because instances of `datetime` cannot be converted to `long` in Elasticsearch.

The way to fix it would be to manually define the mapping for the index, which is imperfect.

Alternative solution would be introduction of a flag in MongoDB connector configuration that exposes `datetime_conversion` option. Additionally we can have a flag that will be "treat datetimes as longs" if needed, but it looks like an overkill.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

## Release Note

MongoDB connector: set default `datetime_conversion` to `DatetimeConversion.DATETIME_AUTO` to try to prevent errors when receiving out-of-range `datetime` values from MongoDB. See https://www.mongodb.com/docs/languages/python/pymongo-driver/current/data-formats/dates-and-times/#handling-out-of-range-datetimes for additional information.