### PR TITLE
[9.3] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 18c6218 (#4129)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:382371407c9279319484a10ab00780d9738b0fa293b2d74177d0381c074d7da9
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:18c62187e8e27e3331c8bff8a0e03c670b869cfb353d1a37a923073139e3da84
 USER root
 COPY . /app
 WORKDIR /app

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1628,7 +1628,7 @@ SOFTWARE.
 
 
 anyio
-4.14.1
+4.14.2
 MIT
 The MIT License (MIT)
 
@@ -4146,7 +4146,7 @@ Apache Software License
 
 
 google-auth
-2.55.2
+2.56.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -7576,8 +7576,8 @@ SOFTWARE.
 
 
 stone
-3.4.0
-MIT License
+3.5.1
+MIT
 Copyright (c) 2020 Dropbox Inc., http://www.dropbox.com/
 
     Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 18c6218 (#4129)