### PR TITLE
Update VERSION_PATH

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -11,5 +11,5 @@
     "^v9.3.0$": "main",
     "^v(\\d+).(\\d+)(.\\d+)*$": "$1.$2"
   },
-  "upstream": "elastic/app/connectors_service/connectors"
+  "upstream": "elastic/connectors"
 }


### PR DESCRIPTION
Should fix `main` builds failures like [this one](https://buildkite.com/elastic/connectors/builds/20676#019a4904-11aa-4763-acea-dfbbaabcbab5)

> ++ VERSION_PATH=/opt/buildkite-agent/builds/bk-agent-prod-aws-1762162307404853761/elastic/connectors/connectors/VERSION
> ...
> cat: /opt/buildkite-agent/builds/bk-agent-prod-aws-1762162307404853761/elastic/connectors/connectors/VERSION: No such file or directory
> ...
> /opt/buildkite-agent/builds/bk-agent-prod-aws-1762162307404853761/elastic/connectors/.buildkite/publish/publish-common.sh: line 39: connectors/build.yaml: No such file or directory

~Also should fix backport process, as the GH action was failing to check for the version in order to work out auto-labelling.. 🤞~