### PR TITLE
[9.2] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 5323f01 (#4086)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:0de7da2e9be4158da4b8fb14f82da705b0ef338d93e33bd6dea201cffe4e6776
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:5323f01f61453bb3b90e6132c2e2a4de23d5a9ce3f0030e6074f38086f61cdf5
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1602,7 +1602,7 @@ Apache License
 
 
 anyio
-4.13.0
+4.14.0
 MIT
 The MIT License (MIT)
 
@@ -4090,7 +4090,7 @@ Apache Software License
 
 
 google-auth
-2.53.0
+2.55.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -8047,8 +8047,8 @@ limitations under the License.
 
 
 tzlocal
-5.3.1
-MIT License
+5.4.3
+MIT
 Copyright 2011-2017 Lennart Regebro
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4324,7 +4324,7 @@ SOFTWARE.
 
 
 greenlet
-3.5.1
+3.5.2
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:


### PR DESCRIPTION
Backports the following commits to 9.2:
* Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 5323f01 (Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 5323f01 #4086)

---

Manual backport of #4086. The automated backport failed due to conflicts because the 9.2 branch had a different Docker digest (`0de7da2`) than what the auto-backport expected (`ab85d61`), and the `NOTICE.txt` file is located at the repo root in 9.2 (not `app/connectors_service/NOTICE.txt` as in main).

Changes applied:
- `Dockerfile.wolfi`: updated digest to `5323f01f61453bb3b90e6132c2e2a4de23d5a9ce3f0030e6074f38086f61cdf5`
- `NOTICE.txt`: updated `greenlet` from `3.5.1` to `3.5.2`

Made with [Cursor](https://cursor.com)