### PR TITLE
Handle "Everyone Except External Users" group

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -2628,8 +2628,20 @@ class SharepointOnlineDataSource(BaseDataSource):
         a reference to a group's owners, or an individual, and will act accordingly.
         :param member: The dict representing a generic SPO entity. May be a group or an individual
         :return: the access control list (ACL) for this "member"
+
+        Detect when a member has the login name: c:0-.f|rolemanager|spo-grid-all-users.
+        Map it to a standard identifier in _allow_access_control.
         """
         login_name = member.get("LoginName")
+
+        # Handle "Everyone Except External Users" group
+        if login_name and login_name.startswith(
+            "c:0-.f|rolemanager|spo-grid-all-users"
+        ):
+            self._logger.debug(
+                f"Detected 'Everyone Except External Users' group: '{member.get('Title')}'."
+            )
+            return ["group:EveryoneExceptExternalUsers"]
 
         # 'LoginName' looking like a group indicates a group
         is_group = (

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -3673,6 +3673,18 @@ class TestSharepointOnlineDataSource:
                 [_prefix_group(GROUP_ONE_ID)],
             ),
             (
+                # Everyone Except External Users group (access control: mapped group identifier)
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "LoginName": "c:0-.f|rolemanager|spo-grid-all-users",
+                        "Title": "Everyone except external users",
+                    },
+                    "RoleDefinitionBindings": READ_BINDING,
+                },
+                ["group:EveryoneExceptExternalUsers"],
+            ),
+            (
                 # Unknown type (access control: nothing)
                 {
                     "Member": {


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/###

Background
Currently, the SharePoint connector does not properly process files and folders that are shared with the "Everyone Except External Users" group. This group has a unique loginName format:c:0-.f|rolemanager|spo-grid-all-users

This login name is not recognized by the _access_control_for_member() function, which currently only supports:

c:0o.c|federateddirectoryclaimprovider|
c:0t.c|tenant|
As a result, these permissions are skipped, and the _access_control_list field remains incomplete, causing the documents to miss appropriate access metadata.

Problem
Documents or folders with permissions granted to the "Everyone Except External Users" group are being ignored by the connector, leading to inaccurate access control metadata.

Task
Modify the SharePoint connector to correctly process and include the "Everyone Except External Users" group when encountered.

Required Changes
Detect when a member has the login name: c:0-.f|rolemanager|spo-grid-all-users
Map it to a standard identifier in _allow_access_control, for example: group:EveryoneExceptExternalUsers
Update the logic in the async def _access_control_for_member(self, member): function to support this case.

Acceptance Criteria
The connector must:
Recognize the spo-grid-all-users login name.
Add the mapped identifier (group:EveryoneExceptExternalUsers) to the _allow_access_control field in the document metadata.
Ensure existing logic for federated and tenant groups is unaffected.

#### Pre-Review Checklist
- [ ] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [ ] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [ ] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
