### PR TITLE
[9.3] fix: connectors container can't reach Elasticsearch in stack scripts (#4035)

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -65,7 +65,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 PyJWT
-2.12.1
+2.13.0
 MIT
 The MIT License (MIT)
 
@@ -91,7 +91,7 @@ SOFTWARE.
 
 
 PyMySQL
-1.1.3
+1.2.0
 MIT
 Copyright (c) 2010, 2013 PyMySQL contributors
 
@@ -1044,7 +1044,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 aiohappyeyeballs
-2.6.1
+2.6.2
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -4380,7 +4380,7 @@ SOFTWARE.
 
 
 greenlet
-3.5.0
+3.5.1
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:
@@ -5131,7 +5131,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 idna
-3.15
+3.16
 BSD-3-Clause
 BSD 3-Clause License
 
@@ -8514,7 +8514,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 yarl
-1.23.0
+1.24.2
 Apache-2.0
 
                                  Apache License

--- a/app/connectors_service/config.yml.example
+++ b/app/connectors_service/config.yml.example
@@ -30,7 +30,7 @@
 ## ------------------------------- Elasticsearch -------------------------------
 #
 ## The host of the Elasticsearch deployment.
-#elasticsearch.host: http://localhost:9200
+#elasticsearch.host: http://elasticsearch:9200
 #
 #
 ## The API key for Elasticsearch connection.

--- a/app/connectors_service/config.yml.example
+++ b/app/connectors_service/config.yml.example
@@ -30,7 +30,7 @@
 ## ------------------------------- Elasticsearch -------------------------------
 #
 ## The host of the Elasticsearch deployment.
-#elasticsearch.host: http://elasticsearch:9200
+#elasticsearch.host: http://localhost:9200
 #
 #
 ## The API key for Elasticsearch connection.

--- a/app/connectors_service/scripts/stack/copy-config.sh
+++ b/app/connectors_service/scripts/stack/copy-config.sh
@@ -33,6 +33,7 @@ if [[ "$is_example_config" == true ]]; then
     fi
     $sed_cmd '/connectors:/s/^#//g' "$script_config"
     $sed_cmd '/elasticsearch.host/s/^#//g' "$script_config"
+    $sed_cmd '/^elasticsearch\.host:/s|localhost|elasticsearch|g' "$script_config"
     $sed_cmd '/elasticsearch.username/s/^#//g' "$script_config"
     $sed_cmd '/elasticsearch.password/s/^#//g' "$script_config"
 

--- a/app/connectors_service/scripts/stack/docker/docker-compose.yml
+++ b/app/connectors_service/scripts/stack/docker/docker-compose.yml
@@ -50,7 +50,8 @@ services:
     volumes:
       - ${CURDIR}/connectors-config:/config
     command: /app/bin/elastic-ingest -c /config/config.yml
-    network_mode: "elastic"
+    networks:
+      - elastic
 
 volumes:
   conn-es-data:

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -206,7 +206,7 @@ Apache License
 
 
 aiohappyeyeballs
-2.6.1
+2.6.2
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -1220,7 +1220,7 @@ Apache License
 
 
 idna
-3.15
+3.16
 BSD-3-Clause
 BSD 3-Clause License
 
@@ -1799,7 +1799,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 yarl
-1.23.0
+1.24.2
 Apache-2.0
 
                                  Apache License


### PR DESCRIPTION
Backports the following commits to 9.3:\n - fix: connectors container can reach Elasticsearch in stack scripts (#4035)\n - fix: rewrite localhost to elasticsearch hostname when copying stack config (#4035)