### PR TITLE
[8.19] Update aiomysql Version (#3858)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1372,8 +1372,8 @@ SOFTWARE.
 
 
 aiomysql
-0.1.1
-MIT License
+0.3.0
+UNKNOWN
 Copyright (c) 2010, 2013 PyMySQL contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,6 +1,6 @@
 aiohttp==3.11.10
 aiofiles==23.2.1
-aiomysql==0.1.1
+aiomysql==0.3.0
 httpx==0.27.0
 httpx-ntlm==1.4.0
 elasticsearch[async]==8.17.1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update aiomysql Version (#3858)](https://github.com/elastic/connectors/pull/3858)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)