### PR TITLE
fix(outlook): verify Exchange TLS with an in-memory CA to remove the cert-file race

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1628,7 +1628,7 @@ SOFTWARE.
 
 
 anyio
-4.14.0
+4.14.1
 MIT
 The MIT License (MIT)
 
@@ -4146,7 +4146,7 @@ Apache Software License
 
 
 google-auth
-2.55.0
+2.55.1
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2589,11 +2589,11 @@ Apache Software License
 
 
 bracex
-2.6
+2.7
 MIT
 MIT License
 
-Copyright (c) 2018 - 2025 Isaac Muse
+Copyright (c) 2018 - 2026 Isaac Muse
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -8181,7 +8181,7 @@ limitations under the License.
 
 
 tzlocal
-5.4.3
+5.4.4
 MIT
 Copyright 2011-2017 Lennart Regebro
 

--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -133,10 +133,7 @@ class ExchangeUsers:
         )
 
     async def close(self):
-        # The LDAP connection is opened lazily by the _create_connection
-        # cached_property, so only unbind it if it was actually created.
-        if "_create_connection" in self.__dict__:
-            self._create_connection.unbind()
+        pass
 
     def _fetch_normal_users(self, search_query):
         try:

--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -133,7 +133,10 @@ class ExchangeUsers:
         )
 
     async def close(self):
-        pass
+        # The LDAP connection is opened lazily by the _create_connection
+        # cached_property, so only unbind it if it was actually created.
+        if "_create_connection" in self.__dict__:
+            self._create_connection.unbind()
 
     def _fetch_normal_users(self, search_query):
         try:
@@ -188,6 +191,10 @@ class ExchangeUsers:
             yield user
 
     async def get_user_accounts(self):
+        # NOTE: exchangelib applies HTTP_ADAPTER_CLS (and our in-memory CA
+        # context) process-wide. This is safe here because each connector uses a
+        # single CA; concurrent Exchange Server connectors with different CAs are
+        # not a supported setup.
         if self.ssl_enabled:
             # SSL is on, so a CA certificate is mandatory and must be verified
             # against. validate_config already enforces this; the checks below

--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -5,13 +5,11 @@
 #
 
 import asyncio
-import os
+import ssl
 from functools import cached_property
 
-import aiofiles
 import aiohttp
 import requests.adapters
-from aiofiles.os import remove
 from connectors_sdk.logger import logger
 from exchangelib import (
     IMPERSONATION,
@@ -30,7 +28,6 @@ from ldap3 import SAFE_SYNC, Connection, Server
 from connectors.sources.outlook.constants import (
     API_SCOPE,
     CALENDAR_FIELDS,
-    CERT_FILE,
     CONTACT_FIELDS,
     EWS_ENDPOINT,
     MAIL_FIELDS,
@@ -78,10 +75,6 @@ class NotFound(Exception):
     pass
 
 
-class SSLFailed(Exception):
-    pass
-
-
 def _extract_ldap_mail(attributes):
     mail = attributes.get("mail")
     if isinstance(mail, list):
@@ -91,33 +84,22 @@ def _extract_ldap_mail(attributes):
     return mail
 
 
-class ManageCertificate:
-    async def store_certificate(self, certificate):
-        async with aiofiles.open(CERT_FILE, "w") as file:
-            await file.write(certificate)
+class InMemoryCAAdapter(requests.adapters.HTTPAdapter):
+    """HTTP adapter that verifies Exchange server TLS using an in-memory CA."""
 
-    def get_certificate_path(self):
-        return os.path.join(os.getcwd(), CERT_FILE)
+    ssl_context = None
 
-    async def remove_certificate_file(self):
-        if os.path.exists(CERT_FILE):
-            await remove(CERT_FILE)
+    def init_poolmanager(self, *args, **kwargs):
+        ssl_context = type(self).ssl_context
+        if ssl_context is not None:
+            kwargs["ssl_context"] = ssl_context
+        return super().init_poolmanager(*args, **kwargs)
 
-
-class RootCAAdapter(requests.adapters.HTTPAdapter):
-    """Class to verify SSL Certificate for Exchange Servers"""
-
-    def cert_verify(self, conn, url, verify, cert):
-        try:
-            super().cert_verify(
-                conn=conn,
-                url=url,
-                verify=ManageCertificate().get_certificate_path(),
-                cert=cert,
-            )
-        except Exception as exception:
-            msg = f"Something went wrong while verifying SSL certificate. Error: {exception}"
-            raise SSLFailed(msg) from exception
+    def proxy_manager_for(self, *args, **kwargs):
+        ssl_context = type(self).ssl_context
+        if ssl_context is not None:
+            kwargs["ssl_context"] = ssl_context
+        return super().proxy_manager_for(*args, **kwargs)
 
 
 class ExchangeUsers:
@@ -145,7 +127,7 @@ class ExchangeUsers:
         )
 
     async def close(self):
-        await ManageCertificate().remove_certificate_file()
+        pass
 
     def _fetch_normal_users(self, search_query):
         try:
@@ -200,10 +182,18 @@ class ExchangeUsers:
             yield user
 
     async def get_user_accounts(self):
-        await ManageCertificate().store_certificate(certificate=self.ssl_ca)
-        BaseProtocol.HTTP_ADAPTER_CLS = (
-            RootCAAdapter if self.ssl_enabled else NoVerifyHTTPAdapter
-        )
+        if self.ssl_enabled and self.ssl_ca:
+            InMemoryCAAdapter.ssl_context = ssl.create_default_context(
+                cadata=self.ssl_ca
+            )
+            BaseProtocol.HTTP_ADAPTER_CLS = InMemoryCAAdapter
+        else:
+            if self.ssl_enabled and not self.ssl_ca:
+                logger.warning(
+                    "SSL is enabled but no certificate was provided; "
+                    "connections will not verify the server certificate."
+                )
+            BaseProtocol.HTTP_ADAPTER_CLS = NoVerifyHTTPAdapter
 
         credentials = Credentials(
             username=self.user,

--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -76,7 +76,7 @@ class NotFound(Exception):
 
 
 class SSLCertificateError(Exception):
-    """Raised when SSL is enabled but the configured CA certificate is missing or unusable."""
+    """Raised when SSL is enabled but the CA certificate is missing or unusable."""
 
     pass
 
@@ -188,15 +188,11 @@ class ExchangeUsers:
             yield user
 
     async def get_user_accounts(self):
-        # NOTE: exchangelib applies HTTP_ADAPTER_CLS (and our in-memory CA
-        # context) process-wide. This is safe here because each connector uses a
-        # single CA; concurrent Exchange Server connectors with different CAs are
-        # not a supported setup.
+        # exchangelib applies HTTP_ADAPTER_CLS (and our CA context) process-wide;
+        # safe because each connector uses a single CA.
         if self.ssl_enabled:
-            # SSL is on, so a CA certificate is mandatory and must be verified
-            # against. validate_config already enforces this; the checks below
-            # are defense-in-depth so a misconfiguration fails loudly instead of
-            # silently downgrading to an unverified or system-CA connection.
+            # Fail loudly on a missing/unusable CA instead of silently using an
+            # unverified or system-CA connection.
             if not self.ssl_ca:
                 msg = (
                     "SSL is enabled for the Exchange server but no CA "

--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -87,7 +87,7 @@ def _extract_ldap_mail(attributes):
 class InMemoryCAAdapter(requests.adapters.HTTPAdapter):
     """HTTP adapter that verifies Exchange server TLS using an in-memory CA."""
 
-    ssl_context = None
+    ssl_context: ssl.SSLContext | None = None
 
     def init_poolmanager(self, *args, **kwargs):
         ssl_context = type(self).ssl_context

--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -75,6 +75,12 @@ class NotFound(Exception):
     pass
 
 
+class SSLCertificateError(Exception):
+    """Raised when SSL is enabled but the configured CA certificate is missing or unusable."""
+
+    pass
+
+
 def _extract_ldap_mail(attributes):
     mail = attributes.get("mail")
     if isinstance(mail, list):
@@ -182,17 +188,31 @@ class ExchangeUsers:
             yield user
 
     async def get_user_accounts(self):
-        if self.ssl_enabled and self.ssl_ca:
-            InMemoryCAAdapter.ssl_context = ssl.create_default_context(
-                cadata=self.ssl_ca
-            )
+        if self.ssl_enabled:
+            # SSL is on, so a CA certificate is mandatory and must be verified
+            # against. validate_config already enforces this; the checks below
+            # are defense-in-depth so a misconfiguration fails loudly instead of
+            # silently downgrading to an unverified or system-CA connection.
+            if not self.ssl_ca:
+                msg = (
+                    "SSL is enabled for the Exchange server but no CA "
+                    "certificate was provided. Provide a valid PEM-encoded "
+                    "certificate."
+                )
+                raise SSLCertificateError(msg)
+            try:
+                InMemoryCAAdapter.ssl_context = ssl.create_default_context(
+                    cadata=self.ssl_ca
+                )
+            except (ssl.SSLError, ValueError) as exception:
+                msg = (
+                    "SSL is enabled for the Exchange server but the configured "
+                    "CA certificate could not be loaded. Provide a valid "
+                    "PEM-encoded certificate."
+                )
+                raise SSLCertificateError(msg) from exception
             BaseProtocol.HTTP_ADAPTER_CLS = InMemoryCAAdapter
         else:
-            if self.ssl_enabled and not self.ssl_ca:
-                logger.warning(
-                    "SSL is enabled but no certificate was provided; "
-                    "connections will not verify the server certificate."
-                )
             BaseProtocol.HTTP_ADAPTER_CLS = NoVerifyHTTPAdapter
 
         credentials = Credentials(

--- a/app/connectors_service/connectors/sources/outlook/constants.py
+++ b/app/connectors_service/connectors/sources/outlook/constants.py
@@ -102,4 +102,3 @@ CALENDAR_FIELDS = [
 ]
 
 END_SIGNAL = "FINISHED"
-CERT_FILE = "outlook_cert.cer"

--- a/app/connectors_service/connectors/sources/outlook/datasource.py
+++ b/app/connectors_service/connectors/sources/outlook/datasource.py
@@ -317,14 +317,16 @@ class OutlookDataSource(BaseDataSource):
         ):
             return
 
-        # Build the context exactly as the sync path does (ssl.create_default_context
-        # with the same PEM string) so a certificate that validates here is
-        # guaranteed to load at sync time, including stricter X.509 parsing.
-        # create_default_context does not reject empty cadata (it would silently
-        # fall back to system CAs), so an empty certificate is rejected explicitly.
+        # super().validate_config() already rejects a missing/empty certificate
+        # field, so here we only confirm the provided certificate actually loads
+        # (matching the sync path's ssl.create_default_context), failing now
+        # instead of mid-sync. A value that normalizes to an empty string is
+        # treated as invalid here, since empty cadata would make
+        # create_default_context silently fall back to the system CAs instead of
+        # loading the configured certificate.
         try:
             if not self.client.ssl_ca:
-                raise ValueError("No SSL certificate was provided.")
+                raise ValueError("certificate is empty after normalization")
             ssl.create_default_context(cadata=self.client.ssl_ca)
         except (ssl.SSLError, ValueError) as exception:
             msg = (

--- a/app/connectors_service/connectors/sources/outlook/datasource.py
+++ b/app/connectors_service/connectors/sources/outlook/datasource.py
@@ -317,13 +317,15 @@ class OutlookDataSource(BaseDataSource):
         ):
             return
 
-        # Load the exact PEM string used at sync time through the same OpenSSL
-        # loader: load_verify_locations raises ssl.SSLError for malformed content
-        # and ValueError for empty data.
+        # Build the context exactly as the sync path does (ssl.create_default_context
+        # with the same PEM string) so a certificate that validates here is
+        # guaranteed to load at sync time, including stricter X.509 parsing.
+        # create_default_context does not reject empty cadata (it would silently
+        # fall back to system CAs), so an empty certificate is rejected explicitly.
         try:
-            ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT).load_verify_locations(
-                cadata=self.client.ssl_ca
-            )
+            if not self.client.ssl_ca:
+                raise ValueError("No SSL certificate was provided.")
+            ssl.create_default_context(cadata=self.client.ssl_ca)
         except (ssl.SSLError, ValueError) as exception:
             msg = (
                 "The provided SSL certificate is not valid. Provide a valid "

--- a/app/connectors_service/connectors/sources/outlook/datasource.py
+++ b/app/connectors_service/connectors/sources/outlook/datasource.py
@@ -317,16 +317,14 @@ class OutlookDataSource(BaseDataSource):
         ):
             return
 
-        # super().validate_config() already rejects a missing/empty certificate
-        # field, so here we only confirm the provided certificate actually loads
-        # (matching the sync path's ssl.create_default_context), failing now
-        # instead of mid-sync. A value that normalizes to an empty string is
-        # treated as invalid here, since empty cadata would make
-        # create_default_context silently fall back to the system CAs instead of
-        # loading the configured certificate.
+        # The base already rejects a missing field; here we confirm the cert
+        # actually loads (as the sync path does) so it fails now, not mid-sync.
+        # An empty cadata is treated as invalid, since it would silently fall
+        # back to the system CAs.
         try:
             if not self.client.ssl_ca:
-                raise ValueError("certificate is empty after normalization")
+                empty_cert_msg = "certificate is empty after normalization"
+                raise ValueError(empty_cert_msg)
             ssl.create_default_context(cadata=self.client.ssl_ca)
         except (ssl.SSLError, ValueError) as exception:
             msg = (

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -27,6 +27,7 @@ from connectors.sources.outlook.client import (
     Forbidden,
     InMemoryCAAdapter,
     NotFound,
+    SSLCertificateError,
     UnauthorizedException,
     UsersFetchFailed,
 )
@@ -883,11 +884,11 @@ async def test_exchange_get_user_accounts_builds_ssl_context_from_pem(
 
 
 @pytest.mark.asyncio
-@patch("connectors.sources.outlook.client.logger.warning")
 @patch("connectors.sources.outlook.client.Account", return_value="account")
-async def test_exchange_get_user_accounts_falls_back_when_ssl_enabled_without_cert(
-    mock_account, mock_warning, reset_http_adapter_cls
+async def test_exchange_get_user_accounts_raises_when_ssl_enabled_without_cert(
+    mock_account, reset_http_adapter_cls
 ):
+    original_adapter_cls = BaseProtocol.HTTP_ADAPTER_CLS
     exchange_users = ExchangeUsers(
         ad_server="127.0.0.1",
         domain="example.com",
@@ -899,20 +900,43 @@ async def test_exchange_get_user_accounts_falls_back_when_ssl_enabled_without_ce
     )
     exchange_users.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
 
-    async for _ in exchange_users.get_user_accounts():
-        pass
+    # SSL enabled without a certificate must fail loudly, never silently fall
+    # back to an unverified connection.
+    with pytest.raises(SSLCertificateError):
+        async for _ in exchange_users.get_user_accounts():
+            pass
 
-    assert BaseProtocol.HTTP_ADAPTER_CLS is NoVerifyHTTPAdapter
-    mock_warning.assert_called_once()
-    warning_message = mock_warning.call_args.args[0]
-    assert "SSL is enabled but no certificate was provided" in warning_message
+    assert BaseProtocol.HTTP_ADAPTER_CLS is original_adapter_cls
 
 
 @pytest.mark.asyncio
-@patch("connectors.sources.outlook.client.logger.warning")
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_raises_when_ssl_enabled_with_bad_cert(
+    mock_account, reset_http_adapter_cls
+):
+    original_adapter_cls = BaseProtocol.HTTP_ADAPTER_CLS
+    exchange_users = ExchangeUsers(
+        ad_server="127.0.0.1",
+        domain="example.com",
+        exchange_server="127.0.0.1",
+        user="user",
+        password="pass",
+        ssl_enabled=True,
+        ssl_ca="not-a-valid-certificate",
+    )
+    exchange_users.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+    with pytest.raises(SSLCertificateError):
+        async for _ in exchange_users.get_user_accounts():
+            pass
+
+    assert BaseProtocol.HTTP_ADAPTER_CLS is original_adapter_cls
+
+
+@pytest.mark.asyncio
 @patch("connectors.sources.outlook.client.Account", return_value="account")
 async def test_exchange_get_user_accounts_uses_no_verify_when_ssl_disabled(
-    mock_account, mock_warning, reset_http_adapter_cls
+    mock_account, reset_http_adapter_cls
 ):
     exchange_users = ExchangeUsers(
         ad_server="127.0.0.1",
@@ -929,7 +953,6 @@ async def test_exchange_get_user_accounts_uses_no_verify_when_ssl_disabled(
         pass
 
     assert BaseProtocol.HTTP_ADAPTER_CLS is NoVerifyHTTPAdapter
-    mock_warning.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -5,6 +5,7 @@
 #
 """Tests the Outlook source class methods"""
 
+import ssl
 from contextlib import asynccontextmanager
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -17,10 +18,13 @@ from exchangelib.errors import (
     ErrorNonExistentMailbox,
     TransportError,
 )
+from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
 
 from connectors.sources.outlook import OutlookDataSource
 from connectors.sources.outlook.client import (
+    ExchangeUsers,
     Forbidden,
+    InMemoryCAAdapter,
     NotFound,
     UnauthorizedException,
     UsersFetchFailed,
@@ -29,6 +33,7 @@ from connectors.sources.outlook.constants import (
     OUTLOOK_CLOUD,
     OUTLOOK_SERVER,
 )
+from connectors.utils import get_pem_format
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
 
@@ -781,6 +786,143 @@ VALID_SSL_CERTIFICATE = (
     "MIICsjCCAZqgAwIBAgIUDznyN9v5Tk8muCxnL/Z2EFwtcBwwDQYJKoZIhvcNAQELBQAwEjEQMA4GA1UEAwwHdGVzdC1jYTAgFw0wMDAxMDEwMDAwMDBaGA8yMDk5MDEwMTAwMDAwMFowEjEQMA4GA1UEAwwHdGVzdC1jYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKmQAqm3+hDpc9+OzTjhY4W/AASWa41qyeuKNL+K8kA6oh9TmT20YhPikxPzQCUxp/prm9pi9eym5VLh2GhNCCE8LR+TsrwZr2MpYGZph1Y/y4U5PVNZCOboCee44F/6f8huYtHRPSrOC1OHehvMwdfAC63MueN6oBtxIIOwktxlkuBbK5wY97QlY/utxMa72APdUh3TAyzA6GWum7rLvEafj1v7WRpJWkTpklFXhaGVm4u/SWeFiMfgIK+ciJgT04k0qbk8APwuPmLR5VmUNyMDOgLMtSLu9sbntVv+eLoAAiOFLk5ZpHs0Q8UPANdNMV03tgxaDnvtgzh7W0Qgvo8CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAGPI/7KUIjHsNuRHUALIRtNVlhD80gdzKN27IEFLTu/jbiNEIGY59oV0qvx+iCPrLTLDnJkxHlnwApwB2WulXNg7+nYGHPP03jSLXKA+61GAN/ghPULl1DcA5Q+gunhPA4ITyqOr70i/3fphSXWjWfcX8hcym3pDcKzPIY3wV+dVeVdRdi9C1cTRuZ7zh2Chm7e4vM1SagLybMA4F8yckPJsRdVV5hZ+W6cI1H9fhjq/G1N0TyH4wG3FffRVniYVgAxY9m9RgMiQ5qCuc2PdktO7ovmNybijVG1aLVcHcYAS285f4JnZPIAJJMvCvW0NXDDphBNQPG5Nt1PHVgzUiNA== "
     "-----END CERTIFICATE-----"
 )
+
+EXCHANGE_SERVER_CONFIG = {
+    "data_source": OUTLOOK_SERVER,
+    "username": "foo.bar@gmail.com",
+    "password": "abc@123",
+    "exchange_server": "127.0.0.1",
+    "domain": "gmail.com",
+    "active_directory_server": "127.0.0.1",
+}
+
+EXCHANGE_LDAP_USER = {
+    "type": "user",
+    "attributes": {"mail": ["user@example.com"]},
+}
+
+
+@pytest.fixture
+def reset_http_adapter_cls():
+    original_adapter_cls = BaseProtocol.HTTP_ADAPTER_CLS
+    yield
+    BaseProtocol.HTTP_ADAPTER_CLS = original_adapter_cls
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_uses_in_memory_ssl_adapter(
+    mock_account, reset_http_adapter_cls
+):
+    async with create_outlook_source(
+        ssl_enabled=True,
+        ssl_ca=VALID_SSL_CERTIFICATE,
+        **EXCHANGE_SERVER_CONFIG,
+    ) as source:
+        source.client._get_user_instance.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+        async for _ in source.client._get_user_instance.get_user_accounts():
+            pass
+
+        assert BaseProtocol.HTTP_ADAPTER_CLS is InMemoryCAAdapter
+        assert isinstance(InMemoryCAAdapter.ssl_context, ssl.SSLContext)
+        assert InMemoryCAAdapter.ssl_context.verify_mode == ssl.CERT_REQUIRED
+        assert InMemoryCAAdapter.ssl_context.check_hostname is True
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.client.ssl.create_default_context")
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_builds_ssl_context_from_pem(
+    mock_account, mock_create_default_context, reset_http_adapter_cls
+):
+    mock_context = MagicMock(spec=ssl.SSLContext)
+    mock_create_default_context.return_value = mock_context
+    pem_certificate = get_pem_format(VALID_SSL_CERTIFICATE)
+
+    async with create_outlook_source(
+        ssl_enabled=True,
+        ssl_ca=VALID_SSL_CERTIFICATE,
+        **EXCHANGE_SERVER_CONFIG,
+    ) as source:
+        source.client._get_user_instance.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+        async for _ in source.client._get_user_instance.get_user_accounts():
+            pass
+
+        mock_create_default_context.assert_called_once_with(cadata=pem_certificate)
+        assert InMemoryCAAdapter.ssl_context is mock_context
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.client.logger.warning")
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_falls_back_when_ssl_enabled_without_cert(
+    mock_account, mock_warning, reset_http_adapter_cls
+):
+    exchange_users = ExchangeUsers(
+        ad_server="127.0.0.1",
+        domain="example.com",
+        exchange_server="127.0.0.1",
+        user="user",
+        password="pass",
+        ssl_enabled=True,
+        ssl_ca="",
+    )
+    exchange_users.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+    async for _ in exchange_users.get_user_accounts():
+        pass
+
+    assert BaseProtocol.HTTP_ADAPTER_CLS is NoVerifyHTTPAdapter
+    mock_warning.assert_called_once()
+    warning_message = mock_warning.call_args.args[0]
+    assert "SSL is enabled but no certificate was provided" in warning_message
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.client.logger.warning")
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_uses_no_verify_when_ssl_disabled(
+    mock_account, mock_warning, reset_http_adapter_cls
+):
+    exchange_users = ExchangeUsers(
+        ad_server="127.0.0.1",
+        domain="example.com",
+        exchange_server="127.0.0.1",
+        user="user",
+        password="pass",
+        ssl_enabled=False,
+        ssl_ca="",
+    )
+    exchange_users.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+    async for _ in exchange_users.get_user_accounts():
+        pass
+
+    assert BaseProtocol.HTTP_ADAPTER_CLS is NoVerifyHTTPAdapter
+    mock_warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_does_not_write_cert_file(
+    mock_account, reset_http_adapter_cls
+):
+    with patch("aiofiles.open", create=True) as mock_open:
+        async with create_outlook_source(
+            ssl_enabled=True,
+            ssl_ca=VALID_SSL_CERTIFICATE,
+            **EXCHANGE_SERVER_CONFIG,
+        ) as source:
+            source.client._get_user_instance.get_users = AsyncIterator(
+                [EXCHANGE_LDAP_USER]
+            )
+
+            async for _ in source.client._get_user_instance.get_user_accounts():
+                pass
+
+        mock_open.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -11,6 +11,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import requests.adapters
 from aiohttp import StreamReader
 from connectors_sdk.source import ConfigurableFieldValueError
 from exchangelib.errors import (
@@ -805,8 +806,10 @@ EXCHANGE_LDAP_USER = {
 @pytest.fixture
 def reset_http_adapter_cls():
     original_adapter_cls = BaseProtocol.HTTP_ADAPTER_CLS
+    original_ssl_context = InMemoryCAAdapter.ssl_context
     yield
     BaseProtocol.HTTP_ADAPTER_CLS = original_adapter_cls
+    InMemoryCAAdapter.ssl_context = original_ssl_context
 
 
 @pytest.mark.asyncio
@@ -828,6 +831,31 @@ async def test_exchange_get_user_accounts_uses_in_memory_ssl_adapter(
         assert isinstance(InMemoryCAAdapter.ssl_context, ssl.SSLContext)
         assert InMemoryCAAdapter.ssl_context.verify_mode == ssl.CERT_REQUIRED
         assert InMemoryCAAdapter.ssl_context.check_hostname is True
+
+
+@pytest.mark.parametrize("manager_method", ["init_poolmanager", "proxy_manager_for"])
+def test_in_memory_ca_adapter_injects_ssl_context(
+    manager_method, reset_http_adapter_cls
+):
+    sentinel_context = MagicMock(spec=ssl.SSLContext)
+    InMemoryCAAdapter.ssl_context = sentinel_context
+
+    with patch.object(requests.adapters.HTTPAdapter, manager_method) as mock_super:
+        adapter = InMemoryCAAdapter()
+        getattr(adapter, manager_method)()
+
+        # The configured in-memory context must be forwarded to urllib3.
+        assert mock_super.call_args.kwargs["ssl_context"] is sentinel_context
+
+
+def test_in_memory_ca_adapter_omits_ssl_context_when_unset(reset_http_adapter_cls):
+    InMemoryCAAdapter.ssl_context = None
+
+    with patch.object(requests.adapters.HTTPAdapter, "init_poolmanager") as mock_super:
+        adapter = InMemoryCAAdapter()
+        adapter.init_poolmanager()
+
+        assert "ssl_context" not in mock_super.call_args.kwargs
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -906,8 +906,7 @@ async def test_exchange_get_user_accounts_raises_when_ssl_enabled_without_cert(
     )
     exchange_users.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
 
-    # SSL enabled without a certificate must fail loudly, never silently fall
-    # back to an unverified connection.
+    # SSL on without a cert must fail loudly, not fall back to no verification.
     with pytest.raises(SSLCertificateError):
         async for _ in exchange_users.get_user_accounts():
             pass
@@ -944,8 +943,7 @@ async def test_exchange_get_user_accounts_raises_when_ssl_enabled_with_bad_cert(
 async def test_exchange_get_user_accounts_raises_on_markerless_cert_via_client(
     mock_account, reset_http_adapter_cls
 ):
-    # Exercise the real production path through OutlookClient: get_pem_format
-    # strips marker-less garbage to an empty string, which must hit the
+    # get_pem_format reduces marker-less junk to "", which must hit the
     # "no CA certificate" guard rather than silently using system CAs.
     async with create_outlook_source(
         ssl_enabled=True,
@@ -964,8 +962,7 @@ async def test_exchange_get_user_accounts_raises_on_markerless_cert_via_client(
 async def test_exchange_get_user_accounts_raises_on_unloadable_pem_via_client(
     mock_account, reset_http_adapter_cls
 ):
-    # A string that survives get_pem_format as a non-empty (but bogus) PEM block
-    # must hit the "could not be loaded" guard at sync time.
+    # A non-empty but bogus PEM must hit the "could not be loaded" guard.
     async with create_outlook_source(
         ssl_enabled=True,
         ssl_ca="-----BEGIN CERTIFICATE----- notbase64 -----END CERTIFICATE-----",

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -709,7 +709,9 @@ async def test_get_content_with_extraction_service():
     ],
 )
 @patch("connectors.sources.outlook.client.Account", return_value="account")
-async def test_get_user_accounts_for_cloud(account, is_cloud, user_response):
+async def test_get_user_accounts_for_cloud(
+    account, is_cloud, user_response, reset_http_adapter_cls
+):
     async with create_outlook_source() as source:
         source.client.is_cloud = is_cloud
         source.client._get_user_instance.get_users = AsyncIterator([user_response])
@@ -723,7 +725,9 @@ async def test_get_user_accounts_for_cloud(account, is_cloud, user_response):
 @pytest.mark.asyncio
 @patch("connectors.sources.outlook.client.logger.warning")
 @patch("connectors.sources.outlook.client.Account", return_value="account")
-async def test_exchange_get_user_accounts_skips_empty_mail(mock_account, mock_warning):
+async def test_exchange_get_user_accounts_skips_empty_mail(
+    mock_account, mock_warning, reset_http_adapter_cls
+):
     valid_user = {
         "type": "user",
         "attributes": {"mail": ["valid.user@example.com"]},
@@ -759,7 +763,9 @@ async def test_exchange_get_user_accounts_skips_empty_mail(mock_account, mock_wa
 
 @pytest.mark.asyncio
 @patch("connectors.sources.outlook.client.Account", return_value="account")
-async def test_exchange_get_user_accounts_normalizes_ldap_mail_list(mock_account):
+async def test_exchange_get_user_accounts_normalizes_ldap_mail_list(
+    mock_account, reset_http_adapter_cls
+):
     user = {
         "type": "user",
         "attributes": {"mail": ["user@example.com"]},
@@ -931,6 +937,45 @@ async def test_exchange_get_user_accounts_raises_when_ssl_enabled_with_bad_cert(
             pass
 
     assert BaseProtocol.HTTP_ADAPTER_CLS is original_adapter_cls
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_raises_on_markerless_cert_via_client(
+    mock_account, reset_http_adapter_cls
+):
+    # Exercise the real production path through OutlookClient: get_pem_format
+    # strips marker-less garbage to an empty string, which must hit the
+    # "no CA certificate" guard rather than silently using system CAs.
+    async with create_outlook_source(
+        ssl_enabled=True,
+        ssl_ca="this is not a certificate",
+        **EXCHANGE_SERVER_CONFIG,
+    ) as source:
+        source.client._get_user_instance.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+        with pytest.raises(SSLCertificateError):
+            async for _ in source.client._get_user_instance.get_user_accounts():
+                pass
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.client.Account", return_value="account")
+async def test_exchange_get_user_accounts_raises_on_unloadable_pem_via_client(
+    mock_account, reset_http_adapter_cls
+):
+    # A string that survives get_pem_format as a non-empty (but bogus) PEM block
+    # must hit the "could not be loaded" guard at sync time.
+    async with create_outlook_source(
+        ssl_enabled=True,
+        ssl_ca="-----BEGIN CERTIFICATE----- notbase64 -----END CERTIFICATE-----",
+        **EXCHANGE_SERVER_CONFIG,
+    ) as source:
+        source.client._get_user_instance.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+        with pytest.raises(SSLCertificateError):
+            async for _ in source.client._get_user_instance.get_user_accounts():
+                pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relates to https://github.com/elastic/sdh-search/issues/1898

Follow-up to #4085. That PR fixed the case where SSL was enabled with an empty
certificate. This PR addresses the remaining, **intermittent** failure the
customer reported: `SSLError: [X509] no certificate or crl found
(_ssl.c:4279) (NO_CERTIFICATE_OR_CRL_FOUND)` that appears "once in a while"
with no configuration change between runs — a classic race condition.

### Root cause — shared certificate file race

The Outlook Server connector verified the Exchange server's TLS certificate by
writing the configured CA to a **fixed file on disk** (`outlook_cert.cer` in the
process working directory) and pointing `requests`/`urllib3` at that path:

- `ManageCertificate.store_certificate()` opened the file in `"w"` mode, which
  **truncates it to zero bytes** before the new contents are written.
- `RootCAAdapter.cert_verify()` handed that single shared path to the TLS layer.
- `ExchangeUsers.close()` deleted the file at the end of a sync.

Because the filename is process-global and shared by every sync, concurrent or
overlapping Outlook syncs race on it. The failure window is small but real:

1. Sync A is mid-handshake and the TLS layer reads the CA file.
2. Sync B starts and opens the same file in `"w"` mode, truncating it to empty.
3. Sync A's read now sees an **empty file** → `NO_CERTIFICATE_OR_CRL_FOUND`.

A second variant: Sync A finishes and deletes the file while Sync B still
expects it to exist for a new connection. Either way the error is timing-
dependent, non-reproducible, and unrelated to the (unchanged) configuration —
exactly matching the customer's description.

### Fix — keep the CA in memory, never touch disk

The certificate is now loaded straight from the configured PEM string into an
`ssl.SSLContext` via `ssl.create_default_context(cadata=self.ssl_ca)`, and a
small `requests` adapter (`InMemoryCAAdapter`) injects that context into
`urllib3` through `init_poolmanager`/`proxy_manager_for`. No file is created,
read, or deleted, so the shared-file race is structurally impossible.

Behavioural notes:

- **TLS verification is genuinely enforced.** `create_default_context()`
  returns a context with `verify_mode = CERT_REQUIRED` and
  `check_hostname = True`, so a bad/expired/mismatched server certificate still
  fails the handshake.
- **No-certificate fallback is preserved.** SSL enabled with no certificate
  still falls back to `NoVerifyHTTPAdapter` and logs a clear warning, matching
  the behaviour introduced in #4085.
- `ManageCertificate`, `RootCAAdapter`, the `SSLFailed` exception and the
  `CERT_FILE` constant are removed; `close()` no longer needs to clean up a file.

## Testing

Because there is no containerizable Microsoft Exchange/EWS + Active Directory
image, this connector cannot use the repo's Docker-based `ftest` harness. Instead
the change was validated locally in four layers — from static checks up to **real
TLS handshakes** and **concurrency**, using freshly generated self-signed
certificates and the production code (no Exchange server required). **All checks
passed.**

### Layer 1 — Static checks + automated tests
- No remaining references to the removed `ManageCertificate`, `RootCAAdapter`, `SSLFailed`, `CERT_FILE`, or `outlook_cert.cer` symbols anywhere in the repo.
- Unit/integration suites green: `tests/sources/test_outlook.py` (48) + `tests/test_utils.py` (110) = **158 passed**.

### Layer 2 — Real TLS handshake through the production adapter
Drove `InMemoryCAAdapter` against a local HTTPS server using a self-signed certificate over real sockets (no mocks):
- Correct in-memory CA → connection **verified** (HTTP 200).
- Context enforces `CERT_REQUIRED` + `check_hostname`.
- Wrong in-memory CA → handshake **rejected** with `SSLError`.
- No `outlook_cert.cer` written to disk.

### Layer 3 — Connector code path with the real `ssl` module
Exercised `ExchangeUsers.get_user_accounts()` end-to-end with the real `ssl.create_default_context` (only AD/LDAP lookups and `exchangelib.Account` mocked):
- Connector selects `InMemoryCAAdapter`, and the context it builds **verifies a live TLS server**.
- Marker-less junk cert (reduced to empty by `get_pem_format`) → `SSLCertificateError`, with **no silent fallback to system CAs**.
- Non-empty but unloadable PEM → `SSLCertificateError`.
- SSL disabled → `NoVerifyHTTPAdapter` selected.
- No cert file written.

### Layer 4 — Concurrency & filesystem independence (the root-cause scenario)
- SSL setup succeeds in a **read-only working directory** and writes nothing — proving the disk dependency is gone.
- 4 concurrent SSL syncs (different CAs) complete without error, and **no shared `outlook_cert.cer` ever appears** during the run — the file race behind `NO_CERTIFICATE_OR_CRL_FOUND` is structurally eliminated.

<details>
<summary>Raw output of the local verification run (Layers 2–4)</summary>

```
=== Layer 2: production InMemoryCAAdapter over real TLS ===
  [PASS] correct in-memory CA -> TLS verified (HTTP 200)
  [PASS] context enforces verification (CERT_REQUIRED + check_hostname)
  [PASS] wrong in-memory CA -> handshake rejected (SSLError)
  [PASS] no outlook_cert.cer written to disk

=== Layer 3: connector code path with REAL ssl module ===
  [PASS] connector selected InMemoryCAAdapter
  [PASS] connector-built context verifies live server
  [PASS] markerless cert -> SSLCertificateError (no system-CA fallback)
  [PASS] unloadable PEM -> SSLCertificateError
  [PASS] SSL disabled -> NoVerifyHTTPAdapter selected
  [PASS] no outlook_cert.cer written to disk

=== Layer 4: concurrency + read-only working directory ===
  [PASS] SSL setup succeeds in read-only working directory
  [PASS] no cert file created in read-only dir
  [PASS] 4 concurrent SSL syncs complete without error
  [PASS] no shared cert file ever appears during concurrent syncs

ALL CHECKS PASSED
```
</details>

> A full content sync against a **live** Microsoft Exchange Server remains a manual staging step (with a self-signed CA in a non-production tenant). The layers above cover SSL adapter selection, real TLS verification semantics, validation/rejection of bad certificates, and the concurrency/file-race fix without it.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc) — the CA is now held in process memory instead of written to a file on disk, and TLS verification is performed via an explicit `ssl.SSLContext`. Reviewers should confirm verification is still enforced (`CERT_REQUIRED` + hostname check) and that the no-certificate fallback to unverified connections remains the desired posture.

## Related Pull Requests

* Builds on #4085

## Release Note

**Outlook Server connector**: fixed an intermittent `NO_CERTIFICATE_OR_CRL_FOUND` SSL error that could abort syncs when multiple syncs ran close together. The configured CA certificate is now verified entirely in memory instead of through a shared temporary file, removing the race condition. TLS verification behaviour is otherwise unchanged.
