### PR TITLE
[GitHub] Propagate fetch errors instead of swallowing them

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2589,7 +2589,7 @@ Apache Software License
 
 
 bracex
-2.7
+3.0
 MIT
 MIT License
 

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2713,7 +2713,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.7
+3.4.8
 MIT
 MIT License
 

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2713,7 +2713,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.8
+3.4.7
 MIT
 MIT License
 

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1044,7 +1044,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 aiohappyeyeballs
-2.6.2
+2.7.1
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -7872,7 +7872,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 typing_extensions
-4.15.0
+4.16.0
 PSF-2.0
 A. HISTORY OF THE SOFTWARE
 ==========================

--- a/app/connectors_service/connectors/sources/github/client.py
+++ b/app/connectors_service/connectors/sources/github/client.py
@@ -31,6 +31,7 @@ from connectors.sources.github.utils import (
     UNAUTHORIZED,
     ForbiddenException,
     NoInstallationAccessTokenException,
+    RateLimitingError,
     UnauthorizedException,
 )
 from connectors.utils import (
@@ -94,8 +95,6 @@ class GitHubClient:
             f"Rate limit exceeded. Retry after {retry_after} seconds. Resource type: {resource_type}"
         )
         await self._sleeps.sleep(retry_after)
-        msg = "Rate limit exceeded."
-        raise Exception(msg)
 
     def _access_token(self):
         if self.auth_method == PERSONAL_ACCESS_TOKEN:
@@ -126,9 +125,11 @@ class GitHubClient:
                 private_key=self.private_key,
             )
             self._installation_access_token = access_token_response["token"]
-        except gidgethub.RateLimitExceeded:
+        except gidgethub.RateLimitExceeded as exception:
             await self._put_to_sleep("core")
-        except Exception:
+            msg = "Rate limit exceeded."
+            raise RateLimitingError(msg) from exception
+        except gidgethub.GitHubException:
             self._logger.exception(
                 f"Failed to get access token for installation {self._installation_id}.",
                 exc_info=True,
@@ -214,6 +215,8 @@ class GitHubClient:
                     and "api rate limit exceeded" in error.get("message").lower()
                 ):
                     await self._put_to_sleep(resource_type="graphql")
+                    msg = "Rate limit exceeded."
+                    raise RateLimitingError(msg) from exception
 
             if all(error.get("type") in ignore_errors for error in errors):
                 # All errors are ignored, return just the data part without errors
@@ -226,7 +229,7 @@ class GitHubClient:
 
             msg = f"Error while executing query. Exception: {non_ignored_errors}"
             raise Exception(msg) from exception
-        except Exception as e:
+        except gidgethub.GitHubException as e:
             self._logger.debug(
                 f"An unexpected error occurred while executing GraphQL query: {query}. Error: {e}"
             )
@@ -253,8 +256,10 @@ class GitHubClient:
             return await self._get_client.getitem(
                 url=resource, oauth_token=self._access_token()
             )
-        except gidgethub.RateLimitExceeded:
+        except gidgethub.RateLimitExceeded as exception:
             await self._put_to_sleep("core")
+            msg = "Rate limit exceeded."
+            raise RateLimitingError(msg) from exception
         except gidgethub.HTTPException as exception:
             if exception.status_code == UNAUTHORIZED:
                 if self.auth_method == GITHUB_APP:
@@ -270,7 +275,7 @@ class GitHubClient:
                 raise ForbiddenException(msg) from exception
             else:
                 raise
-        except Exception as e:
+        except gidgethub.GitHubException as e:
             self._logger.debug(
                 f"An unexpected error occurred while getting GitHub item: {resource}. Error: {e}"
             )
@@ -350,10 +355,10 @@ class GitHubClient:
                 get_jwt(app_id=self.app_id, private_key=self.private_key),
             )
         # we don't expect any 401 error as the jwt is freshly generated
-        except gidgethub.RateLimitExceeded:
+        except gidgethub.RateLimitExceeded as exception:
             await self._put_to_sleep("core")
-        except Exception:
-            raise
+            msg = "Rate limit exceeded."
+            raise RateLimitingError(msg) from exception
 
     async def _github_app_paginated_get(self, url):
         data, more = await self._github_app_get(url)  # pyright: ignore

--- a/app/connectors_service/connectors/sources/github/datasource.py
+++ b/app/connectors_service/connectors/sources/github/datasource.py
@@ -7,6 +7,7 @@
 from collections import defaultdict
 from functools import partial
 
+import gidgethub
 from connectors_sdk.source import BaseDataSource, ConfigurableFieldValueError
 from connectors_sdk.utils import nested_get_from_dict
 
@@ -395,7 +396,11 @@ class GitHubDataSource(BaseDataSource):
                         org_name = self.configuration["org_name"]
                         self.org_repos.setdefault(org_name, {})[repo_name] = repo_data
             return invalid_repos
-        except Exception as exception:
+        except (
+            gidgethub.GitHubException,
+            UnauthorizedException,
+            ForbiddenException,
+        ) as exception:
             self._logger.exception(
                 f"Error while checking for inaccessible repositories. Exception: {exception}.",
                 exc_info=True,
@@ -498,7 +503,7 @@ class GitHubDataSource(BaseDataSource):
         try:
             await self.github_client.ping()
             self._logger.debug("Successfully connected to GitHub.")
-        except Exception:
+        except (gidgethub.GitHubException, UnauthorizedException, ForbiddenException):
             self._logger.exception("Error while connecting to GitHub.")
             raise
 
@@ -639,35 +644,25 @@ class GitHubDataSource(BaseDataSource):
         # or _get_personal_repos/_get_org_repos, see comments there
         # for potential performance/rate limit implications
         self._logger.info("Fetching repos")
-        try:
-            if (
-                WILDCARD in self.configured_repos
-                and self.configuration["repo_type"] == "other"
+        if (
+            WILDCARD in self.configured_repos
+            and self.configuration["repo_type"] == "other"
+        ):
+            async for user in self._get_owners():
+                async for repo_object in self._get_personal_repos(user):
+                    yield self._convert_repo_object_to_doc(repo_object)
+        elif (
+            WILDCARD in self.configured_repos
+            and self.configuration["repo_type"] == "organization"
+        ):
+            async for org in self._get_owners():
+                async for repo_object in self._get_org_repos(org):
+                    yield self._convert_repo_object_to_doc(repo_object)
+        else:
+            async for repo_object in self._get_configured_repos(
+                configured_repos=self.configured_repos
             ):
-                async for user in self._get_owners():
-                    async for repo_object in self._get_personal_repos(user):
-                        yield self._convert_repo_object_to_doc(repo_object)
-            elif (
-                WILDCARD in self.configured_repos
-                and self.configuration["repo_type"] == "organization"
-            ):
-                async for org in self._get_owners():
-                    async for repo_object in self._get_org_repos(org):
-                        yield self._convert_repo_object_to_doc(repo_object)
-            else:
-                async for repo_object in self._get_configured_repos(
-                    configured_repos=self.configured_repos
-                ):
-                    yield repo_object
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the repository. Exception: {exception}",
-                exc_info=True,
-            )
+                yield repo_object
 
     def _convert_repo_object_to_doc(self, repo_object):
         repo_object = repo_object.copy()
@@ -772,55 +767,59 @@ class GitHubDataSource(BaseDataSource):
         self._logger.info(
             f"Fetching pull requests from '{repo_name}' with response_key '{response_key}' and filter query: '{filter_query}'"
         )
-        try:
-            query = (
-                GithubQuery.SEARCH_QUERY.value
-                if filter_query
-                else GithubQuery.PULL_REQUEST_QUERY.value
-            )
-            owner, repo = self.github_client.get_repo_details(repo_name=repo_name)
-            pull_request_variables = {
-                "owner": owner,
-                "name": repo,
-                "cursor": None,
-                "filter_query": filter_query,
-            }
-            async for response in self.github_client.paginated_api_call(
-                query=query,
-                variables=pull_request_variables,
-                keys=response_key,
+        query = (
+            GithubQuery.SEARCH_QUERY.value
+            if filter_query
+            else GithubQuery.PULL_REQUEST_QUERY.value
+        )
+        owner, repo = self.github_client.get_repo_details(repo_name=repo_name)
+        pull_request_variables = {
+            "owner": owner,
+            "name": repo,
+            "cursor": None,
+            "filter_query": filter_query,
+        }
+        async for response in self.github_client.paginated_api_call(
+            query=query,
+            variables=pull_request_variables,
+            keys=response_key,
+        ):
+            for pull_request in nested_get_from_dict(  # pyright: ignore
+                response, response_key + ["nodes"], default=[]
             ):
-                for pull_request in nested_get_from_dict(  # pyright: ignore
-                    response, response_key + ["nodes"], default=[]
-                ):
+                try:
                     async for pull_request_doc in self._extract_pull_request(
                         pull_request=pull_request, owner=owner, repo=repo
                     ):
                         yield pull_request_doc
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the pull requests. Exception: {exception}",
-                exc_info=True,
-            )
+                except gidgethub.GitHubException as exception:
+                    self._logger.warning(
+                        f"Skipping a pull request from '{repo_name}' due to an error while fetching its details. Exception: {exception}",
+                        exc_info=True,
+                    )
+                    continue
 
     async def _extract_issues(self, response, owner, repo, response_key):
         for issue in nested_get_from_dict(  # pyright: ignore
             response, response_key + ["nodes"], default=[]
         ):
-            issue.update(self._prepare_issue_doc(issue=issue))
-            for field in ["comments", "labels", "assignees"]:
-                await self._fetch_remaining_fields(
-                    type_obj=issue,
-                    object_type=ObjectType.ISSUE.value.lower(),
-                    owner=owner,
-                    repo=repo,
-                    field_type=field,
+            try:
+                issue.update(self._prepare_issue_doc(issue=issue))
+                for field in ["comments", "labels", "assignees"]:
+                    await self._fetch_remaining_fields(
+                        type_obj=issue,
+                        object_type=ObjectType.ISSUE.value.lower(),
+                        owner=owner,
+                        repo=repo,
+                        field_type=field,
+                    )
+                    issue.pop(field)
+            except gidgethub.GitHubException as exception:
+                self._logger.warning(
+                    f"Skipping an issue from '{owner}/{repo}' due to an error while fetching its details. Exception: {exception}",
+                    exc_info=True,
                 )
-                issue.pop(field)
+                continue
             yield issue
 
     async def _fetch_issues(
@@ -832,37 +831,27 @@ class GitHubDataSource(BaseDataSource):
         self._logger.info(
             f"Fetching issues from repo: {repo_name} with response_key: '{response_key}' and filter_query: '{filter_query}'"
         )
-        try:
-            query = (
-                GithubQuery.SEARCH_QUERY.value
-                if filter_query
-                else GithubQuery.ISSUE_QUERY.value
-            )
-            owner, repo = self.github_client.get_repo_details(repo_name=repo_name)
-            issue_variables = {
-                "owner": owner,
-                "name": repo,
-                "cursor": None,
-                "filter_query": filter_query,
-            }
-            async for response in self.github_client.paginated_api_call(
-                query=query,
-                variables=issue_variables,
-                keys=response_key,
+        query = (
+            GithubQuery.SEARCH_QUERY.value
+            if filter_query
+            else GithubQuery.ISSUE_QUERY.value
+        )
+        owner, repo = self.github_client.get_repo_details(repo_name=repo_name)
+        issue_variables = {
+            "owner": owner,
+            "name": repo,
+            "cursor": None,
+            "filter_query": filter_query,
+        }
+        async for response in self.github_client.paginated_api_call(
+            query=query,
+            variables=issue_variables,
+            keys=response_key,
+        ):
+            async for issue in self._extract_issues(
+                response=response, owner=owner, repo=repo, response_key=response_key
             ):
-                async for issue in self._extract_issues(
-                    response=response, owner=owner, repo=repo, response_key=response_key
-                ):
-                    yield issue
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the issues. Exception: {exception}",
-                exc_info=True,
-            )
+                yield issue
 
     async def _fetch_last_commit_timestamp(self, repo_name, path):
         commit, *_ = await self.github_client.get_github_item(  # pyright: ignore
@@ -901,53 +890,49 @@ class GitHubDataSource(BaseDataSource):
         self._logger.info(
             f"Fetching files from repo: '{repo_name}' (branch: '{default_branch}')"
         )
-        try:
-            file_tree = await self.github_client.get_github_item(
-                resource=self.github_client.endpoints["TREE"].format(
-                    repo_name=repo_name, default_branch=default_branch
-                )
+        file_tree = await self.github_client.get_github_item(
+            resource=self.github_client.endpoints["TREE"].format(
+                repo_name=repo_name, default_branch=default_branch
             )
+        )
 
-            for repo_object in file_tree.get("tree", []):
-                if repo_object["type"] == BLOB:
-                    if document := await self._format_file_document(
+        for repo_object in file_tree.get("tree", []):
+            if repo_object["type"] == BLOB:
+                try:
+                    document = await self._format_file_document(
                         repo_object=repo_object, repo_name=repo_name, schema=FILE_SCHEMA
-                    ):
-                        yield document
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the files of {repo_name}. Exception: {exception}",
-                exc_info=True,
-            )
+                    )
+                except gidgethub.GitHubException as exception:
+                    self._logger.warning(
+                        f"Skipping a file from '{repo_name}' due to an error while fetching its details. Exception: {exception}",
+                        exc_info=True,
+                    )
+                    continue
+                if document:
+                    yield document
 
     async def _fetch_files_by_path(self, repo_name, path):
         self._logger.info(f"Fetching files from repo: '{repo_name}' (path: '{path}')")
-        try:
-            for repo_object in await self.github_client.get_github_item(
-                resource=self.github_client.endpoints["PATH"].format(
-                    repo_name=repo_name, path=path
-                )
-            ):  # pyright: ignore
-                if repo_object["type"] == FILE:
-                    if document := await self._format_file_document(
+        for repo_object in await self.github_client.get_github_item(
+            resource=self.github_client.endpoints["PATH"].format(
+                repo_name=repo_name, path=path
+            )
+        ):  # pyright: ignore
+            if repo_object["type"] == FILE:
+                try:
+                    document = await self._format_file_document(
                         repo_object=repo_object,
                         repo_name=repo_name,
                         schema=PATH_SCHEMA,
-                    ):
-                        yield document
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the files of {repo_name}. Exception: {exception}",
-                exc_info=True,
-            )
+                    )
+                except gidgethub.GitHubException as exception:
+                    self._logger.warning(
+                        f"Skipping a file from '{repo_name}' due to an error while fetching its details. Exception: {exception}",
+                        exc_info=True,
+                    )
+                    continue
+                if document:
+                    yield document
 
     async def get_content(self, attachment, timestamp=None, doit=False):
         """Extracts the content for Apache TIKA supported file types.

--- a/app/connectors_service/connectors/sources/github/datasource.py
+++ b/app/connectors_service/connectors/sources/github/datasource.py
@@ -518,11 +518,13 @@ class GitHubDataSource(BaseDataSource):
             "_id": pull_request.pop("id"),
             "_timestamp": pull_request.pop("updatedAt"),
             "type": ObjectType.PULL_REQUEST.value,
-            "issue_comments": pull_request.get("comments", {}).get("nodes"),
+            "issue_comments": (pull_request.get("comments") or {}).get("nodes"),
             "reviews_comments": reviews,
-            "labels_field": pull_request.get("labels", {}).get("nodes"),
-            "assignees_list": pull_request.get("assignees", {}).get("nodes"),
-            "requested_reviewers": pull_request.get("reviewRequests", {}).get("nodes"),
+            "labels_field": (pull_request.get("labels") or {}).get("nodes"),
+            "assignees_list": (pull_request.get("assignees") or {}).get("nodes"),
+            "requested_reviewers": (pull_request.get("reviewRequests") or {}).get(
+                "nodes"
+            ),
         }
 
     def _prepare_issue_doc(self, issue):
@@ -530,9 +532,9 @@ class GitHubDataSource(BaseDataSource):
             "_id": issue.pop("id"),
             "type": ObjectType.ISSUE.value,
             "_timestamp": issue.pop("updatedAt"),
-            "issue_comments": issue.get("comments", {}).get("nodes"),
-            "labels_field": issue.get("labels", {}).get("nodes"),
-            "assignees_list": issue.get("assignees", {}).get("nodes"),
+            "issue_comments": (issue.get("comments") or {}).get("nodes"),
+            "labels_field": (issue.get("labels") or {}).get("nodes"),
+            "assignees_list": (issue.get("assignees") or {}).get("nodes"),
         }
 
     def _prepare_review_doc(self, review):
@@ -543,7 +545,7 @@ class GitHubDataSource(BaseDataSource):
             "author": author.get("login"),
             "body": review.get("body"),
             "state": review.get("state"),
-            "comments": review.get("comments", {}).get("nodes"),
+            "comments": (review.get("comments") or {}).get("nodes"),
         }
 
     async def _fetch_installations(self):
@@ -716,7 +718,7 @@ class GitHubDataSource(BaseDataSource):
                 "es_field": "assignees_list",
             },
         }
-        page_info = type_obj.get(field_type, {}).get("pageInfo", {})
+        page_info = (type_obj.get(field_type) or {}).get("pageInfo", {})
         if page_info.get("hasNextPage"):
             variables = {
                 "owner": owner,
@@ -742,7 +744,7 @@ class GitHubDataSource(BaseDataSource):
     async def _extract_pull_request(self, pull_request, owner, repo):
         reviews = [
             self._prepare_review_doc(review=review)
-            for review in pull_request.get("reviews", {}).get("nodes")
+            for review in (pull_request.get("reviews") or {}).get("nodes") or []
         ]
         pull_request.update(
             self._prepare_pull_request_doc(pull_request=pull_request, reviews=reviews)
@@ -896,7 +898,7 @@ class GitHubDataSource(BaseDataSource):
             )
         )
 
-        for repo_object in file_tree.get("tree", []):
+        for repo_object in file_tree.get("tree") or []:
             if repo_object["type"] == BLOB:
                 try:
                     document = await self._format_file_document(
@@ -1036,9 +1038,9 @@ class GitHubDataSource(BaseDataSource):
             for user in nested_get_from_dict(  # pyright: ignore
                 response, ["repository", "collaborators", "edges"], default=[]
             ):
-                user_id = user.get("node", {}).get("id")
-                user_name = user.get("node", {}).get("login")
-                user_email = user.get("node", {}).get("email")
+                user_id = (user.get("node") or {}).get("id")
+                user_name = (user.get("node") or {}).get("login")
+                user_email = (user.get("node") or {}).get("email")
                 if user_id in self.members[owner]:
                     access_control.append(_prefix_user_id(user_id=user_id))
                     if user_name:

--- a/app/connectors_service/connectors/sources/github/utils.py
+++ b/app/connectors_service/connectors/sources/github/utils.py
@@ -63,3 +63,7 @@ class NoInstallationAccessTokenException(Exception):
 
 class ForbiddenException(Exception):
     pass
+
+
+class RateLimitingError(Exception):
+    pass

--- a/app/connectors_service/tests/sources/test_github.py
+++ b/app/connectors_service/tests/sources/test_github.py
@@ -1596,6 +1596,42 @@ async def test_fetch_issues_skips_document_on_github_exception(patch_logger):
 
 
 @pytest.mark.asyncio
+async def test_fetch_issues_handles_null_connection_fields():
+    # GitHub can return null for connection fields (comments/labels/assignees);
+    # this must not raise, and the issue should still be yielded.
+    issue_response = {
+        "repository": {
+            "issues": {
+                "nodes": [
+                    {
+                        "id": "1",
+                        "updatedAt": "2023-04-19T08:56:23Z",
+                        "comments": None,
+                        "labels": None,
+                        "assignees": None,
+                    }
+                ]
+            }
+        }
+    }
+    async with create_github_source() as source:
+        with patch.object(
+            source.github_client,
+            "paginated_api_call",
+            side_effect=[AsyncIterator([issue_response])],
+        ):
+            issues = [
+                issue
+                async for issue in source._fetch_issues(
+                    repo_name="demo_user/demo_repo",
+                    response_key=[REPOSITORY_OBJECT, "issues"],
+                )
+            ]
+    assert len(issues) == 1
+    assert issues[0]["_id"] == "1"
+
+
+@pytest.mark.asyncio
 async def test_fetch_pull_requests():
     async with create_github_source() as source:
         with patch.object(
@@ -1686,6 +1722,45 @@ async def test_fetch_pull_requests_skips_document_on_github_exception(patch_logg
             ]
         assert pulls == []
         patch_logger.assert_present("Skipping a pull request")
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_handles_null_connection_fields():
+    # GitHub can return null for connection fields (reviews/comments/labels/...);
+    # this must not raise, and the pull request should still be yielded.
+    pull_response = {
+        "repository": {
+            "pullRequests": {
+                "nodes": [
+                    {
+                        "id": "1",
+                        "updatedAt": "2023-07-03T12:24:16Z",
+                        "reviews": None,
+                        "comments": None,
+                        "reviewRequests": None,
+                        "labels": None,
+                        "assignees": None,
+                    }
+                ]
+            }
+        }
+    }
+    async with create_github_source() as source:
+        with patch.object(
+            source.github_client,
+            "paginated_api_call",
+            side_effect=[AsyncIterator([pull_response])],
+        ):
+            pulls = [
+                pull
+                async for pull in source._fetch_pull_requests(
+                    repo_name="demo_user/demo_repo",
+                    response_key=[REPOSITORY_OBJECT, "pullRequests"],
+                )
+            ]
+    assert len(pulls) == 1
+    assert pulls[0]["_id"] == "1"
+    assert pulls[0]["reviews_comments"] == []
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/sources/test_github.py
+++ b/app/connectors_service/tests/sources/test_github.py
@@ -29,6 +29,7 @@ from connectors.sources.github.utils import (
     PERSONAL_ACCESS_TOKEN,
     REPOSITORY_OBJECT,
     ForbiddenException,
+    RateLimitingError,
     UnauthorizedException,
 )
 from tests.commons import AsyncIterator
@@ -1017,8 +1018,56 @@ async def test_get_response_with_rate_limit_exceeded():
 async def test_put_to_sleep():
     async with create_github_source() as source:
         source.github_client._get_retry_after = AsyncMock(return_value=0)
-        with pytest.raises(Exception, match="Rate limit exceeded."):
-            await source.github_client._put_to_sleep("core")
+        # _put_to_sleep only sleeps; callers are responsible for re-raising RateLimitingError
+        assert await source.github_client._put_to_sleep("core") is None
+
+
+@pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+async def test_get_github_item_reraises_rate_limiting_error():
+    async with create_github_source() as source:
+        source.github_client._get_retry_after = AsyncMock(return_value=0)
+        source.github_client._get_client.getitem = AsyncMock(
+            side_effect=gidgethub.RateLimitExceeded(rate_limit=None)
+        )
+        with pytest.raises(RateLimitingError):
+            await source.github_client.get_github_item("/user")
+
+
+@pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+async def test_graphql_reraises_rate_limiting_error_on_rate_limited_query_error():
+    async with create_github_source() as source:
+        source.github_client._get_retry_after = AsyncMock(return_value=0)
+        source.github_client._get_client.graphql = Mock(
+            side_effect=QueryError(
+                {
+                    "errors": [
+                        {
+                            "type": "RATE_LIMITED",
+                            "message": "API rate limit exceeded for user ID: 123456",
+                        }
+                    ]
+                }
+            )
+        )
+        with pytest.raises(RateLimitingError):
+            await source.github_client.graphql(
+                query="QUERY", variables={"owner": "demo_user"}
+            )
+
+
+@pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+@patch("connectors.sources.github.client.get_jwt", Mock(return_value="jwt"))
+async def test_github_app_get_reraises_rate_limiting_error():
+    async with create_github_source(auth_method=GITHUB_APP) as source:
+        source.github_client._get_retry_after = AsyncMock(return_value=0)
+        source.github_client._get_client._make_request = AsyncMock(
+            side_effect=gidgethub.RateLimitExceeded(rate_limit=None)
+        )
+        with pytest.raises(RateLimitingError):
+            await source.github_client._github_app_get("/app")
 
 
 @pytest.mark.asyncio
@@ -1372,16 +1421,18 @@ async def test_fetch_repos_organization():
 @pytest.mark.asyncio
 async def test_fetch_repos_when_user_repos_is_available():
     async with create_github_source(repos="demo_user/demo_repo, , demo_repo") as source:
+        repository_response = {
+            "repository": {
+                "id": "123",
+                "updatedAt": "2023-04-17T12:55:01Z",
+                "nameWithOwner": "demo_user/demo_repo",
+            }
+        }
         source.github_client.graphql = AsyncMock(
             side_effect=[
                 {"viewer": {"login": "owner1"}},
-                {
-                    "repository": {
-                        "id": "123",
-                        "updatedAt": "2023-04-17T12:55:01Z",
-                        "nameWithOwner": "demo_user/demo_repo",
-                    }
-                },
+                deepcopy(repository_response),
+                deepcopy(repository_response),
             ]
         )
         async for repo in source._fetch_repos():
@@ -1402,6 +1453,21 @@ async def test_fetch_repos_with_client_exception(exception):
     async with create_github_source() as source:
         source.github_client.graphql = Mock(side_effect=exception())
         with pytest.raises(exception):
+            async for _ in source._fetch_repos():
+                pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_repos_propagates_github_exception():
+    # Failing to list repositories must fail the sync instead of being swallowed
+    async with create_github_source() as source:
+        source._get_owners = Mock(return_value=AsyncIterator(["demo_user"]))
+        source.github_client.get_user_repos = Mock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with pytest.raises(gidgethub.HTTPException):
             async for _ in source._fetch_repos():
                 pass
 
@@ -1483,13 +1549,60 @@ async def test_fetch_issues_with_client_exception(exception):
 
 
 @pytest.mark.asyncio
+async def test_fetch_issues_propagates_github_exception():
+    # A page-level GitHub failure must fail the sync instead of being swallowed
+    async with create_github_source() as source:
+        source.github_client.paginated_api_call = Mock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with pytest.raises(gidgethub.HTTPException):
+            async for _ in source._fetch_issues(
+                repo_name="demo_user/demo_repo",
+                response_key=[REPOSITORY_OBJECT, "issues"],
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_issues_skips_document_on_github_exception(patch_logger):
+    # A failure while enriching a single issue is logged and skipped, not raised
+    issue_response = {
+        "repository": {
+            "issues": {"nodes": [{"id": "1", "updatedAt": "2023-04-19T08:56:23Z"}]}
+        }
+    }
+    async with create_github_source() as source:
+        source._fetch_remaining_fields = AsyncMock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with patch.object(
+            source.github_client,
+            "paginated_api_call",
+            side_effect=[AsyncIterator([issue_response])],
+        ):
+            issues = [
+                issue
+                async for issue in source._fetch_issues(
+                    repo_name="demo_user/demo_repo",
+                    response_key=[REPOSITORY_OBJECT, "issues"],
+                )
+            ]
+        assert issues == []
+        patch_logger.assert_present("Skipping an issue")
+
+
+@pytest.mark.asyncio
 async def test_fetch_pull_requests():
     async with create_github_source() as source:
         with patch.object(
             source.github_client,
             "paginated_api_call",
             side_effect=[
-                AsyncIterator([MOCK_RESPONSE_PULL]),
+                AsyncIterator([deepcopy(MOCK_RESPONSE_PULL)]),
                 AsyncIterator([MOCK_COMMENTS_RESPONSE]),
                 AsyncIterator([MOCK_REVIEW_REQUESTED_RESPONSE]),
                 AsyncIterator([MOCK_LABELS_RESPONSE]),
@@ -1518,6 +1631,61 @@ async def test_fetch_pull_requests_with_client_exception(exception):
                 response_key=[REPOSITORY_OBJECT, "pullRequests"],
             ):
                 pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_propagates_github_exception():
+    # A page-level GitHub failure must fail the sync instead of being swallowed
+    async with create_github_source() as source:
+        source.github_client.paginated_api_call = Mock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with pytest.raises(gidgethub.HTTPException):
+            async for _ in source._fetch_pull_requests(
+                repo_name="demo_user/demo_repo",
+                response_key=[REPOSITORY_OBJECT, "pullRequests"],
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_skips_document_on_github_exception(patch_logger):
+    # A failure while enriching a single pull request is logged and skipped, not raised
+    pull_response = {
+        "repository": {
+            "pullRequests": {
+                "nodes": [
+                    {
+                        "id": "1",
+                        "updatedAt": "2023-07-03T12:24:16Z",
+                        "reviews": {"nodes": []},
+                    }
+                ]
+            }
+        }
+    }
+    async with create_github_source() as source:
+        source._fetch_remaining_fields = AsyncMock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with patch.object(
+            source.github_client,
+            "paginated_api_call",
+            side_effect=[AsyncIterator([pull_response])],
+        ):
+            pulls = [
+                pull
+                async for pull in source._fetch_pull_requests(
+                    repo_name="demo_user/demo_repo",
+                    response_key=[REPOSITORY_OBJECT, "pullRequests"],
+                )
+            ]
+        assert pulls == []
+        patch_logger.assert_present("Skipping a pull request")
 
 
 @pytest.mark.asyncio
@@ -1567,7 +1735,7 @@ async def test_fetch_pull_requests_with_deleted_users():
             source.github_client,
             "paginated_api_call",
             side_effect=[
-                AsyncIterator([MOCK_RESPONSE_PULL]),
+                AsyncIterator([deepcopy(MOCK_RESPONSE_PULL)]),
                 AsyncIterator([MOCK_COMMENTS_RESPONSE]),
                 AsyncIterator([MOCK_REVIEW_REQUESTED_RESPONSE]),
                 AsyncIterator([MOCK_LABELS_RESPONSE]),
@@ -1643,6 +1811,37 @@ async def test_fetch_files_when_error_occurs(exception):
         with pytest.raises(exception):
             async for _ in source._fetch_files("demo_repo", "main"):
                 pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_files_propagates_github_exception():
+    # Failing to fetch the repository tree must fail the sync instead of being swallowed
+    async with create_github_source() as source:
+        source.github_client.get_github_item = Mock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with pytest.raises(gidgethub.HTTPException):
+            async for _ in source._fetch_files("demo_repo", "main"):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_files_skips_document_on_github_exception(patch_logger):
+    # A failure while fetching a single file's details is logged and skipped, not raised
+    async with create_github_source() as source:
+        with patch.object(
+            source.github_client,
+            "get_github_item",
+            side_effect=[
+                deepcopy(MOCK_TREE),
+                gidgethub.HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+            ],
+        ):
+            files = [doc async for doc in source._fetch_files("demo_repo", "main")]
+        assert files == []
+        patch_logger.assert_present("Skipping a file")
 
 
 @pytest.mark.asyncio

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -206,7 +206,7 @@ Apache License
 
 
 aiohappyeyeballs
-2.6.2
+2.7.1
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -1515,7 +1515,7 @@ THE SOFTWARE.
 
 
 typing_extensions
-4.15.0
+4.16.0
 PSF-2.0
 A. HISTORY OF THE SOFTWARE
 ==========================


### PR DESCRIPTION
## Summary

Fixes the GitHub connector silently swallowing errors during sync. Previously each fetch method wrapped its whole body in `try/except Exception: log warning`, so a sync could "succeed" while syncing nothing (e.g. if no issues could be fetched at all). This implements the two-tier error handling requested in the issue, removes the broad exception handling, and hardens null-handling of GraphQL responses.

Part of #2393, closes #2395.

## Changes

### Two-tier error handling (`datasource.py`)
- **Page/API-level failures propagate** out of `_fetch_repos` / `_fetch_pull_requests` / `_fetch_issues` / `_fetch_files` / `_fetch_files_by_path`, so the sync fails when data genuinely can't be fetched.
- **Per-document enrichment failures are WARN-logged and skipped** via narrow guards that catch only `gidgethub.GitHubException`, so a single bad issue/PR/file no longer aborts the whole sync.

### Transient rate limiting
- `_put_to_sleep` now only sleeps; its callers re-raise a dedicated `RateLimitingError`, which is not in `skipped_exceptions`, so the existing `@retryable` layer retries it.

### No more bare `except Exception`
- Replaced across the `github/` package with `gidgethub.GitHubException` (plus the connector's own `UnauthorizedException` / `ForbiddenException` in log-and-reraise spots like `ping` and `_get_invalid_repos_for_personal_access_token`).

### Null-safe GraphQL response handling
- GitHub can return `null` for connection fields (`reviews`, `comments`, `labels`, `assignees`, `reviewRequests`, `tree`, edge nodes). The old `x.get("key", {}).get(...)` pattern crashes with `AttributeError`/`TypeError` when the key is present but its value is `null` (`.get()` only applies the default when the key is absent). Switched the fetch/prepare helpers to the `... or {}` / `... or []` idiom so a single such document can no longer abort the sync.

### Tests
- Added coverage for propagation vs. per-item skip for each fetch method, `RateLimitingError` propagation, and regression tests for issues/PRs with null connection fields.
- Fixed a latent test-isolation bug where shared mock fixtures were mutated across tests and the resulting error was hidden by the old catch-all (now `deepcopy`).

## Acceptance criteria

- [x] GitHub connector fails syncs if no issues can be synced (page-level errors propagate)
- [x] GitHub connector attempts retries for errors that look transient (`@retryable` + `RateLimitingError`)
- [x] Errors with limited scope (single documents / edge cases) are moved past with WARN logging

## Test plan

- `pytest tests/sources/test_github.py` — 121 passed
- Passes across multiple random orderings (`-p randomly` seeds 1/2/42/100/777)
- `ruff check` clean on changed files

## Notes for reviewers

- The per-item guard wraps `_fetch_remaining_fields`, which itself makes paginated calls. The design assumes systemic backend failures surface on the initial page fetch (which propagates and fails the sync). If a systemic error only manifested during per-item enrichment, it could be WARN-skipped for every document without failing the sync. Happy to add per-repo "synced at least one" tracking if we want a hard guarantee.
- `raise Exception(msg)` remains for non-rate-limited GraphQL `QueryError`s in `graphql()`; left as-is as a possible small follow-up.
