### PR TITLE
[8.19] Fix Outlook connector crash on localized Exchange servers (contacts folder) (#4065)

### DIFF
--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -26,6 +26,7 @@ from exchangelib import (
     Identity,
     OAuth2Credentials,
 )
+from exchangelib.errors import ErrorFolderNotFound
 from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
 from ldap3 import SAFE_SYNC, Connection, Server
 
@@ -637,12 +638,11 @@ class OutlookClient:
                 f"Fetching {mail_type['folder']} mails for {account.primary_smtp_address}"
             )
             if mail_type["folder"] == "archive":
-                # If 'Archive' folder is not present, skipping the iteration
+                # msg_folder_root is locale-agnostic; the "Archive" leaf has no
+                # distinguished ID, so resolve it by name and skip if absent.
                 try:
-                    folder_object = (
-                        account.root / "Top of Information Store" / "Archive"
-                    )
-                except Exception:  # noqa S112
+                    folder_object = account.msg_folder_root / "Archive"
+                except ErrorFolderNotFound:
                     continue
             else:
                 folder_object = getattr(account, mail_type["folder"])
@@ -668,7 +668,15 @@ class OutlookClient:
             yield task
 
     async def get_contacts(self, account):
-        folder = account.root / "Top of Information Store" / "Contacts"
+        # account.contacts uses a distinguished folder ID, which is locale-agnostic
+        # unlike name-based paths that break on non-English Exchange servers.
+        try:
+            folder = account.contacts
+        except ErrorFolderNotFound:
+            self._logger.warning(
+                f"Could not resolve Contacts folder for {account.primary_smtp_address}, skipping."
+            )
+            return
         for contact in await asyncio.to_thread(folder.all().only, *CONTACT_FIELDS):
             yield contact
 

--- a/tests/sources/test_outlook.py
+++ b/tests/sources/test_outlook.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import StreamReader
+from exchangelib.errors import ErrorFolderNotFound
 
 from connectors.source import ConfigurableFieldValueError
 from connectors.sources.outlook import (
@@ -163,18 +164,14 @@ class MockException(Exception):
         self.status = status
 
 
-class CustomPath:
+class MockMsgFolderRoot:
+    """Mocks account.msg_folder_root, under which "Archive" is resolved by name."""
+
     def __truediv__(self, path):
-        # Simulate hierarchy navigation and return a list of dictionaries
-        if path == "Top of Information Store":
-            return self
-        elif path == "Archive":
+        if path == "Archive":
             return MockOutlookObject(object_type=MAIL)
-        elif path == "Contacts":
-            return MockOutlookObject(object_type=CONTACT)
-        else:
-            msg = "Unsupported path element"
-            raise ValueError(msg)
+        msg = "Unsupported path element"
+        raise ValueError(msg)
 
 
 class MockAttachmentId:
@@ -284,11 +281,12 @@ class MockAccount:
 
         self.inbox = MockOutlookObject(object_type=MAIL)
         self.sent = MockOutlookObject(object_type=MAIL)
-        self.root = MockOutlookObject(object_type=MAIL)
         self.junk = MockOutlookObject(object_type=MAIL)
         self.tasks = MockOutlookObject(object_type=TASK)
         self.calendar = MockOutlookObject(object_type=CALENDAR)
-        self.root = CustomPath()
+        # Accessed via distinguished folder IDs.
+        self.contacts = MockOutlookObject(object_type=CONTACT)
+        self.msg_folder_root = MockMsgFolderRoot()
         self.primary_smtp_address = "alex.wilber@gmail.com"
 
 
@@ -717,6 +715,41 @@ async def test_get_docs():
         )
         async for document, _ in source.get_docs():
             assert document in EXPECTED_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_get_contacts_resolves_via_distinguished_folder_id():
+    async with create_outlook_source() as source:
+        account = MockAccount()
+        contacts = [contact async for contact in source.client.get_contacts(account)]
+        assert [contact.id for contact in contacts] == ["contact_1"]
+
+
+@pytest.mark.asyncio
+async def test_get_contacts_skips_when_folder_not_found():
+    async with create_outlook_source() as source:
+        account = MagicMock()
+        account.primary_smtp_address = "alex.wilber@gmail.com"
+        type(account).contacts = mock.PropertyMock(
+            side_effect=ErrorFolderNotFound("no")
+        )
+
+        contacts = [contact async for contact in source.client.get_contacts(account)]
+        assert contacts == []
+
+
+@pytest.mark.asyncio
+async def test_get_mails_skips_archive_when_folder_not_found():
+    async with create_outlook_source() as source:
+        account = MockAccount()
+        account.msg_folder_root = MagicMock()
+        account.msg_folder_root.__truediv__.side_effect = ErrorFolderNotFound("no")
+
+        folders = [
+            mail_type["folder"]
+            async for _, mail_type in source.client.get_mails(account)
+        ]
+        assert folders == ["inbox", "sent", "junk"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix Outlook connector crash on localized Exchange servers (contacts folder) (#4065)
