### PR TITLE
[9.2] [Network Drive] Fix DLS file permission check not properly taking credentials (#3873)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1602,7 +1602,7 @@ Apache License
 
 
 anyio
-4.11.0
+4.12.0
 MIT
 The MIT License (MIT)
 

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -647,6 +647,7 @@ class NASDataSource(BaseDataSource):
                 username=self.username,
                 password=self.password,
                 port=self.port,
+                connection_cache=self._connection_cache,
             ) as file:
                 chunk = True
                 while chunk:
@@ -700,7 +701,10 @@ class NASDataSource(BaseDataSource):
                 buffering=0,
                 file_type=file_type,
                 desired_access=access,
+                username=self.username,
+                password=self.password,
                 port=self.port,
+                connection_cache=self._connection_cache,
             ) as file:
                 descriptor = self.security_info.get_descriptor(
                     file_descriptor=file.fd, info=SECURITY_INFO_DACL


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Network Drive] Fix DLS file permission check not properly taking credentials (#3873)](https://github.com/elastic/connectors/pull/3873)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)