### PR TITLE
fix(outlook): harden sync against missing Exchange field values

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2713,7 +2713,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.7
+3.4.8
 MIT
 MIT License
 

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1044,7 +1044,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 aiohappyeyeballs
-2.6.2
+2.7.1
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -7872,7 +7872,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 typing_extensions
-4.15.0
+4.16.0
 PSF-2.0
 A. HISTORY OF THE SOFTWARE
 ==========================

--- a/app/connectors_service/connectors/sources/outlook/client.py
+++ b/app/connectors_service/connectors/sources/outlook/client.py
@@ -405,15 +405,19 @@ class OutlookClient:
             self._logger.debug(
                 f"Fetching {mail_type['folder']} mails for {account.primary_smtp_address}"
             )
-            if mail_type["folder"] == "archive":
-                # msg_folder_root is locale-agnostic; the "Archive" leaf has no
-                # distinguished ID, so resolve it by name and skip if absent.
-                try:
+            try:
+                if mail_type["folder"] == "archive":
+                    # msg_folder_root is locale-agnostic; the "Archive" leaf has no
+                    # distinguished ID, so resolve it by name and skip if absent.
                     folder_object = account.msg_folder_root / "Archive"
-                except ErrorFolderNotFound:
-                    continue
-            else:
-                folder_object = getattr(account, mail_type["folder"])
+                else:
+                    folder_object = getattr(account, mail_type["folder"])
+            except ErrorFolderNotFound:
+                self._logger.warning(
+                    f"Could not resolve {mail_type['folder']} folder for "
+                    f"{account.primary_smtp_address}, skipping."
+                )
+                continue
 
             for mail in await asyncio.to_thread(folder_object.all().only, *MAIL_FIELDS):
                 yield mail, mail_type

--- a/app/connectors_service/connectors/sources/outlook/datasource.py
+++ b/app/connectors_service/connectors/sources/outlook/datasource.py
@@ -16,7 +16,7 @@ from connectors_sdk.utils import (
 from exchangelib.errors import ErrorNonExistentMailbox
 
 from connectors.access_control import ACCESS_CONTROL, es_access_control_query
-from connectors.sources.outlook.client import OutlookClient
+from connectors.sources.outlook.client import OutlookClient, _extract_ldap_mail
 from connectors.sources.outlook.constants import (
     CALENDAR_ATTACHMENT,
     DEFAULT_TIMEZONE,
@@ -38,6 +38,14 @@ from connectors.utils import html_to_text
 class OutlookDocFormatter:
     """Format Outlook object documents to Elasticsearch document"""
 
+    @staticmethod
+    def _calendar_meeting_type(calendar):
+        if calendar.type == "Single":
+            return "Single"
+        if calendar.recurrence and calendar.recurrence.pattern:
+            return f"Recurring {calendar.recurrence.pattern}"
+        return calendar.type
+
     def mails_doc_formatter(self, mail, mail_type, timezone):
         return {
             "_id": mail.id,
@@ -46,15 +54,21 @@ class OutlookDocFormatter:
             ),
             "title": mail.subject,
             "type": mail_type["constant"],
-            "sender": mail.sender.email_address,
+            "sender": mail.sender.email_address if mail.sender else None,
             "to_recipients": [
-                recipient.email_address for recipient in (mail.to_recipients or [])
+                recipient.email_address
+                for recipient in (mail.to_recipients or [])
+                if recipient and recipient.email_address
             ],
             "cc_recipients": [
-                recipient.email_address for recipient in (mail.cc_recipients or [])
+                recipient.email_address
+                for recipient in (mail.cc_recipients or [])
+                if recipient and recipient.email_address
             ],
             "bcc_recipients": [
-                recipient.email_address for recipient in (mail.bcc_recipients or [])
+                recipient.email_address
+                for recipient in (mail.bcc_recipients or [])
+                if recipient and recipient.email_address
             ],
             "importance": mail.importance,
             "categories": list((mail.categories or [])),
@@ -69,10 +83,10 @@ class OutlookDocFormatter:
             ),
             "type": "Calendar",
             "title": calendar.subject,
-            "meeting_type": "Single"
-            if calendar.type == "Single"
-            else f"Recurring {calendar.recurrence.pattern}",
-            "organizer": calendar.organizer.email_address,
+            "meeting_type": self._calendar_meeting_type(calendar),
+            "organizer": calendar.organizer.email_address
+            if calendar.organizer
+            else None,
         }
 
         if child_calendar in ["Folder (Birthdays)", "Birthdays (Birthdays)"]:
@@ -89,7 +103,9 @@ class OutlookDocFormatter:
                     "attendees": [
                         attendee.mailbox.email_address
                         for attendee in (calendar.required_attendees or [])
-                        if attendee.mailbox.email_address
+                        if attendee
+                        and attendee.mailbox
+                        and attendee.mailbox.email_address
                     ],
                     "start_date": ews_format_to_datetime(
                         source_datetime=calendar.start, timezone=timezone
@@ -137,12 +153,14 @@ class OutlookDocFormatter:
             ),
             "name": contact.display_name,
             "email_addresses": [
-                email.email for email in (contact.email_addresses or [])
+                email.email
+                for email in (contact.email_addresses or [])
+                if email and email.email
             ],
             "contact_numbers": [
                 number.phone_number
-                for number in contact.phone_numbers or []
-                if number.phone_number
+                for number in (contact.phone_numbers or [])
+                if number and number.phone_number
             ],
             "company_name": contact.company_name,
             "birthday": ews_format_to_datetime(
@@ -151,8 +169,11 @@ class OutlookDocFormatter:
         }
 
     def attachment_doc_formatter(self, attachment, attachment_type, timezone):
+        attachment_id = (
+            attachment.attachment_id.id if attachment.attachment_id else None
+        )
         return {
-            "_id": attachment.attachment_id.id,
+            "_id": attachment_id,
             "title": attachment.name,
             "type": attachment_type,
             "_timestamp": ews_format_to_datetime(
@@ -356,7 +377,7 @@ class OutlookDataSource(BaseDataSource):
             if self.configuration["data_source"] == OUTLOOK_CLOUD:
                 for user in users.get("value", []):
                     yield await self._user_access_control_doc(user=user)
-            elif users.get("attributes", {}).get("mail"):
+            elif _extract_ldap_mail(users.get("attributes", {})):
                 yield await self._user_access_control_doc_for_server(users=users)
 
     async def _user_access_control_doc(self, user):
@@ -383,9 +404,13 @@ class OutlookDataSource(BaseDataSource):
         )
 
     async def _user_access_control_doc_for_server(self, users):
-        name_metadata = users.get("dn", "").split("=", 1)[1]
-        display_name = name_metadata.split(",", 1)[0]
-        user_email = users.get("attributes", {}).get("mail")
+        dn = users.get("dn", "")
+        if "=" in dn:
+            name_metadata = dn.split("=", 1)[1]
+            display_name = name_metadata.split(",", 1)[0]
+        else:
+            display_name = dn or ""
+        user_email = _extract_ldap_mail(users.get("attributes", {}))
         user_id = hash_id(user_email)
 
         _prefixed_user_id = _prefix_user_id(user_id=user_id)
@@ -425,6 +450,9 @@ class OutlookDataSource(BaseDataSource):
         Returns:
             dictionary: Content document with _id, _timestamp and attachment content
         """
+        if not attachment.attachment_id:
+            return
+
         file_size = attachment.size
         if not (doit and file_size > 0):
             return
@@ -463,7 +491,12 @@ class OutlookDataSource(BaseDataSource):
     async def _fetch_attachments(
         self, attachment_type, outlook_object, timezone, account
     ):
-        for attachment in outlook_object.attachments:
+        for attachment in outlook_object.attachments or []:
+            if not attachment.attachment_id:
+                self._logger.warning(
+                    f"Skipping attachment without an ID on item {outlook_object.id}"
+                )
+                continue
             document = self.doc_formatter.attachment_doc_formatter(
                 attachment=attachment,
                 attachment_type=attachment_type,

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -1271,7 +1271,8 @@ async def test_get_mails_skips_junk_when_folder_not_found():
         class MockAccountWithoutJunk(MockAccount):
             @property
             def junk(self):
-                raise ErrorFolderNotFound("no")
+                msg = "no"
+                raise ErrorFolderNotFound(msg)
 
             @junk.setter
             def junk(self, value):

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -32,9 +32,12 @@ from connectors.sources.outlook.client import (
     UsersFetchFailed,
 )
 from connectors.sources.outlook.constants import (
+    INBOX_MAIL_OBJECT,
+    MAIL_ATTACHMENT,
     OUTLOOK_CLOUD,
     OUTLOOK_SERVER,
 )
+from connectors.sources.outlook.datasource import OutlookDocFormatter
 from connectors.utils import get_pem_format
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
@@ -1159,6 +1162,122 @@ async def test_get_contacts_skips_when_folder_not_found():
         assert contacts == []
 
 
+def test_mails_doc_formatter_handles_missing_sender():
+    mail = MailDocument()
+    mail.sender = None
+
+    document = OutlookDocFormatter().mails_doc_formatter(
+        mail=mail,
+        mail_type={"constant": INBOX_MAIL_OBJECT},
+        timezone=TIMEZONE,
+    )
+
+    assert document["sender"] is None
+    assert document["to_recipients"] == ["dummy.user@gmail.com"]
+
+
+def test_calendar_doc_formatter_handles_missing_organizer():
+    calendar = CalendarDocument()
+    calendar.organizer = None
+
+    document = OutlookDocFormatter().calendar_doc_formatter(
+        calendar=calendar,
+        child_calendar="Calendar",
+        timezone=TIMEZONE,
+    )
+
+    assert document["organizer"] is None
+
+
+def test_calendar_doc_formatter_handles_occurrence_without_recurrence():
+    calendar = CalendarDocument()
+    calendar.type = "Occurrence"
+    calendar.recurrence = None
+
+    document = OutlookDocFormatter().calendar_doc_formatter(
+        calendar=calendar,
+        child_calendar="Calendar",
+        timezone=TIMEZONE,
+    )
+
+    assert document["meeting_type"] == "Occurrence"
+
+
+def test_calendar_doc_formatter_skips_attendees_without_mailbox():
+    calendar = CalendarDocument()
+    attendee_without_mailbox = MagicMock()
+    attendee_without_mailbox.mailbox = None
+    calendar.required_attendees = [attendee_without_mailbox]
+
+    document = OutlookDocFormatter().calendar_doc_formatter(
+        calendar=calendar,
+        child_calendar="Calendar",
+        timezone=TIMEZONE,
+    )
+
+    assert document["attendees"] == []
+
+
+def test_contact_doc_formatter_handles_missing_email_and_phone_entries():
+    contact = ContactDocument()
+    contact.email_addresses = [None, MagicMock(email=None)]
+    contact.phone_numbers = [None, MagicMock(phone_number=None)]
+
+    document = OutlookDocFormatter().contact_doc_formatter(
+        contact=contact,
+        timezone=TIMEZONE,
+    )
+
+    assert document["email_addresses"] == []
+    assert document["contact_numbers"] == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_attachments_skips_attachment_without_id():
+    async with create_outlook_source() as source:
+        mail = MailDocument()
+        mail.attachments = [
+            MockAttachment(
+                attachment_id=None,
+                name="broken.txt",
+                size=100,
+                last_modified_time="2023-12-12T01:01:01Z",
+                content=RESPONSE_CONTENT,
+            )
+        ]
+        source._logger = MagicMock()
+        account = MockAccount()
+
+        attachments = [
+            document
+            async for document, _ in source._fetch_attachments(
+                attachment_type=MAIL_ATTACHMENT,
+                outlook_object=mail,
+                timezone=TIMEZONE,
+                account=account,
+            )
+        ]
+
+        assert attachments == []
+        source._logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_mails_skips_junk_when_folder_not_found():
+    async with create_outlook_source() as source:
+        account = MockAccount()
+        type(account).junk = mock.PropertyMock(side_effect=ErrorFolderNotFound("no"))
+        account.msg_folder_root = MagicMock()
+        account.msg_folder_root.__truediv__.side_effect = ErrorFolderNotFound("no")
+
+        folders = [
+            mail_type["folder"]
+            async for _, mail_type in source.client.get_mails(account)
+        ]
+
+        assert folders == ["inbox", "sent"]
+
+
 @pytest.mark.asyncio
 async def test_get_mails_skips_archive_when_folder_not_found():
     async with create_outlook_source() as source:
@@ -1187,6 +1306,40 @@ async def test_get_access_control(is_cloud, user_response):
         async for access_control in source.get_access_control():
             acl.append(access_control)
         assert len(acl) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_access_control_for_server_normalizes_ldap_mail_list():
+    async with create_outlook_source() as source:
+        source.configuration.get_field("data_source").value = "outlook_server"
+        user_response = {
+            "attributes": {"mail": ["dummy@es.local"]},
+            "dn": "CN=Dummy,CN=Users,DC=es,DC=local",
+        }
+        source.client._get_user_instance.get_users = AsyncIterator([user_response])
+        source._dls_enabled = MagicMock(return_value=True)
+        acl = []
+        async for access_control in source.get_access_control():
+            acl.append(access_control)
+        assert len(acl) == 1
+        assert acl[0]["identity"]["email"] == "email:dummy@es.local"
+
+
+@pytest.mark.asyncio
+async def test_get_access_control_for_server_handles_malformed_dn():
+    async with create_outlook_source() as source:
+        source.configuration.get_field("data_source").value = "outlook_server"
+        user_response = {
+            "attributes": {"mail": "dummy@es.local"},
+            "dn": "",
+        }
+        source.client._get_user_instance.get_users = AsyncIterator([user_response])
+        source._dls_enabled = MagicMock(return_value=True)
+        acl = []
+        async for access_control in source.get_access_control():
+            acl.append(access_control)
+        assert len(acl) == 1
+        assert acl[0]["identity"]["display_name"] == "name:"
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -1265,8 +1265,19 @@ async def test_fetch_attachments_skips_attachment_without_id():
 @pytest.mark.asyncio
 async def test_get_mails_skips_junk_when_folder_not_found():
     async with create_outlook_source() as source:
-        account = MockAccount()
-        type(account).junk = mock.PropertyMock(side_effect=ErrorFolderNotFound("no"))
+        # Subclass so the folder override stays local and does not leak into
+        # the shared MockAccount used by other tests (pytest runs in random order).
+        # The no-op setter lets MockAccount.__init__ assign junk; reads raise.
+        class MockAccountWithoutJunk(MockAccount):
+            @property
+            def junk(self):
+                raise ErrorFolderNotFound("no")
+
+            @junk.setter
+            def junk(self, value):
+                pass
+
+        account = MockAccountWithoutJunk()
         account.msg_folder_root = MagicMock()
         account.msg_folder_root.__truediv__.side_effect = ErrorFolderNotFound("no")
 

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -206,7 +206,7 @@ Apache License
 
 
 aiohappyeyeballs
-2.6.2
+2.7.1
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -1515,7 +1515,7 @@ THE SOFTWARE.
 
 
 typing_extensions
-4.15.0
+4.16.0
 PSF-2.0
 A. HISTORY OF THE SOFTWARE
 ==========================


### PR DESCRIPTION
## Related to  https://github.com/elastic/sdh-search/issues/1898

## Summary
- Handle nullable mail, calendar, contact, and attachment fields so a single malformed Exchange item no longer aborts the sync (fixes the customer `'NoneType' object has no attribute 'email_address'` failure on `mail.sender`).
- Skip optional mail folders (inbox/sent/junk/archive) when absent instead of failing the whole account.
- Harden on-prem DLS access-control sync for list-valued LDAP `mail` attributes and malformed DNs.

Relates to https://github.com/elastic/sdh-search/issues/1898

## Test plan
- [x] `pytest tests/sources/test_outlook.py` (57 tests)
