### PR TITLE
fix(deps): bump requests to 2.33.0 for CVE-2026-25645

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -7109,7 +7109,7 @@ SOFTWARE.
 
 
 requests
-2.32.4
+2.33.0
 Apache Software License
 
                                  Apache License

--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "pywinrm==0.4.3",
     "pyyaml==6.0.1",
     "redis==5.0.1",
-    "requests==2.32.4",
+    "requests==2.33.0",
     "simple-term-menu==1.6.4",
     "sqlalchemy-pytds==0.3.5",
     "SQLAlchemy[asyncio]==2.0.1; platform_machine=='arm64'",
@@ -95,7 +95,7 @@ tests = [
     "pytest-randomly==3.13.0",
     "pytest-fail-slow==0.3.0",
     "pyright==1.1.317",
-    "requests==2.32.4",
+    "requests==2.33.0",
 ]
 
 ftest= [

--- a/libs/connectors_sdk/pyproject.toml
+++ b/libs/connectors_sdk/pyproject.toml
@@ -40,7 +40,7 @@ tests = [
     "pytest-randomly==3.13.0",
     "pytest-fail-slow==0.3.0",
     "pyright==1.1.317",
-    "requests==2.32.4",
+    "requests==2.33.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Part of

- Security statement request: https://github.com/elastic/security/issues/12759
- CVE record: https://www.cve.org/CVERecord?id=CVE-2026-25645

## Summary

Bumps `requests` from `2.32.4` to `2.33.0` to remediate **CVE-2026-25645** ([GHSA-gc5v-m9x4-r6x2](https://github.com/advisories/GHSA-gc5v-m9x4-r6x2)).

`requests.utils.extract_zipped_paths()` (< 2.33.0) uses a predictable filename when extracting files from zip archives into the system temp directory (CWE-377, Insecure Temporary File). If the target file already exists it is reused without validation, so a local attacker with write access to the temp dir could pre-create a malicious file that gets loaded in place of the legitimate one. Requests 2.33.0 extracts to a non-deterministic location.

**Not Affected**: connectors never calls `extract_zipped_paths()` (verified via repo-wide search) — standard usage of `requests` is not impacted. Bumped proactively so scanners no longer flag the CVE.

Part of https://www.cve.org/CVERecord?id=CVE-2026-25645

## Changes

- `app/connectors_service/pyproject.toml`: `requests==2.32.4` → `2.33.0` (runtime + tests extras)
- `libs/connectors_sdk/pyproject.toml`: `requests==2.32.4` → `2.33.0`

## Scanner A/B (`CVE-2026-25645`)

| Tool | Before | After |
|------|--------|-------|
| pip-audit | reported (PYSEC-2026-2275, alias CVE-2026-25645) | clear |
| Trivy | reported | clear |
| Snyk | reported (SNYK-PYTHON-REQUESTS-15763443) | clear |

## Test plan

- [x] `make clean install autoformat lint test PYTHON=python3.11` — lint clean, 2293 tests passed (one flaky `test_s3.py::test_close_with_client_session`, unrelated to `requests`, passes on isolated + full re-run)
- [x] Scanner A/B confirms the CVE clears on all three tools that reported it

## Changes Requiring Extra Attention

- [x] Security-related changes (dependency CVE remediation)

Made with [Cursor](https://cursor.com)