### PR TITLE
[8.19] [Jira] Stop connector process memory from growing across full syncs (#4062)

### DIFF
--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -389,7 +389,10 @@ class JiraClient:
         self._logger.info(info_msg)
         async for response in self.paginated_api_call(url_name=ISSUES, jql=jql):
             for issue in response.get("issues", []):
-                yield issue
+                # Yield only the key to avoid pinning the large search payload.
+                issue_key = issue.get("key")
+                if issue_key:
+                    yield issue_key
 
     async def get_issues_for_issue_key(self, key):
         try:
@@ -957,73 +960,80 @@ class JiraDataSource(BaseDataSource):
             )
             async for project in self.jira_client.get_projects():
                 await self._put_projects(project=project, timestamp=timestamp)
-            await self.queue.put("FINISHED")  # pyright: ignore
         except Exception as exception:
             self._logger.warning(
                 f"Skipping data for type: {PROJECT}. Error: {exception}"
             )
+        finally:
+            # Always signal completion so the consumer drains.
+            await self.queue.put("FINISHED")  # pyright: ignore
 
-    async def _put_issue(self, issue):
+    async def _put_issue(self, issue_key):
         """Put a specific issue as per the given issue_key in a queue
 
         Args:
-            issue (dict): Issue representation containing the key to enqueue
+            issue_key (str): Issue key identifying the issue to fetch and enqueue
         """
-        async for issue_metadata in self.jira_client.get_issues_for_issue_key(
-            key=issue.get("key")
-        ):
-            response_custom_fields = {}
-            response_fields = copy(issue_metadata.get("fields"))
-            for k, v in response_fields.items():
-                if self.custom_fields.get(k):
-                    response_custom_fields[self.custom_fields[k]] = v
+        try:
+            async for issue_metadata in self.jira_client.get_issues_for_issue_key(
+                key=issue_key
+            ):
+                response_custom_fields = {}
+                response_fields = copy(issue_metadata.get("fields"))
+                for k, v in response_fields.items():
+                    if self.custom_fields.get(k):
+                        response_custom_fields[self.custom_fields[k]] = v
 
-            for k in self.custom_fields.keys():
-                if k in response_fields:
-                    del response_fields[k]
+                for k in self.custom_fields.keys():
+                    if k in response_fields:
+                        del response_fields[k]
 
-            document = {
-                "_id": f"{response_fields.get('project', {}).get('name')}-{issue_metadata.get('key')}",
-                "_timestamp": response_fields.get("updated"),
-                "Key": issue_metadata.get("key"),
-                "Type": response_fields.get("issuetype", {}).get("name"),
-                "Issue": response_fields,
-                "Custom_Fields": response_custom_fields,
-            }
+                document = {
+                    "_id": f"{response_fields.get('project', {}).get('name')}-{issue_metadata.get('key')}",
+                    "_timestamp": response_fields.get("updated"),
+                    "Key": issue_metadata.get("key"),
+                    "Type": response_fields.get("issuetype", {}).get("name"),
+                    "Issue": response_fields,
+                    "Custom_Fields": response_custom_fields,
+                }
 
-            if restrictions := [
-                restriction.get("restrictionValue")
-                for restriction in response_fields.get("issuerestriction", {})
-                .get("issuerestrictions", {})
-                .get("projectrole", [])
-            ]:
-                issue_access_control = []
-                for role_id in restrictions:
-                    access_control = await anext(
-                        self.jira_client.project_role_members(
-                            project=response_fields.get("project"),
-                            role_id=role_id,
-                            access_control=set(),
+                if restrictions := [
+                    restriction.get("restrictionValue")
+                    for restriction in response_fields.get("issuerestriction", {})
+                    .get("issuerestrictions", {})
+                    .get("projectrole", [])
+                ]:
+                    issue_access_control = []
+                    for role_id in restrictions:
+                        access_control = await anext(
+                            self.jira_client.project_role_members(
+                                project=response_fields.get("project"),
+                                role_id=role_id,
+                                access_control=set(),
+                            )
                         )
+                        issue_access_control.extend(list(access_control))
+                else:
+                    issue_access_control = await self._issue_access_control(
+                        issue_key=issue_metadata.get("key"),
+                        project=response_fields.get("project"),
                     )
-                    issue_access_control.extend(list(access_control))
-            else:
-                issue_access_control = await self._issue_access_control(
-                    issue_key=issue_metadata.get("key"),
-                    project=response_fields.get("project"),
+                document_with_access_control = self._decorate_with_access_control(
+                    document=document, access_control=issue_access_control
                 )
-            document_with_access_control = self._decorate_with_access_control(
-                document=document, access_control=issue_access_control
-            )
-            await self.queue.put((document_with_access_control, None))  # pyright: ignore
-            attachments = issue_metadata.get("fields", {}).get("attachment")
-            if len(attachments) > 0:
-                await self._put_attachment(
-                    attachments=attachments,
-                    issue_key=issue_metadata.get("key"),
-                    access_control=issue_access_control,
+                await self.queue.put(
+                    (document_with_access_control, None)  # pyright: ignore
                 )
-        await self.queue.put("FINISHED")  # pyright: ignore
+                attachments = issue_metadata.get("fields", {}).get("attachment")
+                if len(attachments) > 0:
+                    await self._put_attachment(
+                        attachments=attachments,
+                        issue_key=issue_metadata.get("key"),
+                        access_control=issue_access_control,
+                    )
+        finally:
+            # Always signal completion (even on error); the error still propagates.
+            await self.queue.put("FINISHED")  # pyright: ignore
 
     async def _get_issues(self, custom_query=""):
         """Get issues with the help of REST APIs
@@ -1041,10 +1051,13 @@ class JiraDataSource(BaseDataSource):
             else projects_query
         )
 
-        async for issue in self.jira_client.get_issues_for_jql(jql=jql):
-            await self.fetchers.put(partial(self._put_issue, issue))
-            self.tasks += 1
-        await self.queue.put("FINISHED")  # pyright: ignore
+        try:
+            async for issue_key in self.jira_client.get_issues_for_jql(jql=jql):
+                await self.fetchers.put(partial(self._put_issue, issue_key))
+                self.tasks += 1
+        finally:
+            # Always signal completion (even on error); the error still propagates.
+            await self.queue.put("FINISHED")  # pyright: ignore
 
     async def _put_attachment(self, attachments, issue_key, access_control):
         """Put attachments of a specific issue in a queue

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -9,7 +9,7 @@ import ssl
 from contextlib import asynccontextmanager
 from copy import copy
 from unittest import mock
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import aiohttp
 import pytest
@@ -836,8 +836,80 @@ async def test_put_issue():
         source.get_content = Mock(return_value=EXPECTED_CONTENT)
 
         with patch("aiohttp.ClientSession.get", side_effect=side_effect_function):
-            await source._put_issue(issue=MOCK_ISSUE)
+            await source._put_issue(issue_key=MOCK_ISSUE["key"])
             assert source.queue.qsize() == 3
+
+
+@pytest.mark.asyncio
+async def test_put_issue_emits_finished_on_error():
+    """FINISHED is still emitted on error, and the error propagates."""
+
+    async with create_jira_source() as source:
+        source.jira_client.get_issues_for_issue_key = Mock(
+            side_effect=Exception("boom")
+        )
+
+        with pytest.raises(Exception, match="boom"):
+            await source._put_issue(issue_key="TP-1")
+
+        items = []
+        while not source.queue.empty():
+            _, item = await source.queue.get()
+            items.append(item)
+        assert items == ["FINISHED"]
+
+
+@freeze_time("2023-01-24T04:07:19")
+@pytest.mark.asyncio
+async def test_get_projects_emits_finished_on_error():
+    """FINISHED sentinel is enqueued even if fetching projects fails."""
+
+    async with create_jira_source() as source:
+        source.jira_client.get_timezone = AsyncMock(side_effect=Exception("boom"))
+
+        await source._get_projects()
+
+        items = []
+        while not source.queue.empty():
+            _, item = await source.queue.get()
+            items.append(item)
+        assert items == ["FINISHED"]
+
+
+@pytest.mark.asyncio
+async def test_get_issues_schedules_put_issue_with_key_only():
+    """_get_issues schedules _put_issue with the key, not the full payload."""
+
+    async with create_jira_source() as source:
+        source.jira_client.get_issues_for_jql = Mock(
+            return_value=AsyncIterator(["TP-1", "TP-2"])
+        )
+        source.fetchers.put = AsyncMock()
+
+        await source._get_issues()
+
+        scheduled_args = [
+            call.args[0].args for call in source.fetchers.put.await_args_list
+        ]
+        assert scheduled_args == [("TP-1",), ("TP-2",)]
+        assert source.tasks == 2
+
+        _, item = await source.queue.get()
+        assert item == "FINISHED"
+
+
+@pytest.mark.asyncio
+async def test_get_issues_emits_finished_on_error():
+    """FINISHED is still emitted on error, and the error propagates."""
+
+    async with create_jira_source() as source:
+        source.jira_client.get_issues_for_jql = Mock(side_effect=Exception("boom"))
+
+        with pytest.raises(Exception, match="boom"):
+            await source._get_issues()
+
+        _, item = await source.queue.get()
+        assert item == "FINISHED"
 
 
 @pytest.mark.asyncio
@@ -1054,7 +1126,8 @@ async def test_get_issues_for_jql_uses_deprecated_v2_search_for_server(data_sour
         in requested_urls
     )
     assert all("rest/api/3/search/jql" not in url for url in requested_urls)
-    assert issues == [MOCK_ISSUE, MOCK_ISSUE_TYPE_BUG]
+    # get_issues_for_jql yields only keys.
+    assert issues == [MOCK_ISSUE["key"], MOCK_ISSUE_TYPE_BUG["key"]]
 
 
 @pytest.mark.asyncio
@@ -1108,7 +1181,8 @@ async def test_get_issues_for_jql_uses_cursor_based_v3_search_for_cloud():
         in requested_urls
     )
     assert all("rest/api/2/search" not in url for url in requested_urls)
-    assert issues == [MOCK_ISSUE]
+    # get_issues_for_jql yields only keys.
+    assert issues == [MOCK_ISSUE["key"]]
 
 
 @pytest.mark.parametrize(

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -9,7 +9,7 @@ import ssl
 from contextlib import asynccontextmanager
 from copy import copy
 from unittest import mock
-from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import aiohttp
 import pytest


### PR DESCRIPTION
## Summary

Manual backport of #4062 (main commit `9d208b57`) to `8.19`, adapted from the modular `connectors/sources/atlassian/jira/{client.py,datasource.py}` layout on main to the single-file `connectors/sources/jira.py` structure on this branch.

Fixes https://github.com/elastic/connectors/issues/3914 — in agentless deployments the connector is a long-lived process; repeated Jira full syncs caused RSS to climb and could eventually OOM.

### What changed (matches original intent)

1. **`JiraClient.get_issues_for_jql`** — yields only the issue **key** instead of the full `fields=*all` search payload. Each issue is already re-fetched per key via `get_issues_for_issue_key`, so retaining the full search object pinned large payloads on the fetcher queue and inflated peak memory.

2. **`JiraDataSource` producers** (`_get_projects`, `_get_issues`, `_put_issue`) — emit the `FINISHED` sentinel from a `finally` block so the consumer's task counter always drains even when a producer raises. Errors still propagate unchanged; this removes a failure mode where a stranded consumer could leave work in memory indefinitely.

### Files changed

- `connectors/sources/jira.py` — client + datasource logic ported into single file
- `tests/sources/test_jira.py` — four new tests for FINISHED-on-error and key-only scheduling; updated existing `get_issues_for_jql` assertions

### Gaps / notes

- Skipped `NOTICE.txt` and `libs` edits from the original commit (not applicable to this backport).
- No structural differences in behavior expected beyond the single-file port.

## Test plan

- [x] `PYTHONPATH=. pytest tests/sources/test_jira.py -q` — **56 passed**


Made with [Cursor](https://cursor.com)