### PR TITLE
Add more search teams to buildkite pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -86,6 +86,8 @@ spec:
           access_level: "READ_ONLY"
         search-extract-and-transform: {}
         search-productivity-team: {}
+        search-inference-team: {}
+        enterprise-search: {}
 
 # ------------------------------------------------------------------------------
 # nightly pipelines
@@ -151,6 +153,8 @@ spec:
           access_level: "READ_ONLY"
         search-extract-and-transform: {}
         search-productivity-team: {}
+        search-inference-team: {}
+        enterprise-search: {}
 
 ---
 apiVersion: "backstage.io/v1alpha1"
@@ -213,6 +217,8 @@ spec:
           access_level: "READ_ONLY"
         search-extract-and-transform: {}
         search-productivity-team: {}
+        search-inference-team: {}
+        enterprise-search: {}
 
 ########
 # Docker image build and publish - manual release
@@ -243,5 +249,7 @@ spec:
       teams:
         search-extract-and-transform: {}
         search-productivity-team: {}
+        search-inference-team: {}
+        enterprise-search: {}
         everyone:
           access_level: "READ_ONLY"


### PR DESCRIPTION
Addressing a thread that came up a couple of times in recent releases, where folks in charge of 8.x releases were unable to retrigger DRAs for new version for `connectors` repo.

A bit of guessing, added 
* [enterprise-search](https://buildkite.com/organizations/elastic/teams/enterprise-search/members)
* [search-inference](https://buildkite.com/organizations/elastic/teams/search-inference-team/members)

Couldn't find bk teams for the other search teams.