### PR TITLE
[8.19] fix(deps): bump cffi to 2.0.0 to unblock cryptography 46.0.7 (CVE-2026-34073, CVE-2026-26007) (#4238)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -978,7 +978,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 aiohappyeyeballs
-2.6.2
+2.7.1
 Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -1262,8 +1262,8 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 aiohttp
-3.11.10
-Apache Software License
+3.13.3
+Apache-2.0 AND MIT
    Copyright aio-libs contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -1536,7 +1536,7 @@ Apache License
 
 
 anyio
-4.13.0
+4.14.2
 MIT
 The MIT License (MIT)
 
@@ -2497,11 +2497,11 @@ Apache Software License
 
 
 bracex
-2.6
+3.0.1
 MIT
 MIT License
 
-Copyright (c) 2018 - 2025 Isaac Muse
+Copyright (c) 2018 - 2026 Isaac Muse
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -2565,14 +2565,14 @@ one at http://mozilla.org/MPL/2.0/.
 
 
 cffi
-1.16.0
-MIT License
+2.0.0
+MIT
 
 Except when otherwise stated (look for LICENSE files in directories or
 information at the beginning of each file) all software and
 documentation is licensed as follows: 
 
-    The MIT License
+    MIT No Attribution
 
     Permission is hereby granted, free of charge, to any person 
     obtaining a copy of this software and associated documentation 
@@ -2580,10 +2580,7 @@ documentation is licensed as follows:
     restriction, including without limitation the rights to use, 
     copy, modify, merge, publish, distribute, sublicense, and/or 
     sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included 
-    in all copies or substantial portions of the Software.
+    Software is furnished to do so.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
     OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
@@ -2596,7 +2593,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.7
+3.4.9
 MIT
 MIT License
 
@@ -2622,8 +2619,8 @@ SOFTWARE.
 
 
 click
-8.1.7
-BSD License
+8.3.3
+BSD-3-Clause
 Copyright 2014 Pallets
 
 Redistribution and use in source and binary forms, with or without
@@ -2710,8 +2707,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 cryptography
-44.0.3
-Apache Software License; BSD License
+46.0.7
+Apache-2.0 OR BSD-3-Clause
 This software is made available under the terms of *either* of the licenses
 found in LICENSE.APACHE or LICENSE.BSD. Contributions to cryptography are made
 under the terms of *both* these licenses.
@@ -2998,7 +2995,7 @@ Apache Software License
 
 
 elastic_agent_client
-0.0.1.dev1
+0.0.2
 Other/Proprietary License
 ELASTIC LICENSE AGREEMENT
 
@@ -3406,7 +3403,7 @@ Apache-2.0
 
 
 elasticsearch-connectors
-8.19.17
+8.19.19
 Apache Software License
 Elastic License 2.0
 
@@ -4000,7 +3997,7 @@ Apache Software License
 
 
 google-auth
-2.54.0
+2.56.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -4234,7 +4231,7 @@ SOFTWARE.
 
 
 greenlet
-3.5.2
+3.5.3
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:
@@ -4269,8 +4266,8 @@ THE SOFTWARE.
 
 
 grpcio
-1.81.1
-Apache-2.0
+1.74.0
+Apache Software License
 
                                  Apache License
                            Version 2.0, January 2004
@@ -4476,16 +4473,6 @@ Apache-2.0
 
 -----------------------------------------------------------
 
-Following applies to:
-./src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
-./src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
-./src/objective-c/!ProtoCompiler.podspec
-./src/objective-c/BoringSSL-GRPC.podspec
-./templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.inja
-./templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.inja
-./templates/src/objective-c/!ProtoCompiler.podspec.inja
-./templates/src/objective-c/BoringSSL-GRPC.podspec.template
-
 BSD 3-Clause License
 
 Copyright 2016, Google Inc.
@@ -4517,9 +4504,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------------------------------------------------------
-
-Following applies to:
-./etc/roots.pem
 
 Mozilla Public License Version 2.0
 ==================================
@@ -5502,7 +5486,7 @@ Apache Software License
 
 
 msal
-1.30.0
+1.32.3
 MIT License
 The MIT License (MIT)
 
@@ -5864,14 +5848,6 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 END OF TERMS AND CONDITIONS
 
 
-packaging
-26.2
-Apache-2.0 OR BSD-2-Clause
-This software is made available under the terms of *either* of the licenses
-found in LICENSE.APACHE or LICENSE.BSD. Contributions to this software is made
-under the terms of *both* these licenses.
-
-
 propcache
 0.5.2
 Apache Software License
@@ -6080,7 +6056,7 @@ Apache Software License
 
 
 protobuf
-5.27.5
+5.29.6
 3-Clause BSD License
 Copyright 2008 Google Inc.  All rights reserved.
 
@@ -6117,7 +6093,7 @@ support library is itself covered by the above license.
 
 
 pyOpenSSL
-24.3.0
+26.0.0
 Apache Software License
 
                                  Apache License
@@ -6324,8 +6300,8 @@ Apache Software License
 
 
 pyasn1
-0.6.0
-BSD License
+0.6.4
+BSD-2-Clause
 Copyright (c) 2005-2020, Ilya Etingof <etingof@gmail.com>
 All rights reserved.
 
@@ -6353,7 +6329,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 pyasn1_modules
-0.4.1
+0.4.2
 BSD License
 Copyright (c) 2005-2020, Ilya Etingof <etingof@gmail.com>
 All rights reserved.
@@ -6704,7 +6680,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The above BSD License Applies to all code, even that also covered by Apache 2.0.
 
 python-tds
-1.12.0
+1.15.0
 MIT
 The MIT License (MIT)
 
@@ -7392,12 +7368,249 @@ UNKNOWN
 UNKNOWN
 
 types-protobuf
-5.27.0.20240920
-Apache Software License
-UNKNOWN
+5.29.1.20250403
+Apache-2.0
+The "typeshed" project is licensed under the terms of the Apache license, as
+reproduced below.
+
+= = = = =
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+= = = = =
+
+Parts of typeshed are licensed under different licenses (like the MIT
+license), reproduced below.
+
+= = = = =
+
+The MIT License
+
+Copyright (c) 2015 Jukka Lehtosalo and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+= = = = =
+
 
 typing_extensions
-4.15.0
+4.16.0
 PSF-2.0
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -7686,11 +7899,12 @@ Apache Software License
 UNKNOWN
 
 tzdata
-2026.2
+2026.3
 Apache-2.0
 Apache Software License 2.0
 
 Copyright (c) 2020, Paul Ganssle (Google)
+Copyright (c) 2026, Stan Ulbrych
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -7706,8 +7920,8 @@ limitations under the License.
 
 
 tzlocal
-5.3.1
-MIT License
+5.4.4
+MIT
 Copyright 2011-2017 Lennart Regebro
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -8039,7 +8253,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 yarl
-1.24.2
+1.24.5
 Apache-2.0
 
                                  Apache License

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -6,7 +6,7 @@ httpx-ntlm==1.4.0
 elasticsearch[async]==8.17.1
 elastic-transport==8.15.1
 pyyaml==6.0.1
-cffi==1.16.0
+cffi==2.0.0
 envyaml==1.10.211231
 ecs-logging==2.0.0
 pympler==1.0.1


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump cffi to 2.0.0 to unblock cryptography 46.0.7 (CVE-2026-34073, CVE-2026-26007) (#4238)

The automated backport could not cherry-pick #4238 because 8.19 uses the older layout: dependencies live in `requirements/framework.txt` (not `app/connectors_service/pyproject.toml`). The equivalent pin `cffi==1.16.0` -> `cffi==2.0.0` was applied there.

`cryptography` is transitive and was capped at **46.0.0** by the old `cffi` pin (`cryptography` 46.0.5+ require `cffi>=2.0.0`). Bumping `cffi` lets it resolve to **46.0.7**, clearing:
- **CVE-2026-26007** (fixed in 46.0.5)
- **CVE-2026-34073** (fixed in 46.0.6)
- **CVE-2026-39892** (fixed in 46.0.7)

`pyOpenSSL==26.0.0` (already on 8.19 via #4232) provides the `cryptography` floor and keeps the ceiling at 46.x.

### Dependency resolution A/B (8.19, Python 3.11)

Installing `requirements/x86_64.txt`:

| `cffi` pin | resolved `cryptography` |
|------------|-------------------------|
| `1.16.0` (before) | `46.0.0` |
| `2.0.0` (after)   | `46.0.7` |

### NOTICE.txt (fully regenerated)

`NOTICE.txt` was regenerated from the real resolved dependency tree via `make clean install autoformat lint test PYTHON=python3.11` (pip-licenses). It now reflects `cffi 2.0.0` and `cryptography 46.0.7`, and — because 8.19's `NOTICE.txt` had gone stale — it also captures drift that recent security backports left unwritten (aiohttp `3.11.10` -> `3.13.3` #4234, click `8.1.7` -> `8.3.3` #4236, pyOpenSSL `24.3.0` -> `26.0.0` #4232, pyasn1 `0.6.0` -> `0.6.4` #4233, elastic-agent-client `0.0.1.dev1` -> `0.0.2` / protobuf `5.27.5` -> `5.29.6` #4235, plus transitive updates). This brings `NOTICE.txt` into its cleanest, freshest state.

### Local validation (Python 3.11)

`make clean install autoformat lint test PYTHON=python3.11`:
- **2437 tests passed**, ruff `check`/`format --check` clean, coverage **92.39%** (>= 92% gate).
- The single `--fail-slow` flag on `tests/sources/test_s3.py::test_close_with_client_session` is a timing-threshold artifact (`1.28s > 1.0s`, "Test passed but took too long"), not a functional failure.

Made with [Cursor](https://cursor.com)
