### PR TITLE
Backport freezing to 8.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ scripts/stack/connectors-config
 *credentials*
 *secret*
 kubeconfig
+
+# This file is actually not real, it's derived and should only be present in the docker images as a "lock" file declaring versions that are used
+requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=nonroot:nonroot . /app
 
 USER nonroot
 WORKDIR /app
-RUN make clean install
+RUN make clean install freeze
 RUN ln -s .venv/bin /app/bin
 
 USER root

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -2,6 +2,6 @@ FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:7aca1919568ce6a77e620a2bfef1
 USER root
 COPY . /app
 WORKDIR /app
-RUN make clean install
+RUN make clean install freeze
 RUN ln -s .venv/bin /app/bin
 ENTRYPOINT []

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,22 @@ ftrace: .venv/bin/pytest .venv/bin/elastic-ingest $(DOCKERFILE_FTEST_PATH)
 run: install
 	.venv/bin/elastic-ingest
 
+freeze: .venv/bin/python
+	# It looks a little insane, but hear me out.
+	# Snyk CLI does not use local PIP, it runs its own copy of it and does not really respect some things that we have in pyproject.toml
+	# For example relative file paths are not allowed, or evaluation of env variables are not possible while allowed.
+	# So to make things work we need to convert our requirements to requirements.txt file so that snyk could run its scanning against it
+	# Pipdeptree is able to actually produce requirements.txt file that contains both direct and transitive dependencies of the service
+	# So when included to a docker artefact, for example, it should give accurate description of what's actually installed into the .venv
+	# We pin <4.0.0 because 4.* requires rust toolkit and our docker images doesn't have it
+	.venv/bin/pip install --quiet "pipdeptree<4.0.0"
+	.venv/bin/pipdeptree \
+		--freeze \
+		--exclude elasticsearch-connectors,pipdeptree \
+		> requirements.txt
+	# Delete it so that it's not left in the artefacts
+	.venv/bin/pip uninstall --quiet pipdeptree -y
+
 default-config: install
 	.venv/bin/elastic-ingest --action config --service-type $(SERVICE_TYPE)
 


### PR DESCRIPTION
Manual backport of https://github.com/elastic/connectors/pull/4253

Since we don't do any scanning of deps on `main` we only needed a mainfest in our docker image.

This change in essence just makes it so that docker images emit `requirements.txt` during build that are just a snapshot of all current dependencies. Then Snyk will be able to see it (it's pretty silly and requires `requirements.txt` or `requirements-*.txt` or `requirements_*.txt` to be present to scan).

Fun side problem: our dependencies differ per architecture. The approach in this PR works in a way that _current_ docker image dependencies are frozen, so `requirements.txt` will be different per CPU architecture, but it's okay.