### PR TITLE
[Connectors Python] Fix PostgreSQL timestamp issue

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -91,7 +91,7 @@ SOFTWARE.
 
 
 PyMySQL
-1.1.3
+1.2.0
 MIT
 Copyright (c) 2010, 2013 PyMySQL contributors
 

--- a/app/connectors_service/connectors/sources/postgresql/client.py
+++ b/app/connectors_service/connectors/sources/postgresql/client.py
@@ -95,6 +95,32 @@ class PostgreSQLClient:
             )
         )
 
+    async def is_track_commit_timestamp_enabled(self):
+        """Return True iff `track_commit_timestamp` is `on` on the server.
+
+        When this setting is off, `pg_xact_commit_timestamp(xmin)` returns NULL for
+        every row, so the connector has no signal for detecting row-level changes
+        and must fall back to reindexing on every sync.
+        """
+        try:
+            [value] = await anext(
+                fetch(
+                    cursor_func=partial(
+                        self.get_cursor,
+                        self.queries.track_commit_timestamp_setting(),
+                    ),
+                    fetch_size=1,
+                    retry_count=self.retry_count,
+                )
+            )
+        except Exception as exception:
+            self._logger.warning(
+                f"Could not read 'track_commit_timestamp' setting: {exception}. "
+                "Assuming it is off and reindexing on every sync."
+            )
+            return False
+        return str(value).strip().lower() == "on"
+
     async def get_tables_to_fetch(self, is_filtering=False):
         tables = configured_tables(self.tables)
         if is_wildcard(tables) or is_filtering:

--- a/app/connectors_service/connectors/sources/postgresql/datasource.py
+++ b/app/connectors_service/connectors/sources/postgresql/datasource.py
@@ -25,6 +25,7 @@ from asyncpg.types import (
     Polygon,
 )
 from connectors_sdk.source import BaseDataSource
+from connectors_sdk.utils import iso_utc
 from sqlalchemy.exc import ProgrammingError
 
 from connectors.sources.postgresql.client import PostgreSQLClient
@@ -242,6 +243,36 @@ class PostgreSQLDataSource(BaseDataSource):
         )
         return row
 
+    def _resolve_table_timestamp(self, last_update_times, track_enabled, label):
+        """Pick the per-table `_timestamp` for the documents about to be emitted.
+
+        - If `MAX(pg_xact_commit_timestamp(xmin))` returned a real value, use it.
+        - If it returned NULL but `track_commit_timestamp` is on, return None: this
+          is a stable value, so the sink will dedup unchanged documents on later
+          syncs. Once any DML happens, MAX flips to a real timestamp and the table
+          gets reindexed.
+        - If `track_commit_timestamp` is off, fall back to `iso_utc()`. We have no
+          way to detect row-level changes, so we must reindex on every sync (this
+          matches the behavior the docs promise when the setting is off).
+        """
+        if last_update_times:
+            return max(last_update_times)
+        if track_enabled:
+            self._logger.warning(
+                f"No commit timestamp available for {label}. "
+                "'track_commit_timestamp' is on but no transactions have committed "
+                "since it was enabled - documents will use a stable null timestamp "
+                "until then."
+            )
+            return None
+        self._logger.warning(
+            f"'track_commit_timestamp' is off; cannot detect row-level changes for "
+            f"{label}. All documents will be reindexed on every sync. Enable "
+            "'track_commit_timestamp = on' on the PostgreSQL server to get "
+            "incremental syncs."
+        )
+        return iso_utc()
+
     async def get_primary_key(self, tables):
         self._logger.debug(f"Extracting primary keys for tables: {tables}")
         primary_key_columns = []
@@ -312,6 +343,8 @@ class PostgreSQLDataSource(BaseDataSource):
             )
             return
 
+        track_enabled = await self.postgresql_client.is_track_commit_timestamp_enabled()
+
         last_update_times = []
         for table in tables:
             try:
@@ -326,16 +359,11 @@ class PostgreSQLDataSource(BaseDataSource):
             if last_update_time is not None:
                 last_update_times.append(last_update_time)
 
-        # `MAX(pg_xact_commit_timestamp(xmin))` is NULL when `track_commit_timestamp`
-        # is off or no transactions have committed since enabling it. Keep `_timestamp`
-        # stable (None) - falling back to `iso_utc()` would force a reindex every sync.
-        last_update_time = max(last_update_times) if last_update_times else None
-        if last_update_time is None:
-            self._logger.warning(
-                f"No commit timestamp available for tables: {', '.join(tables)}. "
-                "Ensure 'track_commit_timestamp = on' is set on the PostgreSQL server "
-                "and that data has been committed since enabling it."
-            )
+        last_update_time = self._resolve_table_timestamp(
+            last_update_times=last_update_times,
+            track_enabled=track_enabled,
+            label=f"tables: {', '.join(tables)}",
+        )
 
         async for row in self.yield_rows_for_query(
             primary_key_columns=primary_key_columns, tables=tables, query=query
@@ -358,6 +386,9 @@ class PostgreSQLDataSource(BaseDataSource):
             self._logger.debug(f"Total '{row_count}' rows found in table '{table}'")
             keys, order_by_columns = await self.get_primary_key(tables=[table])
             if keys:
+                track_enabled = (
+                    await self.postgresql_client.is_track_commit_timestamp_enabled()
+                )
                 try:
                     last_update_time = (
                         await self.postgresql_client.get_table_last_update_time(
@@ -369,17 +400,13 @@ class PostgreSQLDataSource(BaseDataSource):
                         f"Unable to fetch last_updated_time for table '{table}'"
                     )
                     last_update_time = None
-                # `MAX(pg_xact_commit_timestamp(xmin))` is NULL when `track_commit_timestamp`
-                # is off or no transactions have committed since enabling it. Keep
-                # `_timestamp` stable (None) - falling back to `iso_utc()` would force a
-                # reindex every sync.
-                if last_update_time is None:
-                    self._logger.warning(
-                        f"No commit timestamp available for table '{table}'. "
-                        "Ensure 'track_commit_timestamp = on' is set on the PostgreSQL "
-                        "server and that data has been committed in this table since "
-                        "enabling it."
-                    )
+                last_update_time = self._resolve_table_timestamp(
+                    last_update_times=[last_update_time]
+                    if last_update_time is not None
+                    else [],
+                    track_enabled=track_enabled,
+                    label=f"table '{table}'",
+                )
                 async for row in self.yield_rows_for_query(
                     primary_key_columns=keys,
                     tables=[table],

--- a/app/connectors_service/connectors/sources/postgresql/datasource.py
+++ b/app/connectors_service/connectors/sources/postgresql/datasource.py
@@ -25,7 +25,6 @@ from asyncpg.types import (
     Polygon,
 )
 from connectors_sdk.source import BaseDataSource
-from connectors_sdk.utils import iso_utc
 from sqlalchemy.exc import ProgrammingError
 
 from connectors.sources.postgresql.client import PostgreSQLClient
@@ -319,14 +318,24 @@ class PostgreSQLDataSource(BaseDataSource):
                 last_update_time = (
                     await self.postgresql_client.get_table_last_update_time(table)
                 )
-                last_update_times.append(last_update_time)
             except Exception:
-                self._logger.warning("Last update time is not found for Table: {table}")
-                last_update_times.append(iso_utc())
+                self._logger.warning(
+                    f"Last update time is not found for Table: {table}"
+                )
+                last_update_time = None
+            if last_update_time is not None:
+                last_update_times.append(last_update_time)
 
-        last_update_time = (
-            max(last_update_times) if len(last_update_times) else iso_utc()
-        )
+        # `MAX(pg_xact_commit_timestamp(xmin))` is NULL when `track_commit_timestamp`
+        # is off or no transactions have committed since enabling it. Keep `_timestamp`
+        # stable (None) - falling back to `iso_utc()` would force a reindex every sync.
+        last_update_time = max(last_update_times) if last_update_times else None
+        if last_update_time is None:
+            self._logger.warning(
+                f"No commit timestamp available for tables: {', '.join(tables)}. "
+                "Ensure 'track_commit_timestamp = on' is set on the PostgreSQL server "
+                "and that data has been committed since enabling it."
+            )
 
         async for row in self.yield_rows_for_query(
             primary_key_columns=primary_key_columns, tables=tables, query=query
@@ -338,7 +347,7 @@ class PostgreSQLDataSource(BaseDataSource):
                     row=row,
                     doc_id=doc_id,
                     table=tables,
-                    timestamp=last_update_time or iso_utc(),
+                    timestamp=last_update_time,
                 )
             )
 
@@ -357,9 +366,20 @@ class PostgreSQLDataSource(BaseDataSource):
                     )
                 except Exception:
                     self._logger.warning(
-                        f"Unable to fetch last_updated_time for table  '{table}'"
+                        f"Unable to fetch last_updated_time for table '{table}'"
                     )
                     last_update_time = None
+                # `MAX(pg_xact_commit_timestamp(xmin))` is NULL when `track_commit_timestamp`
+                # is off or no transactions have committed since enabling it. Keep
+                # `_timestamp` stable (None) - falling back to `iso_utc()` would force a
+                # reindex every sync.
+                if last_update_time is None:
+                    self._logger.warning(
+                        f"No commit timestamp available for table '{table}'. "
+                        "Ensure 'track_commit_timestamp = on' is set on the PostgreSQL "
+                        "server and that data has been committed in this table since "
+                        "enabling it."
+                    )
                 async for row in self.yield_rows_for_query(
                     primary_key_columns=keys,
                     tables=[table],
@@ -374,7 +394,7 @@ class PostgreSQLDataSource(BaseDataSource):
                             row=row,
                             doc_id=doc_id,
                             table=table,
-                            timestamp=last_update_time or iso_utc(),
+                            timestamp=last_update_time,
                         )
                     )
             else:

--- a/app/connectors_service/connectors/sources/postgresql/queries.py
+++ b/app/connectors_service/connectors/sources/postgresql/queries.py
@@ -13,6 +13,10 @@ class PostgreSQLQueries(Queries):
         """Query to ping source"""
         return "SELECT 1+1"
 
+    def track_commit_timestamp_setting(self):
+        """Query the server-wide value of `track_commit_timestamp` ('on' or 'off')."""
+        return "SHOW track_commit_timestamp"
+
     def all_tables(self, **kwargs):
         """Query to get all tables"""
         return f"SELECT table_name FROM information_schema.tables WHERE table_catalog = '{kwargs['database']}' and table_schema = '{kwargs['schema']}'"

--- a/app/connectors_service/tests/sources/test_postgresql.py
+++ b/app/connectors_service/tests/sources/test_postgresql.py
@@ -153,6 +153,8 @@ class CursorAsync:
                 schema=SCHEMA, table=CUSTOMER_TABLE
             ):
                 return [("2023-02-21T08:37:15+00:00",)]
+            elif self.query == query_object.track_commit_timestamp_setting():
+                return [("on",)]
             elif self.query.lower() == "select * from customer":
                 return [(1, "customer_1"), (2, "customer_2")]
             elif self.query == query_object.ping():
@@ -478,14 +480,18 @@ async def test_get_docs():
 
 @freeze_time(TIME)
 @pytest.mark.asyncio
-async def test_get_docs_when_last_update_time_is_none_does_not_fall_back_to_iso_utc():
-    """When `MAX(pg_xact_commit_timestamp(xmin))` is NULL (track_commit_timestamp off,
-    or just enabled with no commits since), docs must use a stable `_timestamp = None`
-    instead of a fresh `iso_utc()` that would force a full reindex every sync.
+async def test_get_docs_when_track_commit_timestamp_on_and_max_is_null_uses_stable_none():
+    """`track_commit_timestamp = on` but no DML has committed since: MAX returns NULL.
+    Docs must use a stable `_timestamp = None` so the sink can dedup unchanged
+    docs on subsequent syncs. The previous `iso_utc()` fallback caused a full
+    reindex every sync, which is the customer-reported bug.
     """
     async with create_postgresql_source() as source:
         with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
             source.engine = create_async_engine(POSTGRESQL_CONNECTION_STRING)
+            source.postgresql_client.is_track_commit_timestamp_enabled = AsyncMock(
+                return_value=True
+            )
             source.postgresql_client.get_table_last_update_time = AsyncMock(
                 return_value=None
             )
@@ -500,15 +506,46 @@ async def test_get_docs_when_last_update_time_is_none_does_not_fall_back_to_iso_
 
 @freeze_time(TIME)
 @pytest.mark.asyncio
-async def test_get_docs_when_last_update_time_raises_does_not_fall_back_to_iso_utc():
-    """If `get_table_last_update_time` raises, fall back to a stable `_timestamp = None`
-    rather than a fresh `iso_utc()` that would force a full reindex every sync.
+async def test_get_docs_when_track_commit_timestamp_off_falls_back_to_iso_utc():
+    """When `track_commit_timestamp` is off, the connector cannot detect row-level
+    changes. To match the documented contract ("all data will be indexed in every
+    sync"), it must keep using `iso_utc()` so existing-doc dedup never matches and
+    every row is reindexed. Returning a stable null here would silently drop row
+    updates.
     """
     async with create_postgresql_source() as source:
         with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
             source.engine = create_async_engine(POSTGRESQL_CONNECTION_STRING)
+            source.postgresql_client.is_track_commit_timestamp_enabled = AsyncMock(
+                return_value=False
+            )
             source.postgresql_client.get_table_last_update_time = AsyncMock(
-                side_effect=Exception("track_commit_timestamp is off")
+                return_value=None
+            )
+
+            actual_response = []
+            async for doc in source.get_docs():
+                actual_response.append(doc[0])
+
+            assert len(actual_response) == 2
+            assert all(doc["_timestamp"] == TIME for doc in actual_response)
+
+
+@freeze_time(TIME)
+@pytest.mark.asyncio
+async def test_get_docs_when_last_update_time_raises_with_track_on_uses_stable_none():
+    """If `get_table_last_update_time` raises but `track_commit_timestamp` is on,
+    fall back to a stable `_timestamp = None` rather than a fresh `iso_utc()` that
+    would force a full reindex every sync.
+    """
+    async with create_postgresql_source() as source:
+        with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
+            source.engine = create_async_engine(POSTGRESQL_CONNECTION_STRING)
+            source.postgresql_client.is_track_commit_timestamp_enabled = AsyncMock(
+                return_value=True
+            )
+            source.postgresql_client.get_table_last_update_time = AsyncMock(
+                side_effect=Exception("transient failure")
             )
 
             actual_response = []
@@ -521,7 +558,7 @@ async def test_get_docs_when_last_update_time_raises_does_not_fall_back_to_iso_u
 
 @freeze_time(TIME)
 @pytest.mark.asyncio
-async def test_get_docs_with_advanced_rules_when_last_update_time_is_none_does_not_fall_back_to_iso_utc():
+async def test_get_docs_with_advanced_rules_when_track_on_and_max_is_null_uses_stable_none():
     """Same `_timestamp = None` guarantee for the advanced sync rules / custom query path."""
     async with create_source(
         PostgreSQLDataSource,
@@ -531,6 +568,9 @@ async def test_get_docs_with_advanced_rules_when_last_update_time_is_none_does_n
         port=5432,
     ) as source:
         with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
+            source.postgresql_client.is_track_commit_timestamp_enabled = AsyncMock(
+                return_value=True
+            )
             source.postgresql_client.get_table_last_update_time = AsyncMock(
                 return_value=None
             )

--- a/app/connectors_service/tests/sources/test_postgresql.py
+++ b/app/connectors_service/tests/sources/test_postgresql.py
@@ -17,7 +17,7 @@ from ipaddress import (
     IPv6Interface,
     IPv6Network,
 )
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, patch
 from uuid import UUID
 
 import pytest
@@ -474,6 +474,86 @@ async def test_get_docs():
 
             # Assert
             assert actual_response == expected_response
+
+
+@freeze_time(TIME)
+@pytest.mark.asyncio
+async def test_get_docs_when_last_update_time_is_none_does_not_fall_back_to_iso_utc():
+    """When `MAX(pg_xact_commit_timestamp(xmin))` is NULL (track_commit_timestamp off,
+    or just enabled with no commits since), docs must use a stable `_timestamp = None`
+    instead of a fresh `iso_utc()` that would force a full reindex every sync.
+    """
+    async with create_postgresql_source() as source:
+        with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
+            source.engine = create_async_engine(POSTGRESQL_CONNECTION_STRING)
+            source.postgresql_client.get_table_last_update_time = AsyncMock(
+                return_value=None
+            )
+
+            actual_response = []
+            async for doc in source.get_docs():
+                actual_response.append(doc[0])
+
+            assert len(actual_response) == 2
+            assert all(doc["_timestamp"] is None for doc in actual_response)
+
+
+@freeze_time(TIME)
+@pytest.mark.asyncio
+async def test_get_docs_when_last_update_time_raises_does_not_fall_back_to_iso_utc():
+    """If `get_table_last_update_time` raises, fall back to a stable `_timestamp = None`
+    rather than a fresh `iso_utc()` that would force a full reindex every sync.
+    """
+    async with create_postgresql_source() as source:
+        with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
+            source.engine = create_async_engine(POSTGRESQL_CONNECTION_STRING)
+            source.postgresql_client.get_table_last_update_time = AsyncMock(
+                side_effect=Exception("track_commit_timestamp is off")
+            )
+
+            actual_response = []
+            async for doc in source.get_docs():
+                actual_response.append(doc[0])
+
+            assert len(actual_response) == 2
+            assert all(doc["_timestamp"] is None for doc in actual_response)
+
+
+@freeze_time(TIME)
+@pytest.mark.asyncio
+async def test_get_docs_with_advanced_rules_when_last_update_time_is_none_does_not_fall_back_to_iso_utc():
+    """Same `_timestamp = None` guarantee for the advanced sync rules / custom query path."""
+    async with create_source(
+        PostgreSQLDataSource,
+        database="xe",
+        tables="*",
+        schema="public",
+        port=5432,
+    ) as source:
+        with patch.object(AsyncEngine, "connect", return_value=ConnectionAsync()):
+            source.postgresql_client.get_table_last_update_time = AsyncMock(
+                return_value=None
+            )
+
+            filtering = Filter(
+                {
+                    ADVANCED_SNIPPET: {
+                        "value": [
+                            {
+                                "tables": ["emp_table"],
+                                "query": "select * from emp_table",
+                            },
+                        ]
+                    }
+                }
+            )
+
+            actual_response = []
+            async for doc in source.get_docs(filtering=filtering):
+                actual_response.append(doc[0])
+
+            assert len(actual_response) > 0
+            assert all(doc["_timestamp"] is None for doc in actual_response)
 
 
 @freeze_time(TIME)


### PR DESCRIPTION
## Was created for https://github.com/elastic/sdh-search/issues/1882

After enabling `track_commit_timestamp = on` on the PostgreSQL server (per the [tutorial](https://www.elastic.co/docs/reference/search-connectors/es-postgresql-connector-client-tutorial#es-postgresql-connector-client-tutorial-postgresql-prerequisites)), customers were still seeing the entire table re-indexed on every sync instead of getting incremental behavior (to be confirmed by support person).

### Root cause

The connector runs `SELECT MAX(pg_xact_commit_timestamp(xmin)) FROM <table>` to derive a per-table `_timestamp`. PostgreSQL only records commit timestamps for transactions that commit *after* `track_commit_timestamp` is enabled, so for pre-existing rows `pg_xact_commit_timestamp(xmin)` returns `NULL`. If no DML has hit the table since enabling the setting, `MAX(...)` is `NULL` too — and the connector fell back to `iso_utc()`:

```python
timestamp=last_update_time or iso_utc(),
```

`iso_utc()` returns the current time on every sync, so `existing._timestamp != incoming._timestamp` always, and the sink re-indexes every document on every sync.

### Fix

The connector now distinguishes the three real-world states explicitly, by querying `SHOW track_commit_timestamp` (new helper `is_track_commit_timestamp_enabled` on `PostgreSQLClient`):

| `track_commit_timestamp` | `MAX(pg_xact_commit_timestamp(xmin))` | `_timestamp` emitted | Sync behavior |
|---|---|---|---|
| `on`, recent DML | real timestamp | that timestamp | incremental dedup (unchanged) |
| `on`, no DML since enabling **or** query raises | `NULL` | `None` (stable) | one-time reindex on upgrade, then dedup works |
| `off` | `NULL` | `iso_utc()` (fresh per sync) | full reindex every sync — matches the documented contract |

The `track_commit_timestamp = off` branch is critical: returning a stable `null` there would let the sink skip `null == null` between syncs and **silently drop row updates**, since the database has no change-detection signal at all. The `iso_utc()` fallback is preserved exactly for that case.

Additional fixes carried with this PR (all strict improvements, no behavioral risk):

- Filter `None` out of `last_update_times` before `max()` to avoid a latent `TypeError` in `_yield_docs_custom_query` when one table returns `None` and another a string.
- Promote the exception-path warning to an f-string so the table name is actually interpolated (was logged literally as `{table}`).
- New diagnostic warnings tell operators exactly what state was observed: *"`track_commit_timestamp` is on but no DML since"* vs *"`track_commit_timestamp` is off; reindexing on every sync"*.
- Centralize the per-table timestamp decision in a single helper (`_resolve_table_timestamp`) shared by the standard and advanced-rules paths so the policy can't drift between them.

### Backward compatibility

- Tables where `MAX(pg_xact_commit_timestamp(xmin))` returns a real timestamp are unaffected (identical input/output).
- Customers running with `track_commit_timestamp = off` keep the existing behavior (full reindex every sync, as documented). No regression, no silent data loss.
- Indices polluted by the previous `iso_utc()` churn while `track_commit_timestamp = on` pay a **one-time** reindex on the first post-upgrade sync (existing iso_utc strings overwritten with `null`), then stabilize.
- `_timestamp` is a `date` field in ES; storing `null` is supported and does not require any mapping changes. The framework's read path (`yield_existing_documents_metadata`) already returns `None` for missing/`null` values; the sink's compare-and-skip path uses `==`, so `None == None → skip`.
- No SDK or sink contract is changed (verified against `connectors/es/sink.py` lines 651-677, 778-779, 837-852: the `if TIMESTAMP_FIELD not in doc: doc[TIMESTAMP_FIELD] = iso_utc()` fallback uses `not in`, so a present-with-`None` value is preserved).
- Other connectors (e.g. MSSQL) use a different mechanism for last-update detection and are intentionally out of scope.

### Edge cases verified

Traced explicitly: pre-existing index + setting just enabled + no DML; new row inserted between syncs; row deletion; setting toggled `on → off` between syncs; `off → on` between syncs; `SHOW track_commit_timestamp` query failing or returning unexpected values; mid-sync flips; fresh empty index; multi-table advanced rules with mixed update states.

In every case the connector either produces correct incremental behavior or — when the database can give us no change-detection signal — falls back to "reindex everything" (the documented contract).

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

Note for reviewers: customers running the buggy code today with `track_commit_timestamp = on` will see a single full re-index on the first sync after upgrade for any table whose `MAX(pg_xact_commit_timestamp(xmin))` returns `NULL`. After that one sync, syncs with no DML will correctly skip every document. Customers running with `track_commit_timestamp = off` see no behavior change.

## Related Pull Requests

_None._

## Release Note

Fix PostgreSQL connector re-indexing all documents on every sync after enabling `track_commit_timestamp = on`. The connector now reads `SHOW track_commit_timestamp` to pick the correct policy: when the setting is on, documents from rows whose commit timestamp is unknown carry a stable null `_timestamp` so the Elasticsearch sink can skip unchanged documents on subsequent syncs; when the setting is off, the connector continues to reindex on every sync as documented (avoiding any silent loss of row updates).
