### PR TITLE
[8.19] fix(deps): bump aiohttp to 3.13.3 for CVE-2025-69223 (#4210)

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,4 +1,4 @@
-aiohttp==3.11.10
+aiohttp==3.13.3
 aiofiles==23.2.1
 aiomysql==0.3.0
 httpx==0.27.0


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump aiohttp to 3.13.3 for CVE-2025-69223 (#4210)

Made with [Cursor](https://cursor.com)