### PR TITLE
Fix DRA file not containing the whole project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ install:
 	cd $(connectors_sdk_dir); make install
 	cd $(app_dir); make install
 
+install-agent: install
+
 install-package:
 	cd $(connectors_sdk_dir); make install-package
 	cd $(app_dir); make install-package
@@ -57,5 +59,8 @@ docker-run:
 docker-push:
 	docker push $(DOCKER_IMAGE_NAME):$(VERSION)-SNAPSHOT
 
-zip:
-	cd $(app_dir); make zip
+zip: clean
+	zip -r \
+		$(PACKAGE_NAME_VERSION).zip \
+		./* \
+		-x  *htmlcov*/* *docs*/* Dockerfile* *ruff_cache*/* *pytest_cache*/* *__pycache__*/* *build*/* *egg-info*/*

--- a/app/connectors_service/Makefile
+++ b/app/connectors_service/Makefile
@@ -119,12 +119,6 @@ agent-docker-all: agent-docker-build agent-docker-run
 sdist: .venv/bin/python
 	.venv/bin/python -m build --sdist
 
-zip: sdist
-	cd dist && \
-	tar -xzf $(PACKAGE_NAME_VERSION).tar.gz && \
-	zip -r $(PACKAGE_NAME_VERSION).zip $(PACKAGE_NAME_VERSION)/ && \
-	rm -rf $(PACKAGE_NAME_VERSION)/
-
 deps-csv: .venv/bin/pip-licenses
 	mkdir -p dist
 	.venv/bin/pip-licenses --format=csv --with-urls > dist/dependencies.csv

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1346,8 +1346,8 @@ Apache-2.0
 
 
 aioitertools
-0.12.0
-MIT License
+0.13.0
+UNKNOWN
 MIT License
 
 Copyright (c) 2022 Amethyst Reese
@@ -4145,7 +4145,7 @@ Apache Software License
 
 
 google-auth
-2.42.1
+2.43.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
Minor fix to unlock Agent DRA: we need to actually zip the whole project for now.