### PR TITLE
Fix DLS query to use .keyword instead of .enum

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1906,7 +1906,7 @@ SOFTWARE.
 
 
 azure-core
-1.40.0
+1.41.0
 MIT
 Copyright (c) Microsoft Corporation.
 
@@ -4146,7 +4146,7 @@ Apache Software License
 
 
 google-auth
-2.50.0
+2.52.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -8213,7 +8213,7 @@ made under the terms of *both* these licenses.
 
 
 urllib3
-2.6.3
+2.7.0
 MIT
 MIT License
 

--- a/app/connectors_service/connectors/access_control.py
+++ b/app/connectors_service/connectors/access_control.py
@@ -19,7 +19,7 @@ DLS_QUERY = """{
                             },
                             {
                                 "terms": {
-                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                                    "_allow_access_control.keyword": {{#toJson}}access_control{{/toJson}}
                                 }
                             }
                         ]

--- a/app/connectors_service/tests/test_access_control.py
+++ b/app/connectors_service/tests/test_access_control.py
@@ -35,7 +35,7 @@ async def test_access_control_query():
                             },
                             {
                                 "terms": {
-                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                                    "_allow_access_control.keyword": {{#toJson}}access_control{{/toJson}}
                                 }
                             }
                         ]


### PR DESCRIPTION
## Summary

- Fix DLS query template to use `_allow_access_control.keyword` instead of `_allow_access_control.enum`
- Update corresponding test assertion

The `.enum` sub-field was created by the custom dynamic mapping template in `settings.py`, which was removed in PR #3013 (v9.0.0). Under Elasticsearch's default dynamic mapping, string fields get a `.keyword` sub-field instead.

This caused DLS-protected documents to be silently filtered out for any content index created on 9.0+.

Closes #4005

## Test plan

- [ ] Existing unit test updated and passes
- [ ] Set up a connector with DLS on 9.0+, run content + access control sync, verify DLS queries return expected results


### Release Note

Fixes a bug for Connectors Document Level Security, where the generated query filter used an incorrect subfield