### PR TITLE
[8.19] Fix DLS query to use .keyword instead of .enum (#4006)

### DIFF
--- a/connectors/access_control.py
+++ b/connectors/access_control.py
@@ -19,7 +19,7 @@ DLS_QUERY = """{
                             },
                             {
                                 "terms": {
-                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                                    "_allow_access_control.keyword": {{#toJson}}access_control{{/toJson}}
                                 }
                             }
                         ]

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -35,7 +35,7 @@ async def test_access_control_query():
                             },
                             {
                                 "terms": {
-                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                                    "_allow_access_control.keyword": {{#toJson}}access_control{{/toJson}}
                                 }
                             }
                         ]


### PR DESCRIPTION
## Summary

Manual backport of #4006 to `8.19`, adapted to the pre-monorepo layout.

Fixes the DLS query template to use `_allow_access_control.keyword` instead of `_allow_access_control.enum`. The `.enum` sub-field was removed when the custom dynamic mapping template was dropped in v9.0.0; default Elasticsearch mapping uses `.keyword` instead.

## Files changed

- `connectors/access_control.py` — update DLS query field from `.enum` to `.keyword`
- `tests/test_access_control.py` — update matching test assertion

## Skipped (not applicable to 8.19)

- `NOTICE.txt` dependency version bumps from the original commit

## Test plan

- [x] `PYTHONPATH=. pytest tests/test_access_control.py -q` — 4 passed

Made with [Cursor](https://cursor.com)