### PR TITLE
fix: remove unused elasticsearch-connectors-sdk dependency

### DIFF
--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -74,8 +74,7 @@ dependencies = [
     "tabulate==0.9.0",
     "tzcron==1.0.0",
     "uvloop==0.20.0; sys_platform != 'win32'",
-    "wcmatch==8.4.1",
-    "elasticsearch-connectors-sdk"
+    "wcmatch==8.4.1"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Remove `elasticsearch-connectors-sdk` from `app/connectors_service/pyproject.toml` — this package is not used by the connectors service.
