### PR TITLE
fix(deps): bump cffi to 2.0.0 to unblock cryptography 46.0.7 (CVE-2026-34073, CVE-2026-26007)

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2523,7 +2523,7 @@ Apache Software License
 
 
 bracex
-3.0
+3.0.1
 MIT
 MIT License
 
@@ -2616,14 +2616,14 @@ one at http://mozilla.org/MPL/2.0/.
 
 
 cffi
-1.16.0
-MIT License
+2.0.0
+MIT
 
 Except when otherwise stated (look for LICENSE files in directories or
 information at the beginning of each file) all software and
 documentation is licensed as follows: 
 
-    The MIT License
+    MIT No Attribution
 
     Permission is hereby granted, free of charge, to any person 
     obtaining a copy of this software and associated documentation 
@@ -2631,10 +2631,7 @@ documentation is licensed as follows:
     restriction, including without limitation the rights to use, 
     copy, modify, merge, publish, distribute, sublicense, and/or 
     sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included 
-    in all copies or substantial portions of the Software.
+    Software is furnished to do so.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
     OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
@@ -2761,7 +2758,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 cryptography
-46.0.0
+46.0.7
 Apache-2.0 OR BSD-3-Clause
 This software is made available under the terms of *either* of the licenses
 found in LICENSE.APACHE or LICENSE.BSD. Contributions to cryptography are made

--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "azure-storage-blob==12.19.1",
     "beautifulsoup4==4.12.2",
     "certifi==2024.7.4",
-    "cffi==1.16.0",
+    "cffi==2.0.0",
     "click==8.3.3",
     "colorama==0.4.6",
     "cron-schedule-triggers==0.0.11",


### PR DESCRIPTION
## Part of https://github.com/elastic/security/issues/12506
## Part of https://github.com/elastic/security/issues/12502

`cryptography` is a transitive dependency (pulled by `pyOpenSSL`, `msal`, `azure-*`, `google-auth`, `oracledb`, `pyspnego`, `requests-ntlm`, `smbprotocol`). PR #4203 raised its floor by bumping `pyOpenSSL` 26.0.0 + `msal` 1.32.3, but in the **full** connectors dependency set the direct pin `cffi==1.16.0` capped `cryptography` at **46.0.0** — because `cryptography` 46.0.5+ require `cffi>=2.0.0` on Python 3.9+.

As a result, on `main`:
- **CVE-2026-26007** (fixed in 46.0.5) — still present
- **CVE-2026-34073** (fixed in 46.0.6) — still present
- **CVE-2026-39892** (fixed in 46.0.7) — still present

This PR bumps `cffi` 1.16.0 → **2.0.0**, which lets `cryptography` resolve to **46.0.7** (the ceiling under `pyOpenSSL<47`), clearing all three. `NOTICE.txt` regenerated accordingly.

Connectors is **Not Affected** by these CVEs (it never imports `cryptography` or calls its X.509 verification / EC key-loading APIs; TLS is delegated to OpenSSL/system trust), but the pin is corrected for scanner/SBOM hygiene.

> Note: `cffi` 2.0.0 is a major-version bump. Full `make clean install autoformat lint test` passes locally (2292 tests, 92.18% coverage).

> Out of scope: `CVE-2026-34180` / `GHSA-537c-gmf6-5ccf` remain (Snyk/Trivy), fixed only in `cryptography` 48.0.1, which `pyOpenSSL<47` blocks; pre-existing, no regression.

### Scanner A/B (`CVE-2026-34073`)

Before = `origin/main` (`cryptography==46.0.0`), After = this PR (`cryptography==46.0.7`).

| Tool | Before | After |
|------|--------|-------|
| pip-audit | reported | clear |
| Trivy | reported | clear |
| Snyk | reported | clear |

### Scanner A/B (`CVE-2026-26007`)

| Tool | Before | After |
|------|--------|-------|
| pip-audit | reported | clear |
| Trivy | reported | clear |
| Snyk | reported | clear |

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)

## Release Note

Bump `cffi` to 2.0.0 so `cryptography` resolves to 46.0.7, addressing CVE-2026-34073, CVE-2026-26007, and CVE-2026-39892.

Made with [Cursor](https://cursor.com)