### PR TITLE
Fix worker_mode condition in service_types doc comment

### DIFF
--- a/app/connectors_service/config.yml.example
+++ b/app/connectors_service/config.yml.example
@@ -234,7 +234,7 @@
 ##    This allows partitioning the load allowing to spread different connector types between different
 ##    physical instance that can be bigger or smaller depending on the load and hardware requirements.
 ##    If `service.worker_mode` is `false` then this setting is ignored.
-##    If `service.worker_mode` is `false` then you should explicitly provide service types you want the service to handle
+##    If `service.worker_mode` is `true` then you should explicitly provide service types you want the service to handle
 ##    Example: ['mongodb', 'mysql']
 #service.service_types: []
 #


### PR DESCRIPTION
## Summary
Small docs-only follow-up to #4108.

The `config.yml.example` comment for `service.service_types` currently reads:

> If `service.worker_mode` is `false` then you should explicitly provide service types you want the service to handle

That has the condition backwards. `service.service_types` is only used (and required) when `service.worker_mode` is **`true`** — the line directly above already states that the setting is ignored when `worker_mode` is `false`. As written, the comment tells users to set `service_types` in exactly the case where it is ignored.

This changes the condition from `false` to `true`.

## Test plan
- [ ] Docs-only change; no code affected. Confirm the two comment lines in `config.yml.example` now describe the `false` (ignored) and `true` (must provide) cases respectively.

Made with [Cursor](https://cursor.com)