### PR TITLE
fix(deps): bump aiohttp to 3.14.1

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1262,9 +1262,197 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 aiohttp
-3.13.3
+3.14.1
 Apache-2.0 AND MIT
-   Copyright aio-libs contributors.
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright aio-libs contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -2523,7 +2711,7 @@ Apache Software License
 
 
 bracex
-3.0
+3.0.1
 MIT
 MIT License
 

--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "aioboto3==12.4.0",
     "aiofiles==23.2.1",
     "aiogoogle==5.3.0",
-    "aiohttp==3.13.3",
+    "aiohttp==3.14.1",
     "aiomysql==0.3.0",
     "asyncpg==0.29.0",
     "azure-identity==1.19.0",
@@ -138,6 +138,10 @@ filterwarnings = [
     "ignore:.*pkg_resources.*:DeprecationWarning",
     # SQLAlchemy uses deprecated APIs internally
     "ignore:.*dbapi().*:DeprecationWarning",
+    # aiohttp 3.14 deprecates BasicAuth in favor of encode_basic_auth(); the helper
+    # still works and is used by several source clients. Benign until aiohttp 4.0.
+    "ignore:BasicAuth is deprecated:DeprecationWarning",
+    "ignore:The 'auth' parameter is deprecated:DeprecationWarning",
     # aiogoogle inherits on top of AioHttpSession, which is not recommended by aiohttp
     "ignore:Inheritance class AiohttpSession from ClientSession is discouraged:DeprecationWarning",
     # aiogoogle inherits on top of RetryableAioHttpSession, which is not recommended by aiohttp

--- a/app/connectors_service/tests/conftest.py
+++ b/app/connectors_service/tests/conftest.py
@@ -4,16 +4,29 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
+import inspect
 import io
 import os
 import re
 import sys
 import traceback
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import pytest_asyncio
+from aiohttp.client_reqrep import ClientResponse
 from aioresponses import aioresponses
+
+# aiohttp 3.14 made `stream_writer` a required kwarg of ClientResponse.__init__ that aioresponses omits.
+# Inject a no-op when absent; inert on aiohttp <3.14. See aio-libs/aiohttp#12815, pnuckowski/aioresponses#289.
+if "stream_writer" in inspect.signature(ClientResponse.__init__).parameters:
+    _orig_client_response_init = ClientResponse.__init__
+
+    def _patched_client_response_init(self, *args, **kwargs):
+        kwargs.setdefault("stream_writer", Mock(output_size=0))
+        _orig_client_response_init(self, *args, **kwargs)
+
+    ClientResponse.__init__ = _patched_client_response_init
 
 
 class Logger:

--- a/libs/connectors_sdk/NOTICE.txt
+++ b/libs/connectors_sdk/NOTICE.txt
@@ -490,9 +490,197 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 aiohttp
-3.13.3
+3.14.1
 Apache-2.0 AND MIT
-   Copyright aio-libs contributors.
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright aio-libs contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/libs/connectors_sdk/pyproject.toml
+++ b/libs/connectors_sdk/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.10,<3.12"
 dependencies = [
     "aiofiles==23.2.1",
-    "aiohttp==3.13.3",
+    "aiohttp==3.14.1",
     "base64io==1.0.3",
     "fastjsonschema==2.16.2",
     "ecs-logging==2.0.0",

--- a/libs/connectors_sdk/tests/conftest.py
+++ b/libs/connectors_sdk/tests/conftest.py
@@ -4,10 +4,24 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 
+import inspect
 import traceback
+from unittest.mock import Mock
 
 import pytest
+from aiohttp.client_reqrep import ClientResponse
 from aioresponses import aioresponses
+
+# aiohttp 3.14 made `stream_writer` a required kwarg of ClientResponse.__init__ that aioresponses omits.
+# Inject a no-op when absent; inert on aiohttp <3.14. See aio-libs/aiohttp#12815, pnuckowski/aioresponses#289.
+if "stream_writer" in inspect.signature(ClientResponse.__init__).parameters:
+    _orig_client_response_init = ClientResponse.__init__
+
+    def _patched_client_response_init(self, *args, **kwargs):
+        kwargs.setdefault("stream_writer", Mock(output_size=0))
+        _orig_client_response_init(self, *args, **kwargs)
+
+    ClientResponse.__init__ = _patched_client_response_init
 
 
 class Logger:


### PR DESCRIPTION
## Part of https://github.com/elastic/security/issues/12526

Bumps `aiohttp` `3.13.3` → `3.14.1` in both `app/connectors_service` and `libs/connectors_sdk`. This single bump remediates **21** `aiohttp` CVEs currently reported against the `main` pin (`3.13.3`) — every CVE fixed in aiohttp `3.13.4`, `3.14.0`, and `3.14.1`. The full list (with tracking issues) is in the Scanner A/B section below.

connectors uses `aiohttp` only as an HTTP **client** (`aiohttp.ClientSession`) and never runs an aiohttp web server, so the server-side CVEs in this set are **Not Affected** in practice. The bump is applied proactively to clear the advisories and keep the dependency current.

### aiohttp 3.14 test compatibility (no runtime change)

aiohttp 3.14 added a required `stream_writer` argument to `ClientResponse` (which breaks `aioresponses`, which has no released fix) and deprecated `BasicAuth` / the `auth=` parameter. To keep the suite green with **no runtime behavior change**:

- A self-gating `aioresponses` shim in both test `conftest.py` files — injects a no-op `stream_writer` when the caller omits it; inert on aiohttp `<3.14` and once `aioresponses` ships a fix.
- Two benign deprecation warnings (`BasicAuth`, `auth=`) added to `filterwarnings`, consistent with the existing third-party deprecation ignores in this repo.

The `auth=` / `BasicAuth` → `encode_basic_auth()` migration is deferred to a follow-up before aiohttp 4.0.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)

## Scanner A/B (aiohttp `3.13.3` → `3.14.1`)

Before = `aiohttp==3.13.3` (current `main` pin) · After = `aiohttp==3.14.1` (this PR). `pip-audit`, `Trivy`, and `Snyk` were each run against both pins.

| Tool | Before (`3.13.3`) | After (`3.14.1`) |
|------|-------------------|------------------|
| pip-audit | 21 reported | 0 — clear |
| Trivy | 21 reported | 0 — clear |
| Snyk | 21 reported | 0 — clear |

All **21** CVEs / issues remediated by this PR — reported on `3.13.3` by all three tools, clear on `3.14.1`:

| CVE | Issue | Fixed in aiohttp | Before | After |
|-----|-------|------------------|--------|-------|
| CVE-2026-22815 | elastic/security#12501 | 3.13.4 | reported | clear |
| CVE-2026-34513 | elastic/security#12507 | 3.13.4 | reported | clear |
| CVE-2026-34514 | elastic/security#12508 | 3.13.4 | reported | clear |
| CVE-2026-34515 | elastic/security#12509 | 3.13.4 | reported | clear |
| CVE-2026-34516 | elastic/security#12510 | 3.13.4 | reported | clear |
| CVE-2026-34517 | elastic/security#12511 | 3.13.4 | reported | clear |
| CVE-2026-34518 | elastic/security#12512 | 3.13.4 | reported | clear |
| CVE-2026-34519 | elastic/security#12513 | 3.13.4 | reported | clear |
| CVE-2026-34520 | elastic/security#12514 | 3.13.4 | reported | clear |
| CVE-2026-34525 | elastic/security#12515 | 3.13.4 | reported | clear |
| CVE-2026-34993 | elastic/security#12516 | 3.14.0 | reported | clear |
| CVE-2026-47265 | elastic/security#12519 | 3.14.0 | reported | clear |
| CVE-2026-50269 | elastic/security#12537 | 3.14.0 | reported | clear |
| CVE-2026-54273 | elastic/security#12526 | 3.14.1 | reported | clear |
| CVE-2026-54274 | elastic/security#12527 | 3.14.1 | reported | clear |
| CVE-2026-54275 | elastic/security#12528 | 3.14.1 | reported | clear |
| CVE-2026-54276 | elastic/security#12529 | 3.14.1 | reported | clear |
| CVE-2026-54277 | elastic/security#12530 | 3.14.1 | reported | clear |
| CVE-2026-54278 | elastic/security#12531 | 3.14.1 | reported | clear |
| CVE-2026-54279 | elastic/security#12532 | 3.14.1 | reported | clear |
| CVE-2026-54280 | elastic/security#12533 | 3.14.1 | reported | clear |

<sub>The 8 CVEs fixed in aiohttp `3.13.3` (`CVE-2025-69223`…`CVE-2025-69230`, elastic/security#12492–#12499) are already remediated on `main` and are out of scope for this PR.</sub>

## Release Note

Bump `aiohttp` to `3.14.1` to remediate 21 reported CVEs.
