### PR TITLE
[8.19] [Connectors Python] Fix JWT RFC violation: cast GitHub App ID to string for iss claim (#4027)

### DIFF
--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -664,7 +664,7 @@ class GitHubClient:
         self._logger = logger
         self.auth_method = auth_method
         self.base_url = base_url
-        self.app_id = app_id if self.auth_method == GITHUB_APP else None
+        self.app_id = str(app_id) if self.auth_method == GITHUB_APP else None
         self.private_key = private_key if self.auth_method == GITHUB_APP else None
         self._personal_access_token = (
             token if self.auth_method == PERSONAL_ACCESS_TOKEN else None

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -857,6 +857,14 @@ def get_json_mock(mock_response, status):
 
 
 @pytest.mark.asyncio
+async def test_github_app_id_stored_as_string():
+    """app_id arrives as int from the config layer but must be a string for JWT iss claim (RFC 7519 §4.1.1)."""
+    async with create_github_source(auth_method=GITHUB_APP) as source:
+        assert isinstance(source.github_client.app_id, str)
+        assert source.github_client.app_id == "10"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("field", ["repositories", "token"])
 async def test_validate_config_missing_fields_then_raise(field):
     async with create_github_source() as source:


### PR DESCRIPTION
## Summary

Manual backport of #4027 to `8.19`, adapted to the pre-monorepo single-file GitHub connector layout.

**Original PR:** https://github.com/elastic/connectors/pull/4027 (squash commit `209ccc40` on `main`)

**Problem:** The GitHub connector passed `app_id` as an integer into gidgethub's JWT construction. PyJWT ≥ 2.11.0 enforces RFC 7519 §4.1.1, requiring the `iss` claim to be a string, causing `TypeError: Issuer (iss) must be a string.` for GitHub App connections.

**Fix:** Cast `app_id` to `str` in `GitHubClient.__init__` when auth method is `GITHUB_APP`.

## Files changed

- `connectors/sources/github.py` — cast `app_id` to `str` in `GitHubClient.__init__`
- `tests/sources/test_github.py` — add `test_github_app_id_stored_as_string` regression test

## Adaptation notes

- On `main`, the fix lives in `app/connectors_service/connectors/sources/github/client.py`; on `8.19` the GitHub connector is a single file (`connectors/sources/github.py`), so the change was applied directly there.
- No `NOTICE.txt` or `libs/connectors_sdk` changes (not present on `8.19`).

## Test plan

- [x] `PYTHONPATH=. pytest tests/sources/test_github.py -q` — **109 passed**


Made with [Cursor](https://cursor.com)