### PR TITLE
[9.3] Update `python-tds` dependency version from 1.12.0 to 1.15.0 in pyproject.toml (#4015)

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -5131,7 +5131,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 idna
-3.14
+3.15
 BSD-3-Clause
 BSD 3-Clause License
 
@@ -6918,7 +6918,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The above BSD License Applies to all code, even that also covered by Apache 2.0.
 
 python-tds
-1.12.0
+1.15.0
 MIT
 The MIT License (MIT)
 

--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "pydantic==2.10.6",
     "pympler==1.0.1",
     "python-dateutil==2.8.2",
-    "python-tds==1.12.0",
+    "python-tds==1.15.0",
     "pytz==2019.3",
     "pywinrm==0.4.3",
     "pyyaml==6.0.1",

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -1220,7 +1220,7 @@ Apache License
 
 
 idna
-3.14
+3.15
 BSD-3-Clause
 BSD 3-Clause License
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Update python-tds dependency version from 1.12.0 to 1.15.0 in pyproject.toml
 (#4015)](https://github.com/elastic/connectors/issues/4015)


### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)