### PR TITLE
[8.19] fix(outlook): verify Exchange TLS with an in-memory CA to remove the cert-file race (#4094)

### DIFF
--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -6,17 +6,14 @@
 """Microsoft Outlook source module is responsible to fetch documents from Outlook server or cloud platforms."""
 
 import asyncio
-import os
 import ssl
 from copy import copy
 from datetime import date
 from functools import cached_property, partial
 
-import aiofiles
 import aiohttp
 import exchangelib
 import requests.adapters
-from aiofiles.os import remove
 from exchangelib import (
     IMPERSONATION,
     OAUTH2,
@@ -146,7 +143,6 @@ CALENDAR_FIELDS = [
 ]
 
 END_SIGNAL = "FINISHED"
-CERT_FILE = "outlook_cert.cer"
 
 
 def ews_format_to_datetime(source_datetime, timezone):
@@ -211,7 +207,9 @@ class NotFound(Exception):
     pass
 
 
-class SSLFailed(Exception):
+class SSLCertificateError(Exception):
+    """Raised when SSL is enabled but the CA certificate is missing or unusable."""
+
     pass
 
 
@@ -224,33 +222,22 @@ def _extract_ldap_mail(attributes):
     return mail
 
 
-class ManageCertificate:
-    async def store_certificate(self, certificate):
-        async with aiofiles.open(CERT_FILE, "w") as file:
-            await file.write(certificate)
+class InMemoryCAAdapter(requests.adapters.HTTPAdapter):
+    """HTTP adapter that verifies Exchange server TLS using an in-memory CA."""
 
-    def get_certificate_path(self):
-        return os.path.join(os.getcwd(), CERT_FILE)
+    ssl_context: ssl.SSLContext | None = None
 
-    async def remove_certificate_file(self):
-        if os.path.exists(CERT_FILE):
-            await remove(CERT_FILE)
+    def init_poolmanager(self, *args, **kwargs):
+        ssl_context = type(self).ssl_context
+        if ssl_context is not None:
+            kwargs["ssl_context"] = ssl_context
+        return super().init_poolmanager(*args, **kwargs)
 
-
-class RootCAAdapter(requests.adapters.HTTPAdapter):
-    """Class to verify SSL Certificate for Exchange Servers"""
-
-    def cert_verify(self, conn, url, verify, cert):
-        try:
-            super().cert_verify(
-                conn=conn,
-                url=url,
-                verify=ManageCertificate().get_certificate_path(),
-                cert=cert,
-            )
-        except Exception as exception:
-            msg = f"Something went wrong while verifying SSL certificate. Error: {exception}"
-            raise SSLFailed(msg) from exception
+    def proxy_manager_for(self, *args, **kwargs):
+        ssl_context = type(self).ssl_context
+        if ssl_context is not None:
+            kwargs["ssl_context"] = ssl_context
+        return super().proxy_manager_for(*args, **kwargs)
 
 
 class ExchangeUsers:
@@ -278,7 +265,7 @@ class ExchangeUsers:
         )
 
     async def close(self):
-        await ManageCertificate().remove_certificate_file()
+        pass
 
     def _fetch_normal_users(self, search_query):
         try:
@@ -333,10 +320,32 @@ class ExchangeUsers:
             yield user
 
     async def get_user_accounts(self):
-        await ManageCertificate().store_certificate(certificate=self.ssl_ca)
-        BaseProtocol.HTTP_ADAPTER_CLS = (
-            RootCAAdapter if self.ssl_enabled else NoVerifyHTTPAdapter
-        )
+        # exchangelib applies HTTP_ADAPTER_CLS (and our CA context) process-wide;
+        # safe because each connector uses a single CA.
+        if self.ssl_enabled:
+            # Fail loudly on a missing/unusable CA instead of silently using an
+            # unverified or system-CA connection.
+            if not self.ssl_ca:
+                msg = (
+                    "SSL is enabled for the Exchange server but no CA "
+                    "certificate was provided. Provide a valid PEM-encoded "
+                    "certificate."
+                )
+                raise SSLCertificateError(msg)
+            try:
+                InMemoryCAAdapter.ssl_context = ssl.create_default_context(
+                    cadata=self.ssl_ca
+                )
+            except (ssl.SSLError, ValueError) as exception:
+                msg = (
+                    "SSL is enabled for the Exchange server but the configured "
+                    "CA certificate could not be loaded. Provide a valid "
+                    "PEM-encoded certificate."
+                )
+                raise SSLCertificateError(msg) from exception
+            BaseProtocol.HTTP_ADAPTER_CLS = InMemoryCAAdapter
+        else:
+            BaseProtocol.HTTP_ADAPTER_CLS = NoVerifyHTTPAdapter
 
         credentials = Credentials(
             username=self.user,
@@ -854,13 +863,15 @@ class OutlookDataSource(BaseDataSource):
         ):
             return
 
-        # Load the exact PEM string used at sync time through the same OpenSSL
-        # loader: load_verify_locations raises ssl.SSLError for malformed content
-        # and ValueError for empty data.
+        # The base already rejects a missing field; here we confirm the cert
+        # actually loads (as the sync path does) so it fails now, not mid-sync.
+        # An empty cadata is treated as invalid, since it would silently fall
+        # back to the system CAs.
         try:
-            ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT).load_verify_locations(
-                cadata=self.client.ssl_ca
-            )
+            if not self.client.ssl_ca:
+                empty_cert_msg = "certificate is empty after normalization"
+                raise ValueError(empty_cert_msg)
+            ssl.create_default_context(cadata=self.client.ssl_ca)
         except (ssl.SSLError, ValueError) as exception:
             msg = (
                 "The provided SSL certificate is not valid. Provide a valid "

--- a/tests/sources/test_outlook.py
+++ b/tests/sources/test_outlook.py
@@ -5,28 +5,35 @@
 #
 """Tests the Outlook source class methods"""
 
+import ssl
 from contextlib import asynccontextmanager
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import requests.adapters
 from aiohttp import StreamReader
 from exchangelib.errors import (
     ErrorFolderNotFound,
     ErrorNonExistentMailbox,
     TransportError,
 )
+from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
 
 from connectors.source import ConfigurableFieldValueError
 from connectors.sources.outlook import (
     OUTLOOK_CLOUD,
     OUTLOOK_SERVER,
+    ExchangeUsers,
     Forbidden,
+    InMemoryCAAdapter,
     NotFound,
     OutlookDataSource,
+    SSLCertificateError,
     UnauthorizedException,
     UsersFetchFailed,
 )
+from connectors.utils import get_pem_format
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
 
@@ -700,7 +707,9 @@ async def test_get_content_with_extraction_service():
     ],
 )
 @patch("connectors.sources.outlook.Account", return_value="account")
-async def test_get_user_accounts_for_cloud(account, is_cloud, user_response):
+async def test_get_user_accounts_for_cloud(
+    account, is_cloud, user_response, reset_http_adapter_cls
+):
     async with create_outlook_source() as source:
         source.client.is_cloud = is_cloud
         source.client._get_user_instance.get_users = AsyncIterator([user_response])
@@ -714,7 +723,9 @@ async def test_get_user_accounts_for_cloud(account, is_cloud, user_response):
 @pytest.mark.asyncio
 @patch("connectors.sources.outlook.logger.warning")
 @patch("connectors.sources.outlook.Account", return_value="account")
-async def test_exchange_get_user_accounts_skips_empty_mail(mock_account, mock_warning):
+async def test_exchange_get_user_accounts_skips_empty_mail(
+    mock_account, mock_warning, reset_http_adapter_cls
+):
     valid_user = {
         "type": "user",
         "attributes": {"mail": ["valid.user@example.com"]},
@@ -750,7 +761,9 @@ async def test_exchange_get_user_accounts_skips_empty_mail(mock_account, mock_wa
 
 @pytest.mark.asyncio
 @patch("connectors.sources.outlook.Account", return_value="account")
-async def test_exchange_get_user_accounts_normalizes_ldap_mail_list(mock_account):
+async def test_exchange_get_user_accounts_normalizes_ldap_mail_list(
+    mock_account, reset_http_adapter_cls
+):
     user = {
         "type": "user",
         "attributes": {"mail": ["user@example.com"]},
@@ -779,6 +792,228 @@ VALID_SSL_CERTIFICATE = (
     "MIICsjCCAZqgAwIBAgIUDznyN9v5Tk8muCxnL/Z2EFwtcBwwDQYJKoZIhvcNAQELBQAwEjEQMA4GA1UEAwwHdGVzdC1jYTAgFw0wMDAxMDEwMDAwMDBaGA8yMDk5MDEwMTAwMDAwMFowEjEQMA4GA1UEAwwHdGVzdC1jYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKmQAqm3+hDpc9+OzTjhY4W/AASWa41qyeuKNL+K8kA6oh9TmT20YhPikxPzQCUxp/prm9pi9eym5VLh2GhNCCE8LR+TsrwZr2MpYGZph1Y/y4U5PVNZCOboCee44F/6f8huYtHRPSrOC1OHehvMwdfAC63MueN6oBtxIIOwktxlkuBbK5wY97QlY/utxMa72APdUh3TAyzA6GWum7rLvEafj1v7WRpJWkTpklFXhaGVm4u/SWeFiMfgIK+ciJgT04k0qbk8APwuPmLR5VmUNyMDOgLMtSLu9sbntVv+eLoAAiOFLk5ZpHs0Q8UPANdNMV03tgxaDnvtgzh7W0Qgvo8CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAGPI/7KUIjHsNuRHUALIRtNVlhD80gdzKN27IEFLTu/jbiNEIGY59oV0qvx+iCPrLTLDnJkxHlnwApwB2WulXNg7+nYGHPP03jSLXKA+61GAN/ghPULl1DcA5Q+gunhPA4ITyqOr70i/3fphSXWjWfcX8hcym3pDcKzPIY3wV+dVeVdRdi9C1cTRuZ7zh2Chm7e4vM1SagLybMA4F8yckPJsRdVV5hZ+W6cI1H9fhjq/G1N0TyH4wG3FffRVniYVgAxY9m9RgMiQ5qCuc2PdktO7ovmNybijVG1aLVcHcYAS285f4JnZPIAJJMvCvW0NXDDphBNQPG5Nt1PHVgzUiNA== "
     "-----END CERTIFICATE-----"
 )
+
+EXCHANGE_SERVER_CONFIG = {
+    "data_source": OUTLOOK_SERVER,
+    "username": "foo.bar@gmail.com",
+    "password": "abc@123",
+    "exchange_server": "127.0.0.1",
+    "domain": "gmail.com",
+    "active_directory_server": "127.0.0.1",
+}
+
+EXCHANGE_LDAP_USER = {
+    "type": "user",
+    "attributes": {"mail": ["user@example.com"]},
+}
+
+
+@pytest.fixture
+def reset_http_adapter_cls():
+    original_adapter_cls = BaseProtocol.HTTP_ADAPTER_CLS
+    original_ssl_context = InMemoryCAAdapter.ssl_context
+    yield
+    BaseProtocol.HTTP_ADAPTER_CLS = original_adapter_cls
+    InMemoryCAAdapter.ssl_context = original_ssl_context
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.Account", return_value="account")
+async def test_exchange_get_user_accounts_uses_in_memory_ssl_adapter(
+    mock_account, reset_http_adapter_cls
+):
+    async with create_outlook_source(
+        ssl_enabled=True,
+        ssl_ca=VALID_SSL_CERTIFICATE,
+        **EXCHANGE_SERVER_CONFIG,
+    ) as source:
+        source.client._get_user_instance.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+        async for _ in source.client._get_user_instance.get_user_accounts():
+            pass
+
+        assert BaseProtocol.HTTP_ADAPTER_CLS is InMemoryCAAdapter
+        assert isinstance(InMemoryCAAdapter.ssl_context, ssl.SSLContext)
+        assert InMemoryCAAdapter.ssl_context.verify_mode == ssl.CERT_REQUIRED
+        assert InMemoryCAAdapter.ssl_context.check_hostname is True
+
+
+@pytest.mark.parametrize("manager_method", ["init_poolmanager", "proxy_manager_for"])
+def test_in_memory_ca_adapter_injects_ssl_context(
+    manager_method, reset_http_adapter_cls
+):
+    sentinel_context = MagicMock(spec=ssl.SSLContext)
+    InMemoryCAAdapter.ssl_context = sentinel_context
+
+    with patch.object(requests.adapters.HTTPAdapter, manager_method) as mock_super:
+        adapter = InMemoryCAAdapter()
+        getattr(adapter, manager_method)()
+
+        # The configured in-memory context must be forwarded to urllib3.
+        assert mock_super.call_args.kwargs["ssl_context"] is sentinel_context
+
+
+def test_in_memory_ca_adapter_omits_ssl_context_when_unset(reset_http_adapter_cls):
+    InMemoryCAAdapter.ssl_context = None
+
+    with patch.object(requests.adapters.HTTPAdapter, "init_poolmanager") as mock_super:
+        adapter = InMemoryCAAdapter()
+        adapter.init_poolmanager()
+
+        assert "ssl_context" not in mock_super.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.ssl.create_default_context")
+@patch("connectors.sources.outlook.Account", return_value="account")
+async def test_exchange_get_user_accounts_builds_ssl_context_from_pem(
+    mock_account, mock_create_default_context, reset_http_adapter_cls
+):
+    mock_context = MagicMock(spec=ssl.SSLContext)
+    mock_create_default_context.return_value = mock_context
+    pem_certificate = get_pem_format(VALID_SSL_CERTIFICATE)
+
+    async with create_outlook_source(
+        ssl_enabled=True,
+        ssl_ca=VALID_SSL_CERTIFICATE,
+        **EXCHANGE_SERVER_CONFIG,
+    ) as source:
+        source.client._get_user_instance.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+        async for _ in source.client._get_user_instance.get_user_accounts():
+            pass
+
+        mock_create_default_context.assert_called_once_with(cadata=pem_certificate)
+        assert InMemoryCAAdapter.ssl_context is mock_context
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.Account", return_value="account")
+async def test_exchange_get_user_accounts_raises_when_ssl_enabled_without_cert(
+    mock_account, reset_http_adapter_cls
+):
+    original_adapter_cls = BaseProtocol.HTTP_ADAPTER_CLS
+    exchange_users = ExchangeUsers(
+        ad_server="127.0.0.1",
+        domain="example.com",
+        exchange_server="127.0.0.1",
+        user="user",
+        password="pass",
+        ssl_enabled=True,
+        ssl_ca="",
+    )
+    exchange_users.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+    # SSL on without a cert must fail loudly, not fall back to no verification.
+    with pytest.raises(SSLCertificateError):
+        async for _ in exchange_users.get_user_accounts():
+            pass
+
+    assert BaseProtocol.HTTP_ADAPTER_CLS is original_adapter_cls
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.Account", return_value="account")
+async def test_exchange_get_user_accounts_raises_when_ssl_enabled_with_bad_cert(
+    mock_account, reset_http_adapter_cls
+):
+    original_adapter_cls = BaseProtocol.HTTP_ADAPTER_CLS
+    exchange_users = ExchangeUsers(
+        ad_server="127.0.0.1",
+        domain="example.com",
+        exchange_server="127.0.0.1",
+        user="user",
+        password="pass",
+        ssl_enabled=True,
+        ssl_ca="not-a-valid-certificate",
+    )
+    exchange_users.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+    with pytest.raises(SSLCertificateError):
+        async for _ in exchange_users.get_user_accounts():
+            pass
+
+    assert BaseProtocol.HTTP_ADAPTER_CLS is original_adapter_cls
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.Account", return_value="account")
+async def test_exchange_get_user_accounts_raises_on_markerless_cert_via_client(
+    mock_account, reset_http_adapter_cls
+):
+    # get_pem_format reduces marker-less junk to "", which must hit the
+    # "no CA certificate" guard rather than silently using system CAs.
+    async with create_outlook_source(
+        ssl_enabled=True,
+        ssl_ca="this is not a certificate",
+        **EXCHANGE_SERVER_CONFIG,
+    ) as source:
+        source.client._get_user_instance.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+        with pytest.raises(SSLCertificateError):
+            async for _ in source.client._get_user_instance.get_user_accounts():
+                pass
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.Account", return_value="account")
+async def test_exchange_get_user_accounts_raises_on_unloadable_pem_via_client(
+    mock_account, reset_http_adapter_cls
+):
+    # A non-empty but bogus PEM must hit the "could not be loaded" guard.
+    async with create_outlook_source(
+        ssl_enabled=True,
+        ssl_ca="-----BEGIN CERTIFICATE----- notbase64 -----END CERTIFICATE-----",
+        **EXCHANGE_SERVER_CONFIG,
+    ) as source:
+        source.client._get_user_instance.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+        with pytest.raises(SSLCertificateError):
+            async for _ in source.client._get_user_instance.get_user_accounts():
+                pass
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.Account", return_value="account")
+async def test_exchange_get_user_accounts_uses_no_verify_when_ssl_disabled(
+    mock_account, reset_http_adapter_cls
+):
+    exchange_users = ExchangeUsers(
+        ad_server="127.0.0.1",
+        domain="example.com",
+        exchange_server="127.0.0.1",
+        user="user",
+        password="pass",
+        ssl_enabled=False,
+        ssl_ca="",
+    )
+    exchange_users.get_users = AsyncIterator([EXCHANGE_LDAP_USER])
+
+    async for _ in exchange_users.get_user_accounts():
+        pass
+
+    assert BaseProtocol.HTTP_ADAPTER_CLS is NoVerifyHTTPAdapter
+
+
+@pytest.mark.asyncio
+@patch("connectors.sources.outlook.Account", return_value="account")
+async def test_exchange_get_user_accounts_does_not_write_cert_file(
+    mock_account, reset_http_adapter_cls
+):
+    with patch("aiofiles.open", create=True) as mock_open:
+        async with create_outlook_source(
+            ssl_enabled=True,
+            ssl_ca=VALID_SSL_CERTIFICATE,
+            **EXCHANGE_SERVER_CONFIG,
+        ) as source:
+            source.client._get_user_instance.get_users = AsyncIterator(
+                [EXCHANGE_LDAP_USER]
+            )
+
+            async for _ in source.client._get_user_instance.get_user_accounts():
+                pass
+
+        mock_open.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Manual backport of #4094 to `8.19`.

The [auto-backport bot failed for 8.19](https://github.com/elastic/connectors/pull/4094) ("Commit could not be cherrypicked due to conflicts") because the connector layout differs between branches: `main` splits Outlook into a package (`app/connectors_service/connectors/sources/outlook/{client,constants,datasource}.py`) while `8.19` keeps it as a single module (`connectors/sources/outlook.py`). The change has therefore been hand-ported; it is **functionally identical** to the merged PR.

## Summary
- Load the configured CA directly into an `ssl.SSLContext` via `ssl.create_default_context(cadata=...)` and inject it into `urllib3` through a new `InMemoryCAAdapter` (`init_poolmanager`/`proxy_manager_for`).
- Remove the on-disk certificate machinery (`ManageCertificate`, `RootCAAdapter`, `SSLFailed`, `CERT_FILE` / `outlook_cert.cer`); `ExchangeUsers.close()` no longer cleans up a file.
- SSL enabled with a missing/unusable CA now raises `SSLCertificateError` instead of silently downgrading to an unverified/system-CA connection.
- `validate_config` confirms the cert actually loads (via `create_default_context`) so misconfig fails up front rather than mid-sync.

This structurally eliminates the shared-file race behind the intermittent `NO_CERTIFICATE_OR_CRL_FOUND` SSL error. TLS verification behaviour is otherwise unchanged (`CERT_REQUIRED` + hostname check).

## Test plan
- [x] `tests/sources/test_outlook.py` — **48 passed** (includes the new in-memory adapter, SSL-context, error-path, and no-cert-file-written tests ported from the original PR).
- [x] `ruff check` + `ruff format --check` clean on changed files.

## Release Note
**Outlook Server connector**: fixed an intermittent `NO_CERTIFICATE_OR_CRL_FOUND` SSL error that could abort syncs when multiple syncs ran close together. The configured CA certificate is now verified entirely in memory instead of through a shared temporary file, removing the race condition. TLS verification behaviour is otherwise unchanged.

Backport of #4094.

Made with [Cursor](https://cursor.com)