### PR TITLE
Fix Outlook connector crash on localized Exchange servers (contacts folder)

### DIFF
--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -379,11 +379,10 @@ class OutlookClient:
                 f"Fetching {mail_type['folder']} mails for {account.primary_smtp_address}"
             )
             if mail_type["folder"] == "archive":
-                # If 'Archive' folder is not present, skipping the iteration
+                # msg_folder_root is locale-agnostic; the "Archive" leaf has no
+                # distinguished ID, so resolve it by name and skip if absent.
                 try:
-                    folder_object = (
-                        account.root / "Top of Information Store" / "Archive"
-                    )
+                    folder_object = account.msg_folder_root / "Archive"
                 except ErrorFolderNotFound:
                     continue
             else:
@@ -410,15 +409,14 @@ class OutlookClient:
             yield task
 
     async def get_contacts(self, account):
+        # account.contacts uses a distinguished folder ID, which is locale-agnostic
+        # unlike name-based paths that break on non-English Exchange servers.
         try:
-            folder = account.root / "Top of Information Store" / "Contacts"
+            folder = account.contacts
         except ErrorFolderNotFound:
-            try:
-                folder = account.contacts
-            except ErrorFolderNotFound:
-                self._logger.warning(
-                    f"Could not resolve Contacts folder for {account.primary_smtp_address}, skipping."
-                )
-                return
+            self._logger.warning(
+                f"Could not resolve Contacts folder for {account.primary_smtp_address}, skipping."
+            )
+            return
         for contact in await asyncio.to_thread(folder.all().only, *CONTACT_FIELDS):
             yield contact

--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -23,6 +23,7 @@ from exchangelib import (
     Identity,
     OAuth2Credentials,
 )
+from exchangelib.errors import ErrorFolderNotFound
 from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
 from ldap3 import SAFE_SYNC, Connection, Server
 
@@ -383,7 +384,7 @@ class OutlookClient:
                     folder_object = (
                         account.root / "Top of Information Store" / "Archive"
                     )
-                except Exception:  # noqa S112
+                except ErrorFolderNotFound:
                     continue
             else:
                 folder_object = getattr(account, mail_type["folder"])
@@ -409,6 +410,15 @@ class OutlookClient:
             yield task
 
     async def get_contacts(self, account):
-        folder = account.root / "Top of Information Store" / "Contacts"
+        try:
+            folder = account.root / "Top of Information Store" / "Contacts"
+        except ErrorFolderNotFound:
+            try:
+                folder = account.contacts
+            except ErrorFolderNotFound:
+                self._logger.warning(
+                    f"Could not resolve Contacts folder for {account.primary_smtp_address}, skipping."
+                )
+                return
         for contact in await asyncio.to_thread(folder.all().only, *CONTACT_FIELDS):
             yield contact

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -741,6 +741,20 @@ async def test_get_contacts_skips_when_folder_not_found():
 
 
 @pytest.mark.asyncio
+async def test_get_mails_skips_archive_when_folder_not_found():
+    async with create_outlook_source() as source:
+        account = MockAccount()
+        account.msg_folder_root = MagicMock()
+        account.msg_folder_root.__truediv__.side_effect = ErrorFolderNotFound("no")
+
+        folders = [
+            mail_type["folder"]
+            async for _, mail_type in source.client.get_mails(account)
+        ]
+        assert folders == ["inbox", "sent", "junk"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "is_cloud, user_response",
     [(True, {"value": [{"mail": "dummy.user@gmail.com"}]})],

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp import StreamReader
 from connectors_sdk.source import ConfigurableFieldValueError
+from exchangelib.errors import ErrorFolderNotFound
 
 from connectors.sources.outlook import OutlookDataSource
 from connectors.sources.outlook.client import (
@@ -165,18 +166,14 @@ class MockException(Exception):
         self.status = status
 
 
-class CustomPath:
+class MockMsgFolderRoot:
+    """Mocks account.msg_folder_root, under which "Archive" is resolved by name."""
+
     def __truediv__(self, path):
-        # Simulate hierarchy navigation and return a list of dictionaries
-        if path == "Top of Information Store":
-            return self
-        elif path == "Archive":
+        if path == "Archive":
             return MockOutlookObject(object_type=MAIL)
-        elif path == "Contacts":
-            return MockOutlookObject(object_type=CONTACT)
-        else:
-            msg = "Unsupported path element"
-            raise ValueError(msg)
+        msg = "Unsupported path element"
+        raise ValueError(msg)
 
 
 class MockAttachmentId:
@@ -286,11 +283,12 @@ class MockAccount:
 
         self.inbox = MockOutlookObject(object_type=MAIL)
         self.sent = MockOutlookObject(object_type=MAIL)
-        self.root = MockOutlookObject(object_type=MAIL)
         self.junk = MockOutlookObject(object_type=MAIL)
         self.tasks = MockOutlookObject(object_type=TASK)
         self.calendar = MockOutlookObject(object_type=CALENDAR)
-        self.root = CustomPath()
+        # Accessed via distinguished folder IDs.
+        self.contacts = MockOutlookObject(object_type=CONTACT)
+        self.msg_folder_root = MockMsgFolderRoot()
         self.primary_smtp_address = "alex.wilber@gmail.com"
 
 
@@ -719,6 +717,27 @@ async def test_get_docs():
         )
         async for document, _ in source.get_docs():
             assert document in EXPECTED_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_get_contacts_resolves_via_distinguished_folder_id():
+    async with create_outlook_source() as source:
+        account = MockAccount()
+        contacts = [contact async for contact in source.client.get_contacts(account)]
+        assert [contact.id for contact in contacts] == ["contact_1"]
+
+
+@pytest.mark.asyncio
+async def test_get_contacts_skips_when_folder_not_found():
+    async with create_outlook_source() as source:
+        account = MagicMock()
+        account.primary_smtp_address = "alex.wilber@gmail.com"
+        type(account).contacts = mock.PropertyMock(
+            side_effect=ErrorFolderNotFound("no")
+        )
+
+        contacts = [contact async for contact in source.client.get_contacts(account)]
+        assert contacts == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Fixes https://github.com/elastic/connectors/issues/4064
## Fixes https://github.com/elastic/sdh-search/issues/1898

## Problem

On non-English Exchange servers, default folder names are localized. The connector resolved folders by their English display names (e.g. `account.root / "Top of Information Store" / "Contacts"`), which raises `ErrorFolderNotFound` on localized deployments. For the Contacts folder this was unhandled and crashed the sync.

## Fix

Resolve folders by their locale-agnostic **distinguished folder IDs** instead of display names:

- **Contacts:** `get_contacts` now uses `account.contacts` (backed by the `"contacts"` distinguished folder ID). If it still can't be resolved, it logs a warning and skips instead of crashing the sync.
- **Archive:** the parent is now resolved via `account.msg_folder_root` (the `"msgfolderroot"` ID, i.e. "Top of Information Store") instead of its display name. The bare `except Exception` was also tightened to `except ErrorFolderNotFound`.

## Testing

- Unit tests cover both folders: successful ID-based resolution, and graceful skip when the folder is missing.
- No functional (ftest) coverage: Outlook has no emulated backend, and the issue only reproduces on a non-English Exchange server. Manual verification is via the shared M365 tenant with the mailbox locale changed (admin access required).

## Known limitation: Archive leaf folder

The `"Archive"` leaf folder must still be resolved by name, because Microsoft never assigned it a distinguished folder ID in EWS — there is no locale-agnostic way to reach it. On localized servers it is skipped (existing behavior, now via the specific `ErrorFolderNotFound` catch). A full fix would require exposing the archive folder name as a connector config option so users can supply their localized name.