### PR TITLE
[Connectors Python] Fix JWT RFC violation: cast GitHub App ID to string for iss claim

### DIFF
--- a/app/connectors_service/connectors/sources/github/client.py
+++ b/app/connectors_service/connectors/sources/github/client.py
@@ -49,7 +49,7 @@ class GitHubClient:
         self._logger = logger
         self.auth_method = auth_method
         self.base_url = base_url
-        self.app_id = app_id if self.auth_method == GITHUB_APP else None
+        self.app_id = str(app_id) if self.auth_method == GITHUB_APP else None
         self.private_key = private_key if self.auth_method == GITHUB_APP else None
         self._personal_access_token = (
             token if self.auth_method == PERSONAL_ACCESS_TOKEN else None

--- a/app/connectors_service/tests/sources/test_github.py
+++ b/app/connectors_service/tests/sources/test_github.py
@@ -859,6 +859,14 @@ def get_json_mock(mock_response, status):
 
 
 @pytest.mark.asyncio
+async def test_github_app_id_stored_as_string():
+    """app_id arrives as int from the config layer but must be a string for JWT iss claim (RFC 7519 §4.1.1)."""
+    async with create_github_source(auth_method=GITHUB_APP) as source:
+        assert isinstance(source.github_client.app_id, str)
+        assert source.github_client.app_id == "10"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("field", ["repositories", "token"])
 async def test_validate_config_missing_fields_then_raise(field):
     async with create_github_source() as source:


### PR DESCRIPTION
## Closes https://github.com/elastic/sdh-search/issues/1881

The GitHub connector was passing `app_id` as an integer into `gidgethub`'s JWT construction. This caused PyJWT ≥ 2.11.0 to raise `TypeError: Issuer (iss) must be a string.` when generating authentication tokens for GitHub App connections, making the connector completely unable to sync.

**Root cause:** The `app_id` config field is declared as `"type": "int"`, so it is coerced to an integer by the configuration layer. PyJWT 2.11.0 (released late 2024) began enforcing RFC 7519 §4.1.1, which requires the `iss` (issuer) JWT claim to be a string. Versions of PyJWT before 2.11.0 silently accepted integers, so this went undetected.

**Fix:** Cast `app_id` to `str` at the point it is stored in `GitHubClient.__init__`. This is the correct boundary — the conversion is co-located with the code that uses the value for JWT construction, and is safe regardless of PyJWT version (older versions accepted both, newer versions require a string).

No dependency version changes are needed. A regression test is included to pin the type contract.

## Testing

**Smoke test — local verification**

Ran a minimal script directly against `GitHubClient` using the installed venv, passing `app_id` as an integer (exactly as the config layer delivers it):

```bash
cd app/connectors_service
.venv/bin/python - <<'EOF'
from connectors.sources.github.client import GitHubClient
from connectors.sources.github.utils import GITHUB_APP

client = GitHubClient(
    auth_method=GITHUB_APP, base_url="https://api.github.com",
    app_id=3715575, private_key="unused",
    token=None, ssl_enabled=False, ssl_ca=None,
)
print(type(client.app_id), repr(client.app_id))
EOF
```

| Branch | Output |
|---|---|
| `main` | `<class 'int'> 3715575` — bug confirmed |
| fix branch | `<class 'str'> '3715575'` — fix confirmed |

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference

#### Changes Requiring Extra Attention

None — this is a one-line type coercion at initialisation with no behavioural change for valid inputs. `str(str_value)` is a no-op, so the fix is fully backward-compatible with environments running older PyJWT.

## Related Pull Requests

None — standalone fix.

## Release Note

Fixed a `TypeError: Issuer (iss) must be a string` crash that prevented GitHub App authentication from working in connector environments running PyJWT ≥ 2.11.0. The GitHub App ID is now correctly passed as a string in the JWT `iss` claim, as required by RFC 7519.