### PR TITLE
[8.19] fix(deps): bump click to 8.3.3 for CVE-2026-7246 (#4189)

### DIFF
--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -111,10 +111,13 @@ cli.add_command(login)
 
 
 # Connector group
-@click.group(invoke_without_command=False, help="Connectors management")
+# invoke_without_command + manual help keeps exit code 0 on bare `connector`
+# (Click 8.2+ no_args_is_help would exit 2).
+@click.group(invoke_without_command=True, help="Connectors management")
 @click.pass_context
 def connector(ctx):
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @click.command(name="list", help="List all existing connectors")
@@ -384,10 +387,11 @@ cli.add_command(connector)
 
 
 # Index group
-@click.group(invoke_without_command=False, help="Search indices management")
-@click.pass_obj
-def index(obj):
-    pass
+@click.group(invoke_without_command=True, help="Search indices management")
+@click.pass_context
+def index(ctx):
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @click.command(name="list", help="Show all indices")
@@ -470,10 +474,11 @@ cli.add_command(index)
 
 
 # Job group
-@click.group(invoke_without_command=False, help="Sync jobs management")
-@click.pass_obj
-def job(obj):
-    pass
+@click.group(invoke_without_command=True, help="Sync jobs management")
+@click.pass_context
+def job(ctx):
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @click.command(help="Start a sync job.")

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -34,7 +34,7 @@ exchangelib==5.4.0
 ldap3==2.9.1
 lxml==6.1.0
 pywinrm==0.4.3
-click==8.1.7
+click==8.3.3
 colorama==0.4.6
 tabulate==0.9.0
 redis==5.0.1

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -42,6 +42,44 @@ def mock_job_es_client():
         yield mock
 
 
+# Click 8.2+ no longer falls back to prompt defaults on EOF, so every
+# interactive `connector create` prompt must receive an explicit line. Prompt
+# order: index name, index language, connector name, then the MongoDB service
+# configuration fields (ssl_ca/tls_insecure are only prompted when ssl_enabled
+# is True).
+def _mongodb_create_input(
+    index_name="test_connector",
+    language="en",
+    connector_name="test-connector-name",
+    host="http://localhost/",
+    user="username",
+    password="password",
+    database="database",
+    collection="collection",
+    direct_connection="False",
+    ssl_enabled="False",
+    datetime_conversion="DATETIME",
+):
+    return (
+        "\n".join(
+            [
+                index_name,
+                language,
+                connector_name,
+                host,
+                user,
+                password,
+                database,
+                collection,
+                direct_connection,
+                ssl_enabled,
+                datetime_conversion,
+            ]
+        )
+        + "\n"
+    )
+
+
 @pytest.mark.parametrize("commands", [["-v"], ["--version"]])
 def test_version(commands):
     runner = CliRunner()
@@ -56,6 +94,17 @@ def test_help_page(commands):
     result = runner.invoke(cli, commands)
     assert "Usage:" in result.output
     assert "Options:" in result.output
+    assert "Commands:" in result.output
+
+
+@pytest.mark.parametrize("group", ["connector", "index", "job"])
+def test_group_help_without_subcommands(group):
+    runner = CliRunner()
+    result = runner.invoke(cli, [group])
+    # Groups mirror the root CLI: print help and exit 0 (not the Click 8.2+
+    # no_args_is_help exit code 2).
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
     assert "Commands:" in result.output
 
 
@@ -172,19 +221,7 @@ def test_connector_list_one_connector():
 def test_connector_create(patch_click_confirm):
     runner = CliRunner()
 
-    # configuration for the MongoDB connector
-    input_params = "\n".join(
-        [
-            "test_connector",
-            "en",
-            "http://localhost/",
-            "username",
-            "password",
-            "database",
-            "collection",
-            "False",
-        ]
-    )
+    input_params = _mongodb_create_input()
 
     with patch(
         "connectors.protocol.connectors.ConnectorIndex.index",
@@ -221,19 +258,7 @@ def test_connector_create_with_native_flags(
 ):
     runner = CliRunner()
 
-    # configuration for the MongoDB connector
-    input_params = "\n".join(
-        [
-            input_index_name,
-            "en",
-            "http://localhost/",
-            "username",
-            "password",
-            "database",
-            "collection",
-            "False",
-        ]
-    )
+    input_params = _mongodb_create_input(index_name=input_index_name)
 
     with patch(
         "connectors.protocol.connectors.ConnectorIndex.index",
@@ -264,19 +289,7 @@ def test_connector_create_with_native_flags(
 def test_connector_create_from_index(patch_click_confirm):
     runner = CliRunner()
 
-    # configuration for the MongoDB connector
-    input_params = "\n".join(
-        [
-            "test-connector",
-            "en",
-            "http://localhost/",
-            "username",
-            "password",
-            "database",
-            "collection",
-            "False",
-        ]
-    )
+    input_params = _mongodb_create_input(index_name="test-connector")
 
     with patch(
         "connectors.protocol.connectors.ConnectorIndex.index",
@@ -420,19 +433,7 @@ def test_connector_create_and_update_the_service_config():
     connector_id = "new_connector_id"
     service_type = "mongodb"
 
-    # configuration for the MongoDB connector
-    input_params = "\n".join(
-        [
-            "test_connector",
-            "en",
-            "http://localhost/",
-            "username",
-            "password",
-            "database",
-            "collection",
-            "False",
-        ]
-    )
+    input_params = _mongodb_create_input()
 
     with patch(
         "connectors.protocol.connectors.ConnectorIndex.index",
@@ -476,19 +477,7 @@ def test_connector_create_and_update_the_service_config():
 def test_connector_create_native_connector(patched_confirm):
     runner = CliRunner()
 
-    # configuration for the MongoDB connector
-    input_params = "\n".join(
-        [
-            "test-connector",
-            "en",
-            "http://localhost/",
-            "username",
-            "password",
-            "database",
-            "collection",
-            "False",
-        ]
-    )
+    input_params = _mongodb_create_input(index_name="test-connector")
 
     with patch(
         "connectors.cli.connector.Connector._Connector__create_api_key",


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump click to 8.3.3 for CVE-2026-7246 (#4189)

The 8.19 branch uses `requirements/framework.txt` (not the `main` layout), so the pin was applied there. The Click 8.2+ behavior changes from the original PR were ported to the 8.19 CLI: the `connector`/`index`/`job` groups now use `invoke_without_command` + manual help (bare invocation stays exit 0 instead of Click 8.2+ `no_args_is_help` exit 2), and the `connector create` tests were updated to feed explicit values for every prompt (Click 8.2+ no longer applies prompt defaults on EOF).

Validated locally on Python 3.11: `tests/test_connectors_cli.py` passes (44 passed) with `click==8.3.3`, and `ruff check`/`ruff format --check` are clean.

Made with [Cursor](https://cursor.com)