### PR TITLE
[8.19] Update python-tds dependency version from 1.12.0 to 1.15.0 (#4015)

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -22,7 +22,7 @@ azure-storage-blob==12.19.1
 SQLAlchemy==2.0.1
 oracledb==2.3.0
 asyncpg==0.29.0
-python-tds==1.12.0
+python-tds==1.15.0
 sqlalchemy-pytds==0.3.5
 pyOpenSSL==24.3.0
 dropbox==11.36.2


### PR DESCRIPTION
## Summary

Manual backport of #4015 to `8.19`.

On `main`, this change bumps `python-tds` from `1.12.0` to `1.15.0` in `pyproject.toml` (and updates NOTICE.txt). The `8.19` branch does not use `pyproject.toml`; Python dependencies are pinned in `requirements/*.txt`, so the bump was applied there instead.

## Requirements files changed

- `requirements/framework.txt`: `python-tds==1.12.0` → `python-tds==1.15.0`

## Requirements files checked (no `python-tds` pin found)

- `requirements/x86_64.txt`
- `requirements/aarch64.txt`
- `requirements/arm64.txt`
- `requirements/agent.txt`
- `requirements/ftest.txt`
- `requirements/tests.txt`

## Context

`python-tds==1.12.0` imports the removed `pkg_resources` module at load time, which breaks Microsoft SQL Server (`mssql+pytds`) syncs on the official Wolfi-based docker image. `python-tds==1.15.0` removes that dependency.

## Test plan

- [ ] Verify `grep -rn "python-tds" requirements/` shows only `1.15.0` pins
- [ ] Confirm MSSQL connector / `mssql+pytds` SQLAlchemy dialect works on the 8.19 image build


Made with [Cursor](https://cursor.com)