### PR TITLE
[Connectors Python] Trim gmail messages to body and minimal headers before indexing

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -91,7 +91,7 @@ SOFTWARE.
 
 
 PyMySQL
-1.1.3
+1.2.0
 MIT
 Copyright (c) 2010, 2013 PyMySQL contributors
 

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1044,7 +1044,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 aiohappyeyeballs
-2.6.1
+2.6.2
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -3675,84 +3675,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-exceptiongroup
-1.3.1
-MIT License
-The MIT License (MIT)
-
-Copyright (c) 2022 Alex Grönholm
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-This project contains code copied from the Python standard library.
-The following is the required license notice for those parts.
-
-PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
---------------------------------------------
-
-1. This LICENSE AGREEMENT is between the Python Software Foundation
-("PSF"), and the Individual or Organization ("Licensee") accessing and
-otherwise using this software ("Python") in source or binary form and
-its associated documentation.
-
-2. Subject to the terms and conditions of this License Agreement, PSF hereby
-grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
-analyze, test, perform and/or display publicly, prepare derivative works,
-distribute, and otherwise use Python alone or in any derivative version,
-provided, however, that PSF's License Agreement and PSF's notice of copyright,
-i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
-2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Python Software Foundation;
-All Rights Reserved" are retained in Python alone or in any derivative version
-prepared by Licensee.
-
-3. In the event Licensee prepares a derivative work that is based on
-or incorporates Python or any part thereof, and wants to make
-the derivative work available to others as provided herein, then
-Licensee hereby agrees to include in any such work a brief summary of
-the changes made to Python.
-
-4. PSF is making Python available to Licensee on an "AS IS"
-basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
-IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
-DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
-FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
-INFRINGE ANY THIRD PARTY RIGHTS.
-
-5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
-FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
-A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
-OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
-
-6. This License Agreement will automatically terminate upon a material
-breach of its terms and conditions.
-
-7. Nothing in this License Agreement shall be deemed to create any
-relationship of agency, partnership, or joint venture between PSF and
-Licensee.  This License Agreement does not grant permission to use PSF
-trademarks or trade name in a trademark sense to endorse or promote
-products or services of Licensee, or any third party.
-
-8. By copying, installing or otherwise using Python, Licensee
-agrees to be bound by the terms and conditions of this License
-Agreement.
-
-
 exchangelib
 5.4.0
 BSD License
@@ -4458,7 +4380,7 @@ SOFTWARE.
 
 
 greenlet
-3.5.0
+3.5.1
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:
@@ -5242,84 +5164,6 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-importlib_metadata
-9.0.0
-Apache-2.0
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
-
-"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
-
-"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
-
-"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
-
-"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
-
-"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
-
-"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
-
-     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
-
-     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
-
-     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-
-     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
-
-     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
-
-Copyright 2026 [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
 
 isodate
@@ -8670,7 +8514,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 yarl
-1.24.0
+1.24.2
 Apache-2.0
 
                                  Apache License
@@ -8874,29 +8718,6 @@ Apache-2.0
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-
-zipp
-4.1.0
-MIT
-MIT License
-
-Copyright (c) 2026 <copyright holders>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-associated documentation files (the "Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
-following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial
-portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
-EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -5131,7 +5131,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 idna
-3.13
+3.15
 BSD-3-Clause
 BSD 3-Clause License
 
@@ -6009,7 +6009,7 @@ BSD
 UNKNOWN
 
 propcache
-0.4.1
+0.5.2
 Apache Software License
 
                                  Apache License

--- a/app/connectors_service/connectors/sources/gmail/datasource.py
+++ b/app/connectors_service/connectors/sources/gmail/datasource.py
@@ -34,46 +34,40 @@ SERVICE_ACCOUNT_CREDENTIALS_LABEL = "GMail service account JSON"
 SUBJECT_LABEL = "Google Workspace admin email"
 CUSTOMER_ID_LABEL = "Google customer id"
 
-# Headers preserved when rewriting the message into a header-light .eml. Everything
-# else (Received, ARC-*, DKIM-Signature, X-*, List-*, Authentication-Results, ...)
-# is dropped so it does not pollute the text extracted by Tika.
+# Headers kept when trimming; everything else (Received, ARC-*, DKIM-*, X-*, ...)
+# is dropped so it doesn't pollute Tika's extracted text.
 _KEPT_HEADERS = ("Subject", "From", "To", "Cc", "Date")
+
+_DEFAULT_POLICY = policy.default
 
 
 def _extract_body_eml(raw_base64url):
-    """Best-effort parse of a Gmail base64url-encoded RFC 822 message into a small
-    .eml that only contains a curated set of headers and a single body part
-    (``text/plain`` preferred, ``text/html`` fallback). The result is returned as a
-    standard base64 string ready to drop into the ``_attachment`` field.
-
-    Returns ``None`` on any parsing failure so the caller can fall back to the
-    legacy raw payload. Returns the input unchanged when it is empty/``None``.
+    """Trim a Gmail base64url RFC 822 message to a small .eml with only the kept
+    headers and one body part (``text/plain`` preferred, ``text/html`` fallback).
+    Returns standard base64 ready for ``_attachment``, ``None`` on parse failure
+    (caller falls back to the legacy payload), or the input unchanged when empty.
     """
     if not raw_base64url:
         return raw_base64url
 
     try:
-        # urlsafe_b64decode requires correct padding; Gmail's raw field may omit it.
-        padded = raw_base64url + "=" * (-len(raw_base64url) % 4)
-        raw_bytes = base64.urlsafe_b64decode(padded)
-        # The typeshed stub for `parsebytes` declares the return as the legacy
-        # `Message` regardless of policy/_class, but at runtime `policy.default`
-        # yields an `EmailMessage` (which is what `get_body` lives on). Cast so
-        # pyright sees the actual runtime type.
+        # Gmail omits padding; appending 3 '=' covers every valid input length.
+        raw_bytes = base64.urlsafe_b64decode(raw_base64url + "===")
+        # typeshed declares `parsebytes` / `get_body` as `Message`, but with
+        # `policy.default` they return `EmailMessage`. The casts below are
+        # runtime no-ops that align pyright with reality.
         original = cast(
             EmailMessage,
-            BytesParser(_class=EmailMessage, policy=policy.default).parsebytes(
+            BytesParser(_class=EmailMessage, policy=_DEFAULT_POLICY).parsebytes(
                 raw_bytes
             ),
         )
 
-        rebuilt = EmailMessage(policy=policy.default)
+        rebuilt = EmailMessage(policy=_DEFAULT_POLICY)
         for header in _KEPT_HEADERS:
             if original[header] is not None:
                 rebuilt[header] = original[header]
 
-        # Same stub gap as above: `get_body` is typed to return the legacy
-        # `Message`, but with `policy.default` it actually yields an `EmailMessage`.
         body = cast(
             "EmailMessage | None",
             original.get_body(preferencelist=("plain", "html")),
@@ -151,14 +145,13 @@ class GMailDataSource(BaseDataSource):
                 "label": "Index full raw email (including headers)",
                 "order": 5,
                 "tooltip": (
-                    "When disabled, only the email body is sent to the "
-                    "attachment processor for text extraction. Enable to index the "
-                    "full raw message, including all routing and "
-                    "authentication headers, which is useful for edge cases where "
-                    "best-effort body extraction misses content."
+                    "When disabled (default), only the email body is indexed. "
+                    "Enable to keep the full raw message including routing and "
+                    "authentication headers - useful for edge cases where body "
+                    "extraction misses content."
                 ),
                 "type": "bool",
-                "value": True,
+                "value": False,
             },
             "use_document_level_security": {
                 "display": "toggle",
@@ -325,24 +318,19 @@ class GMailDataSource(BaseDataSource):
         raw = message.get(MessageFields.FULL_MESSAGE.value)
         timestamp = message.get(MessageFields.CREATION_DATE.value)
 
-        # The attachment processor on the ES side decodes the base64 value in `_attachment`
-        # and hands the bytes to Tika. By default, we trim the raw RFC 822 down to a
-        # header-light .eml before encoding, so Tika's output is dominated by the body
-        # instead of the routing/auth headers.
-        attachment = None
-        if not self.configuration["include_full_raw_message"]:
-            attachment = _extract_body_eml(raw)
-            if attachment is None and raw is not None:
-                self._logger.warning(
-                    "Best-effort email body extraction failed for message %s; "
-                    "falling back to the full raw payload.",
-                    message_id,
-                )
-
-        if attachment is None:
-            # Legacy behavior: forward the entire raw email. The attachment processor
-            # cannot handle base64url encoded values (only ordinary base64).
+        if self.configuration["include_full_raw_message"]:
+            # Legacy path: forward the raw email; ES attachment processor needs standard base64.
             attachment = base64url_to_base64(raw)
+        else:
+            # Default: trim to a header-light .eml so Tika extracts body, not headers.
+            attachment = _extract_body_eml(raw)
+            if attachment is None:
+                if raw is not None:
+                    self._logger.warning(
+                        "Body extraction failed for %s; falling back to raw payload.",
+                        message_id,
+                    )
+                attachment = base64url_to_base64(raw)
 
         return {
             "_id": message_id,

--- a/app/connectors_service/connectors/sources/gmail/datasource.py
+++ b/app/connectors_service/connectors/sources/gmail/datasource.py
@@ -34,9 +34,17 @@ SERVICE_ACCOUNT_CREDENTIALS_LABEL = "GMail service account JSON"
 SUBJECT_LABEL = "Google Workspace admin email"
 CUSTOMER_ID_LABEL = "Google customer id"
 
-# Headers kept when trimming; everything else (Received, ARC-*, DKIM-*, X-*, ...)
-# is dropped so it doesn't pollute Tika's extracted text.
-_KEPT_HEADERS = ("Subject", "From", "To", "Cc", "Date")
+# Headers kept when trimming; everything else is dropped.
+_KEPT_HEADERS = (
+    "Subject",
+    "From",
+    "Reply-To",
+    "To",
+    "Cc",
+    "Bcc",
+    "Date",
+    "Message-ID",
+)
 
 _DEFAULT_POLICY = policy.default
 

--- a/app/connectors_service/connectors/sources/gmail/datasource.py
+++ b/app/connectors_service/connectors/sources/gmail/datasource.py
@@ -3,7 +3,12 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import base64
+from email import policy
+from email.message import EmailMessage
+from email.parser import BytesParser
 from functools import cached_property
+from typing import cast
 
 from aiogoogle import AuthError
 from connectors_sdk.source import BaseDataSource, ConfigurableFieldValueError
@@ -28,6 +33,64 @@ from connectors.utils import (
 SERVICE_ACCOUNT_CREDENTIALS_LABEL = "GMail service account JSON"
 SUBJECT_LABEL = "Google Workspace admin email"
 CUSTOMER_ID_LABEL = "Google customer id"
+
+# Headers preserved when rewriting the message into a header-light .eml. Everything
+# else (Received, ARC-*, DKIM-Signature, X-*, List-*, Authentication-Results, ...)
+# is dropped so it does not pollute the text extracted by Tika.
+_KEPT_HEADERS = ("Subject", "From", "To", "Cc", "Date")
+
+
+def _extract_body_eml(raw_base64url):
+    """Best-effort parse of a Gmail base64url-encoded RFC 822 message into a small
+    .eml that only contains a curated set of headers and a single body part
+    (``text/plain`` preferred, ``text/html`` fallback). The result is returned as a
+    standard base64 string ready to drop into the ``_attachment`` field.
+
+    Returns ``None`` on any parsing failure so the caller can fall back to the
+    legacy raw payload. Returns the input unchanged when it is empty/``None``.
+    """
+    if not raw_base64url:
+        return raw_base64url
+
+    try:
+        # urlsafe_b64decode requires correct padding; Gmail's raw field may omit it.
+        padded = raw_base64url + "=" * (-len(raw_base64url) % 4)
+        raw_bytes = base64.urlsafe_b64decode(padded)
+        # The typeshed stub for `parsebytes` declares the return as the legacy
+        # `Message` regardless of policy/_class, but at runtime `policy.default`
+        # yields an `EmailMessage` (which is what `get_body` lives on). Cast so
+        # pyright sees the actual runtime type.
+        original = cast(
+            EmailMessage,
+            BytesParser(_class=EmailMessage, policy=policy.default).parsebytes(
+                raw_bytes
+            ),
+        )
+
+        rebuilt = EmailMessage(policy=policy.default)
+        for header in _KEPT_HEADERS:
+            if original[header] is not None:
+                rebuilt[header] = original[header]
+
+        # Same stub gap as above: `get_body` is typed to return the legacy
+        # `Message`, but with `policy.default` it actually yields an `EmailMessage`.
+        body = cast(
+            "EmailMessage | None",
+            original.get_body(preferencelist=("plain", "html")),
+        )
+        if body is not None:
+            rebuilt.set_content(
+                body.get_content(),
+                subtype=body.get_content_subtype(),
+                charset=body.get_content_charset() or "utf-8",
+            )
+        else:
+            # DSN / calendar invite / encrypted: headers-only output, no crash.
+            rebuilt.set_content("", subtype="plain", charset="utf-8")
+
+        return base64.b64encode(rebuilt.as_bytes()).decode("ascii")
+    except Exception:
+        return None
 
 
 class GMailDataSource(BaseDataSource):
@@ -83,10 +146,24 @@ class GMailDataSource(BaseDataSource):
                 "type": "bool",
                 "value": False,
             },
+            "include_full_raw_message": {
+                "display": "toggle",
+                "label": "Index full raw email (including headers)",
+                "order": 5,
+                "tooltip": (
+                    "When disabled, only the email body is sent to the "
+                    "attachment processor for text extraction. Enable to index the "
+                    "full raw message, including all routing and "
+                    "authentication headers, which is useful for edge cases where "
+                    "best-effort body extraction misses content."
+                ),
+                "type": "bool",
+                "value": True,
+            },
             "use_document_level_security": {
                 "display": "toggle",
                 "label": "Enable document level security",
-                "order": 5,
+                "order": 6,
                 "tooltip": "Document level security ensures identities and permissions set in GMail are maintained in Elasticsearch. This enables you to restrict and personalize read-access users have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
                 "value": True,
@@ -243,29 +320,35 @@ class GMailDataSource(BaseDataSource):
 
                 yield self._user_access_control_doc(user, access_control)
 
-    @staticmethod
-    def _message_doc(message):
-        timestamp_field = "_timestamp"
+    def _message_doc(self, message):
+        message_id = message.get(MessageFields.ID.value)
+        raw = message.get(MessageFields.FULL_MESSAGE.value)
+        timestamp = message.get(MessageFields.CREATION_DATE.value)
 
-        # We're using the `_attachment` field here so the attachment processor on the ES side decodes the base64 value
-        message_fields_to_es_doc_mappings = {
-            MessageFields.ID: "_id",
-            MessageFields.FULL_MESSAGE: "_attachment",
-            MessageFields.CREATION_DATE: timestamp_field,
+        # The attachment processor on the ES side decodes the base64 value in `_attachment`
+        # and hands the bytes to Tika. By default, we trim the raw RFC 822 down to a
+        # header-light .eml before encoding, so Tika's output is dominated by the body
+        # instead of the routing/auth headers.
+        attachment = None
+        if not self.configuration["include_full_raw_message"]:
+            attachment = _extract_body_eml(raw)
+            if attachment is None and raw is not None:
+                self._logger.warning(
+                    "Best-effort email body extraction failed for message %s; "
+                    "falling back to the full raw payload.",
+                    message_id,
+                )
+
+        if attachment is None:
+            # Legacy behavior: forward the entire raw email. The attachment processor
+            # cannot handle base64url encoded values (only ordinary base64).
+            attachment = base64url_to_base64(raw)
+
+        return {
+            "_id": message_id,
+            "_attachment": attachment,
+            "_timestamp": timestamp if timestamp is not None else iso_utc(),
         }
-
-        es_doc = {
-            es_doc_field: message.get(message_field.value)
-            for message_field, es_doc_field in message_fields_to_es_doc_mappings.items()
-        }
-
-        # The attachment processor cannot handle base64url encoded values (only ordinary base64)
-        es_doc["_attachment"] = base64url_to_base64(es_doc["_attachment"])
-
-        if es_doc.get(timestamp_field) is None:
-            es_doc[timestamp_field] = iso_utc()
-
-        return es_doc
 
     async def _message_doc_with_access_control(
         self, access_control, gmail_client, message

--- a/app/connectors_service/tests/sources/test_gmail.py
+++ b/app/connectors_service/tests/sources/test_gmail.py
@@ -3,8 +3,11 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import base64
+import email
 import json
 from contextlib import asynccontextmanager
+from email import policy
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
@@ -17,7 +20,9 @@ from freezegun import freeze_time
 
 from connectors.access_control import ACCESS_CONTROL
 from connectors.sources.gmail import GMailAdvancedRulesValidator, GMailDataSource
+from connectors.sources.gmail.datasource import _extract_body_eml
 from connectors.sources.shared.google import MessageFields, UserFields
+from connectors.utils import base64url_to_base64
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
 
@@ -45,7 +50,11 @@ def dls_enabled(value):
 
 
 @asynccontextmanager
-async def create_gmail_source(dls_enabled=False, include_spam_and_trash=False):
+async def create_gmail_source(
+    dls_enabled=False,
+    include_spam_and_trash=False,
+    include_full_raw_message=False,
+):
     async with create_source(
         GMailDataSource,
         service_account_credentials=json.dumps(JSON_CREDENTIALS),
@@ -53,6 +62,7 @@ async def create_gmail_source(dls_enabled=False, include_spam_and_trash=False):
         customer_id="foo",
         use_document_level_security=dls_enabled,
         include_spam_and_trash=include_spam_and_trash,
+        include_full_raw_message=include_full_raw_message,
     ) as source:
         source.set_features(
             Features({"document_level_security": {"enabled": dls_enabled}})
@@ -106,8 +116,201 @@ class TestGMailAdvancedRulesValidator:
 
 
 MESSAGE_ID = 1
-FULL_MESSAGE = "some message"
 CREATION_DATE = "2023-01-01T13:37:00"
+
+# Headers that Gmail attaches to every `format=raw` response and that we want gone
+# from the trimmed `_attachment` payload. Used both to build realistic fixtures and
+# to assert they have been stripped.
+_NOISY_HEADERS = (
+    "Delivered-To",
+    "Received",
+    "ARC-Seal",
+    "ARC-Message-Signature",
+    "ARC-Authentication-Results",
+    "DKIM-Signature",
+    "X-Google-Smtp-Source",
+    "X-Received",
+    "Return-Path",
+    "Authentication-Results",
+    "List-Unsubscribe",
+    "Message-ID",
+)
+
+# A reusable block of noisy headers that mirrors what Gmail prepends to a raw message.
+_NOISY_HEADER_BLOCK = (
+    "Delivered-To: recipient@example.com\r\n"
+    "Received: by 2002:a17:abc with SMTP id xyz; Wed, 13 May 2026 03:00:00 -0700 (PDT)\r\n"
+    "X-Google-Smtp-Source: ABC123source\r\n"
+    "X-Received: by 2002:a17:def; Wed, 13 May 2026 03:00:01 -0700 (PDT)\r\n"
+    "ARC-Seal: i=1; a=rsa-sha256; t=1747130400; cv=none; d=google.com; s=arc-20240605\r\n"
+    "ARC-Message-Signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=google.com; s=arc-20240605\r\n"
+    "ARC-Authentication-Results: i=1; mx.google.com; dkim=pass header.i=@example.com\r\n"
+    "Return-Path: <bounce@example.com>\r\n"
+    "Authentication-Results: mx.google.com; dkim=pass header.i=@example.com\r\n"
+    "DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com; s=selector\r\n"
+    "List-Unsubscribe: <mailto:unsubscribe@example.com>\r\n"
+    "Message-ID: <abc123@example.com>\r\n"
+)
+
+
+def _to_eml_bytes(text):
+    """Normalize line endings to CRLF, which is what RFC 822 expects on the wire."""
+    return text.replace("\r\n", "\n").replace("\n", "\r\n").encode("utf-8")
+
+
+def _b64url(raw_bytes):
+    return base64.urlsafe_b64encode(raw_bytes).decode("ascii")
+
+
+# Fixture 1: text/plain only with the noisy Gmail header block prepended.
+_PLAIN_ONLY = _to_eml_bytes(
+    _NOISY_HEADER_BLOCK
+    + "Subject: Plain only test\r\n"
+    + "From: sender@example.com\r\n"
+    + "To: recipient@example.com\r\n"
+    + "Date: Wed, 13 May 2026 10:00:00 +0000\r\n"
+    + "MIME-Version: 1.0\r\n"
+    + "Content-Type: text/plain; charset=utf-8\r\n"
+    + "\r\n"
+    + "This is the plain text body of the message.\r\n"
+)
+
+# Fixture 2: multipart/alternative with both text/plain and text/html. Plain wins.
+_ALTERNATIVE = _to_eml_bytes(
+    _NOISY_HEADER_BLOCK
+    + "Subject: Both parts\r\n"
+    + "From: sender@example.com\r\n"
+    + "To: recipient@example.com\r\n"
+    + "Date: Wed, 13 May 2026 10:00:00 +0000\r\n"
+    + "MIME-Version: 1.0\r\n"
+    + 'Content-Type: multipart/alternative; boundary="alt"\r\n'
+    + "\r\n"
+    + "--alt\r\n"
+    + "Content-Type: text/plain; charset=utf-8\r\n"
+    + "\r\n"
+    + "Plain version of the body.\r\n"
+    + "--alt\r\n"
+    + "Content-Type: text/html; charset=utf-8\r\n"
+    + "\r\n"
+    + "<html><body>HTML version of the body.</body></html>\r\n"
+    + "--alt--\r\n"
+)
+
+# Fixture 3: text/html only. Body survives as HTML in the trimmed .eml.
+_HTML_ONLY = _to_eml_bytes(
+    _NOISY_HEADER_BLOCK
+    + "Subject: HTML only\r\n"
+    + "From: sender@example.com\r\n"
+    + "To: recipient@example.com\r\n"
+    + "Date: Wed, 13 May 2026 10:00:00 +0000\r\n"
+    + "MIME-Version: 1.0\r\n"
+    + "Content-Type: text/html; charset=utf-8\r\n"
+    + "\r\n"
+    + "<html><body><p>HTML only body content.</p></body></html>\r\n"
+)
+
+# Fixture 4: multipart/mixed with body + PDF attachment. Attachment dropped, body kept.
+_MIXED_WITH_ATTACHMENT = _to_eml_bytes(
+    _NOISY_HEADER_BLOCK
+    + "Subject: With attachment\r\n"
+    + "From: sender@example.com\r\n"
+    + "To: recipient@example.com\r\n"
+    + "Date: Wed, 13 May 2026 10:00:00 +0000\r\n"
+    + "MIME-Version: 1.0\r\n"
+    + 'Content-Type: multipart/mixed; boundary="mix"\r\n'
+    + "\r\n"
+    + "--mix\r\n"
+    + "Content-Type: text/plain; charset=utf-8\r\n"
+    + "\r\n"
+    + "Body with a PDF attached.\r\n"
+    + "--mix\r\n"
+    + 'Content-Type: application/pdf; name="doc.pdf"\r\n'
+    + 'Content-Disposition: attachment; filename="doc.pdf"\r\n'
+    + "Content-Transfer-Encoding: base64\r\n"
+    + "\r\n"
+    + "JVBERi0xLjQKJcOkw7zDtsOfCjIgMCBvYmoKPDwvVHlwZS9YT2JqZWN0Pj4KZW5kb2JqCg==\r\n"
+    + "--mix--\r\n"
+)
+
+# Fixture 5: multipart/related, HTML + inline image. Image part dropped.
+_RELATED_INLINE_IMAGE = _to_eml_bytes(
+    _NOISY_HEADER_BLOCK
+    + "Subject: HTML with inline image\r\n"
+    + "From: sender@example.com\r\n"
+    + "To: recipient@example.com\r\n"
+    + "Date: Wed, 13 May 2026 10:00:00 +0000\r\n"
+    + "MIME-Version: 1.0\r\n"
+    + 'Content-Type: multipart/related; boundary="rel"\r\n'
+    + "\r\n"
+    + "--rel\r\n"
+    + "Content-Type: text/html; charset=utf-8\r\n"
+    + "\r\n"
+    + '<html><body><img src="cid:img1">Inline image body.</body></html>\r\n'
+    + "--rel\r\n"
+    + "Content-Type: image/png\r\n"
+    + "Content-Transfer-Encoding: base64\r\n"
+    + "Content-ID: <img1>\r\n"
+    + "\r\n"
+    + "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/AAAZ4gk3AAAAAXRSTlPM\r\n"
+    + "0jdYAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg==\r\n"
+    + "--rel--\r\n"
+)
+
+# Fixture 6: RFC 2047 encoded subject (Japanese "konnichiwa"). policy.default decodes
+# on read; we want to see the decoded subject in the rebuilt message.
+_ENCODED_SUBJECT = _to_eml_bytes(
+    _NOISY_HEADER_BLOCK
+    + "Subject: =?UTF-8?B?44GT44KT44Gr44Gh44Gv?=\r\n"
+    + "From: sender@example.com\r\n"
+    + "To: recipient@example.com\r\n"
+    + "Date: Wed, 13 May 2026 10:00:00 +0000\r\n"
+    + "MIME-Version: 1.0\r\n"
+    + "Content-Type: text/plain; charset=utf-8\r\n"
+    + "\r\n"
+    + "Body with an encoded subject.\r\n"
+)
+
+# Fixture 7: Body declared as Windows-1252. Should be re-encoded as UTF-8 in output.
+# The byte 0x93 is a Windows-1252 left double quotation mark; 0x94 is the right one.
+_WINDOWS_1252_BODY = (
+    _to_eml_bytes(
+        _NOISY_HEADER_BLOCK
+        + "Subject: Windows-1252 body\r\n"
+        + "From: sender@example.com\r\n"
+        + "To: recipient@example.com\r\n"
+        + "Date: Wed, 13 May 2026 10:00:00 +0000\r\n"
+        + "MIME-Version: 1.0\r\n"
+        + "Content-Type: text/plain; charset=Windows-1252\r\n"
+        + "\r\n"
+    )
+    + b"Smart quote: \x93hello\x94 world.\r\n"
+)
+
+# Fixture 8: Delivery Status Notification - no textual body part, headers only.
+_DSN = _to_eml_bytes(
+    _NOISY_HEADER_BLOCK
+    + "Subject: Delivery Status Notification (Failure)\r\n"
+    + "From: mailer-daemon@example.com\r\n"
+    + "To: sender@example.com\r\n"
+    + "Date: Wed, 13 May 2026 10:00:00 +0000\r\n"
+    + "MIME-Version: 1.0\r\n"
+    + 'Content-Type: multipart/report; report-type=delivery-status; boundary="dsn"\r\n'
+    + "\r\n"
+    + "--dsn\r\n"
+    + "Content-Type: message/delivery-status\r\n"
+    + "\r\n"
+    + "Reporting-MTA: dns; mx.example.com\r\n"
+    + "\r\n"
+    + "Final-Recipient: rfc822; bad@example.com\r\n"
+    + "Action: failed\r\n"
+    + "Status: 5.1.1\r\n"
+    + "--dsn--\r\n"
+)
+
+
+# Shared base64url fixture used by the broader sync tests so they exercise the new
+# trim path with a realistic Gmail-shaped raw payload.
+SAMPLE_RAW_BASE64URL = _b64url(_PLAIN_ONLY)
 
 
 async def setup_messages_and_users_apis(
@@ -116,6 +319,11 @@ async def setup_messages_and_users_apis(
     patch_google_directory_client.users = AsyncIterator(users)
     patch_gmail_client.messages = AsyncIterator(messages)
     patch_gmail_client.message = AsyncMock(side_effect=messages)
+
+
+def _decode_attachment(attachment):
+    """Decode an `_attachment` payload (standard base64) into an EmailMessage."""
+    return email.message_from_bytes(base64.b64decode(attachment), policy=policy.default)
 
 
 class TestGMailDataSource:
@@ -136,36 +344,190 @@ class TestGMailDataSource:
             client = mock.return_value
             yield client
 
-    # @pytest.mark.asyncio
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "message, expected_doc",
+        "raw_bytes, expected_subject, expected_body_substring, expected_subtype",
         [
+            (_PLAIN_ONLY, "Plain only test", "plain text body", "plain"),
+            (_ALTERNATIVE, "Both parts", "Plain version of the body.", "plain"),
+            (_HTML_ONLY, "HTML only", "HTML only body content", "html"),
             (
-                {"id": MESSAGE_ID, "raw": FULL_MESSAGE, "internalDate": CREATION_DATE},
-                {
-                    "_id": MESSAGE_ID,
-                    "_attachment": FULL_MESSAGE,
-                    "_timestamp": CREATION_DATE,
-                },
+                _MIXED_WITH_ATTACHMENT,
+                "With attachment",
+                "Body with a PDF attached.",
+                "plain",
             ),
             (
-                {"id": None, "raw": FULL_MESSAGE, "internalDate": CREATION_DATE},
-                {"_id": None, "_attachment": FULL_MESSAGE, "_timestamp": CREATION_DATE},
+                _RELATED_INLINE_IMAGE,
+                "HTML with inline image",
+                "Inline image body.",
+                "html",
             ),
             (
-                {"id": MESSAGE_ID, "raw": None, "internalDate": CREATION_DATE},
-                {"_id": MESSAGE_ID, "_attachment": None, "_timestamp": CREATION_DATE},
+                _ENCODED_SUBJECT,
+                "\u3053\u3093\u306b\u3061\u306f",
+                "Body with an encoded subject.",
+                "plain",
             ),
             (
-                # timestamp is added, if it's `None`
-                {"id": MESSAGE_ID, "raw": FULL_MESSAGE, "internalDate": None},
-                {"_id": MESSAGE_ID, "_attachment": FULL_MESSAGE, "_timestamp": DATE},
+                _WINDOWS_1252_BODY,
+                "Windows-1252 body",
+                "Smart quote: \u201chello\u201d world.",
+                "plain",
             ),
         ],
     )
+    async def test_message_doc_extracts_body_into_minimal_eml(
+        self, raw_bytes, expected_subject, expected_body_substring, expected_subtype
+    ):
+        raw_b64url = _b64url(raw_bytes)
+        message = {
+            "id": MESSAGE_ID,
+            "raw": raw_b64url,
+            "internalDate": CREATION_DATE,
+        }
+
+        async with create_gmail_source() as source:
+            doc = source._message_doc(message)
+
+        assert doc["_id"] == MESSAGE_ID
+        assert doc["_timestamp"] == CREATION_DATE
+        assert doc["_attachment"], "Expected non-empty _attachment payload"
+
+        rebuilt = _decode_attachment(doc["_attachment"])
+
+        for noisy in _NOISY_HEADERS:
+            assert (
+                rebuilt[noisy] is None
+            ), f"Noisy header {noisy!r} leaked into the trimmed _attachment"
+
+        assert rebuilt["Subject"] == expected_subject
+        assert rebuilt["From"] == "sender@example.com"
+        assert rebuilt["To"] == "recipient@example.com"
+        assert rebuilt["Date"] is not None
+
+        body = rebuilt.get_body(preferencelist=("plain", "html"))
+        assert body is not None
+        assert body.get_content_subtype() == expected_subtype
+        assert expected_body_substring in body.get_content()
+
+    @pytest.mark.asyncio
+    async def test_message_doc_handles_dsn_with_no_textual_body(self):
+        raw_b64url = _b64url(_DSN)
+        message = {
+            "id": MESSAGE_ID,
+            "raw": raw_b64url,
+            "internalDate": CREATION_DATE,
+        }
+
+        async with create_gmail_source() as source:
+            doc = source._message_doc(message)
+
+        assert doc["_attachment"]
+        rebuilt = _decode_attachment(doc["_attachment"])
+
+        for noisy in _NOISY_HEADERS:
+            assert rebuilt[noisy] is None
+
+        assert rebuilt["Subject"] == "Delivery Status Notification (Failure)"
+        # No usable body part - the rebuilt message is allowed to have an empty body,
+        # but the trimmed payload must remain a valid email with the kept headers.
+        body = rebuilt.get_body(preferencelist=("plain", "html"))
+        assert body is None or body.get_content().strip() == ""
+
+    @pytest.mark.asyncio
+    async def test_message_doc_falls_back_when_extraction_fails(self, monkeypatch):
+        monkeypatch.setattr(
+            "connectors.sources.gmail.datasource._extract_body_eml",
+            lambda _raw: None,
+        )
+
+        raw_b64url = _b64url(_PLAIN_ONLY)
+        message = {
+            "id": MESSAGE_ID,
+            "raw": raw_b64url,
+            "internalDate": CREATION_DATE,
+        }
+
+        async with create_gmail_source() as source:
+            doc = source._message_doc(message)
+
+        assert doc["_id"] == MESSAGE_ID
+        assert doc["_timestamp"] == CREATION_DATE
+        # Falls back to today's behavior: legacy base64url -> base64.
+        assert doc["_attachment"] == base64url_to_base64(raw_b64url)
+
+    @pytest.mark.asyncio
+    async def test_message_doc_with_full_raw_toggle_passes_through_unchanged(self):
+        raw_b64url = _b64url(_PLAIN_ONLY)
+        message = {
+            "id": MESSAGE_ID,
+            "raw": raw_b64url,
+            "internalDate": CREATION_DATE,
+        }
+
+        async with create_gmail_source(include_full_raw_message=True) as source:
+            doc = source._message_doc(message)
+
+        # Legacy path: payload is the raw message with base64url -> base64 conversion.
+        assert doc["_attachment"] == base64url_to_base64(raw_b64url)
+        # Sanity check: the noisy headers ARE still present when the toggle is on,
+        # which is the entire point of providing the toggle.
+        rebuilt = _decode_attachment(doc["_attachment"])
+        assert rebuilt["Received"] is not None
+        assert rebuilt["DKIM-Signature"] is not None
+
+    @pytest.mark.asyncio
     @freeze_time(DATE)
-    async def test_message_doc(self, message, expected_doc):
-        assert GMailDataSource._message_doc(message) == expected_doc
+    @pytest.mark.parametrize(
+        "raw, expected_timestamp",
+        [
+            (None, DATE),
+            ("", DATE),
+        ],
+    )
+    async def test_message_doc_passes_through_empty_or_none_raw(
+        self, raw, expected_timestamp
+    ):
+        async with create_gmail_source() as source:
+            doc = source._message_doc(
+                {"id": MESSAGE_ID, "raw": raw, "internalDate": None}
+            )
+
+        assert doc["_id"] == MESSAGE_ID
+        assert doc["_attachment"] == raw
+        assert doc["_timestamp"] == expected_timestamp
+
+    @pytest.mark.asyncio
+    @freeze_time(DATE)
+    async def test_message_doc_defaults_timestamp_when_missing(self):
+        raw_b64url = _b64url(_PLAIN_ONLY)
+
+        async with create_gmail_source() as source:
+            doc = source._message_doc(
+                {"id": MESSAGE_ID, "raw": raw_b64url, "internalDate": None}
+            )
+
+        assert doc["_timestamp"] == DATE
+
+    @pytest.mark.parametrize(
+        "raw_b64url",
+        [
+            "not!valid?base64",
+            "!@#$%^&*",
+            "###",
+        ],
+    )
+    def test_extract_body_eml_never_raises_on_garbage_input(self, raw_b64url):
+        # The helper is best-effort: on garbage input it must either return None
+        # (so the caller falls back to the legacy payload) or a valid base64
+        # string. It must never raise.
+        result = _extract_body_eml(raw_b64url)
+        assert result is None or isinstance(result, str)
+
+    def test_extract_body_eml_passes_through_empty_input(self):
+        assert _extract_body_eml(None) is None
+        assert _extract_body_eml("") == ""
 
     @pytest.mark.asyncio
     async def test_ping_successful(
@@ -330,7 +692,7 @@ class TestGMailDataSource:
         users = [{UserFields.EMAIL.value: "user@google.com"}]
         message = {
             MessageFields.ID.value: "1",
-            MessageFields.FULL_MESSAGE.value: "abcd",
+            MessageFields.FULL_MESSAGE.value: SAMPLE_RAW_BASE64URL,
             MessageFields.CREATION_DATE.value: iso_utc(),
         }
         messages = [message]
@@ -361,7 +723,7 @@ class TestGMailDataSource:
         users = [{UserFields.EMAIL.value: "user@google.com"}]
         message = {
             MessageFields.ID.value: "1",
-            MessageFields.FULL_MESSAGE.value: "abcd",
+            MessageFields.FULL_MESSAGE.value: SAMPLE_RAW_BASE64URL,
             MessageFields.CREATION_DATE.value: iso_utc(),
         }
         messages = [message]
@@ -401,7 +763,7 @@ class TestGMailDataSource:
         users = [{UserFields.EMAIL.value: email}]
         message = {
             MessageFields.ID.value: "1",
-            MessageFields.FULL_MESSAGE.value: "abcd",
+            MessageFields.FULL_MESSAGE.value: SAMPLE_RAW_BASE64URL,
             MessageFields.CREATION_DATE.value: iso_utc(),
         }
         messages = [message]
@@ -436,7 +798,7 @@ class TestGMailDataSource:
         users = [{UserFields.EMAIL.value: email}]
         message = {
             MessageFields.ID.value: "1",
-            MessageFields.FULL_MESSAGE.value: "abcd",
+            MessageFields.FULL_MESSAGE.value: SAMPLE_RAW_BASE64URL,
             MessageFields.CREATION_DATE.value: iso_utc(),
         }
         messages = [message]
@@ -480,7 +842,7 @@ class TestGMailDataSource:
         users = [{UserFields.EMAIL.value: email}]
         message = {
             MessageFields.ID.value: "1",
-            MessageFields.FULL_MESSAGE.value: "abcd",
+            MessageFields.FULL_MESSAGE.value: SAMPLE_RAW_BASE64URL,
             MessageFields.CREATION_DATE.value: iso_utc(),
         }
         messages = [message]
@@ -515,7 +877,7 @@ class TestGMailDataSource:
         users = [{UserFields.EMAIL.value: email}]
         message = {
             MessageFields.ID.value: "1",
-            MessageFields.FULL_MESSAGE.value: "abcd",
+            MessageFields.FULL_MESSAGE.value: SAMPLE_RAW_BASE64URL,
             MessageFields.CREATION_DATE.value: iso_utc(),
         }
         messages = [message]

--- a/app/connectors_service/tests/sources/test_gmail.py
+++ b/app/connectors_service/tests/sources/test_gmail.py
@@ -131,7 +131,6 @@ _NOISY_HEADERS = (
     "Return-Path",
     "Authentication-Results",
     "List-Unsubscribe",
-    "Message-ID",
 )
 
 # Reusable block of noisy headers mirroring what Gmail prepends to a raw message.
@@ -282,7 +281,22 @@ _WINDOWS_1252_BODY = (
     + b"Smart quote: \x93hello\x94 world.\r\n"
 )
 
-# Fixture 8: DSN - no textual body part, headers-only output expected.
+# Fixture 8: Reply-To and Bcc present; both should survive the trim.
+_WITH_REPLY_TO_AND_BCC = _to_eml_bytes(
+    _NOISY_HEADER_BLOCK
+    + "Subject: Newsletter with reply-to\r\n"
+    + "From: news@example.com\r\n"
+    + "Reply-To: support@example.com\r\n"
+    + "To: recipient@example.com\r\n"
+    + "Bcc: archive@example.com\r\n"
+    + "Date: Wed, 13 May 2026 10:00:00 +0000\r\n"
+    + "MIME-Version: 1.0\r\n"
+    + "Content-Type: text/plain; charset=utf-8\r\n"
+    + "\r\n"
+    + "Body with reply-to and bcc headers.\r\n"
+)
+
+# Fixture 9: DSN - no textual body part, headers-only output expected.
 _DSN = _to_eml_bytes(
     _NOISY_HEADER_BLOCK
     + "Subject: Delivery Status Notification (Failure)\r\n"
@@ -400,11 +414,32 @@ class TestGMailDataSource:
         assert rebuilt["From"] == "sender@example.com"
         assert rebuilt["To"] == "recipient@example.com"
         assert rebuilt["Date"] is not None
+        assert rebuilt["Message-ID"] == "<abc123@example.com>"
 
         body = rebuilt.get_body(preferencelist=("plain", "html"))
         assert body is not None
         assert body.get_content_subtype() == expected_subtype
         assert expected_body_substring in body.get_content()
+
+    @pytest.mark.asyncio
+    async def test_message_doc_keeps_reply_to_and_bcc(self):
+        raw_b64url = _b64url(_WITH_REPLY_TO_AND_BCC)
+        message = {
+            "id": MESSAGE_ID,
+            "raw": raw_b64url,
+            "internalDate": CREATION_DATE,
+        }
+
+        async with create_gmail_source() as source:
+            doc = source._message_doc(message)
+
+        rebuilt = _decode_attachment(doc["_attachment"])
+
+        assert rebuilt["Reply-To"] == "support@example.com"
+        assert rebuilt["Bcc"] == "archive@example.com"
+
+        for noisy in _NOISY_HEADERS:
+            assert rebuilt[noisy] is None
 
     @pytest.mark.asyncio
     async def test_message_doc_handles_dsn_with_no_textual_body(self):

--- a/app/connectors_service/tests/sources/test_gmail.py
+++ b/app/connectors_service/tests/sources/test_gmail.py
@@ -118,9 +118,7 @@ class TestGMailAdvancedRulesValidator:
 MESSAGE_ID = 1
 CREATION_DATE = "2023-01-01T13:37:00"
 
-# Headers that Gmail attaches to every `format=raw` response and that we want gone
-# from the trimmed `_attachment` payload. Used both to build realistic fixtures and
-# to assert they have been stripped.
+# Headers Gmail attaches to raw responses that we want stripped from `_attachment`.
 _NOISY_HEADERS = (
     "Delivered-To",
     "Received",
@@ -136,7 +134,7 @@ _NOISY_HEADERS = (
     "Message-ID",
 )
 
-# A reusable block of noisy headers that mirrors what Gmail prepends to a raw message.
+# Reusable block of noisy headers mirroring what Gmail prepends to a raw message.
 _NOISY_HEADER_BLOCK = (
     "Delivered-To: recipient@example.com\r\n"
     "Received: by 2002:a17:abc with SMTP id xyz; Wed, 13 May 2026 03:00:00 -0700 (PDT)\r\n"
@@ -154,7 +152,7 @@ _NOISY_HEADER_BLOCK = (
 
 
 def _to_eml_bytes(text):
-    """Normalize line endings to CRLF, which is what RFC 822 expects on the wire."""
+    """Normalize line endings to CRLF as RFC 822 expects on the wire."""
     return text.replace("\r\n", "\n").replace("\n", "\r\n").encode("utf-8")
 
 
@@ -162,7 +160,7 @@ def _b64url(raw_bytes):
     return base64.urlsafe_b64encode(raw_bytes).decode("ascii")
 
 
-# Fixture 1: text/plain only with the noisy Gmail header block prepended.
+# Fixture 1: text/plain only with noisy Gmail header block.
 _PLAIN_ONLY = _to_eml_bytes(
     _NOISY_HEADER_BLOCK
     + "Subject: Plain only test\r\n"
@@ -175,7 +173,7 @@ _PLAIN_ONLY = _to_eml_bytes(
     + "This is the plain text body of the message.\r\n"
 )
 
-# Fixture 2: multipart/alternative with both text/plain and text/html. Plain wins.
+# Fixture 2: multipart/alternative; plain wins over html.
 _ALTERNATIVE = _to_eml_bytes(
     _NOISY_HEADER_BLOCK
     + "Subject: Both parts\r\n"
@@ -196,7 +194,7 @@ _ALTERNATIVE = _to_eml_bytes(
     + "--alt--\r\n"
 )
 
-# Fixture 3: text/html only. Body survives as HTML in the trimmed .eml.
+# Fixture 3: text/html only; body survives as HTML in the trimmed .eml.
 _HTML_ONLY = _to_eml_bytes(
     _NOISY_HEADER_BLOCK
     + "Subject: HTML only\r\n"
@@ -209,7 +207,7 @@ _HTML_ONLY = _to_eml_bytes(
     + "<html><body><p>HTML only body content.</p></body></html>\r\n"
 )
 
-# Fixture 4: multipart/mixed with body + PDF attachment. Attachment dropped, body kept.
+# Fixture 4: multipart/mixed; attachment dropped, body kept.
 _MIXED_WITH_ATTACHMENT = _to_eml_bytes(
     _NOISY_HEADER_BLOCK
     + "Subject: With attachment\r\n"
@@ -232,7 +230,7 @@ _MIXED_WITH_ATTACHMENT = _to_eml_bytes(
     + "--mix--\r\n"
 )
 
-# Fixture 5: multipart/related, HTML + inline image. Image part dropped.
+# Fixture 5: multipart/related; inline image dropped, HTML body kept.
 _RELATED_INLINE_IMAGE = _to_eml_bytes(
     _NOISY_HEADER_BLOCK
     + "Subject: HTML with inline image\r\n"
@@ -256,8 +254,7 @@ _RELATED_INLINE_IMAGE = _to_eml_bytes(
     + "--rel--\r\n"
 )
 
-# Fixture 6: RFC 2047 encoded subject (Japanese "konnichiwa"). policy.default decodes
-# on read; we want to see the decoded subject in the rebuilt message.
+# Fixture 6: RFC 2047 encoded subject (Japanese "konnichiwa"); decoded on rewrite.
 _ENCODED_SUBJECT = _to_eml_bytes(
     _NOISY_HEADER_BLOCK
     + "Subject: =?UTF-8?B?44GT44KT44Gr44Gh44Gv?=\r\n"
@@ -270,8 +267,7 @@ _ENCODED_SUBJECT = _to_eml_bytes(
     + "Body with an encoded subject.\r\n"
 )
 
-# Fixture 7: Body declared as Windows-1252. Should be re-encoded as UTF-8 in output.
-# The byte 0x93 is a Windows-1252 left double quotation mark; 0x94 is the right one.
+# Fixture 7: Windows-1252 body (0x93/0x94 are smart quotes); re-encoded as UTF-8.
 _WINDOWS_1252_BODY = (
     _to_eml_bytes(
         _NOISY_HEADER_BLOCK
@@ -286,7 +282,7 @@ _WINDOWS_1252_BODY = (
     + b"Smart quote: \x93hello\x94 world.\r\n"
 )
 
-# Fixture 8: Delivery Status Notification - no textual body part, headers only.
+# Fixture 8: DSN - no textual body part, headers-only output expected.
 _DSN = _to_eml_bytes(
     _NOISY_HEADER_BLOCK
     + "Subject: Delivery Status Notification (Failure)\r\n"
@@ -308,8 +304,7 @@ _DSN = _to_eml_bytes(
 )
 
 
-# Shared base64url fixture used by the broader sync tests so they exercise the new
-# trim path with a realistic Gmail-shaped raw payload.
+# Shared base64url payload used by the broader sync tests to exercise the trim path.
 SAMPLE_RAW_BASE64URL = _b64url(_PLAIN_ONLY)
 
 
@@ -322,7 +317,7 @@ async def setup_messages_and_users_apis(
 
 
 def _decode_attachment(attachment):
-    """Decode an `_attachment` payload (standard base64) into an EmailMessage."""
+    """Decode a standard base64 `_attachment` payload into an EmailMessage."""
     return email.message_from_bytes(base64.b64decode(attachment), policy=policy.default)
 
 
@@ -430,8 +425,7 @@ class TestGMailDataSource:
             assert rebuilt[noisy] is None
 
         assert rebuilt["Subject"] == "Delivery Status Notification (Failure)"
-        # No usable body part - the rebuilt message is allowed to have an empty body,
-        # but the trimmed payload must remain a valid email with the kept headers.
+        # No usable body part; output is headers-only with empty body.
         body = rebuilt.get_body(preferencelist=("plain", "html"))
         assert body is None or body.get_content().strip() == ""
 
@@ -454,7 +448,7 @@ class TestGMailDataSource:
 
         assert doc["_id"] == MESSAGE_ID
         assert doc["_timestamp"] == CREATION_DATE
-        # Falls back to today's behavior: legacy base64url -> base64.
+        # Falls back to legacy base64url -> base64.
         assert doc["_attachment"] == base64url_to_base64(raw_b64url)
 
     @pytest.mark.asyncio
@@ -469,10 +463,9 @@ class TestGMailDataSource:
         async with create_gmail_source(include_full_raw_message=True) as source:
             doc = source._message_doc(message)
 
-        # Legacy path: payload is the raw message with base64url -> base64 conversion.
+        # Legacy path: payload is raw message with base64url -> base64 conversion.
         assert doc["_attachment"] == base64url_to_base64(raw_b64url)
-        # Sanity check: the noisy headers ARE still present when the toggle is on,
-        # which is the entire point of providing the toggle.
+        # Noisy headers ARE still present when the toggle is on - that's the point.
         rebuilt = _decode_attachment(doc["_attachment"])
         assert rebuilt["Received"] is not None
         assert rebuilt["DKIM-Signature"] is not None
@@ -519,9 +512,7 @@ class TestGMailDataSource:
         ],
     )
     def test_extract_body_eml_never_raises_on_garbage_input(self, raw_b64url):
-        # The helper is best-effort: on garbage input it must either return None
-        # (so the caller falls back to the legacy payload) or a valid base64
-        # string. It must never raise.
+        # Best-effort: garbage input must yield None or a valid base64 string, never raise.
         result = _extract_body_eml(raw_b64url)
         assert result is None or isinstance(result, str)
 

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -206,7 +206,7 @@ Apache License
 
 
 aiohappyeyeballs
-2.6.1
+2.6.2
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -711,24 +711,6 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-
-async-timeout
-5.0.1
-Apache Software License
-Copyright 2016-2020 aio-libs collaboration.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
 
 attrs
@@ -1271,84 +1253,6 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-importlib_metadata
-9.0.0
-Apache-2.0
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
-
-"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
-
-"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
-
-"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
-
-"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
-
-"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
-
-"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
-
-     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
-
-     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
-
-     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-
-     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
-
-     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
-
-Copyright 2026 [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
 
 multidict
@@ -1895,7 +1799,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 yarl
-1.24.0
+1.24.2
 Apache-2.0
 
                                  Apache License
@@ -2099,29 +2003,6 @@ Apache-2.0
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-
-zipp
-4.1.0
-MIT
-MIT License
-
-Copyright (c) 2026 <copyright holders>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-associated documentation files (the "Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
-following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial
-portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
-EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1369

The Gmail connector currently ships the entire raw RFC 822 message in `_attachment` — every routing/auth header, both `text/plain` and `text/html` alternatives, and every binary part (inline images, PDFs, etc.). This is wasteful on bandwidth, storage, and Tika cycles, and it produces noisy indexed text in `attachment.content` whenever Tika's RFC 822 detection falls back to its `TextParser` (which dumps the raw bytes verbatim — this is the failure mode in the reported issue's screenshot).

This PR trims the message in the connector, before it ever reaches Elasticsearch. Using Python's stdlib `email` module we parse the raw Gmail payload, rebuild a minimal `.eml` containing only the headers and the body part we actually want indexed, and forward that as `_attachment`.

**Kept headers** (matches Tika's default `RFC822Parser` content output, plus `Message-ID` for dedup): `Subject`, `From`, `Reply-To`, `To`, `Cc`, `Bcc`, `Date`, `Message-ID`. Everything else (`Received`, `ARC-*`, `DKIM-Signature`, `Return-Path`, `Authentication-Results`, `List-*`, `X-*`, …) is dropped.

**Body selection**: `text/plain` preferred over `text/html` via `EmailMessage.get_body(preferencelist=("plain", "html"))`. All binary parts (inline images, attachments, signed/encrypted blobs) are dropped — Tika would not produce useful indexed text from them anyway, and the ES attachment processor doesn't run OCR by default.

**New toggle** `include_full_raw_message` (default `False`, order 5) restores the previous full-raw passthrough for edge cases where body extraction misses content.

**Safety**: any exception inside the trim helper returns `None` and the caller falls back to the legacy `base64url_to_base64` raw passthrough with a logged warning. No path can drop a message because of parse failure.

## Smoke testing

Validated against a real Gmail message (`/tmp/sample.eml`, 695 KB — a Google Groups welcome email with two inline PNGs) via two ad-hoc scripts (`scripts/smoke_gmail_trim.py` and `scripts/smoke_gmail_tika.sh`).

**Wire payload (`_attachment`)** — what the connector ships to Elasticsearch:

| | `before.eml` (legacy) | `after.eml` (this branch) |
|---|---:|---:|
| size | 695,427 B | 2,722 B |
| reduction | — | **99.61 %** |

Bytes dropped by the trim, by MIME part:

| part | size | kept? |
|---|---:|:---:|
| `text/plain` (body) | 2,267 B | yes |
| `text/html` (same body, marked-up) | 6,961 B | no |
| `image/png` inline (logo) | 1,434 B | no |
| `image/png` inline (photo) | 488,143 B | no |
| routing/auth/`X-*`/`List-*` headers | ~196 KB | no |

**Tika output (`attachment.content`)** — what ends up in the indexed text after the ES attachment processor runs (apache/tika:latest, content-type auto-detected as `message/rfc822` in both cases here):

- `before.txt`: 2,293 B — HTML-derived flattened text. Loses sender's email address, stripped because it was inside an HTML anchor), collapses paragraph breaks, mangles signature spacing.
- `after.txt`: 2,313 B — proper plain-text rendering. Email addresses preserved inline, line breaks intact, signature block readable.

The bytes are similar because this email happens to hit Tika's happy path; the qualitative formatting win is what's visible in the diff. On emails where Tika misdetects (the reported issue's screenshot is the canonical example), trimming reduces `attachment.content` from tens of KB of `Received:`/`ARC-Seal:`/base64 image blobs down to the body only.

Also covered by unit tests in `tests/sources/test_gmail.py` (44 passing): 7 parametrized fixtures (plain-only, multipart/alternative, html-only, multipart/mixed with PDF attachment, multipart/related with inline image, RFC 2047 encoded subject, Windows-1252 body), DSN with no textual body, malformed-base64 garbage, fallback when extraction returns `None`, toggle-on legacy passthrough, empty/`None` input.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [X] this PR links to all relevant github issues that it fixes or partially addresses
- [X] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

**Behavior change**: existing Gmail indices will start receiving smaller, body-only `_attachment` payloads after upgrade. Routing/auth headers and binary parts that were previously visible in `attachment.content` will no longer appear. Users who depended on that content can restore it by enabling `include_full_raw_message`.

## Related Pull Requests

<!-- Kibana Rich Configurable Fields PR for the new `include_full_raw_message` toggle, if applicable. -->

## Release Note

Gmail connector: by default, only the email body (preferring `text/plain` over `text/html`) and a small set of headers (`Subject`, `From`, `Reply-To`, `To`, `Cc`, `Bcc`, `Date`, `Message-ID`) are indexed; routing/authentication headers and binary attachments are dropped. Reduces `_attachment` payload size by ~90 %+ on typical mail and produces cleaner indexed text. Set the new **Index full raw email (including headers)** toggle in the connector configuration to restore the previous behavior.