### PR TITLE
[9.4] [9.4 Release] Updating pipeline.yml with 9.4 branch + removed 9.2 branch (#3990)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1079,7 +1079,7 @@ steps:
   # ----
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"9.3\" || build.branch == \"9.2\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"9.4\" || build.branch == \"9.3\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -4380,7 +4380,7 @@ SOFTWARE.
 
 
 greenlet
-3.3.2
+3.4.0
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[9.4 Release] Updating pipeline.yml with 9.4 branch + removed 9.2 branch (#3990)](https://github.com/elastic/connectors/pull/3990)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)