### PR TITLE
fix(deps): bump lxml to 6.1.0 for CVE-2026-41066

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -5393,8 +5393,10 @@ permanent authorization for you to choose that version for the
 Library.
 
 lxml
-4.9.3
-BSD License
+6.1.0
+BSD-3-Clause
+BSD 3-Clause License
+
 Copyright (c) 2004 Infrae. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -5403,7 +5405,7 @@ met:
 
   1. Redistributions of source code must retain the above copyright
      notice, this list of conditions and the following disclaimer.
-   
+
   2. Redistributions in binary form must reproduce the above copyright
      notice, this list of conditions and the following disclaimer in
      the documentation and/or other materials provided with the

--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "httpx-ntlm==1.4.0",
     "httpx==0.27.0",
     "ldap3==2.9.1",
-    "lxml==4.9.3",
+    "lxml==6.1.0",
     "msal==1.30.0",
     "notion-client==2.2.1",
     "oracledb==2.3.0",


### PR DESCRIPTION
Closes https://github.com/elastic/security/issues/12517

Bump `lxml` from `4.9.3` to `6.1.0` to clear CVE-2026-41066 (GHSA-vfmq-68hx-4jfw) from SBOM/Mend findings. The advisory covers XXE via `iterparse()` / `ETCompatXMLParser()`; connectors only uses lxml as the BeautifulSoup HTML backend in `html_to_text()` and does not call those APIs (Not Affected), but the bump is still warranted to clear the scanner finding.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

### Scanner A/B (`CVE-2026-41066`)

| Tool | Before | After |
|------|--------|-------|
| pip-audit | reported | clear |
| Trivy | reported | clear |
| Snyk | reported | clear |

## Release Note

Bump lxml to 6.1.0 to address CVE-2026-41066.

Made with [Cursor](https://cursor.com)