### PR TITLE
[8.19] fix(deps): pin idna to 3.18 for CVE-2026-45409 (#4239)

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -47,3 +47,4 @@ pyasn1==0.6.4
 azure-identity==1.19.0
 requests==2.32.4
 urllib3==2.7.0
+idna==3.18


### PR DESCRIPTION
Backports #4239 to `8.19`.

The auto-backport could not cherry-pick to `8.19` (the `main` change touches `pyproject.toml`, which does not exist on this line), so this applies the equivalent pin manually.

## What

Pins `idna==3.18` in `requirements/framework.txt`. `idna` is a **transitive** dependency (via `requests` / `httpx` / `aiohttp`→`yarl`) that was previously **unpinned**, so release builds froze whatever `idna` was latest on PyPI at build time. Pinning to `3.18` (>= the fixed `3.15`) makes the fix **deterministic and auditable** on the `8.19` line.

**CVE-2026-45409** (CWE-1333, Medium, CVSS v3 5.3 / v4 6.9): specially crafted inputs to `idna.encode()` reach `valid_contexto` before length rejection, causing excessive CPU (ReDoS/DoS). Fully fixed in `idna 3.15`.

## Testing

`make clean install autoformat lint test PYTHON=python3.11` — lint clean, 2437 tests passed. `NOTICE.txt` needed no change (the build already resolved `idna` to `3.18`; the pin just makes it deterministic).

## Release Note

Pin `idna` to `3.18` to remediate CVE-2026-45409 (denial-of-service in `idna.encode()`).

Part of https://github.com/elastic/security/issues/12518

Made with [Cursor](https://cursor.com)