### PR TITLE
[8.19] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to d01c28b (#4110)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:5323f01f61453bb3b90e6132c2e2a4de23d5a9ce3f0030e6074f38086f61cdf5
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:d01c28b20536b3a806d8c3e46db096f5dde6adbe392dffd42d4f4650df1c6c94
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
Backports the following commits to 8.19:
- Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to d01c28b (#4110)

The automatic backport to `8.19` failed because the `NOTICE.txt` cherry-pick conflicted (on `main` it lives at `app/connectors_service/NOTICE.txt`, on `8.19` at the repo root, with different pinned dependency versions). This PR was created manually and contains only the `Dockerfile.wolfi` base image digest bump (`5323f01` -> `d01c28b`); `NOTICE.txt` is left to be regenerated by CI as it is dependency-state specific for `8.19`.

Original PR: https://github.com/elastic/connectors/pull/4110

Made with [Cursor](https://cursor.com)