### PR TITLE
[8.19] fix: surface a clear, actionable error when SharePoint Online role assignments are unauthorized (#3293) (#4266)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3591,7 +3591,7 @@ Apache-2.0
 
 
 elasticsearch-connectors
-8.19.19
+8.19.20
 Apache Software License
 Elastic License 2.0
 
@@ -4185,7 +4185,7 @@ Apache Software License
 
 
 google-auth
-2.56.0
+2.56.2
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -4419,7 +4419,7 @@ SOFTWARE.
 
 
 greenlet
-3.5.3
+3.5.4
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:
@@ -7474,7 +7474,7 @@ made under the terms of *both* these licenses.
 
 
 soupsieve
-2.9
+2.9.1
 MIT
 MIT License
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1533,25 +1533,39 @@ class SharepointOnlineDataSource(BaseDataSource):
         access_control = set()
         site_admins_access_control = set()
 
-        async for role_assignment in self.client.site_role_assignments(site["webUrl"]):
-            member = role_assignment["Member"]
-            member_access_control = set()
-            member_access_control.update(
-                await self._get_access_control_from_role_assignment(role_assignment)
+        try:
+            async for role_assignment in self.client.site_role_assignments(
+                site["webUrl"]
+            ):
+                member = role_assignment["Member"]
+                member_access_control = set()
+                member_access_control.update(
+                    await self._get_access_control_from_role_assignment(role_assignment)
+                )
+
+                if _is_site_admin(member):
+                    # These are likely in the "Owners" group for the site
+                    site_admins_access_control |= member_access_control
+
+                access_control |= member_access_control
+
+            # This fetches the "Site Collection Administrators", which is distinct from the "Owners" group of the site
+            # however, both should have access to everything in the site, regardless of unique role assignments
+            async for member in self.client.site_admins(site["webUrl"]):
+                site_admins_access_control.update(
+                    await self._access_control_for_member(member)
+                )
+        except PermissionsMissing as e:
+            # Fail with an actionable error instead of the generic "unauthorized".
+            msg = (
+                f"Cannot read access control for site '{site['webUrl']}', required "
+                "for Document Level Security. Reading SharePoint role assignments "
+                "requires the 'Sites.FullControl.All' SharePoint application "
+                "permission. Grant it to the App Registration (required for "
+                "certificate / Entra ID app-only authentication), or disable "
+                "Document Level Security if per-document permissions are not needed."
             )
-
-            if _is_site_admin(member):
-                # These are likely in the "Owners" group for the site
-                site_admins_access_control |= member_access_control
-
-            access_control |= member_access_control
-
-        # This fetches the "Site Collection Administrators", which is distinct from the "Owners" group of the site
-        # however, both should have access to everything in the site, regardless of unique role assignments
-        async for member in self.client.site_admins(site["webUrl"]):
-            site_admins_access_control.update(
-                await self._access_control_for_member(member)
-            )
+            raise PermissionsMissing(msg) from e
 
         return list(access_control), list(site_admins_access_control)
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -3426,6 +3426,28 @@ class TestSharepointOnlineDataSource:
             assert _prefix_email(USER_TWO_EMAIL) in access_control
 
     @pytest.mark.asyncio
+    async def test_site_access_control_permissions_missing_raises_actionable_error(
+        self, patch_sharepoint_client
+    ):
+        # Regression test for https://github.com/elastic/connectors/issues/3293
+        # Reading role assignments over the SharePoint REST API requires
+        # "Sites.FullControl.All". When it is missing (e.g. certificate auth), the
+        # sync must fail with a clear, actionable error rather than a generic one.
+        async with create_spo_source(use_document_level_security=True) as source:
+            patch_sharepoint_client._validate_sharepoint_rest_url = Mock()
+            patch_sharepoint_client.site_role_assignments = Mock(
+                side_effect=PermissionsMissing()
+            )
+
+            site = {"id": 1, "webUrl": "some url"}
+
+            with pytest.raises(PermissionsMissing) as e:
+                await source._site_access_control(site)
+
+            assert "Sites.FullControl.All" in str(e.value)
+            assert "Document Level Security" in str(e.value)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "_dls_enabled, document, access_control, expected_decorated_document",
         [


### PR DESCRIPTION
Backports the following commits to 8.19:

* fix: surface a clear, actionable error when SharePoint Online role assignments are unauthorized (#3293) (#4266)

> **Manual backport.** The auto-backport could not apply cleanly because on
> `8.19` the SharePoint Online source is still the monolithic
> `connectors/sources/sharepoint_online.py` rather than the refactored
> `sharepoint/sharepoint_online/` package used on `main`/`9.x`. The change itself
> is identical (same logic, message, and test).

## Relates to https://github.com/elastic/sdh-search/issues/1941

Also relates to / partially addresses https://github.com/elastic/connectors/issues/3293

The SharePoint Online connector reads role assignments (`_api/web/roleassignments`)
**only** when Document Level Security (DLS) is enabled. This SharePoint REST
endpoint requires the broad `Sites.FullControl.All` permission. With the retired
Azure ACS / client-secret flow that scope was granted implicitly, but with
certificate / Entra ID app-only authentication it must be granted explicitly on
the App Registration.

When that scope is missing, the first `roleassignments` call returns
`Unauthorized`, which the connector raises as `PermissionsMissing`. The original
error (`Received Unauthorized response for .../_api/web/roleassignments ...`) is
generic and does not make it clear that this is a DLS-only requirement or how to
fix it (grant `Sites.FullControl.All`, or disable DLS).

## What this PR changes

DLS is a security feature, so when its required permissions are missing the sync
**should fail loudly** rather than silently indexing documents without their
ACLs. This PR keeps that fail-fast behavior but makes the failure **clear and
actionable**:

- `sharepoint_online._site_access_control()` — catches `PermissionsMissing`
  around the site role-assignment + site-admin fetch and re-raises
  `PermissionsMissing` with an actionable message that names the site, states
  that this is required for Document Level Security, and tells the admin to grant
  `Sites.FullControl.All` (required for certificate / Entra ID app-only auth) or
  disable DLS.

Behavior is otherwise unchanged: role assignments are still only fetched when
DLS is enabled, so connectors with DLS disabled are unaffected.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)

This affects access-control (DLS) behavior. When role assignments cannot be read
the sync now fails with a clear, actionable `PermissionsMissing` error instead
of a generic one. This is intentional fail-fast behavior for a security feature:
we do not want to index documents with incomplete ACLs. The error message tells
the admin exactly how to resolve it.

## Related Pull Requests

* #4266 — original PR (merged to `main`)
* #4267 — `[9.5]` backport
* #4268 — `[9.4]` backport

## Release Note

Improved the SharePoint Online connector error when Document Level Security is
enabled but the app cannot read role assignments (e.g. certificate
authentication without `Sites.FullControl.All`). The sync still fails, but now
with a clear, actionable message explaining that `Sites.FullControl.All` is
required for DLS (or that DLS can be disabled) instead of a generic
`Unauthorized` error.
