### PR TITLE
Fix linters

### DIFF
--- a/app/connectors_service/connectors/sources/dropbox/datasource.py
+++ b/app/connectors_service/connectors/sources/dropbox/datasource.py
@@ -6,6 +6,7 @@
 import json
 from functools import partial
 
+from aiohttp.client_exceptions import ClientResponseError
 from connectors_sdk.source import BaseDataSource
 from connectors_sdk.utils import iso_utc
 
@@ -16,7 +17,6 @@ from connectors.access_control import (
 )
 from connectors.sources.dropbox.client import (
     BASE_URLS,
-    ClientResponseError,
     DropboxClient,
     EndpointName,
 )

--- a/app/connectors_service/connectors/sources/graphql/client.py
+++ b/app/connectors_service/connectors/sources/graphql/client.py
@@ -9,7 +9,9 @@ import aiohttp
 from aiohttp import ClientResponseError
 from connectors_sdk.logger import logger
 from connectors_sdk.source import ConfigurableFieldValueError
-from graphql import VariableNode, Visitor, parse, visit
+from graphql.language import parse, visit
+from graphql.language.ast import VariableNode
+from graphql.language.visitor import Visitor
 
 from connectors.sources.graphql.constants import (
     BASIC,

--- a/app/connectors_service/connectors/sources/graphql/datasource.py
+++ b/app/connectors_service/connectors/sources/graphql/datasource.py
@@ -13,7 +13,7 @@ from connectors_sdk.source import BaseDataSource, ConfigurableFieldValueError
 from connectors_sdk.utils import (
     iso_utc,
 )
-from graphql import parse
+from graphql.language import parse
 
 from connectors.sources.graphql.client import GraphQLClient
 from connectors.sources.graphql.constants import (


### PR DESCRIPTION
Fixed linting step.

- For some reason re-exported imports from `graphql` make `pyright` unhappy. Changed to import from precise packages, rather than from the root
- `from connectors.sources.dropbox.client import ...  ClientResponseError` is a factual mistake, the error comes from `aiohttp`