### PR TITLE
test(google): mock Aiogoogle.discover to stop flaky fail-slow failures

### DIFF
--- a/app/connectors_service/tests/sources/test_google_cloud_storage.py
+++ b/app/connectors_service/tests/sources/test_google_cloud_storage.py
@@ -26,13 +26,18 @@ API_VERSION = "v1"
 
 @asynccontextmanager
 async def create_gcs_source(use_text_extraction_service=False):
-    async with create_source(
-        GoogleCloudStorageDataSource,
-        service_account_credentials=SERVICE_ACCOUNT_CREDENTIALS,
-        retry_count=0,
-        use_text_extraction_service=use_text_extraction_service,
-    ) as source:
-        yield source
+    # Avoid real HTTP to Google's Discovery Service (Aiogoogle.discover).
+    with mock.patch.object(
+        Aiogoogle, "discover", new_callable=mock.AsyncMock
+    ) as mock_discover:
+        mock_discover.return_value = mock.MagicMock()
+        async with create_source(
+            GoogleCloudStorageDataSource,
+            service_account_credentials=SERVICE_ACCOUNT_CREDENTIALS,
+            retry_count=0,
+            use_text_extraction_service=use_text_extraction_service,
+        ) as source:
+            yield source
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/sources/test_google_drive.py
+++ b/app/connectors_service/tests/sources/test_google_drive.py
@@ -38,13 +38,18 @@ MORE_THAN_DEFAULT_FILE_SIZE_LIMIT = 10485760 + 1
 
 @asynccontextmanager
 async def create_gdrive_source(**kwargs):
-    async with create_source(
-        GoogleDriveDataSource,
-        service_account_credentials=SERVICE_ACCOUNT_CREDENTIALS,
-        use_document_level_security=False,
-        **kwargs,
-    ) as source:
-        yield source
+    # Avoid real HTTP to Google's Discovery Service (Aiogoogle.discover).
+    with mock.patch.object(
+        Aiogoogle, "discover", new_callable=mock.AsyncMock
+    ) as mock_discover:
+        mock_discover.return_value = mock.MagicMock()
+        async with create_source(
+            GoogleDriveDataSource,
+            service_account_credentials=SERVICE_ACCOUNT_CREDENTIALS,
+            use_document_level_security=False,
+            **kwargs,
+        ) as source:
+            yield source
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

GCS and Drive unit tests mocked `Aiogoogle.as_service_account` but not `Aiogoogle.discover()`. Production paths still call `discover()`, which downloads Google's Discovery document over HTTP (~0.5s+ per call). On slower hosts (e.g. WSL) that pushed several tests over the default 1s `pytest-fail-slow` threshold even though assertions passed.

Mock `discover` in the shared `create_gcs_source` / `create_gdrive_source` fixtures (same pattern as `test_google.py`). Tests that intentionally patch `discover` with a `side_effect` still override the fixture mock.

### Local verification

Previously flaky tests (call phase was 1.1–1.7s):

| Suite | Result |
|-------|--------|
| 8 previously flaky tests, `--fail-slow=0.5` | 8 passed; call times ~0.01s |
| Full GCS + Drive (74 tests), `--fail-slow=0.25` | 74 passed in 0.62s; slowest call 0.05s |

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in Kibana

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Release Note

N/A — test-only change.

Made with [Cursor](https://cursor.com)