### PR TITLE
[9.2] Fix multiservice death sequence (#3940)

### DIFF
--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -171,16 +171,24 @@ class MultiService:
 
     async def run(self):
         """Runs every service in a task and wait for all tasks."""
-        tasks = [asyncio.create_task(service.run()) for service in self._services]
+        task_to_service = {}
+        for service in self._services:
+            task = asyncio.create_task(service.run())
+            task_to_service[task] = service
 
-        _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+        _, pending = await asyncio.wait(
+            task_to_service.keys(), return_when=asyncio.FIRST_EXCEPTION
+        )
 
         for task in pending:
+            service = task_to_service[task]
+            logger.info(f"Stopping {service.__class__.__name__}...")
+            service.stop()
             task.cancel()
             try:
                 await task
             except asyncio.CancelledError:
-                logger.error("Service did not handle cancellation gracefully.")
+                pass
 
     def shutdown(self, sig):
         logger.info(f"Caught {sig}. Graceful shutdown.")

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -190,7 +190,7 @@ class CancellableSleeps:
                 return await task
             except asyncio.CancelledError:
                 logger.debug("Sleep canceled")
-                return result
+                raise
             finally:
                 self._sleeps.remove(task)
 

--- a/tests/services/test_base.py
+++ b/tests/services/test_base.py
@@ -46,7 +46,10 @@ async def run_service_with_stop_after(service, stop_after=0):
 
         await asyncio.sleep(0)
 
-    await asyncio.gather(service.run(), _terminate())
+    try:
+        await asyncio.gather(service.run(), _terminate())
+    except asyncio.CancelledError:
+        pass
 
 
 async def create_and_run_service(
@@ -106,6 +109,8 @@ async def test_multiservice_run_stops_all_services_when_one_raises_exception():
     assert not service_1.cancelled
     assert service_2.cancelled
     assert service_3.cancelled
+    assert service_2.stopped
+    assert service_3.stopped
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Backport of #3940 to 9.2.
- Fix MultiService shutdown: explicitly stop services before cancelling tasks, preventing braindead process state when one service dies
- Re-raise `CancelledError` in `CancellableSleeps` instead of swallowing it, so cancellation propagates correctly
- Add test assertions verifying services are actually stopped
## Original PR
https://github.com/elastic/connectors/pull/3940