### PR TITLE
[9.3] [MongoDB] Handle out-of-range BSON datetimes to prevent sync failures (#4148)

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -7576,7 +7576,7 @@ SOFTWARE.
 
 
 stone
-3.5.1
+3.5.2
 MIT
 Copyright (c) 2020 Dropbox Inc., http://www.dropbox.com/
 

--- a/app/connectors_service/connectors/sources/mongo/datasource.py
+++ b/app/connectors_service/connectors/sources/mongo/datasource.py
@@ -10,7 +10,15 @@ from copy import deepcopy
 from datetime import datetime
 from tempfile import NamedTemporaryFile
 
-from bson import OLD_UUID_SUBTYPE, Binary, DBRef, Decimal128, ObjectId
+from bson import (
+    OLD_UUID_SUBTYPE,
+    Binary,
+    DatetimeConversion,
+    DatetimeMS,
+    DBRef,
+    Decimal128,
+    ObjectId,
+)
 from bson.binary import UUID_SUBTYPE
 from connectors_sdk.source import BaseDataSource, ConfigurableFieldValueError
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -18,6 +26,10 @@ from pymongo.errors import OperationFailure
 
 from connectors.sources.mongo.validator import MongoAdvancedRulesValidator
 from connectors.utils import get_pem_format
+
+# Config value name -> pymongo enum. "DATETIME" is the legacy default (raises).
+DATETIME_CONVERSION_OPTIONS = dict(DatetimeConversion.__members__)
+DEFAULT_DATETIME_CONVERSION = DatetimeConversion.DATETIME.name
 
 
 class MongoDataSource(BaseDataSource):
@@ -36,6 +48,7 @@ class MongoDataSource(BaseDataSource):
         self.ssl_ca = self.configuration["ssl_ca"]
         self.user = self.configuration["user"]
         self.password = self.configuration["password"]
+        self.datetime_conversion = self.configuration["datetime_conversion"]
         self.tls_insecure = self.configuration["tls_insecure"]
         self.collection = None
 
@@ -99,6 +112,33 @@ class MongoDataSource(BaseDataSource):
                 "ui_restrictions": ["advanced"],
                 "value": False,
             },
+            "datetime_conversion": {
+                "display": "dropdown",
+                "label": "Out-of-range date handling",
+                "options": [
+                    {"label": "Raise an error (legacy)", "value": "DATETIME"},
+                    {"label": "Clamp to the min/max date", "value": "DATETIME_CLAMP"},
+                    {
+                        "label": "Out-of-range dates as epoch milliseconds",
+                        "value": "DATETIME_AUTO",
+                    },
+                    {
+                        "label": "All dates as epoch milliseconds",
+                        "value": "DATETIME_MS",
+                    },
+                ],
+                "order": 10,
+                "required": False,
+                "tooltip": (
+                    "How to handle MongoDB dates outside the supported range "
+                    "(years 1-9999). 'Raise an error' is the legacy behavior; "
+                    "the other options let the sync continue by clamping or "
+                    "storing raw epoch milliseconds."
+                ),
+                "type": "str",
+                "ui_restrictions": ["advanced"],
+                "value": DEFAULT_DATETIME_CONVERSION,
+            },
         }
 
     @contextmanager
@@ -106,6 +146,11 @@ class MongoDataSource(BaseDataSource):
         certfile = ""
         try:
             client_params = {}
+
+            # How to decode out-of-range dates; defaults to legacy (raise).
+            client_params["datetime_conversion"] = DATETIME_CONVERSION_OPTIONS.get(
+                self.datetime_conversion, DatetimeConversion.DATETIME
+            )
 
             if self.configuration["direct_connection"]:
                 client_params["directConnection"] = True
@@ -172,6 +217,9 @@ class MongoDataSource(BaseDataSource):
                 value = value.to_decimal()
             elif isinstance(value, DBRef):
                 value = _serialize(value.as_doc().to_dict())
+            elif isinstance(value, DatetimeMS):
+                # Out-of-range date (DATETIME_AUTO/MS mode); keep raw epoch ms.
+                value = int(value)
             elif isinstance(value, Binary):
                 # UUID_SUBTYPE is guaranteed to properly be serialized cross-platform and cross-driver
                 if value.subtype == UUID_SUBTYPE:
@@ -229,6 +277,14 @@ class MongoDataSource(BaseDataSource):
 
     async def validate_config(self):
         await super().validate_config()
+
+        if self.datetime_conversion not in DATETIME_CONVERSION_OPTIONS:
+            msg = (
+                f"Invalid 'Out-of-range date handling' value '{self.datetime_conversion}'. "
+                f"Must be one of: {', '.join(DATETIME_CONVERSION_OPTIONS)}."
+            )
+            raise ConfigurableFieldValueError(msg)
+
         parsed_url = urllib.parse.urlparse(self.host)
         query_params = urllib.parse.parse_qs(parsed_url.query)
 

--- a/app/connectors_service/tests/sources/test_mongo.py
+++ b/app/connectors_service/tests/sources/test_mongo.py
@@ -10,9 +10,12 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, Mock
 from uuid import UUID
 
+import bson
 import pytest
-from bson import Binary, DBRef, ObjectId
+from bson import Binary, DatetimeConversion, DatetimeMS, DBRef, ObjectId
+from bson.codec_options import CodecOptions
 from bson.decimal128 import Decimal128
+from bson.errors import InvalidBSON
 from connectors_sdk.filtering.validation import Filter
 from connectors_sdk.source import ConfigurableFieldValueError
 from pymongo.errors import OperationFailure
@@ -33,6 +36,7 @@ async def create_mongo_source(
     ssl_enabled=False,
     ssl_ca="",
     tls_insecure=False,
+    datetime_conversion="DATETIME",
 ):
     async with create_source(
         MongoDataSource,
@@ -45,6 +49,7 @@ async def create_mongo_source(
         ssl_enabled=ssl_enabled,
         ssl_ca=ssl_ca,
         tls_insecure=tls_insecure,
+        datetime_conversion=datetime_conversion,
     ) as source:
         yield source
 
@@ -457,11 +462,111 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise(
             },
             {"some_binary_uuid": None},
         ),
+        (
+            # in-range date -> ISO string
+            {"created": datetime(2020, 1, 1, 12, 30, 0)},
+            {"created": "2020-01-01T12:30:00"},
+        ),
+        (
+            # clamped dates -> ISO string
+            {"clamped_max": datetime.max},
+            {"clamped_max": datetime.max.isoformat()},
+        ),
+        (
+            {"clamped_min": datetime.min},
+            {"clamped_min": datetime.min.isoformat()},
+        ),
+        (
+            # DatetimeMS -> raw ms
+            {"ms": DatetimeMS(2**62)},
+            {"ms": 2**62},
+        ),
+        (
+            {"ms_zero": DatetimeMS(0)},
+            {"ms_zero": 0},
+        ),
+        (
+            # nested DatetimeMS
+            {"nested": {"ms": DatetimeMS(5)}, "list": [DatetimeMS(-(2**62))]},
+            {"nested": {"ms": 5}, "list": [-(2**62)]},
+        ),
     ],
 )
 async def test_serialize(raw, output):
     async with create_mongo_source() as source:
         assert source.serialize(raw) == output
+
+
+@pytest.mark.asyncio
+async def test_get_client_defaults_to_legacy_datetime_conversion():
+    # Unconfigured keeps legacy DATETIME (raise); opt-in only.
+    async with create_mongo_source() as source:
+        with source.get_client() as client:
+            assert (
+                client.codec_options.datetime_conversion == DatetimeConversion.DATETIME
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "conversion",
+    ["DATETIME", "DATETIME_CLAMP", "DATETIME_AUTO", "DATETIME_MS"],
+)
+async def test_get_client_uses_configured_datetime_conversion(conversion):
+    async with create_mongo_source(datetime_conversion=conversion) as source:
+        with source.get_client() as client:
+            assert (
+                client.codec_options.datetime_conversion
+                == DatetimeConversion[conversion]
+            )
+
+
+def _encode_out_of_range_date():
+    return bson.encode(
+        {"date": DatetimeMS(2**62)},
+        codec_options=CodecOptions(datetime_conversion=DatetimeConversion.DATETIME_MS),
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_conversion_raises_on_out_of_range_date():
+    # Legacy mode raises on out-of-range dates.
+    async with create_mongo_source(datetime_conversion="DATETIME") as source:
+        with source.get_client() as client:
+            codec = client.codec_options
+        with pytest.raises(InvalidBSON):
+            bson.decode(_encode_out_of_range_date(), codec_options=codec)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "conversion, expected",
+    [
+        # Clamp -> ISO string
+        ("DATETIME_CLAMP", "9999-12-31T23:59:59.999000"),
+        # Auto/MS -> raw ms
+        ("DATETIME_AUTO", 2**62),
+        ("DATETIME_MS", 2**62),
+    ],
+)
+async def test_out_of_range_date_conversion_and_serialization(conversion, expected):
+    # Non-legacy modes let the sync continue.
+    async with create_mongo_source(datetime_conversion=conversion) as source:
+        with source.get_client() as client:
+            codec = client.codec_options
+
+        decoded = bson.decode(_encode_out_of_range_date(), codec_options=codec)
+        serialized = source.serialize(dict(decoded))
+
+        assert serialized["date"] == expected
+
+
+@pytest.mark.asyncio
+async def test_validate_config_rejects_unknown_datetime_conversion():
+    async with create_mongo_source(datetime_conversion="NOT_A_REAL_OPTION") as source:
+        with pytest.raises(ConfigurableFieldValueError) as e:
+            await source.validate_config()
+        assert e.match("NOT_A_REAL_OPTION")
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/test_connectors_cli.py
+++ b/app/connectors_service/tests/test_connectors_cli.py
@@ -384,6 +384,7 @@ def test_connector_create_from_file():
                             "collection": "test",
                             "direct_connection": False,
                             "ssl_enabled": False,
+                            "datetime_conversion": "DATETIME",
                         }
                     )
                 )


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [MongoDB] Handle out-of-range BSON datetimes to prevent sync failures (#4148)

Manual backport: the original PR was labeled for `8.19`, `9.4`, `9.5`, `9.6` but not `9.3`, so the automatic backport never ran for this branch. 9.3 is still receiving patch releases (9.3.8), so this bug fix belongs here too. Cherry-picked cleanly from `62aa206` (`git cherry-pick -x`).

Made with [Cursor](https://cursor.com)