### PR TITLE
[8.19] [Connectors Python] Drop unused expand=permissions,history from space query on Confluence Data Center / Server (#4041)

### DIFF
--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -56,7 +56,11 @@ USER = "user"
 USERS_FOR_DATA_CENTER = "users_for_data_center"
 SEARCH_FOR_DATA_CENTER = "search_for_data_center"
 USERS_FOR_SERVER = "users_for_server"
-SPACE_QUERY = "limit=100&expand=permissions,history"
+SPACE_QUERY_CLOUD = "limit=100&expand=permissions,history"
+# DC/Server omits expand=permissions,history: permissions come from the
+# SPACE_PERMISSION (Extender) endpoint and history is Cloud-only. Avoids HTTP 500
+# on Confluence DC/Server versions affected by CONFSERVER-99908 and similar bugs.
+SPACE_QUERY_DATA_CENTER = "limit=100"
 ATTACHMENT_QUERY = "limit=100&expand=version,history"
 CONTENT_QUERY = "limit=50&expand=ancestors,children.attachment,history.lastUpdated,body.storage,space,space.permissions,restrictions.read.restrictions.user,restrictions.read.restrictions.group"
 SEARCH_QUERY = "limit=100&expand=content.history,content.extensions,content.container,content.space,content.body.storage,space.description,space.history"
@@ -361,9 +365,14 @@ class ConfluenceClient:
                 yield entity
 
     async def fetch_spaces(self):
+        api_query = (
+            SPACE_QUERY_CLOUD
+            if self.data_source_type == CONFLUENCE_CLOUD
+            else SPACE_QUERY_DATA_CENTER
+        )
         async for response in self.paginated_api_call(
             url_name=SPACE,
-            api_query=SPACE_QUERY,
+            api_query=api_query,
         ):
             for space in response.get("results", []):
                 spaces = self.configuration.get("spaces", "")
@@ -874,8 +883,13 @@ class ConfluenceDataSource(BaseDataSource):
         if self.spaces == [WILDCARD]:
             return
         space_keys = []
+        api_query = (
+            SPACE_QUERY_CLOUD
+            if self.confluence_client.data_source_type == CONFLUENCE_CLOUD
+            else SPACE_QUERY_DATA_CENTER
+        )
         async for response in self.confluence_client.paginated_api_call(
-            url_name=SPACE, api_query=SPACE_QUERY
+            url_name=SPACE, api_query=api_query
         ):
             spaces = response.get("results", [])
             space_keys.extend([space.get("key", "") for space in spaces])

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -24,6 +24,8 @@ from connectors.sources.confluence import (
     CONFLUENCE_CLOUD,
     CONFLUENCE_DATA_CENTER,
     CONFLUENCE_SERVER,
+    SPACE_QUERY_CLOUD,
+    SPACE_QUERY_DATA_CENTER,
     BadRequest,
     ConfluenceClient,
     ConfluenceDataSource,
@@ -955,6 +957,61 @@ async def test_fetch_spaces():
         )
         async for response in source.confluence_client.fetch_spaces():
             assert response["id"] == EXPECTED_SPACE["_id"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data_source_type, expected_api_query",
+    [
+        (CONFLUENCE_CLOUD, SPACE_QUERY_CLOUD),
+        (CONFLUENCE_DATA_CENTER, SPACE_QUERY_DATA_CENTER),
+        (CONFLUENCE_SERVER, SPACE_QUERY_DATA_CENTER),
+    ],
+)
+async def test_fetch_spaces_uses_correct_query_for_data_source_type(
+    data_source_type, expected_api_query
+):
+    """fetch_spaces uses the DC/Server-safe query off Cloud (CONFSERVER-99908)."""
+    async with create_confluence_source(data_source=data_source_type) as source:
+        source.confluence_client.paginated_api_call = MagicMock(
+            return_value=AsyncIterator([RESPONSE_SPACE])
+        )
+
+        async for _ in source.confluence_client.fetch_spaces():
+            pass
+
+        source.confluence_client.paginated_api_call.assert_called_once_with(
+            url_name="space",
+            api_query=expected_api_query,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data_source_type, expected_api_query",
+    [
+        (CONFLUENCE_CLOUD, SPACE_QUERY_CLOUD),
+        (CONFLUENCE_DATA_CENTER, SPACE_QUERY_DATA_CENTER),
+        (CONFLUENCE_SERVER, SPACE_QUERY_DATA_CENTER),
+    ],
+)
+async def test_remote_validation_uses_correct_query_for_data_source_type(
+    data_source_type, expected_api_query
+):
+    """_remote_validation uses the DC/Server-safe query off Cloud (CONFSERVER-99908)."""
+    async with create_confluence_source(data_source=data_source_type) as source:
+        source.spaces = ["DM"]
+        source.confluence_client.ping = AsyncMock()
+        source.confluence_client.paginated_api_call = MagicMock(
+            return_value=AsyncIterator([RESPONSE_SPACE_KEYS])
+        )
+
+        await source._remote_validation()
+
+        source.confluence_client.paginated_api_call.assert_called_once_with(
+            url_name="space",
+            api_query=expected_api_query,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Manual backport of #4041 (main commit 123229d1) to `8.19`, adapted from the modular `connectors/sources/atlassian/confluence/` package on main to the single-file `connectors/sources/confluence.py` layout on this branch.

## Files changed

- `connectors/sources/confluence.py`
- `tests/sources/test_confluence.py`

## What changed

- Renamed `SPACE_QUERY` to `SPACE_QUERY_CLOUD` (`limit=100&expand=permissions,history`) and added `SPACE_QUERY_DATA_CENTER` (`limit=100`) with a comment explaining why DC/Server omits the expand parameters (CONFSERVER-99908 and related bugs).
- `ConfluenceClient.fetch_spaces` now selects `SPACE_QUERY_CLOUD` for Confluence Cloud and `SPACE_QUERY_DATA_CENTER` for Data Center / Server.
- `ConfluenceDataSource._remote_validation` applies the same query selection during config validation.
- Cloud behavior is unchanged; DC/Server no longer sends unused `expand=permissions,history` on `/rest/api/space`, avoiding HTTP 500 failures during sync and validation.

## Tests

Two parametrized tests (`test_fetch_spaces_uses_correct_query_for_data_source_type`, `test_remote_validation_uses_correct_query_for_data_source_type`) pin query selection across all three data source types at both call sites.

```
PYTHONPATH=. python -m pytest tests/sources/test_confluence.py -q
68 passed in 2.93s
```

## Gaps / notes

None — the port maps cleanly to the 8.19 single-file structure with no behavioral differences from main.


Made with [Cursor](https://cursor.com)