### PR TITLE
[8.19] [GitHub] Propagate fetch errors instead of swallowing them (#4119)

### DIFF
--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -656,6 +656,10 @@ class ForbiddenException(Exception):
     pass
 
 
+class RateLimitingError(Exception):
+    pass
+
+
 class GitHubClient:
     def __init__(
         self, auth_method, base_url, app_id, private_key, token, ssl_enabled, ssl_ca
@@ -709,8 +713,6 @@ class GitHubClient:
             f"Connector will attempt to retry after {retry_after} seconds."
         )
         await self._sleeps.sleep(retry_after)
-        msg = "Rate limit exceeded."
-        raise Exception(msg)
 
     def _access_token(self):
         if self.auth_method == PERSONAL_ACCESS_TOKEN:
@@ -741,9 +743,11 @@ class GitHubClient:
                 private_key=self.private_key,
             )
             self._installation_access_token = access_token_response["token"]
-        except gidgethub.RateLimitExceeded:
+        except gidgethub.RateLimitExceeded as exception:
             await self._put_to_sleep("core")
-        except Exception:
+            msg = "Rate limit exceeded."
+            raise RateLimitingError(msg) from exception
+        except gidgethub.GitHubException:
             self._logger.exception(
                 f"Failed to get access token for installation {self._installation_id}.",
                 exc_info=True,
@@ -829,6 +833,8 @@ class GitHubClient:
                     and "api rate limit exceeded" in error.get("message").lower()
                 ):
                     await self._put_to_sleep(resource_type="graphql")
+                    msg = "Rate limit exceeded."
+                    raise RateLimitingError(msg) from exception
 
             if all(error.get("type") in ignore_errors for error in errors):
                 # All errors are ignored, return just the data part without errors
@@ -841,7 +847,7 @@ class GitHubClient:
 
             msg = f"Error while executing query. Exception: {non_ignored_errors}"
             raise Exception(msg) from exception
-        except Exception:
+        except gidgethub.GitHubException:
             raise
 
     @retryable(
@@ -865,8 +871,10 @@ class GitHubClient:
             return await self._get_client.getitem(
                 url=resource, oauth_token=self._access_token()
             )
-        except gidgethub.RateLimitExceeded:
+        except gidgethub.RateLimitExceeded as exception:
             await self._put_to_sleep("core")
+            msg = "Rate limit exceeded."
+            raise RateLimitingError(msg) from exception
         except gidgethub.HTTPException as exception:
             if exception.status_code == UNAUTHORIZED:
                 if self.auth_method == GITHUB_APP:
@@ -882,7 +890,7 @@ class GitHubClient:
                 raise ForbiddenException(msg) from exception
             else:
                 raise
-        except Exception as e:
+        except gidgethub.GitHubException as e:
             self._logger.debug(
                 f"An unexpected error occurred while getting GitHub item: {resource}. Error: {e}"
             )
@@ -962,10 +970,10 @@ class GitHubClient:
                 get_jwt(app_id=self.app_id, private_key=self.private_key),
             )
         # we don't expect any 401 error as the jwt is freshly generated
-        except gidgethub.RateLimitExceeded:
+        except gidgethub.RateLimitExceeded as exception:
             await self._put_to_sleep("core")
-        except Exception:
-            raise
+            msg = "Rate limit exceeded."
+            raise RateLimitingError(msg) from exception
 
     async def _github_app_paginated_get(self, url):
         data, more = await self._github_app_get(url)  # pyright: ignore
@@ -1568,7 +1576,11 @@ class GitHubDataSource(BaseDataSource):
                         org_name = self.configuration["org_name"]
                         self.org_repos.setdefault(org_name, {})[repo_name] = repo_data
             return invalid_repos
-        except Exception as exception:
+        except (
+            gidgethub.GitHubException,
+            UnauthorizedException,
+            ForbiddenException,
+        ) as exception:
             self._logger.exception(
                 f"Error while checking for inaccessible repositories. Exception: {exception}.",
                 exc_info=True,
@@ -1671,7 +1683,7 @@ class GitHubDataSource(BaseDataSource):
         try:
             await self.github_client.ping()
             self._logger.debug("Successfully connected to GitHub.")
-        except Exception:
+        except (gidgethub.GitHubException, UnauthorizedException, ForbiddenException):
             self._logger.exception("Error while connecting to GitHub.")
             raise
 
@@ -1686,11 +1698,13 @@ class GitHubDataSource(BaseDataSource):
             "_id": pull_request.pop("id"),
             "_timestamp": pull_request.pop("updatedAt"),
             "type": ObjectType.PULL_REQUEST.value,
-            "issue_comments": pull_request.get("comments", {}).get("nodes"),
+            "issue_comments": (pull_request.get("comments") or {}).get("nodes"),
             "reviews_comments": reviews,
-            "labels_field": pull_request.get("labels", {}).get("nodes"),
-            "assignees_list": pull_request.get("assignees", {}).get("nodes"),
-            "requested_reviewers": pull_request.get("reviewRequests", {}).get("nodes"),
+            "labels_field": (pull_request.get("labels") or {}).get("nodes"),
+            "assignees_list": (pull_request.get("assignees") or {}).get("nodes"),
+            "requested_reviewers": (pull_request.get("reviewRequests") or {}).get(
+                "nodes"
+            ),
         }
 
     def _prepare_issue_doc(self, issue):
@@ -1698,9 +1712,9 @@ class GitHubDataSource(BaseDataSource):
             "_id": issue.pop("id"),
             "type": ObjectType.ISSUE.value,
             "_timestamp": issue.pop("updatedAt"),
-            "issue_comments": issue.get("comments", {}).get("nodes"),
-            "labels_field": issue.get("labels", {}).get("nodes"),
-            "assignees_list": issue.get("assignees", {}).get("nodes"),
+            "issue_comments": (issue.get("comments") or {}).get("nodes"),
+            "labels_field": (issue.get("labels") or {}).get("nodes"),
+            "assignees_list": (issue.get("assignees") or {}).get("nodes"),
         }
 
     def _prepare_review_doc(self, review):
@@ -1711,7 +1725,7 @@ class GitHubDataSource(BaseDataSource):
             "author": author.get("login"),
             "body": review.get("body"),
             "state": review.get("state"),
-            "comments": review.get("comments", {}).get("nodes"),
+            "comments": (review.get("comments") or {}).get("nodes"),
         }
 
     async def _fetch_installations(self):
@@ -1812,35 +1826,25 @@ class GitHubDataSource(BaseDataSource):
         # or _get_personal_repos/_get_org_repos, see comments there
         # for potential performance/rate limit implications
         self._logger.info("Fetching repos")
-        try:
-            if (
-                WILDCARD in self.configured_repos
-                and self.configuration["repo_type"] == "other"
+        if (
+            WILDCARD in self.configured_repos
+            and self.configuration["repo_type"] == "other"
+        ):
+            async for user in self._get_owners():
+                async for repo_object in self._get_personal_repos(user):
+                    yield self._convert_repo_object_to_doc(repo_object)
+        elif (
+            WILDCARD in self.configured_repos
+            and self.configuration["repo_type"] == "organization"
+        ):
+            async for org in self._get_owners():
+                async for repo_object in self._get_org_repos(org):
+                    yield self._convert_repo_object_to_doc(repo_object)
+        else:
+            async for repo_object in self._get_configured_repos(
+                configured_repos=self.configured_repos
             ):
-                async for user in self._get_owners():
-                    async for repo_object in self._get_personal_repos(user):
-                        yield self._convert_repo_object_to_doc(repo_object)
-            elif (
-                WILDCARD in self.configured_repos
-                and self.configuration["repo_type"] == "organization"
-            ):
-                async for org in self._get_owners():
-                    async for repo_object in self._get_org_repos(org):
-                        yield self._convert_repo_object_to_doc(repo_object)
-            else:
-                async for repo_object in self._get_configured_repos(
-                    configured_repos=self.configured_repos
-                ):
-                    yield repo_object
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the repository. Exception: {exception}",
-                exc_info=True,
-            )
+                yield repo_object
 
     def _convert_repo_object_to_doc(self, repo_object):
         repo_object = repo_object.copy()
@@ -1894,7 +1898,7 @@ class GitHubDataSource(BaseDataSource):
                 "es_field": "assignees_list",
             },
         }
-        page_info = type_obj.get(field_type, {}).get("pageInfo", {})
+        page_info = (type_obj.get(field_type) or {}).get("pageInfo", {})
         if page_info.get("hasNextPage"):
             variables = {
                 "owner": owner,
@@ -1920,7 +1924,7 @@ class GitHubDataSource(BaseDataSource):
     async def _extract_pull_request(self, pull_request, owner, repo):
         reviews = [
             self._prepare_review_doc(review=review)
-            for review in pull_request.get("reviews", {}).get("nodes")
+            for review in (pull_request.get("reviews") or {}).get("nodes") or []
         ]
         pull_request.update(
             self._prepare_pull_request_doc(pull_request=pull_request, reviews=reviews)
@@ -1945,55 +1949,59 @@ class GitHubDataSource(BaseDataSource):
         self._logger.info(
             f"Fetching pull requests from '{repo_name}' with response_key '{response_key}' and filter query: '{filter_query}'"
         )
-        try:
-            query = (
-                GithubQuery.SEARCH_QUERY.value
-                if filter_query
-                else GithubQuery.PULL_REQUEST_QUERY.value
-            )
-            owner, repo = self.github_client.get_repo_details(repo_name=repo_name)
-            pull_request_variables = {
-                "owner": owner,
-                "name": repo,
-                "cursor": None,
-                "filter_query": filter_query,
-            }
-            async for response in self.github_client.paginated_api_call(
-                query=query,
-                variables=pull_request_variables,
-                keys=response_key,
+        query = (
+            GithubQuery.SEARCH_QUERY.value
+            if filter_query
+            else GithubQuery.PULL_REQUEST_QUERY.value
+        )
+        owner, repo = self.github_client.get_repo_details(repo_name=repo_name)
+        pull_request_variables = {
+            "owner": owner,
+            "name": repo,
+            "cursor": None,
+            "filter_query": filter_query,
+        }
+        async for response in self.github_client.paginated_api_call(
+            query=query,
+            variables=pull_request_variables,
+            keys=response_key,
+        ):
+            for pull_request in nested_get_from_dict(  # pyright: ignore
+                response, response_key + ["nodes"], default=[]
             ):
-                for pull_request in nested_get_from_dict(  # pyright: ignore
-                    response, response_key + ["nodes"], default=[]
-                ):
+                try:
                     async for pull_request_doc in self._extract_pull_request(
                         pull_request=pull_request, owner=owner, repo=repo
                     ):
                         yield pull_request_doc
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the pull requests. Exception: {exception}",
-                exc_info=True,
-            )
+                except gidgethub.GitHubException as exception:
+                    self._logger.warning(
+                        f"Skipping a pull request from '{repo_name}' due to an error while fetching its details. Exception: {exception}",
+                        exc_info=True,
+                    )
+                    continue
 
     async def _extract_issues(self, response, owner, repo, response_key):
         for issue in nested_get_from_dict(  # pyright: ignore
             response, response_key + ["nodes"], default=[]
         ):
-            issue.update(self._prepare_issue_doc(issue=issue))
-            for field in ["comments", "labels", "assignees"]:
-                await self._fetch_remaining_fields(
-                    type_obj=issue,
-                    object_type=ObjectType.ISSUE.value.lower(),
-                    owner=owner,
-                    repo=repo,
-                    field_type=field,
+            try:
+                issue.update(self._prepare_issue_doc(issue=issue))
+                for field in ["comments", "labels", "assignees"]:
+                    await self._fetch_remaining_fields(
+                        type_obj=issue,
+                        object_type=ObjectType.ISSUE.value.lower(),
+                        owner=owner,
+                        repo=repo,
+                        field_type=field,
+                    )
+                    issue.pop(field)
+            except gidgethub.GitHubException as exception:
+                self._logger.warning(
+                    f"Skipping an issue from '{owner}/{repo}' due to an error while fetching its details. Exception: {exception}",
+                    exc_info=True,
                 )
-                issue.pop(field)
+                continue
             yield issue
 
     async def _fetch_issues(
@@ -2005,37 +2013,27 @@ class GitHubDataSource(BaseDataSource):
         self._logger.info(
             f"Fetching issues from repo: {repo_name} with response_key: '{response_key}' and filter_query: '{filter_query}'"
         )
-        try:
-            query = (
-                GithubQuery.SEARCH_QUERY.value
-                if filter_query
-                else GithubQuery.ISSUE_QUERY.value
-            )
-            owner, repo = self.github_client.get_repo_details(repo_name=repo_name)
-            issue_variables = {
-                "owner": owner,
-                "name": repo,
-                "cursor": None,
-                "filter_query": filter_query,
-            }
-            async for response in self.github_client.paginated_api_call(
-                query=query,
-                variables=issue_variables,
-                keys=response_key,
+        query = (
+            GithubQuery.SEARCH_QUERY.value
+            if filter_query
+            else GithubQuery.ISSUE_QUERY.value
+        )
+        owner, repo = self.github_client.get_repo_details(repo_name=repo_name)
+        issue_variables = {
+            "owner": owner,
+            "name": repo,
+            "cursor": None,
+            "filter_query": filter_query,
+        }
+        async for response in self.github_client.paginated_api_call(
+            query=query,
+            variables=issue_variables,
+            keys=response_key,
+        ):
+            async for issue in self._extract_issues(
+                response=response, owner=owner, repo=repo, response_key=response_key
             ):
-                async for issue in self._extract_issues(
-                    response=response, owner=owner, repo=repo, response_key=response_key
-                ):
-                    yield issue
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the issues. Exception: {exception}",
-                exc_info=True,
-            )
+                yield issue
 
     async def _fetch_last_commit_timestamp(self, repo_name, path):
         commit, *_ = await self.github_client.get_github_item(  # pyright: ignore
@@ -2074,53 +2072,49 @@ class GitHubDataSource(BaseDataSource):
         self._logger.info(
             f"Fetching files from repo: '{repo_name}' (branch: '{default_branch}')"
         )
-        try:
-            file_tree = await self.github_client.get_github_item(
-                resource=self.github_client.endpoints["TREE"].format(
-                    repo_name=repo_name, default_branch=default_branch
-                )
+        file_tree = await self.github_client.get_github_item(
+            resource=self.github_client.endpoints["TREE"].format(
+                repo_name=repo_name, default_branch=default_branch
             )
+        )
 
-            for repo_object in file_tree.get("tree", []):
-                if repo_object["type"] == BLOB:
-                    if document := await self._format_file_document(
+        for repo_object in file_tree.get("tree") or []:
+            if repo_object["type"] == BLOB:
+                try:
+                    document = await self._format_file_document(
                         repo_object=repo_object, repo_name=repo_name, schema=FILE_SCHEMA
-                    ):
-                        yield document
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the files of {repo_name}. Exception: {exception}",
-                exc_info=True,
-            )
+                    )
+                except gidgethub.GitHubException as exception:
+                    self._logger.warning(
+                        f"Skipping a file from '{repo_name}' due to an error while fetching its details. Exception: {exception}",
+                        exc_info=True,
+                    )
+                    continue
+                if document:
+                    yield document
 
     async def _fetch_files_by_path(self, repo_name, path):
         self._logger.info(f"Fetching files from repo: '{repo_name}' (path: '{path}')")
-        try:
-            for repo_object in await self.github_client.get_github_item(
-                resource=self.github_client.endpoints["PATH"].format(
-                    repo_name=repo_name, path=path
-                )
-            ):  # pyright: ignore
-                if repo_object["type"] == FILE:
-                    if document := await self._format_file_document(
+        for repo_object in await self.github_client.get_github_item(
+            resource=self.github_client.endpoints["PATH"].format(
+                repo_name=repo_name, path=path
+            )
+        ):  # pyright: ignore
+            if repo_object["type"] == FILE:
+                try:
+                    document = await self._format_file_document(
                         repo_object=repo_object,
                         repo_name=repo_name,
                         schema=PATH_SCHEMA,
-                    ):
-                        yield document
-        except UnauthorizedException:
-            raise
-        except ForbiddenException:
-            raise
-        except Exception as exception:
-            self._logger.warning(
-                f"Something went wrong while fetching the files of {repo_name}. Exception: {exception}",
-                exc_info=True,
-            )
+                    )
+                except gidgethub.GitHubException as exception:
+                    self._logger.warning(
+                        f"Skipping a file from '{repo_name}' due to an error while fetching its details. Exception: {exception}",
+                        exc_info=True,
+                    )
+                    continue
+                if document:
+                    yield document
 
     async def get_content(self, attachment, timestamp=None, doit=False):
         """Extracts the content for Apache TIKA supported file types.
@@ -2224,9 +2218,9 @@ class GitHubDataSource(BaseDataSource):
             for user in nested_get_from_dict(  # pyright: ignore
                 response, ["repository", "collaborators", "edges"], default=[]
             ):
-                user_id = user.get("node", {}).get("id")
-                user_name = user.get("node", {}).get("login")
-                user_email = user.get("node", {}).get("email")
+                user_id = (user.get("node") or {}).get("id")
+                user_name = (user.get("node") or {}).get("login")
+                user_email = (user.get("node") or {}).get("email")
                 if user_id in self.members[owner]:
                     access_control.append(_prefix_user_id(user_id=user_id))
                     if user_name:

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -27,6 +27,7 @@ from connectors.sources.github import (
     GitHubAdvancedRulesValidator,
     GitHubClient,
     GitHubDataSource,
+    RateLimitingError,
     UnauthorizedException,
 )
 from tests.commons import AsyncIterator
@@ -1015,8 +1016,56 @@ async def test_get_response_with_rate_limit_exceeded():
 async def test_put_to_sleep():
     async with create_github_source() as source:
         source.github_client._get_retry_after = AsyncMock(return_value=0)
-        with pytest.raises(Exception, match="Rate limit exceeded."):
-            await source.github_client._put_to_sleep("core")
+        # _put_to_sleep only sleeps; callers are responsible for re-raising RateLimitingError
+        assert await source.github_client._put_to_sleep("core") is None
+
+
+@pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+async def test_get_github_item_reraises_rate_limiting_error():
+    async with create_github_source() as source:
+        source.github_client._get_retry_after = AsyncMock(return_value=0)
+        source.github_client._get_client.getitem = AsyncMock(
+            side_effect=gidgethub.RateLimitExceeded(rate_limit=None)
+        )
+        with pytest.raises(RateLimitingError):
+            await source.github_client.get_github_item("/user")
+
+
+@pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+async def test_graphql_reraises_rate_limiting_error_on_rate_limited_query_error():
+    async with create_github_source() as source:
+        source.github_client._get_retry_after = AsyncMock(return_value=0)
+        source.github_client._get_client.graphql = Mock(
+            side_effect=QueryError(
+                {
+                    "errors": [
+                        {
+                            "type": "RATE_LIMITED",
+                            "message": "API rate limit exceeded for user ID: 123456",
+                        }
+                    ]
+                }
+            )
+        )
+        with pytest.raises(RateLimitingError):
+            await source.github_client.graphql(
+                query="QUERY", variables={"owner": "demo_user"}
+            )
+
+
+@pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+@patch("connectors.sources.github.get_jwt", Mock(return_value="jwt"))
+async def test_github_app_get_reraises_rate_limiting_error():
+    async with create_github_source(auth_method=GITHUB_APP) as source:
+        source.github_client._get_retry_after = AsyncMock(return_value=0)
+        source.github_client._get_client._make_request = AsyncMock(
+            side_effect=gidgethub.RateLimitExceeded(rate_limit=None)
+        )
+        with pytest.raises(RateLimitingError):
+            await source.github_client._github_app_get("/app")
 
 
 @pytest.mark.asyncio
@@ -1370,16 +1419,18 @@ async def test_fetch_repos_organization():
 @pytest.mark.asyncio
 async def test_fetch_repos_when_user_repos_is_available():
     async with create_github_source(repos="demo_user/demo_repo, , demo_repo") as source:
+        repository_response = {
+            "repository": {
+                "id": "123",
+                "updatedAt": "2023-04-17T12:55:01Z",
+                "nameWithOwner": "demo_user/demo_repo",
+            }
+        }
         source.github_client.graphql = AsyncMock(
             side_effect=[
                 {"viewer": {"login": "owner1"}},
-                {
-                    "repository": {
-                        "id": "123",
-                        "updatedAt": "2023-04-17T12:55:01Z",
-                        "nameWithOwner": "demo_user/demo_repo",
-                    }
-                },
+                deepcopy(repository_response),
+                deepcopy(repository_response),
             ]
         )
         async for repo in source._fetch_repos():
@@ -1400,6 +1451,21 @@ async def test_fetch_repos_with_client_exception(exception):
     async with create_github_source() as source:
         source.github_client.graphql = Mock(side_effect=exception())
         with pytest.raises(exception):
+            async for _ in source._fetch_repos():
+                pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_repos_propagates_github_exception():
+    # Failing to list repositories must fail the sync instead of being swallowed
+    async with create_github_source() as source:
+        source._get_owners = Mock(return_value=AsyncIterator(["demo_user"]))
+        source.github_client.get_user_repos = Mock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with pytest.raises(gidgethub.HTTPException):
             async for _ in source._fetch_repos():
                 pass
 
@@ -1481,13 +1547,96 @@ async def test_fetch_issues_with_client_exception(exception):
 
 
 @pytest.mark.asyncio
+async def test_fetch_issues_propagates_github_exception():
+    # A page-level GitHub failure must fail the sync instead of being swallowed
+    async with create_github_source() as source:
+        source.github_client.paginated_api_call = Mock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with pytest.raises(gidgethub.HTTPException):
+            async for _ in source._fetch_issues(
+                repo_name="demo_user/demo_repo",
+                response_key=[REPOSITORY_OBJECT, "issues"],
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_issues_skips_document_on_github_exception(patch_logger):
+    # A failure while enriching a single issue is logged and skipped, not raised
+    issue_response = {
+        "repository": {
+            "issues": {"nodes": [{"id": "1", "updatedAt": "2023-04-19T08:56:23Z"}]}
+        }
+    }
+    async with create_github_source() as source:
+        source._fetch_remaining_fields = AsyncMock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with patch.object(
+            source.github_client,
+            "paginated_api_call",
+            side_effect=[AsyncIterator([issue_response])],
+        ):
+            issues = [
+                issue
+                async for issue in source._fetch_issues(
+                    repo_name="demo_user/demo_repo",
+                    response_key=[REPOSITORY_OBJECT, "issues"],
+                )
+            ]
+        assert issues == []
+        patch_logger.assert_present("Skipping an issue")
+
+
+@pytest.mark.asyncio
+async def test_fetch_issues_handles_null_connection_fields():
+    # GitHub can return null for connection fields (comments/labels/assignees);
+    # this must not raise, and the issue should still be yielded.
+    issue_response = {
+        "repository": {
+            "issues": {
+                "nodes": [
+                    {
+                        "id": "1",
+                        "updatedAt": "2023-04-19T08:56:23Z",
+                        "comments": None,
+                        "labels": None,
+                        "assignees": None,
+                    }
+                ]
+            }
+        }
+    }
+    async with create_github_source() as source:
+        with patch.object(
+            source.github_client,
+            "paginated_api_call",
+            side_effect=[AsyncIterator([issue_response])],
+        ):
+            issues = [
+                issue
+                async for issue in source._fetch_issues(
+                    repo_name="demo_user/demo_repo",
+                    response_key=[REPOSITORY_OBJECT, "issues"],
+                )
+            ]
+    assert len(issues) == 1
+    assert issues[0]["_id"] == "1"
+
+
+@pytest.mark.asyncio
 async def test_fetch_pull_requests():
     async with create_github_source() as source:
         with patch.object(
             source.github_client,
             "paginated_api_call",
             side_effect=[
-                AsyncIterator([MOCK_RESPONSE_PULL]),
+                AsyncIterator([deepcopy(MOCK_RESPONSE_PULL)]),
                 AsyncIterator([MOCK_COMMENTS_RESPONSE]),
                 AsyncIterator([MOCK_REVIEW_REQUESTED_RESPONSE]),
                 AsyncIterator([MOCK_LABELS_RESPONSE]),
@@ -1516,6 +1665,100 @@ async def test_fetch_pull_requests_with_client_exception(exception):
                 response_key=[REPOSITORY_OBJECT, "pullRequests"],
             ):
                 pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_propagates_github_exception():
+    # A page-level GitHub failure must fail the sync instead of being swallowed
+    async with create_github_source() as source:
+        source.github_client.paginated_api_call = Mock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with pytest.raises(gidgethub.HTTPException):
+            async for _ in source._fetch_pull_requests(
+                repo_name="demo_user/demo_repo",
+                response_key=[REPOSITORY_OBJECT, "pullRequests"],
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_skips_document_on_github_exception(patch_logger):
+    # A failure while enriching a single pull request is logged and skipped, not raised
+    pull_response = {
+        "repository": {
+            "pullRequests": {
+                "nodes": [
+                    {
+                        "id": "1",
+                        "updatedAt": "2023-07-03T12:24:16Z",
+                        "reviews": {"nodes": []},
+                    }
+                ]
+            }
+        }
+    }
+    async with create_github_source() as source:
+        source._fetch_remaining_fields = AsyncMock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with patch.object(
+            source.github_client,
+            "paginated_api_call",
+            side_effect=[AsyncIterator([pull_response])],
+        ):
+            pulls = [
+                pull
+                async for pull in source._fetch_pull_requests(
+                    repo_name="demo_user/demo_repo",
+                    response_key=[REPOSITORY_OBJECT, "pullRequests"],
+                )
+            ]
+        assert pulls == []
+        patch_logger.assert_present("Skipping a pull request")
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_handles_null_connection_fields():
+    # GitHub can return null for connection fields (reviews/comments/labels/...);
+    # this must not raise, and the pull request should still be yielded.
+    pull_response = {
+        "repository": {
+            "pullRequests": {
+                "nodes": [
+                    {
+                        "id": "1",
+                        "updatedAt": "2023-07-03T12:24:16Z",
+                        "reviews": None,
+                        "comments": None,
+                        "reviewRequests": None,
+                        "labels": None,
+                        "assignees": None,
+                    }
+                ]
+            }
+        }
+    }
+    async with create_github_source() as source:
+        with patch.object(
+            source.github_client,
+            "paginated_api_call",
+            side_effect=[AsyncIterator([pull_response])],
+        ):
+            pulls = [
+                pull
+                async for pull in source._fetch_pull_requests(
+                    repo_name="demo_user/demo_repo",
+                    response_key=[REPOSITORY_OBJECT, "pullRequests"],
+                )
+            ]
+    assert len(pulls) == 1
+    assert pulls[0]["_id"] == "1"
+    assert pulls[0]["reviews_comments"] == []
 
 
 @pytest.mark.asyncio
@@ -1565,7 +1808,7 @@ async def test_fetch_pull_requests_with_deleted_users():
             source.github_client,
             "paginated_api_call",
             side_effect=[
-                AsyncIterator([MOCK_RESPONSE_PULL]),
+                AsyncIterator([deepcopy(MOCK_RESPONSE_PULL)]),
                 AsyncIterator([MOCK_COMMENTS_RESPONSE]),
                 AsyncIterator([MOCK_REVIEW_REQUESTED_RESPONSE]),
                 AsyncIterator([MOCK_LABELS_RESPONSE]),
@@ -1641,6 +1884,37 @@ async def test_fetch_files_when_error_occurs(exception):
         with pytest.raises(exception):
             async for _ in source._fetch_files("demo_repo", "main"):
                 pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_files_propagates_github_exception():
+    # Failing to fetch the repository tree must fail the sync instead of being swallowed
+    async with create_github_source() as source:
+        source.github_client.get_github_item = Mock(
+            side_effect=gidgethub.HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        )
+        with pytest.raises(gidgethub.HTTPException):
+            async for _ in source._fetch_files("demo_repo", "main"):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_files_skips_document_on_github_exception(patch_logger):
+    # A failure while fetching a single file's details is logged and skipped, not raised
+    async with create_github_source() as source:
+        with patch.object(
+            source.github_client,
+            "get_github_item",
+            side_effect=[
+                deepcopy(MOCK_TREE),
+                gidgethub.HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+            ],
+        ):
+            files = [doc async for doc in source._fetch_files("demo_repo", "main")]
+        assert files == []
+        patch_logger.assert_present("Skipping a file")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Manual backport of #4119 to `8.19`.

The GitHub connector previously wrapped each fetch method in `try/except Exception: log warning`, so a sync could "succeed" while syncing nothing (e.g. if no issues could be fetched at all). This ports the two-tier error handling, removes the broad exception handling, and hardens null-handling of GraphQL responses.

The automated backport could not cherry-pick because `main` has since split the GitHub connector into a package (`app/connectors_service/connectors/sources/github/{client,datasource,utils}.py`), whereas `8.19` still uses the single module `connectors/sources/github.py`. The changes were therefore ported by hand into that single module.

## Changes

- **Two-tier error handling**: page/API-level failures propagate out of `_fetch_repos` / `_fetch_pull_requests` / `_fetch_issues` / `_fetch_files` / `_fetch_files_by_path` (so the sync fails when data genuinely can't be fetched), while per-document enrichment failures are WARN-logged and skipped via narrow `gidgethub.GitHubException` guards.
- **Transient rate limiting**: added `RateLimitingError`. `_put_to_sleep` now only sleeps; its callers (`get_github_item`, `graphql`, `_update_installation_access_token`, `_github_app_get`) re-raise `RateLimitingError`, which is not in `skipped_exceptions`, so the existing `@retryable` layer retries it.
- **No more bare `except Exception`**: replaced with `gidgethub.GitHubException` (plus the connector's own `UnauthorizedException` / `ForbiddenException` in log-and-reraise spots like `ping` and `_get_invalid_repos_for_personal_access_token`).
- **Null-safe GraphQL handling**: switched connection-field access (`reviews`, `comments`, `labels`, `assignees`, `reviewRequests`, `tree`, edge nodes) to the `... or {}` / `... or []` idiom so a single document with `null` connection fields can no longer abort the sync.
- **Tests**: ported coverage for propagation vs. per-item skip for each fetch method, `RateLimitingError` propagation, null-connection-field regressions, and the `deepcopy` test-isolation fixes.

## Test plan

- `make clean install autoformat lint test PYTHON=python3.11` — lint clean; `tests/sources/test_github.py` passes (121 passed), overall coverage 92.35%.
- The only failures in the full suite are pre-existing `pytest-randomly` ordering flakiness in `test_google_drive.py` / `test_google_cloud_storage.py` (they pass in isolation and with a deterministic order); they are unrelated to these GitHub-only changes.

Part of #2393, closes #2395 for 8.19.

Made with [Cursor](https://cursor.com)