### PR TITLE
[Connectors Python] Lower default max file download size from 10MiB to 8MiB

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -4146,7 +4146,7 @@ Apache Software License
 
 
 google-auth
-2.55.1
+2.55.2
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2615,7 +2615,7 @@ SOFTWARE.
 
 
 build
-1.5.0
+1.5.1
 MIT
 Copyright © 2019 Filipe Laíns <filipe.lains@gmail.com>
 

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2713,7 +2713,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.7
+3.4.9
 MIT
 MIT License
 

--- a/app/connectors_service/config.yml.example
+++ b/app/connectors_service/config.yml.example
@@ -258,7 +258,7 @@
 #
 ##  The maximum size (in bytes) of files that the framework should be willing
 ##    to download and/or process.
-#service.max_file_download_size: 10485760
+#service.max_file_download_size: 8388608
 #
 #
 ##  The interval (in seconds) to run job cleanup task.

--- a/app/connectors_service/connectors/config.py
+++ b/app/connectors_service/connectors/config.py
@@ -37,7 +37,7 @@ DEFAULT_MAX_CONCURRENCY = 5
 DEFAULT_CONCURRENT_DOWNLOADS = 10
 
 # --- File handling defaults ----------------------------------------------------------
-DEFAULT_MAX_FILE_SIZE = 10485760  # 10MiB
+DEFAULT_MAX_FILE_SIZE = 8388608  # 8MiB
 
 
 def load_config(config_file):

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -947,7 +947,7 @@ Apache Software License
 
 
 build
-1.5.0
+1.5.1
 MIT
 Copyright © 2019 Filipe Laíns <filipe.lains@gmail.com>
 


### PR DESCRIPTION
Lowers the default `service.max_file_download_size` from 10MiB (10485760) to 8MiB (8388608).

Aligns the connectors default with the new 8MiB `ingest.attachment.max_field_size` cap that Elasticsearch Serverless enforces on the Ingest Attachment Processor.

Changes:
- `connectors/config.py`: `DEFAULT_MAX_FILE_SIZE` → 8388608
- `config.yml.example`: `service.max_file_download_size` → 8388608

## Release Note

Lowered the default maximum file download size (`service.max_file_download_size`) from 10MiB to 8MiB.