### PR TITLE
Add 9.5 to DRA publishing branches

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1082,7 +1082,7 @@ steps:
   # trailing comment -- it is used as an anchor to locate this exact line.
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"9.5\" || build.branch == \"9.4\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"9.5\" || build.branch == \"9.4\" || build.branch == \"9.3\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1082,7 +1082,7 @@ steps:
   # trailing comment -- it is used as an anchor to locate this exact line.
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"9.4\" || build.branch == \"9.3\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"9.5\" || build.branch == \"9.4\" || build.branch == \"8.19\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2713,7 +2713,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.7
+3.4.9
 MIT
 MIT License
 
@@ -4146,7 +4146,7 @@ Apache Software License
 
 
 google-auth
-2.55.1
+2.55.2
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
Part of the 9.5.0 release setup (day-after-feature-freeze, minor). Recreated from #4140 on a non-`release/*` branch so CI's NOTICE auto-commit isn't blocked by the "Require a PR" ruleset.

Adds the new `9.5` maintenance branch to the "DRA publishing" conditional in `.buildkite/pipeline.yml`. Purely additive — `9.3` is kept because 9.3.8 (elastic/search-team#15106) is still an active release. Window is now `main, 9.5, 9.4, 9.3, 8.19`.

Backported to the `9.5` branch in #4141 so `9.5` builds publish DRA artifacts.

Release issue: elastic/search-team#14357

Made with [Cursor](https://cursor.com)