### PR TITLE
[8.19] Fix Slack connector float timestamp causing messages to be deleted on scheduled syncs (#3032) (#3997)

### DIFF
--- a/connectors/sources/slack.py
+++ b/connectors/sources/slack.py
@@ -277,8 +277,10 @@ class SlackDataSource(BaseDataSource):
             yield message, None
 
     async def channels_and_messages(self):
-        current_unix_timestamp = time.time()
-        past_unix_timestamp = current_unix_timestamp - self.n_days_to_fetch * 24 * 3600
+        current_unix_timestamp = int(time.time())
+        past_unix_timestamp = int(
+            current_unix_timestamp - self.n_days_to_fetch * 24 * 3600
+        )
         async for channel in self.slack_client.list_channels(
             not self.auto_join_channels
         ):

--- a/tests/sources/test_slack.py
+++ b/tests/sources/test_slack.py
@@ -207,9 +207,10 @@ async def test_slack_data_source_get_docs(slack_data_source, mock_responses):
 
     current_timestamp = time.time()
     with mock.patch("time.time", return_value=current_timestamp):
-        old_timestamp = (
+        old_timestamp = int(
             current_timestamp - configuration["fetch_last_n_days"] * 24 * 3600
         )
+        current_timestamp = int(current_timestamp)
         docs = []
         async for doc, _ in slack_data_source.get_docs():
             docs.append(doc)
@@ -233,3 +234,38 @@ async def test_slack_data_source_convert_usernames(slack_data_source):
     remapped_message = slack_data_source.remap_message(message, channel)
 
     assert remapped_message["text"] == "<@user_one> Hello, <@USERID2>"
+
+
+@pytest.mark.asyncio
+async def test_channels_and_messages_uses_integer_timestamps(slack_data_source):
+    """
+    Regression test for #3032
+    Slack conversations.history API returns no messages when timestamps
+    include decimal places. Verify timestamps are truncated to int.
+    """
+    original_client = slack_data_source.slack_client
+    await original_client.close()
+
+    mock_client = AsyncMock()
+    mock_client.list_channels = AsyncIterator(
+        [{"id": "1", "name": "channel1", "is_member": True}]
+    )
+    mock_client.list_messages = AsyncIterator([])
+    mock_client.close = AsyncMock()
+    slack_data_source.slack_client = mock_client
+
+    float_timestamp = 1745123456.561659
+    with mock.patch("time.time", return_value=float_timestamp):
+        async for _ in slack_data_source.channels_and_messages():
+            pass
+
+        call_args = mock_client.list_messages.call_args
+        oldest = call_args[0][1]
+        latest = call_args[0][2]
+
+        assert isinstance(
+            oldest, int
+        ), f"oldest timestamp should be int, got {type(oldest)}"
+        assert isinstance(
+            latest, int
+        ), f"latest timestamp should be int, got {type(latest)}"


### PR DESCRIPTION
## Summary

Manual backport of #3997 (squash commit fac84d28 on `main`) to the `8.19` branch.

Adapted to the pre-monorepo single-file Slack connector layout (`connectors/sources/slack.py` instead of `connectors/sources/slack/datasource.py`).

NOTICE.txt and `libs/connectors_sdk` changes from the original PR were intentionally omitted (not applicable to 8.19).

## Changes

- `connectors/sources/slack.py` — truncate `time.time()` float timestamps to `int` before passing to Slack `conversations.history` API (`oldest`/`latest` params)
- `tests/sources/test_slack.py` — update existing test expectations and add `test_channels_and_messages_uses_integer_timestamps` regression test for #3032

## Test plan

- [x] `PYTHONPATH=. pytest tests/sources/test_slack.py -q` — **9 passed**


Made with [Cursor](https://cursor.com)