### PR TITLE
[8.19] chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker digest to cc3bb21 (#3975)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:fdce1eb0255cda1e58df675d737956246836191149e2d79ba322298e3d102916
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:cc3bb21598334d2acf754b357148183ec3c6fefb4f90a422482e1fe2c0089e9f
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1602,8 +1602,8 @@ Apache License
 
 
 anyio
-4.12.0
-MIT
+4.13.0
+UNKNOWN
 The MIT License (MIT)
 
 Copyright (c) 2018 Alex Grönholm


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker digest to cc3bb21 (#3975)](https://github.com/elastic/connectors/pull/3975)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)