### PR TITLE
[8.19] fix(deps): bump pyOpenSSL to 26.3.0 and msal to 1.37.0 for CVE-2026-34180 (#4270)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2895,7 +2895,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 cryptography
-46.0.7
+49.0.0
 Apache-2.0 OR BSD-3-Clause
 This software is made available under the terms of *either* of the licenses
 found in LICENSE.APACHE or LICENSE.BSD. Contributions to cryptography are made
@@ -5674,7 +5674,7 @@ Apache Software License
 
 
 msal
-1.32.3
+1.37.0
 MIT License
 The MIT License (MIT)
 
@@ -6281,7 +6281,7 @@ support library is itself covered by the above license.
 
 
 pyOpenSSL
-26.0.0
+26.3.0
 Apache Software License
 
                                  Apache License

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -25,11 +25,11 @@ oracledb==2.3.0
 asyncpg==0.29.0
 python-tds==1.15.0
 sqlalchemy-pytds==0.3.5
-pyOpenSSL==26.0.0
+pyOpenSSL==26.3.0
 beautifulsoup4==4.12.2
 gidgethub==5.2.1
 wcmatch==8.4.1
-msal==1.32.3
+msal==1.37.0
 exchangelib==5.4.0
 ldap3==2.9.1
 lxml==6.1.0


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump pyOpenSSL to 26.3.0 and msal to 1.37.0 for CVE-2026-34180 (#4270)

Made with [Cursor](https://cursor.com)