### PR TITLE
Update .backportrc.json

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -10,7 +10,7 @@
   "fork": false,
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
-    "^v9.4.0$": "main",
+    "^v9.5.0$": "main",
     "^v(\\d+).(\\d+)(.\\d+)*$": "$1.$2"
   },
   "upstream": "elastic/connectors"


### PR DESCRIPTION
Backporting to 9.4.0 did not work because of `branchLabelMapping` counting `main` as `v9.4.0`.

This fixes it, we'll need to re-backport stuff after this is merged.