### PR TITLE
[8.19] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 0de7da2 (#4042)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:fdce1eb0255cda1e58df675d737956246836191149e2d79ba322298e3d102916
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:0de7da2e9be4158da4b8fb14f82da705b0ef338d93e33bd6dea201cffe4e6776
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -65,8 +65,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 PyJWT
-2.10.1
-MIT License
+2.13.0
+MIT
 The MIT License (MIT)
 
 Copyright (c) 2015-2022 José Padilla
@@ -91,7 +91,7 @@ SOFTWARE.
 
 
 PyMySQL
-1.1.2
+1.2.0
 MIT
 Copyright (c) 2010, 2013 PyMySQL contributors
 
@@ -140,8 +140,8 @@ SOFTWARE.
 
 
 Pygments
-2.19.2
-BSD License
+2.20.0
+BSD-2-Clause
 Copyright (c) 2006-2022 by the respective authors (see AUTHORS file).
 All rights reserved.
 
@@ -1044,7 +1044,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 aiohappyeyeballs
-2.6.1
+2.6.2
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -1602,7 +1602,7 @@ Apache License
 
 
 anyio
-4.12.0
+4.13.0
 MIT
 The MIT License (MIT)
 
@@ -1854,7 +1854,7 @@ Copyright (C) 2016-present the asyncpg authors and contributors.
 
 
 attrs
-25.4.0
+26.1.0
 MIT
 The MIT License (MIT)
 
@@ -1880,8 +1880,8 @@ SOFTWARE.
 
 
 azure-core
-1.37.0
-MIT License
+1.41.0
+MIT
 Copyright (c) Microsoft Corporation.
 
 MIT License
@@ -2605,31 +2605,6 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-cachetools
-6.2.3
-UNKNOWN
-The MIT License (MIT)
-
-Copyright (c) 2014-2025 Thomas Kemmer
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
 certifi
 2024.7.4
 Mozilla Public License 2.0 (MPL 2.0)
@@ -2687,7 +2662,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.5
+3.4.7
 MIT
 MIT License
 
@@ -3521,7 +3496,7 @@ Apache-2.0
 
 
 elasticsearch-connectors
-8.19.9
+8.19.17
 Apache Software License
 Elastic License 2.0
 
@@ -4115,7 +4090,7 @@ Apache Software License
 
 
 google-auth
-2.43.0
+2.53.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -4349,8 +4324,8 @@ SOFTWARE.
 
 
 greenlet
-3.3.0
-MIT AND Python-2.0
+3.5.1
+MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:
 
@@ -4384,8 +4359,8 @@ THE SOFTWARE.
 
 
 grpcio
-1.76.0
-Apache Software License
+1.81.0
+Apache-2.0
 
                                  Apache License
                            Version 2.0, January 2004
@@ -4591,6 +4566,16 @@ Apache Software License
 
 -----------------------------------------------------------
 
+Following applies to:
+./src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
+./src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+./src/objective-c/!ProtoCompiler.podspec
+./src/objective-c/BoringSSL-GRPC.podspec
+./templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.inja
+./templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.inja
+./templates/src/objective-c/!ProtoCompiler.podspec.inja
+./templates/src/objective-c/BoringSSL-GRPC.podspec.template
+
 BSD 3-Clause License
 
 Copyright 2016, Google Inc.
@@ -4622,6 +4607,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------------------------------------------------------
+
+Following applies to:
+./etc/roots.pem
 
 Mozilla Public License Version 2.0
 ==================================
@@ -5100,11 +5088,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 idna
-3.11
+3.18
 BSD-3-Clause
 BSD 3-Clause License
 
-Copyright (c) 2013-2025, Kim Davies and contributors.
+Copyright (c) 2013-2026, Kim Davies and contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -5167,28 +5155,29 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 jmespath
-1.0.1
+1.1.0
 MIT License
+MIT License
+
 Copyright (c) 2013 Amazon.com, Inc. or its affiliates.  All Rights Reserved
 
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish, dis-
-tribute, sublicense, and/or sell copies of the Software, and to permit
-persons to whom the Software is furnished to do so, subject to the fol-
-lowing conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
-ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ldap3
@@ -5655,7 +5644,7 @@ MIT License
 
 
 multidict
-6.7.0
+6.7.1
 Apache License 2.0
    Copyright 2016 Andrew Svetlov and aio-libs contributors
 
@@ -5964,8 +5953,8 @@ END OF TERMS AND CONDITIONS
 
 
 packaging
-25.0
-Apache Software License; BSD License
+26.2
+Apache-2.0 OR BSD-2-Clause
 This software is made available under the terms of *either* of the licenses
 found in LICENSE.APACHE or LICENSE.BSD. Contributions to this software is made
 under the terms of *both* these licenses.
@@ -5977,7 +5966,7 @@ BSD
 UNKNOWN
 
 propcache
-0.4.1
+0.5.2
 Apache Software License
 
                                  Apache License
@@ -6486,8 +6475,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 pycparser
-2.23
-BSD License
+3.0
+BSD-3-Clause
 pycparser -- A C parser in Python
 
 Copyright (c) 2008-2022, Eli Bendersky
@@ -6724,7 +6713,7 @@ Apache Software License
 
 
 pyspnego
-0.12.0
+0.12.1
 MIT
 MIT License
 
@@ -7126,24 +7115,6 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-rsa
-4.9.1
-Apache Software License
-Copyright 2011 Sybren A. Stüvel <sybren@stuvel.eu>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-
 s3transfer
 0.10.4
 Apache Software License
@@ -7432,11 +7403,11 @@ made under the terms of *both* these licenses.
 
 
 soupsieve
-2.8
+2.8.4
 MIT
 MIT License
 
-Copyright (c) 2018 - 2025 Isaac Muse <isaacmuse@gmail.com>
+Copyright (c) 2018 - 2026 Isaac Muse <isaacmuse@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -7832,8 +7803,8 @@ Apache Software License
 UNKNOWN
 
 tzdata
-2025.2
-Apache Software License
+2026.2
+Apache-2.0
 Apache Software License 2.0
 
 Copyright (c) 2020, Paul Ganssle (Google)
@@ -7884,8 +7855,8 @@ made under the terms of *both* these licenses.
 
 
 urllib3
-2.6.2
-UNKNOWN
+2.7.0
+MIT
 MIT License
 
 Copyright (c) 2008-2020 Andrey Petrov and contributors.
@@ -8173,8 +8144,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 xmltodict
-1.0.3
-UNKNOWN
+1.0.4
+MIT
 Copyright (C) 2012 Martin Blech and individual contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -8185,8 +8156,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 yarl
-1.22.0
-Apache Software License
+1.24.2
+Apache-2.0
 
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 0de7da2 (#4042)](https://github.com/elastic/connectors/pull/4042)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)