### PR TITLE
[9.3] Fix DLS query to use .keyword instead of .enum (#4006)

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -91,7 +91,7 @@ SOFTWARE.
 
 
 PyMySQL
-1.1.2
+1.1.3
 MIT
 Copyright (c) 2010, 2013 PyMySQL contributors
 
@@ -1906,7 +1906,7 @@ SOFTWARE.
 
 
 azure-core
-1.39.0
+1.41.0
 MIT
 Copyright (c) Microsoft Corporation.
 
@@ -4146,7 +4146,7 @@ Apache Software License
 
 
 google-auth
-2.49.2
+2.52.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -5131,7 +5131,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 idna
-3.13
+3.14
 BSD-3-Clause
 BSD 3-Clause License
 
@@ -6009,7 +6009,7 @@ BSD
 UNKNOWN
 
 propcache
-0.4.1
+0.5.2
 Apache Software License
 
                                  Apache License
@@ -8213,7 +8213,7 @@ made under the terms of *both* these licenses.
 
 
 urllib3
-2.6.3
+2.7.0
 MIT
 MIT License
 

--- a/app/connectors_service/connectors/access_control.py
+++ b/app/connectors_service/connectors/access_control.py
@@ -19,7 +19,7 @@ DLS_QUERY = """{
                             },
                             {
                                 "terms": {
-                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                                    "_allow_access_control.keyword": {{#toJson}}access_control{{/toJson}}
                                 }
                             }
                         ]

--- a/app/connectors_service/tests/test_access_control.py
+++ b/app/connectors_service/tests/test_access_control.py
@@ -35,7 +35,7 @@ async def test_access_control_query():
                             },
                             {
                                 "terms": {
-                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                                    "_allow_access_control.keyword": {{#toJson}}access_control{{/toJson}}
                                 }
                             }
                         ]

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -1220,7 +1220,7 @@ Apache License
 
 
 idna
-3.13
+3.14
 BSD-3-Clause
 BSD 3-Clause License
 
@@ -1282,7 +1282,7 @@ under the terms of *both* these licenses.
 
 
 propcache
-0.4.1
+0.5.2
 Apache Software License
 
                                  Apache License


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix DLS query to use .keyword instead of .enum (#4006)](https://github.com/elastic/connectors/pull/4006)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)