### PR TITLE
Grant release-eng build access to connectors pipeline

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -91,7 +91,7 @@ SOFTWARE.
 
 
 PyMySQL
-1.1.2
+1.1.3
 MIT
 Copyright (c) 2010, 2013 PyMySQL contributors
 
@@ -1906,7 +1906,7 @@ SOFTWARE.
 
 
 azure-core
-1.39.0
+1.40.0
 MIT
 Copyright (c) Microsoft Corporation.
 
@@ -4146,7 +4146,7 @@ Apache Software License
 
 
 google-auth
-2.49.2
+2.50.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -76,6 +76,8 @@ spec:
         search-productivity-team: {}
         search-inference-team: {}
         enterprise-search: {}
+        release-eng:
+          access_level: BUILD_AND_READ
 
 # ------------------------------------------------------------------------------
 # nightly pipelines


### PR DESCRIPTION
## Summary

Adds `release-eng: BUILD_AND_READ` to the `connectors` pipeline's teams block so release-eng team members can trigger builds.

## Why

The `connectors-version-bump` pipeline (introduced in #3986) executes a `trigger:` step that starts a DRA build on the target release branch on the main `connectors` pipeline. Buildkite propagates the original triggering user's identity through trigger chains, so the downstream build on `connectors` is created as that user -- and the user needs Build access on `connectors` for the trigger to succeed.

We already granted release-eng `BUILD_AND_READ` on `connectors-version-bump` (so they can trigger our pipeline at all), but missed adding it on the main `connectors` pipeline. This caused failures in [build #3](https://buildkite.com/elastic/connectors-version-bump/builds/3) (9.3.5) and [build #4](https://buildkite.com/elastic/connectors-version-bump/builds/4) (8.19.16) when triggered by Nina Lee, while [build #2](https://buildkite.com/elastic/connectors-version-bump/builds/2) (9.4.1) triggered by Julien Mailleret succeeded -- presumably via individual grants.

This grants team-level access so any release-eng member can complete the version bump end-to-end.

## Test plan

- [ ] After merge and Backstage sync (~few minutes), re-trigger build #3 or #4 from the centralized pipeline and confirm the `Trigger DRA build on ${BRANCH}` step succeeds