### PR TITLE
[8.19] [Connectors Python] Adjust defaults to be more resilient (#4009)

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -68,11 +68,11 @@
 #
 #
 ##  The request timeout to be passed to transport in options.
-#elasticsearch.request_timeout: 120
+#elasticsearch.request_timeout: 240
 #
 #
 ##  The maximum wait duration (in seconds) for the Elasticsearch connection.
-#elasticsearch.max_wait_duration: 60
+#elasticsearch.max_wait_duration: 240
 #
 #
 ##  The initial backoff duration (in seconds).
@@ -84,7 +84,7 @@
 #
 #
 ##  Elasticsearch log level
-#elasticsearch.log_level: INFO
+#elasticsearch.log_level: info
 #
 #
 ##  Maximum number of times failed Elasticsearch requests are retried, except bulk requests
@@ -120,16 +120,20 @@
 #
 #
 ##  Maximal interval of time during which MemQueue does not dequeue a single document
-##  For example, if no documents were sent to Elasticsearch within 60 seconds because of
+##  For example, if no documents were sent to Elasticsearch within 1300 seconds because of
 ##  Elasticsearch being overloaded, then an error will be raised.
 ##  This mechanism exists to be a circuit-breaker for stuck jobs and stuck Elasticsearch.
-#elasticsearch.bulk.queue_refresh_timeout: 60
+##  The default is sized for the default `elasticsearch.request_timeout`,
+##  `elasticsearch.max_retries`, and `elasticsearch.retry_interval`. If you raise any of
+##  those, raise this value too -- otherwise the queue may give up on a bulk request that
+##  the retry layer is still legitimately working on.
+#elasticsearch.bulk.queue_refresh_timeout: 1300
 #
 #
 ##  The max size in MB of a bulk request.
 ##    When the next request being prepared reaches that size, the query is
 ##    emitted even if `chunk_size` is not yet reached.
-#elasticsearch.bulk.chunk_max_mem_size: 5
+#elasticsearch.bulk.chunk_max_mem_size: 3
 #
 #
 ##  The max size of the bulk operation to Elasticsearch.

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -10,10 +10,34 @@ from envyaml import EnvYAML
 
 from connectors.logger import logger
 
+# --- Elasticsearch connection defaults -----------------------------------------------
+DEFAULT_ELASTICSEARCH_HOST = "http://localhost:9200"
+DEFAULT_ELASTICSEARCH_REQUEST_TIMEOUT = 240
+DEFAULT_ELASTICSEARCH_MAX_WAIT_DURATION = 240
+DEFAULT_ELASTICSEARCH_RETRY_ON_TIMEOUT = True
 DEFAULT_ELASTICSEARCH_MAX_RETRIES = 5
 DEFAULT_ELASTICSEARCH_RETRY_INTERVAL = 10
+DEFAULT_ELASTICSEARCH_INITIAL_BACKOFF_DURATION = 1
+DEFAULT_ELASTICSEARCH_BACKOFF_MULTIPLIER = 2
 
-DEFAULT_MAX_FILE_SIZE = 10485760  # 10MB
+# --- Elasticsearch bulk-ingest defaults ----------------------------------------------
+DEFAULT_QUEUE_MAX_SIZE = 1024
+DEFAULT_QUEUE_MAX_MEM_SIZE = 25
+DEFAULT_QUEUE_REFRESH_INTERVAL = 1
+# Sized for the default `elasticsearch.request_timeout` (240s) and the default
+# `elasticsearch.max_retries` / `elasticsearch.retry_interval` (5 attempts with linear
+# backoff): 5 × 240 + (10 + 20 + 30 + 40) = 1300s. If any of those defaults change,
+# this value must change too -- otherwise the mem-queue circuit breaker can fire
+# before the retry layer has exhausted its budget.
+DEFAULT_QUEUE_REFRESH_TIMEOUT = 1300
+DEFAULT_CHUNK_SIZE = 500
+DEFAULT_CHUNK_MAX_MEM_SIZE = 3
+DEFAULT_DISPLAY_EVERY = 100
+DEFAULT_MAX_CONCURRENCY = 5
+DEFAULT_CONCURRENT_DOWNLOADS = 10
+
+# --- File handling defaults ----------------------------------------------------------
+DEFAULT_MAX_FILE_SIZE = 10485760  # 10MiB
 
 
 def load_config(config_file):
@@ -60,32 +84,32 @@ log_level_mappings = {
 def _default_config():
     return {
         "elasticsearch": {
-            "host": "http://localhost:9200",
+            "host": DEFAULT_ELASTICSEARCH_HOST,
             "username": "elastic",
             "password": "changeme",
             "ssl": True,
             "verify_certs": True,
             "bulk": {
-                "queue_max_size": 1024,
-                "queue_max_mem_size": 25,
-                "queue_refresh_interval": 1,
-                "queue_refresh_timeout": 600,
-                "display_every": 100,
-                "chunk_size": 1000,
-                "max_concurrency": 5,
-                "chunk_max_mem_size": 5,
+                "queue_max_size": DEFAULT_QUEUE_MAX_SIZE,
+                "queue_max_mem_size": DEFAULT_QUEUE_MAX_MEM_SIZE,
+                "queue_refresh_interval": DEFAULT_QUEUE_REFRESH_INTERVAL,
+                "queue_refresh_timeout": DEFAULT_QUEUE_REFRESH_TIMEOUT,
+                "display_every": DEFAULT_DISPLAY_EVERY,
+                "chunk_size": DEFAULT_CHUNK_SIZE,
+                "max_concurrency": DEFAULT_MAX_CONCURRENCY,
+                "chunk_max_mem_size": DEFAULT_CHUNK_MAX_MEM_SIZE,
                 "max_retries": DEFAULT_ELASTICSEARCH_MAX_RETRIES,
                 "retry_interval": DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,
-                "concurrent_downloads": 10,
+                "concurrent_downloads": DEFAULT_CONCURRENT_DOWNLOADS,
                 "enable_operations_logging": False,
             },
             "max_retries": DEFAULT_ELASTICSEARCH_MAX_RETRIES,
             "retry_interval": DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,
-            "retry_on_timeout": True,
-            "request_timeout": 120,
-            "max_wait_duration": 120,
-            "initial_backoff_duration": 1,
-            "backoff_multiplier": 2,
+            "retry_on_timeout": DEFAULT_ELASTICSEARCH_RETRY_ON_TIMEOUT,
+            "request_timeout": DEFAULT_ELASTICSEARCH_REQUEST_TIMEOUT,
+            "max_wait_duration": DEFAULT_ELASTICSEARCH_MAX_WAIT_DURATION,
+            "initial_backoff_duration": DEFAULT_ELASTICSEARCH_INITIAL_BACKOFF_DURATION,
+            "backoff_multiplier": DEFAULT_ELASTICSEARCH_BACKOFF_MULTIPLIER,
             "log_level": "info",
             "feature_use_connectors_api": True,
         },

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -17,8 +17,14 @@ from elasticsearch import (
 
 from connectors import __version__
 from connectors.config import (
+    DEFAULT_ELASTICSEARCH_BACKOFF_MULTIPLIER,
+    DEFAULT_ELASTICSEARCH_HOST,
+    DEFAULT_ELASTICSEARCH_INITIAL_BACKOFF_DURATION,
     DEFAULT_ELASTICSEARCH_MAX_RETRIES,
+    DEFAULT_ELASTICSEARCH_MAX_WAIT_DURATION,
+    DEFAULT_ELASTICSEARCH_REQUEST_TIMEOUT,
     DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,
+    DEFAULT_ELASTICSEARCH_RETRY_ON_TIMEOUT,
 )
 from connectors.logger import logger, set_extra_logger
 from connectors.utils import (
@@ -48,7 +54,7 @@ class ESClient:
     def __init__(self, config):
         self.serverless = config.get("serverless", False)
         self.config = config
-        self.configured_host = config.get("host", "http://localhost:9200")
+        self.configured_host = config.get("host", DEFAULT_ELASTICSEARCH_HOST)
         self.host = url_to_node_config(
             self.configured_host,
             use_default_ports_for_scheme=True,
@@ -62,8 +68,12 @@ class ESClient:
 
         options = {
             "hosts": [self.host],
-            "request_timeout": config.get("request_timeout", 120),
-            "retry_on_timeout": config.get("retry_on_timeout", True),
+            "request_timeout": config.get(
+                "request_timeout", DEFAULT_ELASTICSEARCH_REQUEST_TIMEOUT
+            ),
+            "retry_on_timeout": config.get(
+                "retry_on_timeout", DEFAULT_ELASTICSEARCH_RETRY_ON_TIMEOUT
+            ),
         }
         logger.debug(f"Initial Elasticsearch node configuration is {self.host}")
 
@@ -103,9 +113,15 @@ class ESClient:
             log_level=logging.getLevelName(level),
             filebeat=logger.filebeat,  # pyright: ignore
         )
-        self.max_wait_duration = config.get("max_wait_duration", 60)
-        self.initial_backoff_duration = config.get("initial_backoff_duration", 5)
-        self.backoff_multiplier = config.get("backoff_multiplier", 2)
+        self.max_wait_duration = config.get(
+            "max_wait_duration", DEFAULT_ELASTICSEARCH_MAX_WAIT_DURATION
+        )
+        self.initial_backoff_duration = config.get(
+            "initial_backoff_duration", DEFAULT_ELASTICSEARCH_INITIAL_BACKOFF_DURATION
+        )
+        self.backoff_multiplier = config.get(
+            "backoff_multiplier", DEFAULT_ELASTICSEARCH_BACKOFF_MULTIPLIER
+        )
 
         options["headers"] = config.get("headers", {})
         options["headers"]["user-agent"] = self.__class__.user_agent

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -25,8 +25,17 @@ import logging
 import time
 
 from connectors.config import (
+    DEFAULT_CHUNK_MAX_MEM_SIZE,
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_CONCURRENT_DOWNLOADS,
+    DEFAULT_DISPLAY_EVERY,
     DEFAULT_ELASTICSEARCH_MAX_RETRIES,
     DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,
+    DEFAULT_MAX_CONCURRENCY,
+    DEFAULT_QUEUE_MAX_MEM_SIZE,
+    DEFAULT_QUEUE_MAX_SIZE,
+    DEFAULT_QUEUE_REFRESH_INTERVAL,
+    DEFAULT_QUEUE_REFRESH_TIMEOUT,
 )
 from connectors.es.management_client import ESManagementClient
 from connectors.es.settings import TIMESTAMP_FIELD, Mappings
@@ -39,13 +48,6 @@ from connectors.protocol.connectors import (
     INDEXED_DOCUMENT_VOLUME,
 )
 from connectors.utils import (
-    DEFAULT_CHUNK_MEM_SIZE,
-    DEFAULT_CHUNK_SIZE,
-    DEFAULT_CONCURRENT_DOWNLOADS,
-    DEFAULT_DISPLAY_EVERY,
-    DEFAULT_MAX_CONCURRENCY,
-    DEFAULT_QUEUE_MEM_SIZE,
-    DEFAULT_QUEUE_SIZE,
     ConcurrentTasks,
     Counters,
     MemQueue,
@@ -997,10 +999,10 @@ class SyncOrchestrator:
             filter_ = Filter()
         if options is None:
             options = {}
-        queue_size = options.get("queue_max_size", DEFAULT_QUEUE_SIZE)
+        queue_size = options.get("queue_max_size", DEFAULT_QUEUE_MAX_SIZE)
         display_every = options.get("display_every", DEFAULT_DISPLAY_EVERY)
-        queue_mem_size = options.get("queue_max_mem_size", DEFAULT_QUEUE_MEM_SIZE)
-        chunk_mem_size = options.get("chunk_max_mem_size", DEFAULT_CHUNK_MEM_SIZE)
+        queue_mem_size = options.get("queue_max_mem_size", DEFAULT_QUEUE_MAX_MEM_SIZE)
+        chunk_mem_size = options.get("chunk_max_mem_size", DEFAULT_CHUNK_MAX_MEM_SIZE)
         max_concurrency = options.get("max_concurrency", DEFAULT_MAX_CONCURRENCY)
         chunk_size = options.get("chunk_size", DEFAULT_CHUNK_SIZE)
         concurrent_downloads = options.get(
@@ -1010,8 +1012,12 @@ class SyncOrchestrator:
         retry_interval = options.get(
             "retry_interval", DEFAULT_ELASTICSEARCH_RETRY_INTERVAL
         )
-        mem_queue_refresh_timeout = options.get("queue_refresh_timeout", 60)
-        mem_queue_refresh_interval = options.get("queue_refresh_interval", 1)
+        mem_queue_refresh_timeout = options.get(
+            "queue_refresh_timeout", DEFAULT_QUEUE_REFRESH_TIMEOUT
+        )
+        mem_queue_refresh_interval = options.get(
+            "queue_refresh_interval", DEFAULT_QUEUE_REFRESH_INTERVAL
+        )
 
         stream = MemQueue(
             maxsize=queue_size,

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -31,14 +31,6 @@ from pympler import asizeof
 from connectors.logger import logger
 
 ACCESS_CONTROL_INDEX_PREFIX = ".search-acl-filter-"
-DEFAULT_CHUNK_SIZE = 500
-DEFAULT_QUEUE_SIZE = 1024
-DEFAULT_DISPLAY_EVERY = 100
-DEFAULT_QUEUE_MEM_SIZE = 5
-DEFAULT_CHUNK_MEM_SIZE = 25
-DEFAULT_MAX_CONCURRENCY = 5
-DEFAULT_CONCURRENT_DOWNLOADS = 10
-
 # Regular expression pattern to match a basic email format (no whitespace, valid domain)
 EMAIL_REGEX_PATTERN = r"^\S+@\S+\.\S+$"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 import pytest
 
-from connectors.config import _nest_configs, load_config
+from connectors.config import _nest_configs, add_defaults, load_config
 
 HERE = os.path.dirname(__file__)
 FIXTURES_DIR = os.path.abspath(os.path.join(HERE, "fixtures"))
@@ -80,3 +80,93 @@ def test_nest_config_when_root_field_does_exists():
     _nest_configs(config, "test", 50)
 
     assert config["test"] == 50
+
+
+def test_bulk_queue_refresh_timeout_outlasts_worst_case_retry_budget():
+    """The mem-queue refresh timeout must outlive a fully retried bulk request.
+
+    `ESManagementClient.bulk_insert` retries through
+    `TransientElasticsearchRetrier.execute_with_retry`, which uses LINEAR_BACKOFF on the
+    top-level `elasticsearch.max_retries` and `elasticsearch.retry_interval`. The
+    worst-case duration of a single bulk send is therefore `max_retries` request
+    attempts (each capped by `request_timeout`) plus the linear backoff sleeps between
+    them. If `queue_refresh_timeout` is shorter than that budget, the queue gives up on
+    a request the retrier is still legitimately working on, and we lose data.
+    """
+    es = add_defaults({})["elasticsearch"]
+    max_retries = es["max_retries"]
+    retry_interval = es["retry_interval"]
+    request_timeout = es["request_timeout"]
+    queue_refresh_timeout = es["bulk"]["queue_refresh_timeout"]
+
+    max_request_time = max_retries * request_timeout
+    backoff_gaps = sum(retry_interval * i for i in range(1, max_retries))
+    worst_case_retry_budget = max_request_time + backoff_gaps
+
+    assert queue_refresh_timeout >= worst_case_retry_budget, (
+        f"queue_refresh_timeout={queue_refresh_timeout}s is shorter than the "
+        f"worst-case bulk retry budget of {worst_case_retry_budget}s"
+    )
+
+
+def test_bulk_chunk_sizes_are_sane():
+    """Chunk size and concurrency knobs need to be in a workable range.
+
+    Tiny chunks make bulk ingest pathologically chatty; huge chunks blow past
+    Elasticsearch's bulk request limits. Memory caps need to leave room for at least one
+    chunk, and concurrency must be positive for any work to happen.
+    """
+    bulk = add_defaults({})["elasticsearch"]["bulk"]
+
+    assert 250 <= bulk["chunk_size"] <= 10_000
+    assert 1 <= bulk["chunk_max_mem_size"] <= bulk["queue_max_mem_size"]
+    assert bulk["max_concurrency"] >= 1
+    assert bulk["queue_max_size"] >= bulk["max_concurrency"]
+
+
+def test_retry_budgets_do_not_blow_up_into_hours():
+    """No single retried operation should be allowed to stall for more than an hour.
+
+    `TransientElasticsearchRetrier` (used by `bulk_insert`) applies LINEAR_BACKOFF on
+    `elasticsearch.max_retries` and `elasticsearch.retry_interval`, so the worst-case
+    bulk has the shape `attempts * request_timeout + sum(backoffs)`. The ES preflight
+    wait loop has its own `max_wait_duration` cap. Setting either high enough to
+    produce hour-plus stalls would silently freeze syncs; we cap the worst case at 1
+    hour per operation as a sanity ceiling.
+    """
+    es = add_defaults({})["elasticsearch"]
+    max_retries = es["max_retries"]
+    retry_interval = es["retry_interval"]
+    request_timeout = es["request_timeout"]
+    max_wait_duration = es["max_wait_duration"]
+    one_hour = 60 * 60
+
+    max_request_time = max_retries * request_timeout
+    backoff_gaps = sum(retry_interval * i for i in range(1, max_retries))
+    bulk_worst_case = max_request_time + backoff_gaps
+
+    assert (
+        bulk_worst_case <= one_hour
+    ), f"bulk retry worst-case {bulk_worst_case}s exceeds 1h ceiling"
+    assert (
+        max_wait_duration <= one_hour
+    ), f"ES preflight max_wait_duration {max_wait_duration}s exceeds 1h ceiling"
+
+
+def test_service_lifecycle_intervals_are_consistent():
+    """Polling / heartbeat / cleanup intervals must respect their natural ordering.
+
+    A worker polls every `idling` seconds, so neither the heartbeat nor the periodic
+    cleanup can be expected to fire faster than that. Preflight has to give Elasticsearch
+    a real chance to come up (more than one attempt, with a non-trivial idle between
+    attempts), and the configured download cap has to be a positive byte count we
+    actually want to permit.
+    """
+    service = add_defaults({})["service"]
+
+    assert service["heartbeat"] > service["idling"]
+    assert service["job_cleanup_interval"] > service["idling"]
+    assert service["preflight_max_attempts"] >= 2
+    assert service["preflight_idle"] >= 1
+    assert service["max_concurrent_content_syncs"] >= 1
+    assert 0 < service["max_file_download_size"] <= 1024**3


### PR DESCRIPTION
## Summary

Manual backport of #4009 (squash commit `5adc09e0` on `main`) to `8.19`, adapted to the pre-monorepo layout.

### Files changed

- `config.yml.example`
- `connectors/config.py`
- `connectors/es/client.py`
- `connectors/es/sink.py`
- `connectors/utils.py`
- `tests/test_config.py`

### Default changes

| Setting | Old | New |
|---|---|---|
| `elasticsearch.request_timeout` | 120 | **240** |
| `elasticsearch.max_wait_duration` | 120 | **240** |
| `elasticsearch.bulk.queue_refresh_timeout` | 600 | **1300** |
| `elasticsearch.bulk.chunk_size` | 1000 | **500** |
| `elasticsearch.bulk.chunk_max_mem_size` | 5 | **3** |

Also centralizes Elasticsearch/bulk default constants in `connectors/config.py`, updates `ESClient` fallbacks to use those constants, moves bulk-ingest defaults out of `connectors/utils.py`, and raises the `SyncOrchestrator` mem-queue `queue_refresh_timeout` fallback from 60s to 1300s.

### Gaps vs main

- **`connectors/agent/config.py`**: not present on `8.19` (Agentless wrapper removal N/A).
- **`test_error_monitor_window_can_observe_threshold`**: omitted — `8.19` has no `elasticsearch.bulk.error_monitor` config block.
- **`config.yml.example` `error_queue_size` comment**: omitted for the same reason.

## Test plan

- [x] `PYTHONPATH=. python -m pytest tests/test_config.py -q` — **12 passed**


Made with [Cursor](https://cursor.com)