### PR TITLE
[8.19] Add .gitignore protection against locally-created credential files (#4159)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,12 @@ config.yml
 .venv
 **/venv
 scripts/stack/connectors-config
+
+# Local secrets and credentials -- never commit these
+.env
+.env.*
+*.pem
+*.key
+*credentials*
+*secret*
+kubeconfig


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Add .gitignore protection against locally-created credential files (#4159)

The automatic backport failed because of conflicts. This is a manual backport limited to the `.gitignore` changes; the `NOTICE.txt` updates from the original PR do not apply to the 8.19 branch layout.

## Test plan
- No functional change — `.gitignore` only affects untracked files going forward

Made with [Cursor](https://cursor.com)