### PR TITLE
fix: Update Docker tarball URLs after ES change

### DIFF
--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -91,10 +91,10 @@ fi
 # Select the appropriate Docker tarball name based on architecture
 case $ARCH in
   x86_64)
-    DOCKER_TARBALL_NAME="elasticsearch-$VERSION-docker-image.tar.gz"
+    DOCKER_TARBALL_NAME="elasticsearch-$VERSION-docker-image-amd64.tar.gz"
     ;;
   aarch64)
-    DOCKER_TARBALL_NAME="elasticsearch-$VERSION-docker-image-aarch64.tar.gz"
+    DOCKER_TARBALL_NAME="elasticsearch-$VERSION-docker-image-arm64.tar.gz"
     ;;
   *)
     echo "Error: Unsupported architecture $ARCH"


### PR DESCRIPTION
## Context

After [recent changes](https://github.com/elastic/elasticsearch/pull/130643/files) in elasticsearch the architecture used is `arm64` rather than `aarch64`, except for the image tag itself. This change updates the tests setup to reflect the new format.

Without it, the tests fail with the message `'Error: Docker tarball URL not found in the manifest.'`

Example: [Buildkite](https://buildkite.com/elastic/connectors/builds/18602#019838b7-8972-4c83-85ba-b0786cdc1d1c)

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
   - [x] This will need to backported as changes are made in `elasticsearch` for other versions. They are currently unmerged.

