### PR TITLE
[8.19] [Python Connectors] Fix sync jobs reporting zero indexed documents when error monitor fires (#4047)

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -191,19 +191,21 @@ class Sink:
         # TODO: retry 429s for individual items here
         res = await self.client.bulk_insert(operations, self.pipeline["name"])
         ids_to_ops = self._map_id_to_op(operations)
-        await self._process_bulk_response(
-            res, ids_to_ops, do_log=self._enable_bulk_operations_logging
-        )
-
-        if res.get("errors"):
-            for item in res["items"]:
-                for op, data in item.items():
-                    if "error" in data:
-                        self._logger.error(
-                            f"operation {op} failed for doc {data['_id']}, {data['error']}"
-                        )
-
-        self._populate_stats(stats, res)
+        # `_process_bulk_response` can raise mid-response, so log failures and
+        # populate stats in `finally` to still count already-accepted docs.
+        try:
+            await self._process_bulk_response(
+                res, ids_to_ops, do_log=self._enable_bulk_operations_logging
+            )
+        finally:
+            if res.get("errors"):
+                for item in res["items"]:
+                    for op, data in item.items():
+                        if "error" in data:
+                            self._logger.error(
+                                f"operation {op} failed for doc {data['_id']}, {data['error']}"
+                            )
+            self._populate_stats(stats, res)
 
         return res
 

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -1206,6 +1206,49 @@ async def test_batch_bulk_with_retry():
 
 
 @pytest.mark.asyncio
+async def test_batch_bulk_still_counts_successful_docs_when_process_bulk_response_raises():
+    """When bulk response processing raises mid-response, docs ES accepted in the same
+    batch must still be reflected in `INDEXED_DOCUMENT_COUNT`."""
+    config = {
+        "username": "elastic",
+        "password": "changeme",
+        "host": "http://nowhere.com:9200",
+    }
+    client = ESManagementClient(config)
+    client.client = AsyncMock()
+    sink = Sink(
+        client=client,
+        queue=None,
+        chunk_size=0,
+        pipeline={"name": "pipeline"},
+        chunk_mem_size=0,
+        max_concurrency=0,
+        max_retries=3,
+        retry_interval=10,
+    )
+
+    items = [{OP_INDEX: {"_id": f"ok_{i}", "result": "created"}} for i in range(5)]
+    client.bulk_insert = AsyncMock(return_value={"items": items, "errors": False})
+
+    stats = {
+        OP_INDEX: {f"ok_{i}": 50 for i in range(5)},
+        OP_UPDATE: {},
+        OP_DELETE: {},
+    }
+
+    with mock.patch.object(
+        sink,
+        "_process_bulk_response",
+        side_effect=RuntimeError("simulated mid-response failure"),
+    ):
+        with pytest.raises(RuntimeError):
+            await sink._batch_bulk([], stats)
+
+    assert sink.counters.get(INDEXED_DOCUMENT_COUNT) == 5
+    assert sink.counters.get(INDEXED_DOCUMENT_VOLUME) == 5 * 50
+
+
+@pytest.mark.asyncio
 async def test_batch_bulk_with_errors(patch_logger):
     config = {
         "username": "elastic",


### PR DESCRIPTION
## Summary

Manual backport of #4047 (squash commit `4e7ed01f` on `main`) to the `8.19` branch, adapted to the pre-monorepo layout.

Original PR: https://github.com/elastic/connectors/pull/4047
Fixes: https://github.com/elastic/connectors/issues/3736

## Files changed

- `connectors/es/sink.py` — moved error logging and `_populate_stats` into a `finally` block in `_batch_bulk` so document counters are updated even when `_process_bulk_response` raises mid-response.
- `tests/test_sink.py` — added `test_batch_bulk_still_counts_successful_docs_when_process_bulk_response_raises` (adapted regression test for the 8.19 codebase).

## Backport gaps

The `8.19` branch does **not** include the `ErrorMonitor` class (added on `main` in #2671, never merged to `8.19`). As a result, the following portions of #4047 could not be ported:

- **`SyncOrchestrator` fix** — `ErrorMonitor(**error_monitor_config)` instead of passing the config dict positionally to `enabled`.
- **`test_sync_orchestrator_passes_error_monitor_config_as_kwargs`** — depends on `ErrorMonitor` and `bulk.error_monitor` config wiring.

The reported production bug (zero `indexed_document_count` when the error monitor fires mid-batch) is specific to deployments with `ErrorMonitor` enabled; that code path is absent on `8.19`. The `_batch_bulk` `finally` change is ported for structural alignment with `main` and defensive correctness if response processing ever raises.

## Test plan

- [x] `PYTHONPATH=. pytest tests/test_sink.py -q` — **82 passed**

Made with [Cursor](https://cursor.com)