### PR TITLE
fix(ci): grant explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/add-labels-main.yml
+++ b/.github/workflows/add-labels-main.yml
@@ -7,6 +7,12 @@ on:
     types:
       - opened
 
+# The repository default is read-only, so the scopes this job needs must be
+# granted here: checkout reads the VERSION file, the action labels the PR.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   add_labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,14 @@ on:
       - labeled
       - closed
 
+# The repository default is read-only, so the scopes this job needs must be
+# granted here: the backport action pushes cherry-pick branches, opens the
+# backport PRs, and comments the result back on the source PR. Approving the
+# backport PRs uses REPO_SCOPED_TOKEN, not GITHUB_TOKEN.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     if: |

--- a/.github/workflows/label-community-issues.yml
+++ b/.github/workflows/label-community-issues.yml
@@ -4,6 +4,12 @@ on:
   issues:
     types: [opened]
 
+# The repository default is read-only, so the scopes this job needs must be
+# granted here: checkout reads the script, which then labels the issue.
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   run-python-script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/4288

The repository's default `GITHUB_TOKEN` permission is now read-only:

```console
$ gh api repos/elastic/connectors/actions/permissions/workflow
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":true}
```

None of the three workflows in `.github/workflows/` declared a `permissions:` block, so they all inherit that default and lose the write access they need. `add_labels` is already failing on every newly opened PR with `HttpError: Resource not accessible by integration` (first seen on #4287, where the labels had to be applied by hand). `backport.yml` and `label-community-issues.yml` have not been triggered since the default changed, but are in the same position.

This declares the scopes each workflow actually needs. An explicit `permissions:` block overrides the read-only repository default, so it fixes the failure while keeping every workflow at least privilege — as opposed to flipping the repository setting back to read/write, which would re-grant write to everything and would presumably be reverted by whatever policy changed it.

The scopes were derived from what each workflow does:

| Workflow | Scopes | Why |
| --- | --- | --- |
| `add-labels-main.yml` | `contents: read`, `pull-requests: write` | `actions/checkout` reads the `VERSION` file; `action-add-labels` labels the PR |
| `backport.yml` | `contents: write`, `pull-requests: write` | the backport action pushes cherry-pick branches, opens the backport PRs, sets labels/assignees/auto-merge, and comments the status back on the source PR |
| `label-community-issues.yml` | `contents: read`, `issues: write` | `actions/checkout` reads the script, which then `POST`s to `/issues/{n}/labels` |

`backport.yml` is the one worth reviewing closely: it is the only workflow here that needs `contents: write`, and it is also the highest-impact one, since auto-backport silently breaking would affect every bugfix release train. Its `approver_token` is a separate PAT (`REPO_SCOPED_TOKEN`) and is unaffected by the `GITHUB_TOKEN` default, so no scope is needed for the approve step.

### Note on the failing `add_labels` check

`add_labels` fails on this PR too, and that is expected rather than a sign the fix does not work. `pull_request_target` always runs the workflow definition from the **base** branch, so this PR is still being evaluated against `main`'s copy, which has no `permissions:` block. The fix can only take effect once merged.

The setup log of that failing run shows the missing scope directly, which is the clearest confirmation of the diagnosis:

```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
  Packages: read
```

`Pull requests` is absent, and that is the 403. On the first PR opened after this merges, the same block should also list `Pull requests: write` and the job should go green.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes

Notes on the checklist items that do not apply cleanly:

- **Automated tests.** There is no test harness for workflow YAML in this repo, and as described above the change cannot be exercised end to end before merge. All three files were verified to parse and to expose the intended scopes:

  ```console
  add-labels-main.yml: parses OK, permissions={'contents': 'read', 'pull-requests': 'write'}
  backport.yml: parses OK, permissions={'contents': 'write', 'pull-requests': 'write'}
  label-community-issues.yml: parses OK, permissions={'contents': 'read', 'issues': 'write'}
  ```

- **Backport.** This is CI configuration for `main` and is deliberately not labelled `auto-backport`: both PR workflows are gated on `branches: main`, so the copies on maintenance branches never run and backporting would only produce noise. Happy to add the label if you would rather keep the branches identical.

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)

Two workflows here run on `pull_request_target`, which executes in the context of the base repository with access to secrets. This PR grants them write scopes, so it is worth confirming the grants are safe. They are: neither workflow checks out or executes code from the pull request head. `add-labels-main.yml` checks out the default ref, which for `pull_request_target` is the base branch, and only reads `VERSION` from it. `backport.yml` checks out a pinned external action repository rather than the PR, and only runs after a PR has been merged into `main`. No untrusted code gains access to the elevated token.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4287 — the PR where the failure first showed up

## Release Note

No user-facing change; CI configuration only.
