### PR TITLE
[8.19] fix(deps): bump lxml to 6.1.0 for CVE-2026-41066 (#4179)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5350,8 +5350,10 @@ permanent authorization for you to choose that version for the
 Library.
 
 lxml
-4.9.3
-BSD License
+6.1.0
+BSD-3-Clause
+BSD 3-Clause License
+
 Copyright (c) 2004 Infrae. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -5360,7 +5362,7 @@ met:
 
   1. Redistributions of source code must retain the above copyright
      notice, this list of conditions and the following disclaimer.
-   
+
   2. Redistributions in binary form must reproduce the above copyright
      notice, this list of conditions and the following disclaimer in
      the documentation and/or other materials provided with the

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -32,7 +32,7 @@ wcmatch==8.4.1
 msal==1.30.0
 exchangelib==5.4.0
 ldap3==2.9.1
-lxml==4.9.3
+lxml==6.1.0
 pywinrm==0.4.3
 click==8.1.7
 colorama==0.4.6


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump lxml to 6.1.0 for CVE-2026-41066 (#4179)

Made with [Cursor](https://cursor.com)