### PR TITLE
Add 9.5 to DRA publishing branches

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1082,7 +1082,7 @@ steps:
   # trailing comment -- it is used as an anchor to locate this exact line.
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"9.5\" || build.branch == \"9.4\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"9.5\" || build.branch == \"9.4\" || build.branch == \"9.3\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1082,7 +1082,7 @@ steps:
   # trailing comment -- it is used as an anchor to locate this exact line.
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"9.4\" || build.branch == \"9.3\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"9.5\" || build.branch == \"9.4\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"


### PR DESCRIPTION
Part of the 9.5.0 release setup (day-after-feature-freeze, minor).

Adds the new `9.5` maintenance branch to the "DRA publishing" conditional in `.buildkite/pipeline.yml` so DRA artifacts are built for `9.5`. Also trims `9.3` from the rolling window (now `main, 9.5, 9.4, 8.19`).

This PR will be backported to the new `9.5` branch so that `9.5` builds publish DRA artifacts.

Release issue: elastic/search-team#14357

Made with [Cursor](https://cursor.com)