### PR TITLE
chore: Remove 8.18 builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -668,7 +668,7 @@ steps:
   # ----
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"9.2\" || build.branch == \"9.1\" || build.branch == \"8.19\" || build.branch == \"8.18\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"9.2\" || build.branch == \"9.1\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -66,10 +66,6 @@ spec:
           branch: "8.19"
           cronline: '@daily'
           message: "Builds, tests, and pushes daily `8.19` DRA artifacts"
-        Daily 8.18:
-          branch: "8.18"
-          cronline: '@daily'
-          message: "Builds, tests, and pushes daily `8.18` DRA artifacts"
       provider_settings:
         skip_pull_request_builds_for_existing_commits: false
         build_pull_request_labels_changed: true
@@ -112,10 +108,6 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors"
       schedules:
-        Daily 8_18:
-          branch: '8.18'
-          cronline: '@daily'
-          message: "Runs daily `8.18` e2e test"
         Daily 8_19:
           branch: '8.19'
           cronline: '@daily'
@@ -168,10 +160,6 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors"
       schedules:
-        Daily 8_18:
-          branch: '8.18'
-          cronline: '@daily'
-          message: "Runs daily `8.18` e2e aarch64 test"
         Daily 8_19:
           branch: '8.19'
           cronline: '@daily'


### PR DESCRIPTION
## Context

- Disables daily builds and tests for 8.18 as they are no longer necessary.
- The pipelines are failing because they cannot pick up a SNAPSHOT of `elasticsearch` for this version as one hadn't been produced in nearly 2 months.
- Regular updates for 8.18 ended with the release of 9.2.
