### PR TITLE
fix(deps): bump aiohttp to 3.13.3 for CVE-2025-69223

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1262,8 +1262,8 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 aiohttp
-3.12.14
-Apache-2.0
+3.13.3
+Apache-2.0 AND MIT
    Copyright aio-libs contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "aioboto3==12.4.0",
     "aiofiles==23.2.1",
     "aiogoogle==5.3.0",
-    "aiohttp==3.12.14",
+    "aiohttp==3.13.3",
     "aiomysql==0.3.0",
     "asyncpg==0.29.0",
     "azure-identity==1.19.0",

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -490,8 +490,8 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 aiohttp
-3.12.14
-Apache-2.0
+3.13.3
+Apache-2.0 AND MIT
    Copyright aio-libs contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/libs/connectors_sdk/pyproject.toml
+++ b/libs/connectors_sdk/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.10,<3.12"
 dependencies = [
     "aiofiles==23.2.1",
-    "aiohttp==3.12.14",
+    "aiohttp==3.13.3",
     "base64io==1.0.3",
     "fastjsonschema==2.16.2",
     "ecs-logging==2.0.0",


### PR DESCRIPTION
## Closes https://github.com/elastic/security/issues/12492

Bump `aiohttp` from 3.12.14 to 3.13.3 to address CVE-2025-69223 (zip-bomb DoS via HTTP parser `auto_decompress` on the aiohttp server). Connectors uses aiohttp as an HTTP client only and is not affected by the server-side attack path; the bump clears the CVE from scanners and keeps the dependency current.

### Scanner A/B (`CVE-2025-69223`)

| Tool | Before | After |
|------|--------|-------|
| pip-audit | reported | clear |
| Trivy | reported | clear |
| Snyk | reported | clear |

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)

## Release Note

Bump aiohttp to 3.13.3 to address CVE-2025-69223.

Made with [Cursor](https://cursor.com)