### PR TITLE
Add 9.5 to DRA publishing branches (9.5 backport)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1082,7 +1082,7 @@ steps:
   # trailing comment -- it is used as an anchor to locate this exact line.
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"9.5\" || build.branch == \"9.4\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"9.5\" || build.branch == \"9.4\" || build.branch == \"9.3\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1082,7 +1082,7 @@ steps:
   # trailing comment -- it is used as an anchor to locate this exact line.
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"9.4\" || build.branch == \"9.3\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"9.5\" || build.branch == \"9.4\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2713,7 +2713,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.7
+3.4.9
 MIT
 MIT License
 
@@ -4146,7 +4146,7 @@ Apache Software License
 
 
 google-auth
-2.55.1
+2.55.2
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
Backport to the `9.5` branch of the DRA-publishing change. Companion `main` PR: #4143.

Adds `9.5` to the "DRA publishing" conditional in `.buildkite/pipeline.yml` so the `9.5` Buildkite build produces the `9.5.0` DRA artifact. Purely additive — `9.3` is kept because 9.3.8 (elastic/search-team#15106) is still an active release.

> Note: originally opened as a backport of #4140, which was closed and superseded by #4143 (recreated on a non-`release/*` branch). The change is identical.

Release issue: elastic/search-team#14357