### PR TITLE
[8.19] fix(deps): bump pyasn1 to 0.6.4 for CVE-2026-30922 (#4197)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,8 @@ filterwarnings =
   ignore::pytest.PytestUnraisableExceptionWarning
 ; this error comes from 8.16 Elasticsearch client: we use some non-GA features in our CI code
   ignore::elasticsearch.exceptions.GeneralAvailabilityWarning
+; ldap3 2.9.1 (last release, unmaintained) imports the deprecated pyasn1 tagMap/typeMap aliases,
+; renamed to TAG_MAP/TYPE_MAP in pyasn1 0.6.1+. The aliases still work; the warning is benign.
+; Needed to allow pyasn1>=0.6.4 (CVE-2026-30922 fix).
+  ignore:tagMap is deprecated:DeprecationWarning
+  ignore:typeMap is deprecated:DeprecationWarning

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -43,6 +43,6 @@ graphql-core==3.2.3
 notion-client==2.2.1
 certifi==2024.7.4
 aioboto3==12.4.0
-pyasn1<0.6.1
+pyasn1==0.6.4
 azure-identity==1.19.0
 requests==2.32.4


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump pyasn1 to 0.6.4 for CVE-2026-30922 (#4197)

Made with [Cursor](https://cursor.com)