### PR TITLE
[8.19] fix(deps): bump requests to 2.33.0 for CVE-2026-25645 (#4274)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -6967,7 +6967,7 @@ SOFTWARE.
 
 
 requests
-2.32.4
+2.33.0
 Apache Software License
 
                                  Apache License

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -45,6 +45,6 @@ certifi==2024.7.4
 aioboto3==12.4.0
 pyasn1==0.6.4
 azure-identity==1.19.0
-requests==2.32.4
+requests==2.33.0
 urllib3==2.7.0
 idna==3.18

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -10,5 +10,5 @@ git+https://github.com/elastic/perf8#egg=perf8
 freezegun==1.2.2
 pytest-fail-slow==0.3.0
 pyright==1.1.317
-requests==2.32.4
+requests==2.33.0
 faker==18.11.2


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump requests to 2.33.0 for CVE-2026-25645 (#4274)

The auto-backport could not cherry-pick to `8.19` because the `main` change touches `app/connectors_service/pyproject.toml` and `libs/connectors_sdk/pyproject.toml`, which do not exist on this line. This applies the equivalent bump manually in `requirements/framework.txt`, `requirements/tests.txt`, and `NOTICE.txt`.

Made with [Cursor](https://cursor.com)