### PR TITLE
[8.19] [Network Drive] Fix DLS file permission check not properly taking credentials (#3873)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1346,8 +1346,8 @@ Apache Software License
 
 
 aioitertools
-0.12.0
-MIT License
+0.13.0
+MIT
 MIT License
 
 Copyright (c) 2022 Amethyst Reese
@@ -1373,7 +1373,7 @@ SOFTWARE.
 
 aiomysql
 0.3.0
-UNKNOWN
+MIT
 Copyright (c) 2010, 2013 PyMySQL contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -1602,7 +1602,7 @@ Apache License
 
 
 anyio
-4.11.0
+4.12.0
 MIT
 The MIT License (MIT)
 
@@ -3521,7 +3521,7 @@ Apache-2.0
 
 
 elasticsearch-connectors
-8.19.6
+8.19.9
 Apache Software License
 Elastic License 2.0
 
@@ -4115,7 +4115,7 @@ Apache Software License
 
 
 google-auth
-2.41.1
+2.43.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -4384,7 +4384,7 @@ THE SOFTWARE.
 
 
 grpcio
-1.75.1
+1.76.0
 Apache Software License
 
                                  Apache License

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -647,6 +647,7 @@ class NASDataSource(BaseDataSource):
                 username=self.username,
                 password=self.password,
                 port=self.port,
+                connection_cache=self._connection_cache,
             ) as file:
                 chunk = True
                 while chunk:
@@ -700,7 +701,10 @@ class NASDataSource(BaseDataSource):
                 buffering=0,
                 file_type=file_type,
                 desired_access=access,
+                username=self.username,
+                password=self.password,
                 port=self.port,
+                connection_cache=self._connection_cache,
             ) as file:
                 descriptor = self.security_info.get_descriptor(
                     file_descriptor=file.fd, info=SECURITY_INFO_DACL


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Network Drive] Fix DLS file permission check not properly taking credentials (#3873)](https://github.com/elastic/connectors/pull/3873)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)