### PR TITLE
[8.19] chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker digest to fdce1eb (#3938)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:a9925189e90f510c3fefad6f243fc546b08abaab5cf446ab5b7eaee97ada83ed
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:fdce1eb0255cda1e58df675d737956246836191149e2d79ba322298e3d102916
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Backport of #3938 to `8.19` branch
- Updates `docker.elastic.co/wolfi/python:3.11-dev` docker digest to `fdce1eb`

Backport of https://github.com/elastic/connectors/pull/3938