### PR TITLE
[8.17] Handle KeyError in the ES sink.py (#3629)

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -299,7 +299,12 @@ class Sink:
             for op, data in item.items():
                 # "result" is only present in successful operations
                 if "result" not in data:
-                    del stats[op][data["_id"]]
+                    if data["_id"] in stats[op]:
+                        del stats[op][data["_id"]]
+                    else:
+                        self._logger.debug(
+                            f"Document {data['_id']} not in stats for operation: {op}"
+                        )
 
         self.counters.increment(
             INDEXED_DOCUMENT_COUNT, len(stats[OP_INDEX]) + len(stats[OP_UPDATE])


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Handle KeyError in the ES sink.py (#3629)](https://github.com/elastic/connectors/pull/3629)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)