### PR TITLE
[Jira] Use deprecated v2 issue search API for Server/Data Center

### DIFF
--- a/app/connectors_service/connectors/sources/atlassian/jira/client.py
+++ b/app/connectors_service/connectors/sources/atlassian/jira/client.py
@@ -11,6 +11,7 @@ from connectors_sdk.logger import logger
 
 from connectors.sources.atlassian.jira.constants import (
     ALL_FIELDS,
+    ALL_ISSUES_JQL,
     DEFAULT_RETRY_SECONDS,
     FETCH_SIZE,
     ISSUE_DATA,
@@ -213,10 +214,6 @@ class JiraClient:
                 await self._handle_client_errors(url=url, exception=exception)
 
     async def _paginated_api_call_cursor_based(self, url_name, jql=None, **kwargs):
-        if not jql and url_name == ISSUES:
-            # only bound jql allowed, so using "key IS NOT EMPTY" as a catch-all for "all issues"
-            jql = "key%20IS%20NOT%20EMPTY"
-
         url = parse.urljoin(
             self.host_url,
             URLS[url_name].format(
@@ -259,11 +256,6 @@ class JiraClient:
                 break
 
     async def _paginated_api_call_offset_based(self, url_name, jql=None, **kwargs):
-        if not jql and url_name == ISSUES_FOR_SERVER:
-            # match cursor-based behaviour: use "key IS NOT EMPTY" as a catch-all for
-            # "all issues" so jql=None isn't formatted as the literal string "None"
-            jql = "key%20IS%20NOT%20EMPTY"
-
         start_at = 0
         self._logger.info(
             f"Started pagination for the API endpoint: {URLS[url_name]} to host: {self.host_url} with the parameters -> startAt: 0, maxResults: {FETCH_SIZE} and jql query: {jql}"
@@ -313,6 +305,11 @@ class JiraClient:
         Yields:
             response: Return api response.
         """
+        if not jql and url_name == ISSUES:
+            # Resolved once here so both pagination styles share a single source of the
+            # bounded "all issues" catch-all and never format jql=None into the URL.
+            jql = ALL_ISSUES_JQL
+
         use_cursor_pagination = (
             url_name == ISSUES and self.data_source_type == JIRA_CLOUD
         )

--- a/app/connectors_service/connectors/sources/atlassian/jira/client.py
+++ b/app/connectors_service/connectors/sources/atlassian/jira/client.py
@@ -16,6 +16,7 @@ from connectors.sources.atlassian.jira.constants import (
     ISSUE_DATA,
     ISSUE_SECURITY_LEVEL,
     ISSUES,
+    ISSUES_FOR_SERVER,
     JIRA_CLOUD,
     JIRA_DATA_CENTER,
     JIRA_SERVER,
@@ -258,6 +259,11 @@ class JiraClient:
                 break
 
     async def _paginated_api_call_offset_based(self, url_name, jql=None, **kwargs):
+        if not jql and url_name == ISSUES_FOR_SERVER:
+            # match cursor-based behaviour: use "key IS NOT EMPTY" as a catch-all for
+            # "all issues" so jql=None isn't formatted as the literal string "None"
+            jql = "key%20IS%20NOT%20EMPTY"
+
         start_at = 0
         self._logger.info(
             f"Started pagination for the API endpoint: {URLS[url_name]} to host: {self.host_url} with the parameters -> startAt: 0, maxResults: {FETCH_SIZE} and jql query: {jql}"
@@ -295,7 +301,9 @@ class JiraClient:
 
     async def paginated_api_call(self, url_name, jql=None, **kwargs):
         """Make a paginated API call for Jira objects using the passed url_name with retry for the failed API calls.
-        Most Jira API endpoints use offset-based pagination. However, some endpoints use cursor-based pagination.
+        Most Jira API endpoints use offset-based pagination. However, the Jira Cloud issue search endpoint
+        (rest/api/3/search/jql) uses cursor-based pagination. Jira Server/Data Center do not expose that
+        endpoint, so issue searches there fall back to the deprecated offset-based rest/api/2/search endpoint.
         This method handles both.
 
         Args:
@@ -305,13 +313,19 @@ class JiraClient:
         Yields:
             response: Return api response.
         """
-        is_cursor_based_pagination = url_name == ISSUES
-        if is_cursor_based_pagination:
+        use_cursor_pagination = (
+            url_name == ISSUES and self.data_source_type == JIRA_CLOUD
+        )
+        if use_cursor_pagination:
             async for response in self._paginated_api_call_cursor_based(
                 url_name=url_name, jql=jql, **kwargs
             ):
                 yield response
         else:
+            if url_name == ISSUES:
+                # Server/DC (especially pre-v10) lack rest/api/3/search/jql; fall back
+                # to the deprecated offset-based rest/api/2/search endpoint.
+                url_name = ISSUES_FOR_SERVER
             async for response in self._paginated_api_call_offset_based(
                 url_name=url_name, jql=jql, **kwargs
             ):

--- a/app/connectors_service/connectors/sources/atlassian/jira/constants.py
+++ b/app/connectors_service/connectors/sources/atlassian/jira/constants.py
@@ -18,6 +18,7 @@ PING = "ping"
 PROJECT = "project"
 PROJECT_BY_KEY = "project_by_key"
 ISSUES = "all_issues"
+ISSUES_FOR_SERVER = "issues_for_server"
 ISSUE_DATA = "issue_data"
 ATTACHMENT_CLOUD = "attachment_cloud"
 ATTACHMENT_SERVER = "attachment_server"
@@ -33,6 +34,7 @@ URLS = {
     PROJECT: "rest/api/2/project?expand=description,lead,url",
     PROJECT_BY_KEY: "rest/api/2/project/{key}",
     ISSUES: "rest/api/3/search/jql?jql={jql}&fields=*all&maxResults={max_results}",
+    ISSUES_FOR_SERVER: "rest/api/2/search?jql={jql}&fields=*all&maxResults={max_results}&startAt={start_at}",
     ISSUE_DATA: "rest/api/2/issue/{id}",
     ATTACHMENT_CLOUD: "rest/api/2/attachment/content/{attachment_id}",
     ATTACHMENT_SERVER: "secure/attachment/{attachment_id}/{attachment_name}",

--- a/app/connectors_service/connectors/sources/atlassian/jira/constants.py
+++ b/app/connectors_service/connectors/sources/atlassian/jira/constants.py
@@ -51,3 +51,6 @@ JIRA_SERVER = "jira_server"
 JIRA_DATA_CENTER = "jira_data_center"
 ATLASSIAN = "atlassian"
 USER_QUERY = "expand=groups,applicationRoles"
+# Bounded JQL catch-all for "all issues". The newer Cloud issue-search API only accepts
+# bounded JQL (empty-string is rejected); every issue has a key, so this matches them all.
+ALL_ISSUES_JQL = "key%20IS%20NOT%20EMPTY"

--- a/app/connectors_service/connectors/sources/atlassian/jira/datasource.py
+++ b/app/connectors_service/connectors/sources/atlassian/jira/datasource.py
@@ -20,6 +20,7 @@ from connectors_sdk.utils import (
 from connectors.access_control import ACCESS_CONTROL
 from connectors.sources.atlassian.jira.client import JiraClient
 from connectors.sources.atlassian.jira.constants import (
+    ALL_ISSUES_JQL,
     ATLASSIAN,
     ATTACHMENT_CLOUD,
     ATTACHMENT_SERVER,
@@ -575,12 +576,11 @@ class JiraDataSource(BaseDataSource):
             Dictionary: Jira issue to get indexed
             issue (dict): Issue response to fetch the attachments
         """
-        wildcard_query = "key%20IS%20NOT%20EMPTY"
         comma_separated_projects = '"' + '","'.join(self.jira_client.projects) + '"'
         projects_query = f"project in ({comma_separated_projects})"
 
         jql = custom_query or (
-            wildcard_query
+            ALL_ISSUES_JQL
             if self.jira_client.projects == [WILDCARD]
             else projects_query
         )

--- a/app/connectors_service/tests/sources/test_jira.py
+++ b/app/connectors_service/tests/sources/test_jira.py
@@ -1077,8 +1077,7 @@ async def test_get_issues_for_jql_none_uses_catch_all_for_server(data_source):
             source.jira_client._get_session(), "get", side_effect=server_side_effect
         ):
             _ = [
-                issue
-                async for issue in source.jira_client.get_issues_for_jql(jql=None)
+                issue async for issue in source.jira_client.get_issues_for_jql(jql=None)
             ]
 
     assert (

--- a/app/connectors_service/tests/sources/test_jira.py
+++ b/app/connectors_service/tests/sources/test_jira.py
@@ -1023,6 +1023,99 @@ async def test_get_docs():
                 assert item in EXPECTED_RESPONSES
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("data_source", [JIRA_SERVER, JIRA_DATA_CENTER])
+async def test_get_issues_for_jql_uses_deprecated_v2_search_for_server(data_source):
+    """Server/Data Center lack rest/api/3/search/jql, so issue searches must fall back
+    to the deprecated offset-based rest/api/2/search endpoint paginated via startAt."""
+    requested_urls = []
+
+    def server_side_effect(url, ssl):
+        requested_urls.append(url)
+        if "startAt=0" in url:
+            return get_json_mock(mock_response={"issues": [MOCK_ISSUE], "total": 150})
+        return get_json_mock(
+            mock_response={"issues": [MOCK_ISSUE_TYPE_BUG], "total": 150}
+        )
+
+    async with create_jira_source(data_source=data_source) as source:
+        with mock.patch.object(
+            source.jira_client._get_session(), "get", side_effect=server_side_effect
+        ):
+            issues = [
+                issue
+                async for issue in source.jira_client.get_issues_for_jql(
+                    jql="key%20IS%20NOT%20EMPTY"
+                )
+            ]
+
+    assert (
+        f"{HOST_URL}/rest/api/2/search?jql=key%20IS%20NOT%20EMPTY&fields=*all&maxResults=100&startAt=0"
+        in requested_urls
+    )
+    assert (
+        f"{HOST_URL}/rest/api/2/search?jql=key%20IS%20NOT%20EMPTY&fields=*all&maxResults=100&startAt=100"
+        in requested_urls
+    )
+    assert all("rest/api/3/search/jql" not in url for url in requested_urls)
+    assert issues == [MOCK_ISSUE, MOCK_ISSUE_TYPE_BUG]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("data_source", [JIRA_SERVER, JIRA_DATA_CENTER])
+async def test_get_issues_for_jql_none_uses_catch_all_for_server(data_source):
+    """jql=None on Server/Data Center must fall back to the "key IS NOT EMPTY" catch-all,
+    consistent with Cloud, instead of formatting the literal string "None" into the URL."""
+    requested_urls = []
+
+    def server_side_effect(url, ssl):
+        requested_urls.append(url)
+        return get_json_mock(mock_response={"issues": [MOCK_ISSUE], "total": 1})
+
+    async with create_jira_source(data_source=data_source) as source:
+        with mock.patch.object(
+            source.jira_client._get_session(), "get", side_effect=server_side_effect
+        ):
+            _ = [
+                issue
+                async for issue in source.jira_client.get_issues_for_jql(jql=None)
+            ]
+
+    assert (
+        f"{HOST_URL}/rest/api/2/search?jql=key%20IS%20NOT%20EMPTY&fields=*all&maxResults=100&startAt=0"
+        in requested_urls
+    )
+    assert all("jql=None" not in url for url in requested_urls)
+
+
+@pytest.mark.asyncio
+async def test_get_issues_for_jql_uses_cursor_based_v3_search_for_cloud():
+    """Jira Cloud must keep using the cursor-based rest/api/3/search/jql endpoint."""
+    requested_urls = []
+
+    def cloud_side_effect(url, ssl):
+        requested_urls.append(url)
+        return get_json_mock(mock_response={"issues": [MOCK_ISSUE]})
+
+    async with create_jira_source(data_source=JIRA_CLOUD) as source:
+        with mock.patch.object(
+            source.jira_client._get_session(), "get", side_effect=cloud_side_effect
+        ):
+            issues = [
+                issue
+                async for issue in source.jira_client.get_issues_for_jql(
+                    jql="key%20IS%20NOT%20EMPTY"
+                )
+            ]
+
+    assert (
+        f"{HOST_URL}/rest/api/3/search/jql?jql=key%20IS%20NOT%20EMPTY&fields=*all&maxResults=100"
+        in requested_urls
+    )
+    assert all("rest/api/2/search" not in url for url in requested_urls)
+    assert issues == [MOCK_ISSUE]
+
+
 @pytest.mark.parametrize(
     "filtering, expected_docs",
     [


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3867
## Closes https://github.com/elastic/connectors/issues/4058
## Closes https://github.com/elastic/sdh-search/issues/1896

PR #3710 migrated the Jira issues endpoint to the new cursor-based `rest/api/3/search/jql` endpoint. That endpoint is not available on Jira Server/Data Center pre-v10, so syncs against those instances fail when fetching issues (see also #4058).

This change makes the connector pick the issue search API based on the configured data source type, following the existing `USERS` vs `USERS_FOR_DATA_CENTER` divergence pattern:

- **Jira Cloud**: keeps using the cursor-based `rest/api/3/search/jql` endpoint (`nextPageToken` pagination).
- **Jira Server / Data Center**: falls back to the deprecated, offset-based `rest/api/2/search` endpoint (`startAt` pagination), which is available on all Server/DC versions.

Both paths now apply the same `key IS NOT EMPTY` catch-all when no JQL is provided, so behavior is consistent across data source types and `jql=None` is never formatted into the URL as the literal string `"None"`.

Confluence is intentionally out of scope: it uses stable v1 REST APIs (`rest/api/search`, `rest/api/content/search`, `rest/api/space`) that remain available on older Server/DC versions and are unaffected by this class of deprecation.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/3710 (introduced the regression)

## Release Note

The Jira connector now falls back to the deprecated `rest/api/2/search` endpoint for Jira Server and Data Center deployments, fixing syncs against versions older than v10 that do not support the newer `rest/api/3/search/jql` endpoint.