### PR TITLE
Rename GitHub team: search-inference-team -> inference-team

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -74,7 +74,7 @@ spec:
           access_level: "READ_ONLY"
         search-extract-and-transform: {}
         search-productivity-team: {}
-        search-inference-team: {}
+        inference-team: {}
         enterprise-search: {}
         release-eng:
           access_level: BUILD_AND_READ
@@ -131,7 +131,7 @@ spec:
           access_level: "READ_ONLY"
         search-extract-and-transform: {}
         search-productivity-team: {}
-        search-inference-team: {}
+        inference-team: {}
         enterprise-search: {}
 
 ---
@@ -183,7 +183,7 @@ spec:
           access_level: "READ_ONLY"
         search-extract-and-transform: {}
         search-productivity-team: {}
-        search-inference-team: {}
+        inference-team: {}
         enterprise-search: {}
 
 ########
@@ -215,7 +215,7 @@ spec:
       teams:
         search-extract-and-transform: {}
         search-productivity-team: {}
-        search-inference-team: {}
+        inference-team: {}
         enterprise-search: {}
         everyone:
           access_level: "READ_ONLY"
@@ -286,7 +286,7 @@ spec:
           access_level: "READ_ONLY"
         search-extract-and-transform: {}
         search-productivity-team: {}
-        search-inference-team: {}
+        inference-team: {}
         enterprise-search: {}
         artifact-management:
           access_level: BUILD_AND_READ


### PR DESCRIPTION
## Summary

The `search-inference-team` GitHub team is being renamed to `inference-team`. This PR updates all references in this repo.

A placeholder `inference-team` team has been created at https://github.com/orgs/elastic/teams/inference-team. The existing team will be renamed in due course — **do not merge this PR until the team rename has happened**, otherwise CODEOWNERS/access rules will point to the wrong team.

## Changes

All occurrences of `search-inference-team` replaced with `inference-team` (including `@elastic/search-inference-team` → `@elastic/inference-team` in CODEOWNERS).

---
🤖 Raised automatically as part of the team rename. Contact @seanhandley with questions.