### PR TITLE
[8.19] chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker digest to 23a4192 (#3880)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:fee8806204dc51e023182cdaf7a443e4c077f06078d4a27ed246916f67f7e16d
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:23a41924ebd3a5a9310aafb9d7033626e96e88d77255e1b4161b18bf5dd0d681
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4349,7 +4349,7 @@ SOFTWARE.
 
 
 greenlet
-3.2.4
+3.3.0
 MIT AND Python-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:
@@ -7884,8 +7884,8 @@ made under the terms of *both* these licenses.
 
 
 urllib3
-2.5.0
-MIT
+2.6.1
+UNKNOWN
 MIT License
 
 Copyright (c) 2008-2020 Andrey Petrov and contributors.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker digest to 23a4192 (#3880)](https://github.com/elastic/connectors/pull/3880)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)