### PR TITLE
Update `python-tds` dependency version from 1.12.0 to 1.15.0 in pyproject.toml

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -5131,7 +5131,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 idna
-3.13
+3.15
 BSD-3-Clause
 BSD 3-Clause License
 
@@ -6009,7 +6009,7 @@ BSD
 UNKNOWN
 
 propcache
-0.4.1
+0.5.2
 Apache Software License
 
                                  Apache License
@@ -6918,7 +6918,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The above BSD License Applies to all code, even that also covered by Apache 2.0.
 
 python-tds
-1.12.0
+1.15.0
 MIT
 The MIT License (MIT)
 

--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "pydantic==2.10.6",
     "pympler==1.0.1",
     "python-dateutil==2.8.2",
-    "python-tds==1.12.0",
+    "python-tds==1.15.0",
     "pytz==2019.3",
     "pywinrm==0.4.3",
     "pyyaml==6.0.1",

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -1220,7 +1220,7 @@ Apache License
 
 
 idna
-3.13
+3.15
 BSD-3-Clause
 BSD 3-Clause License
 
@@ -1282,7 +1282,7 @@ under the terms of *both* these licenses.
 
 
 propcache
-0.4.1
+0.5.2
 Apache Software License
 
                                  Apache License


### PR DESCRIPTION
- Bump versions for `idna` from 3.13 to 3.15, `propcache` from 0.4.1 to 0.5.2, and `python-tds` from 1.12.0 to 1.15.0 in NOTICE.txt.
- Update `python-tds` dependency version from 1.12.0 to 1.15.0 in pyproject.toml.

## Closes https://github.com/elastic/connectors/issues/4014

Bump `python-tds` from `1.12.0` to `1.15.0` so it no longer imports the now-removed `pkg_resources` module at module load time.

Since 8.17.2 the official `docker.elastic.co/integrations/elastic-connectors` image is built on `cgr.dev/chainguard/wolfi-base`, which does not ship `setuptools` in the runtime venv. `python-tds==1.12.0` does `import pkg_resources` unconditionally in `pytds/__init__.py`, which means any sync against a SQL Server data source fails on the first `create_engine("mssql+pytds://...")` call with:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

This affects every published image from `8.17.2` through `9.4.1` and breaks the Microsoft SQL Server connector entirely, plus any other connector that resolves the `mssql+pytds` SQLAlchemy dialect. Dev/CI did not catch it because we install via `pip install -e .`, which pulls `setuptools` into the venv, so `pkg_resources` is always available locally.

Upstream removed the `pkg_resources` import in [denisenkom/pytds#157](https://github.com/denisenkom/pytds/pull/157), released as `python-tds==1.15.0`.

### Verification

Reproduced the customer's failure locally by blocking `pkg_resources` on `sys.meta_path` (simulating the Wolfi runtime):

- With `python-tds==1.12.0`: `import pytds` raises `ModuleNotFoundError: No module named 'pkg_resources'`.
- With `python-tds==1.15.0`: `import pytds`, `import sqlalchemy_pytds`, `from connectors.sources.mssql.client import MSSQLClient`, and `create_engine("mssql+pytds://...")` all succeed.

All 27 existing tests in `app/connectors_service/tests/sources/test_mssql.py` pass on `1.15.0`.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (`v8.19.0`, `v9.1.0`, `v9.2.0`, `v9.3.0`, `v9.4.0`, `v9.5.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases

## Release Note

Fix Microsoft SQL Server (and any other `mssql+pytds` SQLAlchemy) connector failing to start a sync on the official docker image with `ModuleNotFoundError: No module named 'pkg_resources'`. The bundled `python-tds` dependency has been upgraded from `1.12.0` to `1.15.0`, which no longer requires `pkg_resources` (and therefore `setuptools`) at runtime.
