### PR TITLE
Return back snyk scanning

### DIFF
--- a/.buildkite/nightly_steps.yml
+++ b/.buildkite/nightly_steps.yml
@@ -48,7 +48,7 @@ steps:
     command: ".buildkite/run_snyk.sh"
     env:
       PYTHON_VERSION: "3.11"
-    timeout_in_minutes: 5
+    timeout_in_minutes: 15
 
   - label: "🔨 [Python {{ matrix }}] MySQL"
     <<: *retries

--- a/.buildkite/nightly_steps.yml
+++ b/.buildkite/nightly_steps.yml
@@ -1,4 +1,11 @@
 definitions:
+  steps:
+    - step: &test-agents
+        agents:
+          provider: "gcp"
+          machineType: "n1-standard-8"
+          useVault: true
+          image: family/enterprise-search-ubuntu-2204-connectors-py
   retries: &retries
     retry:
       automatic:
@@ -31,6 +38,18 @@ env:
   DOCKERFILE_PATH: "Dockerfile.wolfi"
 
 steps:
+
+  - label: ":snyk: Snyk scan"
+    if: 'build.branch == "main"'
+    <<: *test-agents
+    <<: *retries
+    key: "snyk"
+    soft_fail: true
+    command: ".buildkite/run_snyk.sh"
+    env:
+      PYTHON_VERSION: "3.11"
+    timeout_in_minutes: 5
+
   - label: "🔨 [Python {{ matrix }}] MySQL"
     <<: *retries
     <<: *ftest_defaults

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,6 +53,16 @@ steps:
       PYTHON_VERSION: "3.11" # We don't really care about notice on multiple versions
     timeout_in_minutes: 5
 
+  - label: "Snyk test"
+    <<: *test-agents
+    <<: *retries
+    key: "snyk"
+    command: ".buildkite/run_snyk.sh"
+    env:
+      PYTHON_VERSION: "3.11" # We don't really care about linter on multiple versions for now
+    timeout_in_minutes: 5
+
+
   - wait: ~
 
   - label: ":face_with_peeking_eye: Lint"
@@ -1260,13 +1270,3 @@ steps:
           - test_oss_dockerfile_image_amd64
           - test_oss_dockerfile_image_arm64
         command: ".buildkite/publish/dra/init_dra_publishing.sh"
-
-  - label: "Snyk test"
-    <<: *test-agents
-    <<: *retries
-    key: "snyk"
-    command: ".buildkite/run_snyk.sh"
-    env:
-      PYTHON_VERSION: "3.11" # We don't really care about linter on multiple versions for now
-    timeout_in_minutes: 5
-

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,18 +53,6 @@ steps:
       PYTHON_VERSION: "3.11" # We don't really care about notice on multiple versions
     timeout_in_minutes: 5
 
-  - label: "Snyk test"
-    # if: 'build.branch == "main"'
-    <<: *test-agents
-    <<: *retries
-    key: "snyk"
-    soft_fail: true
-    command: ".buildkite/run_snyk.sh"
-    env:
-      PYTHON_VERSION: "3.11"
-    timeout_in_minutes: 5
-
-
   - wait: ~
 
   - label: ":face_with_peeking_eye: Lint"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1262,9 +1262,11 @@ steps:
         command: ".buildkite/publish/dra/init_dra_publishing.sh"
 
   - label: "Trigger cve-slo-status pipeline for pull docker.elastic.co/integrations/elastic-connectors:9.4.0"
-    trigger: cve-slo-status
-    build:
-      env:
-        CONTAINER: "pull docker.elastic.co/integrations/elastic-connectors:9.4.0"
-    soft_fail: true
+    <<: *test-agents
+    <<: *retries
+    key: "lint"
+    command: ".buildkite/run_snyk.sh"
+    env:
+      PYTHON_VERSION: "3.11" # We don't really care about linter on multiple versions for now
+    timeout_in_minutes: 5
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1261,10 +1261,10 @@ steps:
           - test_oss_dockerfile_image_arm64
         command: ".buildkite/publish/dra/init_dra_publishing.sh"
 
-  - label: "Trigger cve-slo-status pipeline for pull docker.elastic.co/integrations/elastic-connectors:9.4.0"
+  - label: "Snyk test"
     <<: *test-agents
     <<: *retries
-    key: "lint"
+    key: "snyk"
     command: ".buildkite/run_snyk.sh"
     env:
       PYTHON_VERSION: "3.11" # We don't really care about linter on multiple versions for now

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,7 +61,7 @@ steps:
     soft_fail: true
     command: ".buildkite/run_snyk.sh"
     env:
-      PYTHON_VERSION: "3.12"
+      PYTHON_VERSION: "3.11"
     timeout_in_minutes: 5
 
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1260,3 +1260,11 @@ steps:
           - test_oss_dockerfile_image_amd64
           - test_oss_dockerfile_image_arm64
         command: ".buildkite/publish/dra/init_dra_publishing.sh"
+
+  - label: "Trigger cve-slo-status pipeline for pull docker.elastic.co/integrations/elastic-connectors:9.5.0"
+    trigger: cve-slo-status
+    build:
+      env:
+        CONTAINER: "pull docker.elastic.co/integrations/elastic-connectors:9.5.0"
+    soft_fail: true
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1261,10 +1261,10 @@ steps:
           - test_oss_dockerfile_image_arm64
         command: ".buildkite/publish/dra/init_dra_publishing.sh"
 
-  - label: "Trigger cve-slo-status pipeline for pull docker.elastic.co/integrations/elastic-connectors:9.5.0"
+  - label: "Trigger cve-slo-status pipeline for pull docker.elastic.co/integrations/elastic-connectors:9.4.0"
     trigger: cve-slo-status
     build:
       env:
-        CONTAINER: "pull docker.elastic.co/integrations/elastic-connectors:9.5.0"
+        CONTAINER: "pull docker.elastic.co/integrations/elastic-connectors:9.4.0"
     soft_fail: true
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,12 +54,14 @@ steps:
     timeout_in_minutes: 5
 
   - label: "Snyk test"
+    # if: 'build.branch == "main"'
     <<: *test-agents
     <<: *retries
     key: "snyk"
+    soft_fail: true
     command: ".buildkite/run_snyk.sh"
     env:
-      PYTHON_VERSION: "3.11" # We don't really care about linter on multiple versions for now
+      PYTHON_VERSION: "3.12"
     timeout_in_minutes: 5
 
 

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 source .buildkite/shared.sh
 
+BASEDIR=$(realpath $(dirname $0))
+ROOT=$(realpath $BASEDIR/../)
 APP_ROOT=$ROOT/app/connectors_service
 SDK_ROOT=$ROOT/libs/connectors_sdk
 

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -23,9 +23,10 @@ curl -sL --retry-max-time 60 --retry 3 --retry-delay 5 https://static.snyk.io/cl
 chmod +x ./snyk
 
 echo "--- Initializing venv for the test ---"
-python3 -m .snyk-venv
+python3 -m /tmp/.snyk-venv
+
 echo "--- Installing dependencies ---"
-$ROOT/.snyk-venv/bin/pip install \
+/tmp/.snyk-venv/bin/pip install \
         -r $SDK_ROOT/requirements.txt \
         -r $APP_ROOT/requirements.txt
 

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -24,8 +24,10 @@ chmod +x ./snyk
 
 echo "--- Initializing venv for the test ---"
 python3 -m .snyk-venv
-$ROOT/.snyk-venv/bin/pip install --quiet -r $SDK_ROOT/requirements.txt
-$ROOT/.snyk-venv/bin/pip install --quiet -r $APP_ROOT/requirements.txt
+echo "--- Installing dependencies ---"
+$ROOT/.snyk-venv/bin/pip install \
+        -r $SDK_ROOT/requirements.txt \
+        -r $APP_ROOT/requirements.txt
 
 echo "--- Running snyk for SDK..."
 ./snyk test --file=$SDK_ROOT/requirements.txt --command=$ROOT/.venv/bin/python3

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# !!! WARNING DO NOT add -x to avoid leaking vault passwords
+set -euo pipefail
+
+source .buildkite/shared.sh
+
+init_python
+
+make install
+
+echo "--- Logging into snyk...---"
+export SNYK_TOKEN=$(vault read -field=value secret/ci/elastic-connectors/SNYK_TOKEN)
+
+echo "--- Downloading snyk..."
+curl -sL --retry-max-time 60 --retry 3 --retry-delay 5 https://static.snyk.io/cli/latest/snyk-linux -o snyk
+chmod +x ./snyk
+
+echo "--- Running snyk for SDK..."
+./snyk test --file=libs/connectors_sdk/requirements.txt --command=.venv/bin/python3 -- --allow-missing
+
+echo "--- Running snyk for SDK..."
+./snyk test --file=app/connectors_service/requirements.txt --command=.venv/bin/python3 -- --allow-missing

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 
 source .buildkite/shared.sh
 
+APP_ROOT=$ROOT/app/connectors_service
+SDK_ROOT=$ROOT/libs/connectors_sdk
+
+
 init_python
 
 make install freeze
@@ -17,7 +21,7 @@ curl -sL --retry-max-time 60 --retry 3 --retry-delay 5 https://static.snyk.io/cl
 chmod +x ./snyk
 
 echo "--- Running snyk for SDK..."
-./snyk test --file=libs/connectors_sdk/requirements.txt --command=.venv/bin/python3 -- --allow-missing
+./snyk test --file=$SDK_ROOT/requirements.txt --command=$SDK_ROOT/.venv/bin/python3 -- --allow-missing
 
-echo "--- Running snyk for SDK..."
-./snyk test --file=app/connectors_service/requirements.txt --command=.venv/bin/python3 -- --allow-missing
+echo "--- Running snyk for App..."
+./snyk test --file=$APP_ROOT/requirements.txt --command=$APP_ROOT/.venv/bin/python3 -- --allow-missing

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -22,8 +22,13 @@ echo "--- Downloading snyk..."
 curl -sL --retry-max-time 60 --retry 3 --retry-delay 5 https://static.snyk.io/cli/latest/snyk-linux -o snyk
 chmod +x ./snyk
 
+echo "--- Initializing venv for the test ---"
+python3 -m .snyk-venv
+$ROOT/.snyk-venv/bin/pip install --quiet -r $SDK_ROOT/requirements.txt
+$ROOT/.snyk-venv/bin/pip install --quiet -r $APP_ROOT/requirements.txt
+
 echo "--- Running snyk for SDK..."
-./snyk test --file=$SDK_ROOT/requirements.txt --command=$SDK_ROOT/.venv/bin/python3 -- --allow-missing
+./snyk test --file=$SDK_ROOT/requirements.txt --command=$ROOT/.venv/bin/python3
 
 echo "--- Running snyk for App..."
-./snyk test --file=$APP_ROOT/requirements.txt --command=$APP_ROOT/.venv/bin/python3 -- --allow-missing
+./snyk test --file=$APP_ROOT/requirements.txt --command=$ROOT/.venv/bin/python3

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -33,7 +33,7 @@ echo "--- Installing dependencies ---"
         -r $APP_ROOT/requirements.txt
 
 echo "--- Running snyk for SDK..."
-./snyk test --file=$SDK_ROOT/requirements.txt --command=/tmp/.snyk-venv/bin/python3
+./snyk monitor --file=$SDK_ROOT/requirements.txt --command=/tmp/.snyk-venv/bin/python3
 
 echo "--- Running snyk for App..."
-./snyk test --file=$APP_ROOT/requirements.txt --command=/tmp/.snyk-venv/bin/python3
+./snyk monitor --file=$APP_ROOT/requirements.txt --command=/tmp/.snyk-venv/bin/python3

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -13,7 +13,7 @@ SDK_ROOT=$ROOT/libs/connectors_sdk
 
 init_python
 
-make install freeze
+make clean install freeze
 
 echo "--- Logging into snyk...---"
 export SNYK_TOKEN=$(vault read -field=value secret/ci/elastic-connectors/SNYK_TOKEN)
@@ -23,16 +23,13 @@ curl -sL --retry-max-time 60 --retry 3 --retry-delay 5 https://static.snyk.io/cl
 chmod +x ./snyk
 
 echo "--- Initializing venv for the test ---"
+rm -rf /tmp/.snyk-venv
 python3 -m venv /tmp/.snyk-venv
 
 echo "--- Installing dependencies ---"
 
-cat $SDK_ROOT/requirements.txt
-
-cat $APP_ROOT/requirements.txt
-
+# We're only installing app dependencies because SDK dependencies are included there by `make freeze`
 /tmp/.snyk-venv/bin/pip install \
-        -r $SDK_ROOT/requirements.txt \
         -r $APP_ROOT/requirements.txt
 
 echo "--- Running snyk for SDK..."

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -26,6 +26,11 @@ echo "--- Initializing venv for the test ---"
 python3 -m venv /tmp/.snyk-venv
 
 echo "--- Installing dependencies ---"
+
+cat $SDK_ROOT/requirements.txt
+
+cat $APP_ROOT/requirements.txt
+
 /tmp/.snyk-venv/bin/pip install \
         -r $SDK_ROOT/requirements.txt \
         -r $APP_ROOT/requirements.txt

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -23,7 +23,7 @@ curl -sL --retry-max-time 60 --retry 3 --retry-delay 5 https://static.snyk.io/cl
 chmod +x ./snyk
 
 echo "--- Initializing venv for the test ---"
-python3 -m /tmp/.snyk-venv
+python3 -m venv /tmp/.snyk-venv
 
 echo "--- Installing dependencies ---"
 /tmp/.snyk-venv/bin/pip install \

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -7,7 +7,7 @@ source .buildkite/shared.sh
 
 init_python
 
-make install
+make install freeze
 
 echo "--- Logging into snyk...---"
 export SNYK_TOKEN=$(vault read -field=value secret/ci/elastic-connectors/SNYK_TOKEN)

--- a/.buildkite/run_snyk.sh
+++ b/.buildkite/run_snyk.sh
@@ -31,7 +31,7 @@ echo "--- Installing dependencies ---"
         -r $APP_ROOT/requirements.txt
 
 echo "--- Running snyk for SDK..."
-./snyk test --file=$SDK_ROOT/requirements.txt --command=$ROOT/.venv/bin/python3
+./snyk test --file=$SDK_ROOT/requirements.txt --command=/tmp/.snyk-venv/bin/python3
 
 echo "--- Running snyk for App..."
-./snyk test --file=$APP_ROOT/requirements.txt --command=$ROOT/.venv/bin/python3
+./snyk test --file=$APP_ROOT/requirements.txt --command=/tmp/.snyk-venv/bin/python3

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ htmlcov
 **/venv
 app/connectors_service/scripts/stack/connectors-config
 
+# These are only for snyk scanning
+app/connectors_service/requirements.txt
+libs/connectors_sdk/requirements.txt
+
 .python-version
 
 # Local secrets and credentials -- never commit these

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=nonroot:nonroot . /app
 
 USER nonroot
 WORKDIR /app
-RUN make clean install-package
+RUN make clean install-package freeze
 RUN ln -s app/connectors_service/.venv/bin /app/bin
 
 USER root

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -204,7 +204,7 @@ COPY --chown=nonroot:nonroot . /app
 # Install application
 USER nonroot
 WORKDIR /app
-RUN make clean install-package
+RUN make clean install-package freeze
 RUN ln -s app/connectors_service/.venv/bin /app/bin
 
 # Clean up build tools

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -2,6 +2,6 @@ FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:7aca1919568ce6a77e620a2bfef1
 USER root
 COPY . /app
 WORKDIR /app
-RUN make clean install-package
+RUN make clean install-package freeze
 RUN ln -s app/connectors_service/.venv/bin /app/bin
 ENTRYPOINT []

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test: install
 	cd $(connectors_sdk_dir); make test
 	cd $(app_dir); make test
 
-freeze: install
+freeze:
 	cd $(connectors_sdk_dir); make freeze
 	cd $(app_dir); make freeze
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ test: install
 	cd $(connectors_sdk_dir); make test
 	cd $(app_dir); make test
 
+freeze: install
+	cd $(connectors_sdk_dir); make freeze
+	cd $(app_dir); make freeze
+
 ftest: install build-connectors-base-image
 	cd $(app_dir); make ftest NAME=$(NAME)
 

--- a/app/connectors_service/Makefile
+++ b/app/connectors_service/Makefile
@@ -91,7 +91,10 @@ freeze: .venv/bin/python
 	# So when included to a docker artefact, for example, it should give accurate description of what's actually installed into the .venv
 	# We pin <4.0.0 because 4.* requires rust toolkit and our docker images doesn't have it
 	.venv/bin/pip install --quiet "pipdeptree<4.0.0"
-	.venv/bin/pipdeptree --freeze --exclude elasticsearch-connectors,elasticsearch-connectors-sdk > requirements.txt
+	.venv/bin/pipdeptree \
+		--freeze \
+		--exclude elasticsearch-connectors,elasticsearch-connectors-sdk,pipdeptree \
+		> requirements.txt
 	# Delete it so that it's not left in the artefacts
 	.venv/bin/pip uninstall --quiet pipdeptree -y
 

--- a/app/connectors_service/Makefile
+++ b/app/connectors_service/Makefile
@@ -82,7 +82,13 @@ autoformat: .venv/bin/python .venv/bin/ruff .venv/bin/elastic-ingest
 test: .venv/bin/python .venv/bin/elastic-ingest .venv/bin/pytest
 	.venv/bin/pytest --cov-report term-missing --cov-fail-under 90 --cov-report html --cov=connectors --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests
 
-freeze: .venv/bin/python .venv/bin/elastic-ingest
+freeze: .venv/bin/python
+	# It looks a little insane, but hear me out.
+	# Snyk CLI does not use local PIP, it runs its own copy of it and does not really respect some things that we have in pyproject.toml
+	# For example relative file paths are not allowed, or evaluation of env variables are not possible while allowed.
+	# So to make things work we need to convert our requirements to requirements.txt file so that snyk could run its scanning against it
+	# Pipdeptree is able to actually produce requirements.txt file that contains both direct and transitive dependencies of the service
+	# So when included to a docker artefact, for example, it should give accurate description of what's actually installed into the .venv
 	.venv/bin/pip install --quiet pipdeptree
 	.venv/bin/pipdeptree --freeze --exclude elasticsearch-connectors,elasticsearch-connectors-sdk > requirements.txt
 

--- a/app/connectors_service/Makefile
+++ b/app/connectors_service/Makefile
@@ -83,10 +83,8 @@ test: .venv/bin/python .venv/bin/elastic-ingest .venv/bin/pytest
 	.venv/bin/pytest --cov-report term-missing --cov-fail-under 90 --cov-report html --cov=connectors --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests
 
 freeze: .venv/bin/python .venv/bin/elastic-ingest
-	.venv/bin/pip freeze | \
-		grep -v '^-e git+ssh://' | \
-		grep -v 'elasticsearch-connectors-sdk @ file://' \
-		> requirements.txt
+	.venv/bin/pip install --quiet pipdeptree
+	.venv/bin/pipdeptree --freeze --exclude elasticsearch-connectors,elasticsearch-connectors-sdk > requirements.txt
 
 ftest: .venv/bin/pytest
 	tests/ftest.sh $(NAME) $(PERF8)

--- a/app/connectors_service/Makefile
+++ b/app/connectors_service/Makefile
@@ -57,7 +57,7 @@ install-package: .venv/bin/python
 	.venv/bin/pip install -e ".[tests,ftest]"
 
 clean:
-	rm -rf bin lib .venv include elasticsearch_connectors.egg-info .coverage site-packages pyvenv.cfg include.site.python*.greenlet dist build htmlcov
+	rm -rf bin lib .venv include elasticsearch_connectors.egg-info .coverage site-packages pyvenv.cfg include.site.python*.greenlet dist build htmlcov requirements.txt
 
 typecheck: .venv/bin/python .venv/bin/elastic-ingest
 	.venv/bin/pyright connectors

--- a/app/connectors_service/Makefile
+++ b/app/connectors_service/Makefile
@@ -83,7 +83,10 @@ test: .venv/bin/python .venv/bin/elastic-ingest .venv/bin/pytest
 	.venv/bin/pytest --cov-report term-missing --cov-fail-under 90 --cov-report html --cov=connectors --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests
 
 freeze: .venv/bin/python .venv/bin/elastic-ingest
-	.venv/bin/pip freeze requirements.txt
+	.venv/bin/pip freeze | \
+		grep -v '^-e git+ssh://' | \
+		grep -v 'elasticsearch-connectors-sdk @ file://' \
+		> requirements.txt
 
 ftest: .venv/bin/pytest
 	tests/ftest.sh $(NAME) $(PERF8)

--- a/app/connectors_service/Makefile
+++ b/app/connectors_service/Makefile
@@ -82,6 +82,8 @@ autoformat: .venv/bin/python .venv/bin/ruff .venv/bin/elastic-ingest
 test: .venv/bin/python .venv/bin/elastic-ingest .venv/bin/pytest
 	.venv/bin/pytest --cov-report term-missing --cov-fail-under 90 --cov-report html --cov=connectors --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests
 
+freeze: .venv/bin/python .venv/bin/elastic-ingest
+	.venv/bin/pip freeze requirements.txt
 
 ftest: .venv/bin/pytest
 	tests/ftest.sh $(NAME) $(PERF8)

--- a/app/connectors_service/Makefile
+++ b/app/connectors_service/Makefile
@@ -89,8 +89,11 @@ freeze: .venv/bin/python
 	# So to make things work we need to convert our requirements to requirements.txt file so that snyk could run its scanning against it
 	# Pipdeptree is able to actually produce requirements.txt file that contains both direct and transitive dependencies of the service
 	# So when included to a docker artefact, for example, it should give accurate description of what's actually installed into the .venv
-	.venv/bin/pip install --quiet pipdeptree
+	# We pin <4.0.0 because 4.* requires rust toolkit and our docker images doesn't have it
+	.venv/bin/pip install --quiet "pipdeptree<4.0.0"
 	.venv/bin/pipdeptree --freeze --exclude elasticsearch-connectors,elasticsearch-connectors-sdk > requirements.txt
+	# Delete it so that it's not left in the artefacts
+	.venv/bin/pip uninstall --quiet pipdeptree -y
 
 ftest: .venv/bin/pytest
 	tests/ftest.sh $(NAME) $(PERF8)

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -4475,7 +4475,7 @@ SOFTWARE.
 
 
 greenlet
-3.5.3
+3.5.4
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -4241,7 +4241,7 @@ Apache Software License
 
 
 google-auth
-2.56.1
+2.56.2
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -4241,7 +4241,7 @@ Apache Software License
 
 
 google-auth
-2.56.0
+2.56.1
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -7616,7 +7616,7 @@ made under the terms of *both* these licenses.
 
 
 soupsieve
-2.9
+2.9.1
 MIT
 MIT License
 

--- a/libs/connectors_sdk/Makefile
+++ b/libs/connectors_sdk/Makefile
@@ -45,7 +45,7 @@ test: .venv/bin/pytest
 
 freeze: .venv/bin/python
 	.venv/bin/pip freeze | \
-		grep -v '-e git+ssh://git@github.com/elastic/connectors' \
+		grep -v '^-e' \
 		> requirements.txt
 
 autoformat: install .venv/bin/ruff

--- a/libs/connectors_sdk/Makefile
+++ b/libs/connectors_sdk/Makefile
@@ -18,7 +18,7 @@ install-package:
 	$(VENV_DIR)/pip install dist/*.whl
 
 clean:
-	rm -rf bin lib .venv include elasticsearch_connectors_sdk.egg-info .coverage site-packages pyvenv.cfg include.site.python*.greenlet dist build htmlcov
+	rm -rf bin lib .venv include elasticsearch_connectors_sdk.egg-info .coverage site-packages pyvenv.cfg include.site.python*.greenlet dist build htmlcov requirements.txt
 
 
 .venv/bin/pytest: .venv/bin/python

--- a/libs/connectors_sdk/Makefile
+++ b/libs/connectors_sdk/Makefile
@@ -44,9 +44,20 @@ test: .venv/bin/pytest
 	$(VENV_DIR)/pytest --cov-report term-missing --cov-fail-under 80 --cov-report html --cov=connectors_sdk --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests
 
 freeze: .venv/bin/python
-	.venv/bin/pip freeze | \
-		grep -v '^-e' \
+	# It looks a little insane, but hear me out.
+	# Snyk CLI does not use local PIP, it runs its own copy of it and does not really respect some things that we have in pyproject.toml
+	# For example relative file paths are not allowed, or evaluation of env variables are not possible while allowed.
+	# So to make things work we need to convert our requirements to requirements.txt file so that snyk could run its scanning against it
+	# Pipdeptree is able to actually produce requirements.txt file that contains both direct and transitive dependencies of the service
+	# So when included to a docker artefact, for example, it should give accurate description of what's actually installed into the .venv
+	# We pin <4.0.0 because 4.* requires rust toolkit and our docker images doesn't have it
+	.venv/bin/pip install --quiet "pipdeptree<4.0.0"
+	.venv/bin/pipdeptree \
+		--freeze \
+		--exclude elasticsearch-connectors-sdk,pipdeptree \
 		> requirements.txt
+	# Delete it so that it's not left in the artefacts
+	.venv/bin/pip uninstall --quiet pipdeptree -y
 
 autoformat: install .venv/bin/ruff
 	.venv/bin/ruff check connectors_sdk --fix

--- a/libs/connectors_sdk/Makefile
+++ b/libs/connectors_sdk/Makefile
@@ -45,7 +45,7 @@ test: .venv/bin/pytest
 
 freeze: .venv/bin/python
 	.venv/bin/pip freeze | \
-		grep -v '-e git+ssh://git@github.com/elastic/connectors-python' \
+		grep -v '-e git+ssh://git@github.com/elastic/connectors' \
 		> requirements.txt
 
 autoformat: install .venv/bin/ruff

--- a/libs/connectors_sdk/Makefile
+++ b/libs/connectors_sdk/Makefile
@@ -45,7 +45,7 @@ test: .venv/bin/pytest
 
 freeze: .venv/bin/python
 	.venv/bin/pip freeze | \
-		grep -v 'elasticsearch-connectors-sdk @ file://' \
+		grep -v '-e git+ssh://git@github.com/elastic/connectors-python' \
 		> requirements.txt
 
 autoformat: install .venv/bin/ruff

--- a/libs/connectors_sdk/Makefile
+++ b/libs/connectors_sdk/Makefile
@@ -43,6 +43,9 @@ lint: install .venv/bin/ruff typecheck
 test: .venv/bin/pytest
 	$(VENV_DIR)/pytest --cov-report term-missing --cov-fail-under 80 --cov-report html --cov=connectors_sdk --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests
 
+freeze: .venv/bin/python
+	.venv/bin/pip freeze requirements.txt
+
 autoformat: install .venv/bin/ruff
 	.venv/bin/ruff check connectors_sdk --fix
 	.venv/bin/ruff format connectors_sdk

--- a/libs/connectors_sdk/Makefile
+++ b/libs/connectors_sdk/Makefile
@@ -44,7 +44,9 @@ test: .venv/bin/pytest
 	$(VENV_DIR)/pytest --cov-report term-missing --cov-fail-under 80 --cov-report html --cov=connectors_sdk --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests
 
 freeze: .venv/bin/python
-	.venv/bin/pip freeze > requirements.txt
+	.venv/bin/pip freeze | \
+		grep -v 'elasticsearch-connectors-sdk @ file://' \
+		> requirements.txt
 
 autoformat: install .venv/bin/ruff
 	.venv/bin/ruff check connectors_sdk --fix

--- a/libs/connectors_sdk/Makefile
+++ b/libs/connectors_sdk/Makefile
@@ -44,7 +44,7 @@ test: .venv/bin/pytest
 	$(VENV_DIR)/pytest --cov-report term-missing --cov-fail-under 80 --cov-report html --cov=connectors_sdk --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests
 
 freeze: .venv/bin/python
-	.venv/bin/pip freeze requirements.txt
+	.venv/bin/pip freeze > requirements.txt
 
 autoformat: install .venv/bin/ruff
 	.venv/bin/ruff check connectors_sdk --fix


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/15280

This PR returns Snyk scanning back to the table. How it's supposed to work:

1. New `make freeze` action freezes the content of virtual environment for the package into a `requirements.txt` that can be scanned. We clean up entities that are not supported by general pip snyk scanner, such as git references or relative file references
2. We enable snyk scanning on nightlies on `main`. `./snyk monitor` should actually report scan issues in the Snyk UI
3. We package a requirements.json file into docker images

We need to merge this PR and see what Snyk actually reports as some stuff is hard to confirm (namely Docker image scanning)