### PR TITLE
fix(deps): pin idna to 3.18 for CVE-2026-45409

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -2523,7 +2523,7 @@ Apache Software License
 
 
 bracex
-3.0
+3.0.1
 MIT
 MIT License
 

--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "graphql-core==3.2.3",
     "httpx-ntlm==1.4.0",
     "httpx==0.27.0",
+    "idna==3.18",
     "ldap3==2.9.1",
     "lxml==6.1.0",
     "msal==1.32.3",

--- a/libs/connectors_sdk/pyproject.toml
+++ b/libs/connectors_sdk/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "aiohttp==3.13.3",
     "base64io==1.0.3",
     "fastjsonschema==2.16.2",
+    "idna==3.18",
     "ecs-logging==2.0.0",
 ]
 


### PR DESCRIPTION
Part of https://github.com/elastic/security/issues/12518

## Description

`idna` is a **transitive** dependency (pulled in via `requests` / `httpx` / `aiohttp`→`yarl`) that was previously **unpinned**. Because connectors installs with a plain `pip install -e .` (no lockfile / constraints), each release build froze whatever `idna` was latest on PyPI at build time. The shipped **9.4.0 / 9.4.2** images therefore baked in the vulnerable `idna 3.13` (built before the fix `3.15` existed on 2026-05-12), which is what the customer SBOM audit flagged.

`main` currently *happens* to resolve to `idna 3.18` (safe), but only because that is the current PyPI latest — there is no guarantee, and backport/patch rebuilds of the still-supported lines could again freeze an older version. This PR pins `idna==3.18` (>= the fixed `3.15`) in both `app/connectors_service/pyproject.toml` and `libs/connectors_sdk/pyproject.toml` so the fix is **deterministic and auditable** on `main` and every backported line (9.5, 9.4, 9.3, 8.19).

**CVE-2026-45409** (CWE-1333, Medium, CVSS v3 5.3 / v4 6.9): specially crafted inputs to `idna.encode()` reach `valid_contexto` before length rejection, causing excessive CPU (ReDoS/DoS). Incomplete-fix follow-up to CVE-2024-3651; fully fixed in `idna 3.15`.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally (`make clean install autoformat lint test` — 2292 passed)
- [x] Added a label for each target release version

#### Changes Requiring Extra Attention
- [x] Security-related changes (dependency pin for CVE-2026-45409)

### Scanner A/B (`CVE-2026-45409`)

Before = `idna 3.13` (the version shipped in 9.4.0/9.4.2); After = `idna 3.18` (this pin).

| Tool | Before | After |
|------|--------|-------|
| pip-audit | reported | clear |
| Trivy | reported (fixed 3.15) | clear |
| Snyk | reported | clear |

## Release Note

Pin `idna` to `3.18` to remediate CVE-2026-45409 (denial-of-service in `idna.encode()`).

Made with [Cursor](https://cursor.com)