### PR TITLE
[8.19] fix(deps): pin urllib3 to 2.7.0 for CVE-2026-9375 (#4193)

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -46,3 +46,4 @@ aioboto3==12.4.0
 pyasn1<0.6.1
 azure-identity==1.19.0
 requests==2.32.4
+urllib3==2.7.0


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): pin urllib3 to 2.7.0 for CVE-2026-9375 (#4193)

Made with [Cursor](https://cursor.com)