### PR TITLE
[8.19] Add some code coverage for SPO connector to be able to backport/merge stuff again (#3795)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 MarkupSafe
 3.0.3
-UNKNOWN
+BSD-3-Clause
 Copyright 2010 Pallets
 
 Redistribution and use in source and binary forms, with or without
@@ -91,8 +91,8 @@ SOFTWARE.
 
 
 PyMySQL
-1.1.1
-MIT License
+1.1.2
+MIT
 Copyright (c) 2010, 2013 PyMySQL contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -1603,7 +1603,7 @@ Apache License
 
 anyio
 4.11.0
-UNKNOWN
+MIT
 The MIT License (MIT)
 
 Copyright (c) 2018 Alex Grönholm
@@ -1854,8 +1854,8 @@ Copyright (C) 2016-present the asyncpg authors and contributors.
 
 
 attrs
-25.3.0
-UNKNOWN
+25.4.0
+MIT
 The MIT License (MIT)
 
 Copyright (c) 2015 Hynek Schlawack and the attrs contributors
@@ -1880,7 +1880,7 @@ SOFTWARE.
 
 
 azure-core
-1.35.1
+1.36.0
 MIT License
 Copyright (c) Microsoft Corporation.
 
@@ -2164,7 +2164,7 @@ Apache Software License
 
 beautifulsoup4
 4.12.2
-MIT License
+MIT
 Beautiful Soup is made available under the MIT license:
 
  Copyright (c) Leonard Richardson
@@ -2564,7 +2564,7 @@ Apache Software License
 
 bracex
 2.6
-MIT License
+MIT
 MIT License
 
 Copyright (c) 2018 - 2025 Isaac Muse
@@ -2606,7 +2606,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
 cachetools
-6.2.0
+6.2.1
 MIT License
 The MIT License (MIT)
 
@@ -2687,7 +2687,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.3
+3.4.4
 MIT
 MIT License
 
@@ -3341,7 +3341,7 @@ SOFTWARE
 
 elasticsearch
 8.17.1
-Apache Software License
+Apache-2.0
 
                                  Apache License
                            Version 2.0, January 2004
@@ -3521,7 +3521,7 @@ Apache Software License
 
 
 elasticsearch-connectors
-8.19.3
+8.19.6
 Apache Software License
 Elastic License 2.0
 
@@ -4384,7 +4384,7 @@ THE SOFTWARE.
 
 
 grpcio
-1.73.0
+1.75.1
 Apache Software License
 
                                  Apache License
@@ -4999,7 +4999,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 
 grpcio-tools
-1.71.0
+1.71.2
 Apache Software License
 UNKNOWN
 
@@ -5032,7 +5032,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 httpcore
 1.0.9
-BSD License
+BSD-3-Clause
 Copyright © 2020, [Encode OSS Ltd](https://www.encode.io/).
 All rights reserved.
 
@@ -5064,7 +5064,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 httpx
 0.27.0
-BSD License
+BSD-3-Clause
 Copyright © 2019, [Encode OSS Ltd](https://www.encode.io/).
 All rights reserved.
 
@@ -5100,11 +5100,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 idna
-3.10
-BSD License
+3.11
+BSD-3-Clause
 BSD 3-Clause License
 
-Copyright (c) 2013-2024, Kim Davies and contributors.
+Copyright (c) 2013-2025, Kim Davies and contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -5655,8 +5655,8 @@ MIT License
 
 
 multidict
-6.5.0
-Apache Software License
+6.7.0
+Apache License 2.0
    Copyright 2016 Andrew Svetlov and aio-libs contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -5977,7 +5977,7 @@ BSD
 UNKNOWN
 
 propcache
-0.4.0
+0.4.1
 Apache Software License
 
                                  Apache License
@@ -6725,7 +6725,7 @@ Apache Software License
 
 pyspnego
 0.12.0
-UNKNOWN
+MIT
 MIT License
 
 Copyright (c) 2020 Jordan Borean, Red Hat
@@ -7433,7 +7433,7 @@ made under the terms of *both* these licenses.
 
 soupsieve
 2.8
-MIT License
+MIT
 MIT License
 
 Copyright (c) 2018 - 2025 Isaac Muse <isaacmuse@gmail.com>
@@ -7543,8 +7543,8 @@ Apache Software License
 UNKNOWN
 
 typing_extensions
-4.14.1
-UNKNOWN
+4.15.0
+PSF-2.0
 A. HISTORY OF THE SOFTWARE
 ==========================
 
@@ -7885,7 +7885,7 @@ made under the terms of *both* these licenses.
 
 urllib3
 2.5.0
-UNKNOWN
+MIT
 MIT License
 
 Copyright (c) 2008-2020 Andrey Petrov and contributors.
@@ -8144,7 +8144,7 @@ SOFTWARE.
 
 
 wrapt
-1.17.2
+1.17.3
 BSD License
 Copyright (c) 2013-2023, Graham Dumpleton
 All rights reserved.
@@ -8173,7 +8173,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 xmltodict
-1.0.0
+1.0.2
 MIT License
 Copyright (C) 2012 Martin Blech and individual contributors.
 
@@ -8185,7 +8185,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 yarl
-1.21.0
+1.22.0
 Apache Software License
 
                                  Apache License

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -49,7 +49,7 @@ from connectors.sources.sharepoint_online import (
     _prefix_user,
     _prefix_user_id,
 )
-from connectors.utils import iso_utc
+from connectors.utils import ISO_ZULU_TIMESTAMP_FORMAT, iso_utc
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
 
@@ -234,6 +234,8 @@ async def create_spo_source(
     tenant_name="test",
     client_id="2",
     secret_value="3",
+    certificate=None,
+    private_key=None,
     auth_method="secret",
     site_collections=WILDCARD,
     use_document_level_security=False,
@@ -248,6 +250,8 @@ async def create_spo_source(
         tenant_id=tenant_id,
         client_id=client_id,
         secret_value=secret_value,
+        certificate=certificate,
+        private_key=private_key,
         tenant_name=tenant_name,
         site_collections=site_collections,
         use_document_level_security=use_document_level_security,
@@ -2991,15 +2995,63 @@ class TestSharepointOnlineDataSource:
         async with create_spo_source() as source:
             max_drive_item_age = 15
             drive_item = {
-                "name": "test",
-                "lastModifiedDateTime": str(
+                "name": "test.txt",
+                "@microsoft.graph.downloadUrl": "http://localhost/filename",
+                "lastModifiedDateTime": (
                     datetime.utcnow() - timedelta(days=max_drive_item_age + 1)
-                ),
+                ).strftime(ISO_ZULU_TIMESTAMP_FORMAT),
             }
 
             download_result = source.download_function(drive_item, max_drive_item_age)
 
             assert download_result is None
+
+    @pytest.mark.asyncio
+    async def test_download_function_for_file_with_no_lastModifiedDatetTime(self):
+        async with create_spo_source() as source:
+            max_drive_item_age = 15
+            drive_item = {
+                "name": "test.txt",
+                "@microsoft.graph.downloadUrl": "http://localhost/filename",
+            }
+
+            download_result = source.download_function(drive_item, max_drive_item_age)
+
+            assert download_result is None
+
+    @pytest.mark.asyncio
+    async def test_download_function_for_too_large_file(self):
+        async with create_spo_source() as source:
+            max_drive_item_age = 15
+            drive_item = {
+                "name": "test.txt",
+                "@microsoft.graph.downloadUrl": "http://localhost/filename",
+                "size": 5 * 1024 * 1024 * 1024,
+                "lastModifiedDateTime": (
+                    datetime.now(timezone.utc) - timedelta(days=max_drive_item_age - 5)
+                ).strftime(ISO_ZULU_TIMESTAMP_FORMAT),
+            }
+
+            download_result = source.download_function(drive_item, max_drive_item_age)
+
+            assert download_result is None
+
+    @pytest.mark.asyncio
+    async def test_download_function_for_recently_changed_file(self):
+        async with create_spo_source() as source:
+            max_drive_item_age = 15
+            drive_item = {
+                "name": "test.txt",
+                "@microsoft.graph.downloadUrl": "http://localhost/filename",
+                "size": 5000,
+                "lastModifiedDateTime": (
+                    datetime.now(timezone.utc) - timedelta(days=max_drive_item_age - 5)
+                ).strftime(ISO_ZULU_TIMESTAMP_FORMAT),
+            }
+
+            download_result = source.download_function(drive_item, max_drive_item_age)
+
+            assert download_result is not None
 
     def test_get_default_configuration(self):
         config = SharepointOnlineDataSource.get_default_configuration()
@@ -3052,6 +3104,21 @@ class TestSharepointOnlineDataSource:
             patch_sharepoint_client.graph_api_token.get.assert_awaited()
             patch_sharepoint_client.rest_api_token.get.assert_awaited()
             patch_sharepoint_client.site_collections.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_correct_tokens_are_set_when_certificates_are_used(self):
+        private_key = "opens_all_locks"
+        certificate = "its_certified"
+        async with create_spo_source(
+            auth_method="certificate",
+            secret_value=None,
+            private_key=private_key,
+            certificate=certificate,
+        ) as source:
+            client = source.client
+
+            assert isinstance(client.graph_api_token, EntraAPIToken)
+            assert isinstance(client.rest_api_token, EntraAPIToken)
 
     @pytest.mark.asyncio
     async def test_validate_config_when_invalid_tenant(self, patch_sharepoint_client):


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add some code coverage for SPO connector to be able to backport/merge stuff again (#3795)](https://github.com/elastic/connectors/pull/3795)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)