### PR TITLE
Fix VERSION file path in manual release pipeline

### DIFF
--- a/.buildkite/publish/manual-release/restore-stack-version.sh
+++ b/.buildkite/publish/manual-release/restore-stack-version.sh
@@ -7,9 +7,9 @@ CURDIR="$(dirname "$REL_DIR")"
 
 source $CURDIR/publish-common.sh
 
-echo $ORIG_VERSION > $PROJECT_ROOT/connectors/VERSION # removes the timestamp suffix
-UPDATED_VERSION=`cat $PROJECT_ROOT/connectors/VERSION`
+echo $ORIG_VERSION > $PROJECT_ROOT/app/connectors_service/connectors/VERSION # removes the timestamp suffix
+UPDATED_VERSION=`cat $PROJECT_ROOT/app/connectors_service/connectors/VERSION`
 
-git add $PROJECT_ROOT/connectors/VERSION
+git add $PROJECT_ROOT/app/connectors_service/connectors/VERSION
 git commit -m "Restoring version from ${VERSION} to ${UPDATED_VERSION}"
 git push origin ${GIT_BRANCH}

--- a/.buildkite/publish/manual-release/update-release-version.sh
+++ b/.buildkite/publish/manual-release/update-release-version.sh
@@ -7,10 +7,10 @@ CURDIR="$(dirname "$REL_DIR")"
 
 source $CURDIR/publish-common.sh
 
-echo $VERSION > $PROJECT_ROOT/app/connectors/VERSION # adds the timestamp suffix
-UPDATED_VERSION=`cat $PROJECT_ROOT/app/connectors/VERSION`
+echo $VERSION > $PROJECT_ROOT/app/connectors_service/connectors/VERSION # adds the timestamp suffix
+UPDATED_VERSION=`cat $PROJECT_ROOT/app/connectors_service/connectors/VERSION`
 
-git add $PROJECT_ROOT/app/connectors/VERSION
+git add $PROJECT_ROOT/app/connectors_service/connectors/VERSION
 git commit -m "Bumping version from ${ORIG_VERSION} to ${UPDATED_VERSION}"
 git push origin ${GIT_BRANCH}
 

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -20,7 +20,7 @@ steps:
     - label: "Set build metadata"
       commands:
         - buildkite-agent meta-data set timestamp "$(date -u +'%Y%m%d%H%M')"
-        - buildkite-agent meta-data set orig_version "$(cat app/connectors/VERSION)"
+        - buildkite-agent meta-data set orig_version "$(cat app/connectors_service/connectors/VERSION)"
       key: set_timestamp
     - wait
     - label: ":github: update version and tag"


### PR DESCRIPTION

## Closes https://github.com/elastic/search-team/issues/14508
Fix the manual release pipeline (`connectors-docker-build-publish` / `.buildkite/release-pipeline.yml`) so it can actually be triggered against `main`, `9.4`, or `9.3`. Today it fails on the very first step ("Set build metadata") because the `VERSION` file path was never updated after the monorepo restructure.

### What was broken

The monorepo move (#3819, Oct 2025) relocated the connectors `VERSION` file:

```
connectors/VERSION  →  app/connectors_service/connectors/VERSION
```

A follow-up (#3829) updated `publish-common.sh` to point at the new path, which unblocked DRA builds, but the same fix was never applied to the three other files that are *only* exercised by manual in-between releases. As a result, on `main`/`9.4`/`9.3` they reference paths that no longer exist:

| File | Broken reference | Effect |
|---|---|---|
| `.buildkite/release-pipeline.yml` (line 23) | `cat app/connectors/VERSION` | "Set build metadata" step exits non-zero → `orig_version` meta-data never set → entire pipeline aborts |
| `.buildkite/publish/manual-release/update-release-version.sh` | `$PROJECT_ROOT/app/connectors/VERSION` (×3) | Even if the previous step were patched, this would write the bumped version to a path the build process and tag step don't read from |
| `.buildkite/publish/manual-release/restore-stack-version.sh` | `$PROJECT_ROOT/connectors/VERSION` (×3) | The cleanup step would silently restore the wrong file, leaving the real `VERSION` file containing the timestamp suffix on the branch |

The bug was latent because the last in-between release (`v8.17.4+build202504152041`) was cut in April 2025, well before the restructure. Nobody triggered this pipeline against a post-monorepo branch until now.

### What this PR changes

Aligns all three files with the path already used by `publish-common.sh`:

```
$PROJECT_ROOT/app/connectors_service/connectors/VERSION
```

7 line replacements across 3 files, no logic changes.

### Why it is *not* backported below 9.3

The pre-monorepo branches (`9.2`, `9.1`, `8.19`) still keep `VERSION` at `connectors/VERSION` and their pipeline scripts are internally consistent at that path. Backporting this PR there would *break* their manual release pipeline. Backport labels are intentionally limited to `v9.4.0` and `v9.3.0`.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Tested the changes locally (simulated `$PROJECT_ROOT` resolution and the file IO performed by both manual-release scripts; confirmed the new path resolves to the actual `VERSION` file from the directory the scripts run in)
- [x] Added a label for each target release version: `v9.4.0`, `v9.3.0` *(intentionally NOT `v9.2.0` / `v9.1.0` / `v8.19.0` — see "Why it is not backported below 9.3" above)*
- [x] For bugfixes: backport safely to all minor branches **still on the post-monorepo layout**

## Related Pull Requests

* https://github.com/elastic/connectors/pull/3819 — monorepo restructure that introduced the path change
* https://github.com/elastic/connectors/pull/3829 — partial fix that updated `publish-common.sh` only
* https://github.com/elastic/connectors/pull/4015 — `python-tds` 1.15.0 bump that this in-between release will ship

## Release Note

_None — internal CI/release-pipeline fix, no user-visible behavior change._

A few things to know before you paste it:

- I left the issue link as plain text rather than a fake URL. If you want the line to render as the standard "Closes #" link on GitHub, either create a tracking issue first and put its number there, or just replace the whole `## Closes ...` line with `## SDH: https://elastic.my.salesforce.com/500Vv00000sm2emIAA` so reviewers still have one click into the context.
- I dropped the checklist items that don't apply (automated tests, docs, config reference, Kibana mirror PR, security/external-services callout) so the description doesn't read as "lots of unchecked boxes that are actually fine". Add them back if your team prefers the full template.
- The `Related Pull Requests` section is genuinely useful for the reviewer here because the chain of three PRs is what makes the partial-fix story make sense.