### PR TITLE
[8.19] [Connectors Python] Preemptively check bulk batch size against chunk_max_mem_size and perform pre-append flush (#4012)

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -359,10 +359,24 @@ class Sink:
             stats = {OP_INDEX: {}, OP_UPDATE: {}, OP_DELETE: {}}
             bulk_size = 0
             overhead_size = None
-            batch_num = 0
+            batch_num = 0  # incremented per dispatched batch
+
+            async def _dispatch_batch():
+                nonlocal batch_num, stats, bulk_size
+                batch_num += 1
+                await self.bulk_tasks.put(
+                    functools.partial(
+                        self._batch_bulk,
+                        copy.copy(batch),
+                        copy.copy(stats),
+                    ),
+                    name=f"Elasticsearch Sink: _bulk batch #{batch_num}",
+                )
+                batch.clear()
+                stats = {OP_INDEX: {}, OP_UPDATE: {}, OP_DELETE: {}}
+                bulk_size = 0
 
             while True:
-                batch_num += 1
                 doc_size, doc = await self.fetch_doc()
                 if doc in (END_DOCS, EXTRACTOR_ERROR):
                     break
@@ -371,6 +385,16 @@ class Sink:
                 if not doc_id:
                     self._logger.warning(f"Skip document {doc} as '_id' is missing.")
                     continue
+                # Flush before adding if this doc would overflow either cap.
+                # `_bulk_op` emits 1 entry for deletes and 2 for index/update,
+                # so we compare prospective rather than current entry count.
+                entries = 1 if operation == OP_DELETE else 2
+                if batch and (
+                    len(batch) + entries > self.chunk_size
+                    or bulk_size + doc_size > self.chunk_mem_size
+                ):
+                    await _dispatch_batch()
+
                 if operation == OP_DELETE:
                     stats[operation][doc_id] = 0
                 else:
@@ -386,20 +410,12 @@ class Sink:
                     stats[operation][doc_id] = max(doc_size - overhead_size, 0)
                 self.counters.increment(operation, namespace=BULK_OPERATIONS)
                 batch.extend(self._bulk_op(doc, operation))
-
                 bulk_size += doc_size
-                if len(batch) >= self.chunk_size or bulk_size > self.chunk_mem_size:
-                    await self.bulk_tasks.put(
-                        functools.partial(
-                            self._batch_bulk,
-                            copy.copy(batch),
-                            copy.copy(stats),
-                        ),
-                        name=f"Elasticsearch Sink: _bulk batch #{batch_num}",
-                    )
-                    batch.clear()
-                    stats = {OP_INDEX: {}, OP_UPDATE: {}, OP_DELETE: {}}
-                    bulk_size = 0
+
+                # Also flush when this doc fills the batch up to (or past) the
+                # cap, so a full batch isn't held waiting for the next doc.
+                if len(batch) >= self.chunk_size or bulk_size >= self.chunk_mem_size:
+                    await _dispatch_batch()
 
                 await asyncio.sleep(0)
                 self.bulk_tasks.raise_any_exception()

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -24,6 +24,7 @@ from connectors.es.sink import (
     CREATES_QUEUED,
     DELETES_QUEUED,
     DOCS_EXTRACTED,
+    END_DOCS,
     OP_DELETE,
     OP_INDEX,
     OP_UPDATE,
@@ -1702,3 +1703,158 @@ async def test_should_log_error_when_unknown_action_item_returned(patch_logger):
     patch_logger.assert_present(
         successful_action_log_message(DOC_ONE_ID, "create", "created")
     )
+
+
+MIB = 1024 * 1024
+
+
+def _doc(doc_id, op=OP_INDEX):
+    """Build the minimal doc shape `Sink._run` reads: `_op_type`/`_index`/`_id`
+    metadata at the top level, plus a `doc` body for index/update."""
+    doc = {"_op_type": op, "_index": INDEX, "_id": doc_id}
+    if op != OP_DELETE:
+        doc["doc"] = {"id": doc_id}
+    return doc
+
+
+def _doc_ids(batch):
+    """Return the doc IDs in a dispatched bulk batch, in original order.
+
+    A bulk batch is a flat list of action/source lines. Each doc contributes
+    exactly one action line (`{"index"|"update"|"delete": {"_id": ...}}`),
+    so we pull `_id` off those and skip the body payload lines."""
+    return [
+        entry[op]["_id"]
+        for entry in batch
+        for op in (OP_INDEX, OP_UPDATE, OP_DELETE)
+        if op in entry
+    ]
+
+
+def _queue_yielding(items):
+    """Mock queue whose `get` yields the given `(size, doc)` items in order,
+    then `END_DOCS` so `Sink._run` exits cleanly."""
+    queue = Mock()
+    queue.get = AsyncMock(side_effect=[*items, (0, END_DOCS)])
+    return queue
+
+
+def _make_sink(queue, *, chunk_size, chunk_mem_size):
+    sink = Sink(
+        client=None,
+        queue=queue,
+        chunk_size=chunk_size,
+        pipeline={"name": "pipeline"},
+        chunk_mem_size=chunk_mem_size,
+        max_concurrency=2,
+        max_retries=3,
+        retry_interval=0,
+    )
+    sink._batch_bulk = AsyncMock(return_value={"items": []})
+    return sink
+
+
+def _dispatched_batches(sink):
+    """All batches the sink ever dispatched (in-loop + trailing flush)."""
+    return [call_args.args[0] for call_args in sink._batch_bulk.await_args_list]
+
+
+def _capture_in_loop_dispatch_names(sink):
+    """Spy on `sink.bulk_tasks.put` so tests can tell in-loop dispatches
+    (which go through `put`) apart from the trailing END_DOCS flush (which
+    calls `_batch_bulk` directly), and assert on the bulk-request names."""
+    names = []
+
+    async def _put(callable_, name):
+        names.append(name)
+        await callable_()
+
+    sink.bulk_tasks.put = _put
+    return names
+
+
+@pytest.mark.asyncio
+async def test_sink_flushes_before_overflowing_chunk_mem_size():
+    # Original bug: 5 docs at 1/1/1/1/2 MiB with chunk_mem_size=5 used to
+    # dispatch a single 6 MiB batch. The pre-flush must ship the first 4
+    # docs together (4 MiB) and the trailing flush ships the 2 MiB doc alone.
+    items = [
+        (1 * MIB, _doc("1")),
+        (1 * MIB, _doc("2")),
+        (1 * MIB, _doc("3")),
+        (1 * MIB, _doc("4")),
+        (2 * MIB, _doc("5")),
+    ]
+    sink = _make_sink(_queue_yielding(items), chunk_size=1000, chunk_mem_size=5)
+
+    await sink._run()
+
+    assert [_doc_ids(b) for b in _dispatched_batches(sink)] == [
+        ["1", "2", "3", "4"],
+        ["5"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sink_flushes_before_overflowing_chunk_size_with_mixed_ops():
+    # `_bulk_op` emits 1 entry per delete and 2 per index/update. With a
+    # naive `len(batch) >= chunk_size` check, `delete + index + update` would
+    # grow the batch to 5 entries before any flush -- exceeding chunk_size=4.
+    # The prospective pre-flush must split the run so every batch stays <= 4.
+    items = [
+        (1, _doc("1", OP_DELETE)),
+        (1, _doc("2")),
+        (1, _doc("3", OP_UPDATE)),
+        (1, _doc("4")),
+    ]
+    sink = _make_sink(_queue_yielding(items), chunk_size=4, chunk_mem_size=1024)
+
+    await sink._run()
+
+    # First batch: delete + index = 1 + 2 = 3 entries.
+    # Second batch: update + index = 2 + 2 = 4 entries (exactly chunk_size).
+    assert [_doc_ids(b) for b in _dispatched_batches(sink)] == [
+        ["1", "2"],
+        ["3", "4"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sink_dispatches_full_batch_without_waiting_for_next_doc():
+    # When a doc fills the batch exactly to chunk_size, it must be shipped
+    # immediately via `bulk_tasks.put` -- not held until the next doc or the
+    # trailing END_DOCS flush. Also pins that the dispatched-task names
+    # count batches (#1, #2), not fetched docs.
+    items = [(1, _doc(str(i))) for i in range(1, 5)]  # 4 docs -> 2 full batches of 4
+    sink = _make_sink(_queue_yielding(items), chunk_size=4, chunk_mem_size=1024)
+    in_loop_names = _capture_in_loop_dispatch_names(sink)
+
+    await sink._run()
+
+    assert in_loop_names == [
+        "Elasticsearch Sink: _bulk batch #1",
+        "Elasticsearch Sink: _bulk batch #2",
+    ]
+    assert [_doc_ids(b) for b in _dispatched_batches(sink)] == [
+        ["1", "2"],
+        ["3", "4"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sink_dispatches_oversized_single_doc_alone():
+    # A single 10 MiB doc against a 5 MiB cap has no batch to split it from.
+    # The pre-flush must skip (the `if batch` guard prevents an empty bulk
+    # dispatch) and the post-append flush must still ship the doc, so the
+    # loop doesn't stall on a bigger-than-cap document.
+    sink = _make_sink(
+        _queue_yielding([(10 * MIB, _doc("big"))]),
+        chunk_size=1000,
+        chunk_mem_size=5,
+    )
+    in_loop_names = _capture_in_loop_dispatch_names(sink)
+
+    await sink._run()
+
+    assert in_loop_names == ["Elasticsearch Sink: _bulk batch #1"]
+    assert [_doc_ids(b) for b in _dispatched_batches(sink)] == [["big"]]


### PR DESCRIPTION
## Summary

Manual backport of #4012 (squash commit `51cfce39` on `main`) to the `8.19` branch.

On `main`, this change was built on top of #4009 ("Adjust defaults to be more resilient"), which is **not** present on `8.19`. This backport applies the preemptive batch-size logic standalone against the current `8.19` `Sink._run` implementation.

### What changed

- **`connectors/es/sink.py`**: Introduced an internal `_dispatch_batch()` helper and moved the batch threshold check to run **before** appending each document. If adding the next doc would exceed `chunk_size` (using prospective entry count: 1 for deletes, 2 for index/update) or `chunk_mem_size`, the current batch is flushed first. Post-append flush now uses `>=` so a batch that exactly fills the cap is dispatched immediately. Also fixes `batch_num` to increment per dispatched batch rather than per fetched doc (matching #4012 intent).
- **`tests/test_sink.py`**: Added four async unit tests covering the bug-report scenario (1/1/1/1/2 MiB vs 5 MiB cap), mixed-op `chunk_size` boundary flushing, immediate dispatch when a batch fills exactly to `chunk_size`, and oversized single-doc handling without an empty pre-flush.

### Skipped (not applicable to 8.19 backport)

- `NOTICE.txt` dependency refresh from the original PR.

### Gaps / adaptations

- No #4009 default-value changes were ported; only the preemptive flush behavior from #4012.
- Test helpers adapted to 8.19's `Sink` constructor (no `error_monitor` parameter on this branch).

## Files changed

- `connectors/es/sink.py`
- `tests/test_sink.py`

## Test plan

- [x] `PYTHONPATH=. pytest tests/test_sink.py -q` — **85 passed**


Made with [Cursor](https://cursor.com)