### PR TITLE
[8.19] fix(deps): bump pyOpenSSL to 26.0.0 for CVE-2026-27459 (#4203)

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -25,11 +25,11 @@ oracledb==2.3.0
 asyncpg==0.29.0
 python-tds==1.15.0
 sqlalchemy-pytds==0.3.5
-pyOpenSSL==24.3.0
+pyOpenSSL==26.0.0
 beautifulsoup4==4.12.2
 gidgethub==5.2.1
 wcmatch==8.4.1
-msal==1.30.0
+msal==1.32.3
 exchangelib==5.4.0
 ldap3==2.9.1
 lxml==6.1.0


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump pyOpenSSL to 26.0.0 for CVE-2026-27459 (#4203)

Made with [Cursor](https://cursor.com)