### PR TITLE
[9.4] Fix VERSION file path in manual release pipeline (#4018)

### DIFF
--- a/.buildkite/publish/manual-release/restore-stack-version.sh
+++ b/.buildkite/publish/manual-release/restore-stack-version.sh
@@ -7,9 +7,9 @@ CURDIR="$(dirname "$REL_DIR")"
 
 source $CURDIR/publish-common.sh
 
-echo $ORIG_VERSION > $PROJECT_ROOT/connectors/VERSION # removes the timestamp suffix
-UPDATED_VERSION=`cat $PROJECT_ROOT/connectors/VERSION`
+echo $ORIG_VERSION > $PROJECT_ROOT/app/connectors_service/connectors/VERSION # removes the timestamp suffix
+UPDATED_VERSION=`cat $PROJECT_ROOT/app/connectors_service/connectors/VERSION`
 
-git add $PROJECT_ROOT/connectors/VERSION
+git add $PROJECT_ROOT/app/connectors_service/connectors/VERSION
 git commit -m "Restoring version from ${VERSION} to ${UPDATED_VERSION}"
 git push origin ${GIT_BRANCH}

--- a/.buildkite/publish/manual-release/update-release-version.sh
+++ b/.buildkite/publish/manual-release/update-release-version.sh
@@ -7,10 +7,10 @@ CURDIR="$(dirname "$REL_DIR")"
 
 source $CURDIR/publish-common.sh
 
-echo $VERSION > $PROJECT_ROOT/app/connectors/VERSION # adds the timestamp suffix
-UPDATED_VERSION=`cat $PROJECT_ROOT/app/connectors/VERSION`
+echo $VERSION > $PROJECT_ROOT/app/connectors_service/connectors/VERSION # adds the timestamp suffix
+UPDATED_VERSION=`cat $PROJECT_ROOT/app/connectors_service/connectors/VERSION`
 
-git add $PROJECT_ROOT/app/connectors/VERSION
+git add $PROJECT_ROOT/app/connectors_service/connectors/VERSION
 git commit -m "Bumping version from ${ORIG_VERSION} to ${UPDATED_VERSION}"
 git push origin ${GIT_BRANCH}
 

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -20,7 +20,7 @@ steps:
     - label: "Set build metadata"
       commands:
         - buildkite-agent meta-data set timestamp "$(date -u +'%Y%m%d%H%M')"
-        - buildkite-agent meta-data set orig_version "$(cat app/connectors/VERSION)"
+        - buildkite-agent meta-data set orig_version "$(cat app/connectors_service/connectors/VERSION)"
       key: set_timestamp
     - wait
     - label: ":github: update version and tag"


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix VERSION file path in manual release pipeline (#4018)