### PR TITLE
[Connectors Python] Drop unused `space.permissions` from content query on Confluence Data Center / Server

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2589,7 +2589,7 @@ Apache Software License
 
 
 bracex
-2.7
+3.0
 MIT
 MIT License
 

--- a/app/connectors_service/connectors/sources/atlassian/confluence/constants.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/constants.py
@@ -25,7 +25,12 @@ SPACE_QUERY_CLOUD = "limit=100&expand=permissions,history"
 # on Confluence DC/Server versions affected by CONFSERVER-99908 and similar bugs.
 SPACE_QUERY_DATA_CENTER = "limit=100"
 ATTACHMENT_QUERY = "limit=100&expand=version,history"
-CONTENT_QUERY = "limit=50&expand=ancestors,children.attachment,history.lastUpdated,body.storage,space,space.permissions,restrictions.read.restrictions.user,restrictions.read.restrictions.group"
+CONTENT_QUERY_CLOUD = "limit=50&expand=ancestors,children.attachment,history.lastUpdated,body.storage,space,space.permissions,restrictions.read.restrictions.user,restrictions.read.restrictions.group"
+# DC/Server omits space.permissions: space permissions come from the
+# SPACE_PERMISSION (Extender) endpoint and space.permissions is only read on the
+# Cloud code path. Avoids HTTP 500 on Confluence DC/Server versions affected by
+# CONFSERVER-99908 and similar expand=permissions bugs.
+CONTENT_QUERY_DATA_CENTER = "limit=50&expand=ancestors,children.attachment,history.lastUpdated,body.storage,space,restrictions.read.restrictions.user,restrictions.read.restrictions.group"
 SEARCH_QUERY = "limit=100&expand=content.history,content.extensions,content.container,content.space,content.body.storage,space.description,space.history"
 USER_QUERY = "expand=groups,applicationRoles"
 LABEL = "label"

--- a/app/connectors_service/connectors/sources/atlassian/confluence/constants.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/constants.py
@@ -20,16 +20,11 @@ USERS_FOR_DATA_CENTER = "users_for_data_center"
 SEARCH_FOR_DATA_CENTER = "search_for_data_center"
 USERS_FOR_SERVER = "users_for_server"
 SPACE_QUERY_CLOUD = "limit=100&expand=permissions,history"
-# DC/Server omits expand=permissions,history: permissions come from the
-# SPACE_PERMISSION (Extender) endpoint and history is Cloud-only. Avoids HTTP 500
-# on Confluence DC/Server versions affected by CONFSERVER-99908 and similar bugs.
+# DC/Server: drop expand=permissions,history (unused, and 500s per CONFSERVER-99908).
 SPACE_QUERY_DATA_CENTER = "limit=100"
 ATTACHMENT_QUERY = "limit=100&expand=version,history"
 CONTENT_QUERY_CLOUD = "limit=50&expand=ancestors,children.attachment,history.lastUpdated,body.storage,space,space.permissions,restrictions.read.restrictions.user,restrictions.read.restrictions.group"
-# DC/Server omits space.permissions: space permissions come from the
-# SPACE_PERMISSION (Extender) endpoint and space.permissions is only read on the
-# Cloud code path. Avoids HTTP 500 on Confluence DC/Server versions affected by
-# CONFSERVER-99908 and similar expand=permissions bugs.
+# DC/Server: drop space.permissions (unused, and 500s per CONFSERVER-99908).
 CONTENT_QUERY_DATA_CENTER = "limit=50&expand=ancestors,children.attachment,history.lastUpdated,body.storage,space,restrictions.read.restrictions.user,restrictions.read.restrictions.group"
 SEARCH_QUERY = "limit=100&expand=content.history,content.extensions,content.container,content.space,content.body.storage,space.description,space.history"
 USER_QUERY = "expand=groups,applicationRoles"

--- a/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
@@ -24,7 +24,8 @@ from connectors.sources.atlassian.confluence.constants import (
     CONFLUENCE_DATA_CENTER,
     CONFLUENCE_SERVER,
     CONTENT,
-    CONTENT_QUERY,
+    CONTENT_QUERY_CLOUD,
+    CONTENT_QUERY_DATA_CENTER,
     END_SIGNAL,
     MAX_CONCURRENCY,
     MAX_CONCURRENT_DOWNLOADS,
@@ -929,6 +930,11 @@ class ConfluenceDataSource(BaseDataSource):
                         yield document, None
 
         else:
+            content_query = (
+                CONTENT_QUERY_CLOUD
+                if self.confluence_client.data_source_type == CONFLUENCE_CLOUD
+                else CONTENT_QUERY_DATA_CENTER
+            )
             async for space in self._space_coro():
                 yield space, None
                 self._logger.info(f"Fetching docs from space: {space['key']}")
@@ -936,14 +942,14 @@ class ConfluenceDataSource(BaseDataSource):
                 await self.fetchers.put(
                     partial(
                         self._page_blog_coro,
-                        f"{configured_spaces_query}{BLOGPOST}&{CONTENT_QUERY}",
+                        f"{configured_spaces_query}{BLOGPOST}&{content_query}",
                         BLOGPOST,
                     )
                 )
                 await self.fetchers.put(
                     partial(
                         self._page_blog_coro,
-                        f"{configured_spaces_query}{PAGE}&{CONTENT_QUERY}",
+                        f"{configured_spaces_query}{PAGE}&{content_query}",
                         PAGE,
                     )
                 )

--- a/app/connectors_service/tests/sources/test_confluence.py
+++ b/app/connectors_service/tests/sources/test_confluence.py
@@ -36,6 +36,8 @@ from connectors.sources.atlassian.confluence.constants import (
     CONFLUENCE_CLOUD,
     CONFLUENCE_DATA_CENTER,
     CONFLUENCE_SERVER,
+    CONTENT_QUERY_CLOUD,
+    CONTENT_QUERY_DATA_CENTER,
     SPACE_QUERY_CLOUD,
     SPACE_QUERY_DATA_CENTER,
 )
@@ -1264,6 +1266,45 @@ async def test_get_docs(spaces_patch, pages_patch, attachment_patch, content_pat
         async for item, _ in source.get_docs():
             documents.append(item)
         assert documents == expected_responses
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data_source_type, expected_content_query",
+    [
+        (CONFLUENCE_CLOUD, CONTENT_QUERY_CLOUD),
+        (CONFLUENCE_DATA_CENTER, CONTENT_QUERY_DATA_CENTER),
+        (CONFLUENCE_SERVER, CONTENT_QUERY_DATA_CENTER),
+    ],
+)
+@freeze_time("2024-04-02T09:53:15.818621+00:00")
+async def test_get_docs_uses_correct_content_query_for_data_source_type(
+    data_source_type, expected_content_query
+):
+    """get_docs drops space.permissions from the content query off Cloud (CONFSERVER-99908)."""
+    async with create_confluence_source(data_source=data_source_type) as source:
+        source.confluence_client.fetch_spaces = MagicMock(
+            return_value=AsyncIterator([copy(SPACE)])
+        )
+        source.fetch_server_space_permission = AsyncMock(return_value={})
+        with mock.patch.object(
+            ConfluenceDataSource,
+            "fetch_documents",
+            side_effect=[AsyncIterator([]), AsyncIterator([])],
+        ) as fetch_documents_mock:
+            async for _ in source.get_docs():
+                pass
+
+        content_queries = [
+            call.args[0] for call in fetch_documents_mock.call_args_list
+        ]
+        assert len(content_queries) == 2
+        for query in content_queries:
+            assert query.endswith(expected_content_query)
+        if data_source_type == CONFLUENCE_CLOUD:
+            assert all("space.permissions" in query for query in content_queries)
+        else:
+            assert all("space.permissions" not in query for query in content_queries)
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/sources/test_confluence.py
+++ b/app/connectors_service/tests/sources/test_confluence.py
@@ -1295,9 +1295,7 @@ async def test_get_docs_uses_correct_content_query_for_data_source_type(
             async for _ in source.get_docs():
                 pass
 
-        content_queries = [
-            call.args[0] for call in fetch_documents_mock.call_args_list
-        ]
+        content_queries = [call.args[0] for call in fetch_documents_mock.call_args_list]
         assert len(content_queries) == 2
         for query in content_queries:
             assert query.endswith(expected_content_query)


### PR DESCRIPTION
## Related to https://github.com/elastic/sdh-search/issues/1916

Follow-up to #4041.

`CONTENT_QUERY` — sent to `/rest/api/content/search` by `get_docs` → `_page_blog_coro` → `fetch_documents` for page/blog sync — was hard-coded to `limit=50&expand=...,space,space.permissions,restrictions...` for **every** data source type. The `space.permissions` expansion is only consumed on the Confluence **Cloud** code path:

- On Data Center / Server, page/space access control comes from `restrictions` plus the separate `SPACE_PERMISSION` (Extender) endpoint — the `space.permissions` field embedded in content is never read (`_page_blog_coro` reads it only inside the `if data_source_type == CONFLUENCE_CLOUD` branch).

Just like the space query fixed in #4041, sending `space.permissions` on DC/Server is dead weight and belongs to the wider `expand=permissions` defect family that returns **HTTP 500** when the calling user is not a Confluence administrator (CONFSERVER-99908 and related). This is the remaining piece of the DC/Server sync path that pushed customers to over-grant full site admin (see sdh-search#1916), even after #4041 fixed `/rest/api/space`.

### What this PR changes

- Splits `CONTENT_QUERY` into `CONTENT_QUERY_CLOUD` (unchanged, keeps `space.permissions`) and `CONTENT_QUERY_DATA_CENTER` (drops `space.permissions`) in `constants.py`, with a comment explaining the rationale (CONFSERVER-99908).
- `get_docs` now selects `CONTENT_QUERY_CLOUD` for `confluence_cloud` and `CONTENT_QUERY_DATA_CENTER` otherwise — following the existing `fetch_spaces` / `_remote_validation` idiom from #4041.
- Cloud behavior is unchanged.

### Tests

A parametrized test (`test_get_docs_uses_correct_content_query_for_data_source_type`) pins the content-query selection across all three data source types (`confluence_cloud`, `confluence_data_center`, `confluence_server`) and asserts `space.permissions` is present only for Cloud.

```
PYTHONPATH=. python -m pytest tests/sources/test_confluence.py -q
71 passed
```

### Release Note

Fix the Confluence connector requesting the unused `space.permissions` expansion on Confluence Data Center / Server content queries, which could trigger HTTP 500 (CONFSERVER-99908) and forced over-privileged (site-admin) functional accounts. Combined with #4041, space enumeration and content sync on DC/Server no longer require Confluence admin.

## Test plan

- [ ] `pytest tests/sources/test_confluence.py` passes
- [ ] Confluence Cloud sync unchanged (still sends `space.permissions`)
- [ ] Confluence DC/Server sync succeeds with a non-admin functional user that has read/View on the target space(s)

Made with [Cursor](https://cursor.com)