### PR TITLE
Fix CVE-2026-31789: bump wolfi/python base image to patched openssl

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:382371407c9279319484a10ab00780d9738b0fa293b2d74177d0381c074d7da9
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:18c62187e8e27e3331c8bff8a0e03c670b869cfb353d1a37a923073139e3da84
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
## Summary

Remediates **CVE-2026-31789** (`openssl`/`libcrypto3`) reported for the `docker.elastic.co/integrations/elastic-connectors` image in elastic/search-team#14858.

- Bumps the `docker.elastic.co/wolfi/python:3.11-dev` base image in `Dockerfile.wolfi` (the base for the published `elastic-connectors` image) from digest `3823714` (ships `openssl` `3.6.1-r4`, vulnerable) to `18c6218`, which ships `openssl`/`libcrypto3` >= `3.6.2-r0` and includes the fix.
- This is the same digest tracked by the open Renovate PR #4129; here it is scoped to just the CVE-relevant change.

## Are we affected?

- The vulnerable package (`openssl`/`libcrypto3` `3.6.1-r4`) **is present** in the base image, so container scanners (Snyk/Trivy) flag it and the release quality gate requires remediation.
- **Practical exploitability is low**: the flaw is a heap buffer overflow when converting an excessively large (>1 GiB) OCTET STRING (e.g. SKID/AKID in a crafted X.509 cert) to hex, and **only affects 32-bit platforms**. The connectors images are published for `linux/amd64` and `linux/arm64` (64-bit) only, and OpenSSL/Snyk both rate the underlying issue *Low* for this reason.
- Remediation is still applied to clear the scanner finding and satisfy the SLO gate.

## Test plan

- [x] `make lint` (pyright + ruff + version check) — passes
- [x] `make test` — 2261 passed; the 8 Google Cloud Storage / Drive failures are pre-existing `pytest-randomly` test-ordering flakiness on `main` (they pass in isolation) and are unrelated to a base-image digest change
- [ ] CI Trivy scan on the rebuilt `Dockerfile.wolfi` image confirms CVE-2026-31789 is no longer reported

Refs: elastic/search-team#14858

Made with [Cursor](https://cursor.com)