### PR TITLE
[9.3] chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker digest to 29861e7 (#3916)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:27126050c16e8bc7b730d066013c7bd59c97b8fcdedf33365a4f02f316a7aed7
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:29861e712a9eec7c9aad9b3ccb6b9e1c5398d9cfd3732ee2e0722a0bd4c4cb83
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker digest to 29861e7 (#3916)](https://github.com/elastic/connectors/pull/3916)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)