### PR TITLE
chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker di…

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:23a41924ebd3a5a9310aafb9d7033626e96e88d77255e1b4161b18bf5dd0d681
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:e2d3d2bba33963144b9a88fd23285de3acb316ecd00b01dcbe8ac8b806d1ce3d
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1880,7 +1880,7 @@ SOFTWARE.
 
 
 azure-core
-1.36.0
+1.37.0
 MIT License
 Copyright (c) Microsoft Corporation.
 
@@ -2606,8 +2606,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
 cachetools
-6.2.2
-MIT License
+6.2.3
+MIT
 The MIT License (MIT)
 
 Copyright (c) 2014-2025 Thomas Kemmer
@@ -8069,8 +8069,8 @@ Apache Software License
 UNKNOWN
 
 tzdata
-2025.2
-Apache Software License
+2025.3
+Apache-2.0
 Apache Software License 2.0
 
 Copyright (c) 2020, Paul Ganssle (Google)
@@ -8121,7 +8121,7 @@ made under the terms of *both* these licenses.
 
 
 urllib3
-2.6.1
+2.6.2
 MIT
 MIT License
 


### PR DESCRIPTION
Manual backport of https://github.com/elastic/connectors/pull/3886

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [ ] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [ ] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
