### PR TITLE
[8.19] fix(deps): pin PyJWT to 2.13.0 for CVE-2026-48526 (#4183)

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -10,6 +10,7 @@ cffi==1.16.0
 envyaml==1.10.211231
 ecs-logging==2.0.0
 pympler==1.0.1
+PyJWT==2.13.0
 cron-schedule-triggers==0.0.11
 tzcron==1.0.0
 pytz==2019.3


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): pin PyJWT to 2.13.0 for CVE-2026-48526 (#4183)

Made with [Cursor](https://cursor.com)