### PR TITLE
[Outlook Connector] Fix Outlook connector crash on Exchange users without mail attribute

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -8181,7 +8181,7 @@ limitations under the License.
 
 
 tzlocal
-5.4
+5.4.3
 MIT
 Copyright 2011-2017 Lennart Regebro
 

--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -82,6 +82,15 @@ class SSLFailed(Exception):
     pass
 
 
+def _extract_ldap_mail(attributes):
+    mail = attributes.get("mail")
+    if isinstance(mail, list):
+        mail = mail[0] if mail else None
+    if not mail:
+        return None
+    return mail
+
+
 class ManageCertificate:
     async def store_certificate(self, certificate):
         async with aiofiles.open(CERT_FILE, "w") as file:
@@ -210,8 +219,16 @@ class ExchangeUsers:
             if "searchResRef" in user["type"]:
                 continue
 
+            mail = _extract_ldap_mail(user.get("attributes", {}))
+            if mail is None:
+                logger.warning(
+                    "Skipping Active Directory user without a valid mail attribute: "
+                    f"{user.get('dn', 'unknown')}"
+                )
+                continue
+
             user_account = Account(
-                primary_smtp_address=user.get("attributes", {}).get("mail"),
+                primary_smtp_address=mail,
                 config=configuration,
                 access_type=IMPERSONATION,
             )

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -694,7 +694,7 @@ async def test_get_content_with_extraction_service():
     "is_cloud, user_response",
     [
         (True, {"value": [{"mail": "dummy.user@gmail.com"}]}),
-        (False, {"type": "user", "attributes": {"mail": "account"}}),
+        (False, {"type": "user", "attributes": {"mail": ["account@example.com"]}}),
     ],
 )
 @patch("connectors.sources.outlook.client.Account", return_value="account")
@@ -707,6 +707,69 @@ async def test_get_user_accounts_for_cloud(account, is_cloud, user_response):
             source_account
         ) in source.client._get_user_instance.get_user_accounts():
             assert source_account == "account"
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.client.logger.warning")
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_skips_empty_mail(
+    mock_account, mock_warning
+):
+    valid_user = {
+        "type": "user",
+        "attributes": {"mail": ["valid.user@example.com"]},
+    }
+    user_without_mail = {
+        "type": "user",
+        "dn": "CN=NoMail,CN=Users,DC=example,DC=local",
+        "attributes": {"mail": []},
+    }
+    async with create_outlook_source() as source:
+        source.client.is_cloud = False
+        source.client._get_user_instance.get_users = AsyncIterator(
+            [user_without_mail, valid_user]
+        )
+
+        accounts = [
+            account
+            async for account in source.client._get_user_instance.get_user_accounts()
+        ]
+
+        assert accounts == ["account"]
+        mock_account.assert_called_once()
+        assert mock_account.call_args.kwargs["primary_smtp_address"] == (
+            "valid.user@example.com"
+        )
+        mock_warning.assert_called_once()
+        warning_message = mock_warning.call_args.args[0]
+        assert "Skipping Active Directory user without a valid mail attribute" in (
+            warning_message
+        )
+        assert "CN=NoMail,CN=Users,DC=example,DC=local" in warning_message
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_normalizes_ldap_mail_list(mock_account):
+    user = {
+        "type": "user",
+        "attributes": {"mail": ["user@example.com"]},
+    }
+    async with create_outlook_source() as source:
+        source.client.is_cloud = False
+        source.client._get_user_instance.get_users = AsyncIterator([user])
+
+        accounts = [
+            account
+            async for account in source.client._get_user_instance.get_user_accounts()
+        ]
+
+        assert accounts == ["account"]
+        mock_account.assert_called_once_with(
+            primary_smtp_address="user@example.com",
+            config=mock_account.call_args.kwargs["config"],
+            access_type=mock_account.call_args.kwargs["access_type"],
+        )
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -712,9 +712,7 @@ async def test_get_user_accounts_for_cloud(account, is_cloud, user_response):
 @pytest.mark.asyncio
 @patch("connectors.sources.outlook.client.logger.warning")
 @patch("connectors.sources.outlook.client.Account", return_value="account")
-async def test_exchange_get_user_accounts_skips_empty_mail(
-    mock_account, mock_warning
-):
+async def test_exchange_get_user_accounts_skips_empty_mail(mock_account, mock_warning):
     valid_user = {
         "type": "user",
         "attributes": {"mail": ["valid.user@example.com"]},


### PR DESCRIPTION
## Closes https://github.com/elastic/sdh-search/issues/1898

On on-prem Exchange deployments, the Outlook connector listed users from Active Directory and passed the raw LDAP `mail` attribute into `exchangelib.Account`. When an AD entry has no mail address, `ldap3` returns an empty list (`[]`), which caused the sync to fail with `ValueError: primary_smtp_address [] is not an email address`.

This change normalizes LDAP mail values to a string, skips entries without a valid mail attribute, and logs a warning with the user DN so the rest of the sync can continue.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4065 — prior fix for localized Exchange folder names on the same customer deployment

## Release Note

Fixed an issue where the Outlook connector would fail during sync on on-prem Exchange when Active Directory contained users without a mail attribute. Those users are now skipped with a warning instead of aborting the entire sync.
