### PR TITLE
[8.19] fix(deps): bump elastic-agent-client to 0.0.2 and pin protobuf to 5.29.6 for CVE-2026-0994 (#4217)

### DIFF
--- a/requirements/agent.txt
+++ b/requirements/agent.txt
@@ -1,1 +1,2 @@
-elastic-agent-client==0.0.1.dev1
+elastic-agent-client==0.0.2
+protobuf==5.29.6


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump elastic-agent-client to 0.0.2 and pin protobuf to 5.29.6 for CVE-2026-0994 (#4217)

Made with [Cursor](https://cursor.com)