### PR TITLE
[9.3] Fix Slack connector float timestamp causing messages to be deleted on scheduled syncs (#3032) (#3997)

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -7576,7 +7576,7 @@ SOFTWARE.
 
 
 stone
-3.5.1
+3.5.2
 MIT
 Copyright (c) 2020 Dropbox Inc., http://www.dropbox.com/
 

--- a/app/connectors_service/connectors/sources/slack/datasource.py
+++ b/app/connectors_service/connectors/sources/slack/datasource.py
@@ -95,8 +95,10 @@ class SlackDataSource(BaseDataSource):
             yield message, None
 
     async def channels_and_messages(self):
-        current_unix_timestamp = time.time()
-        past_unix_timestamp = current_unix_timestamp - self.n_days_to_fetch * 24 * 3600
+        current_unix_timestamp = int(time.time())
+        past_unix_timestamp = int(
+            current_unix_timestamp - self.n_days_to_fetch * 24 * 3600
+        )
         async for channel in self.slack_client.list_channels(
             not self.auto_join_channels
         ):

--- a/app/connectors_service/tests/sources/test_slack.py
+++ b/app/connectors_service/tests/sources/test_slack.py
@@ -207,9 +207,10 @@ async def test_slack_data_source_get_docs(slack_data_source, mock_responses):
 
     current_timestamp = time.time()
     with mock.patch("time.time", return_value=current_timestamp):
-        old_timestamp = (
+        old_timestamp = int(
             current_timestamp - configuration["fetch_last_n_days"] * 24 * 3600
         )
+        current_timestamp = int(current_timestamp)
         docs = []
         async for doc, _ in slack_data_source.get_docs():
             docs.append(doc)
@@ -233,3 +234,38 @@ async def test_slack_data_source_convert_usernames(slack_data_source):
     remapped_message = slack_data_source.remap_message(message, channel)
 
     assert remapped_message["text"] == "<@user_one> Hello, <@USERID2>"
+
+
+@pytest.mark.asyncio
+async def test_channels_and_messages_uses_integer_timestamps(slack_data_source):
+    """
+    Regression test for #3032
+    Slack conversations.history API returns no messages when timestamps
+    include decimal places. Verify timestamps are truncated to int.
+    """
+    original_client = slack_data_source.slack_client
+    await original_client.close()
+
+    mock_client = AsyncMock()
+    mock_client.list_channels = AsyncIterator(
+        [{"id": "1", "name": "channel1", "is_member": True}]
+    )
+    mock_client.list_messages = AsyncIterator([])
+    mock_client.close = AsyncMock()
+    slack_data_source.slack_client = mock_client
+
+    float_timestamp = 1745123456.561659
+    with mock.patch("time.time", return_value=float_timestamp):
+        async for _ in slack_data_source.channels_and_messages():
+            pass
+
+        call_args = mock_client.list_messages.call_args
+        oldest = call_args[0][1]
+        latest = call_args[0][2]
+
+        assert isinstance(
+            oldest, int
+        ), f"oldest timestamp should be int, got {type(oldest)}"
+        assert isinstance(
+            latest, int
+        ), f"latest timestamp should be int, got {type(latest)}"


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix Slack connector float timestamp causing messages to be deleted on scheduled syncs (#3032) (#3997)

Manual backport: the original PR (#3997) was labeled `v9.5.0` only, so it never auto-backported to 9.3. This is a data-loss bug (scheduled Slack syncs delete all previously indexed messages), and 9.3 is still receiving patch releases (9.3.8), so the fix belongs here. Cherry-picked with `-x` from `fac84d2`; the only conflicts were unrelated `NOTICE.txt` dependency-version lines (`yarl`), resolved in favor of the 9.3 branch's pinned versions.

Note: this fix is also missing from **9.4** (also `v9.5.0`-only) — worth a separate backport / team confirmation.

Made with [Cursor](https://cursor.com)