### PR TITLE
[9.1] [Network Drive] Switch to usage of local connection cache (#3868)

### DIFF
--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -278,7 +278,7 @@ class SMBSession:
                 username=self.username,
                 password=self.password,
                 port=self.port,
-                connection_cache=self._connection_cache
+                connection_cache=self._connection_cache,
             )
         except SMBResponseException as exception:
             self.handle_smb_response_errors(exception=exception)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Network Drive] Switch to usage of local connection cache (#3868)](https://github.com/elastic/connectors/pull/3868)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)