### PR TITLE
fix(outlook): prefix content document identities so DLS can match them

### DIFF
--- a/app/connectors_service/connectors/sources/outlook/datasource.py
+++ b/app/connectors_service/connectors/sources/outlook/datasource.py
@@ -51,6 +51,16 @@ CALENDAR_ITEM_TYPES = (CalendarItem,)
 TASK_ITEM_TYPES = (Task,)
 
 
+def _mailbox_access_control(account):
+    """Identities allowed to read everything in a mailbox.
+
+    These have to stay in the same dialect as the identities granted by
+    `_user_access_control_doc`: DLS matches the two with a terms query, so an
+    address stored here unprefixed is invisible to every user.
+    """
+    return [_prefix_email(account.primary_smtp_address)]
+
+
 class OutlookDocFormatter:
     """Format Outlook object documents to Elasticsearch document"""
 
@@ -465,8 +475,9 @@ class OutlookDataSource(BaseDataSource):
 
     def _decorate_with_access_control(self, document, access_control):
         if self._dls_enabled():
+            identities = document.get(ACCESS_CONTROL, []) + access_control
             document[ACCESS_CONTROL] = list(
-                set(document.get(ACCESS_CONTROL, []) + access_control)
+                {identity for identity in identities if identity is not None}
             )
         return document
 
@@ -553,7 +564,7 @@ class OutlookDataSource(BaseDataSource):
             )
             yield (
                 self._decorate_with_access_control(
-                    document, [account.primary_smtp_address]
+                    document, _mailbox_access_control(account)
                 ),
                 partial(
                     self.get_content, attachment=copy(attachment), timezone=timezone
@@ -577,7 +588,7 @@ class OutlookDataSource(BaseDataSource):
             )
             yield (
                 self._decorate_with_access_control(
-                    document, [account.primary_smtp_address]
+                    document, _mailbox_access_control(account)
                 ),
                 None,
             )
@@ -616,7 +627,7 @@ class OutlookDataSource(BaseDataSource):
                 continue
             yield (
                 self._decorate_with_access_control(
-                    document, [account.primary_smtp_address]
+                    document, _mailbox_access_control(account)
                 ),
                 None,
             )
@@ -637,7 +648,7 @@ class OutlookDataSource(BaseDataSource):
             )
             yield (
                 self._decorate_with_access_control(
-                    document, [account.primary_smtp_address]
+                    document, _mailbox_access_control(account)
                 ),
                 None,
             )
@@ -694,7 +705,7 @@ class OutlookDataSource(BaseDataSource):
         )
         yield (
             self._decorate_with_access_control(
-                document, [account.primary_smtp_address]
+                document, _mailbox_access_control(account)
             ),
             None,
         )

--- a/app/connectors_service/connectors/sources/outlook/utils.py
+++ b/app/connectors_service/connectors/sources/outlook/utils.py
@@ -33,7 +33,11 @@ def ews_format_to_datetime(source_datetime, timezone):
 
 
 def _prefix_email(email):
-    return prefix_identity("email", email)
+    # Access control documents and content documents both route addresses
+    # through here. DLS compares them with a case-sensitive terms query, and a
+    # mailbox's primary SMTP address does not always match the directory's
+    # casing, so normalise in the one place both sides share.
+    return prefix_identity("email", email.lower() if email else email)
 
 
 def _prefix_display_name(user):

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -37,6 +37,7 @@ from exchangelib.items import (
 )
 from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
 
+from connectors.access_control import ACCESS_CONTROL
 from connectors.sources.outlook import OutlookDataSource
 from connectors.sources.outlook.client import (
     ExchangeUsers,
@@ -59,6 +60,7 @@ from connectors.sources.outlook.datasource import (
     TASK_ITEM_TYPES,
     OutlookDocFormatter,
 )
+from connectors.sources.outlook.utils import _prefix_email
 from connectors.utils import get_pem_format
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
@@ -1942,3 +1944,127 @@ async def test_get_access_control_for_server(user_response):
         async for access_control in source.get_access_control():
             acl.append(access_control)
         assert len(acl) == 1
+
+
+# The directory entry for the person whose mailbox MockAccount stands in for.
+MAILBOX_OWNER = {
+    "id": "60e8a9c1-4d2f-4a3b-9a1e-2f0c5d7b8e11",
+    "displayName": "Alex Wilber",
+    "mail": "alex.wilber@gmail.com",
+    "jobTitle": "Engineer",
+}
+
+
+async def _dls_documents(source, account):
+    """Both sides of DLS for one mailbox: what is granted and what is stored."""
+    source._dls_enabled = MagicMock(return_value=True)
+    source.client._get_user_instance.get_user_accounts = AsyncIterator([account])
+
+    access_control_documents = [doc async for doc in source.get_access_control()]
+    content_documents = [doc async for doc, _ in source.get_docs()]
+
+    return access_control_documents, content_documents
+
+
+def _granted_identities(access_control_document):
+    return set(access_control_document["query"]["template"]["params"]["access_control"])
+
+
+@pytest.mark.asyncio
+async def test_content_documents_are_reachable_by_their_owner():
+    # DLS filters content with a terms query over the identities the access
+    # control document grants, so the two sides have to be written in the same
+    # dialect. Where they do not intersect, the owner of a mailbox can retrieve
+    # none of their own documents.
+    async with create_outlook_source() as source:
+        source.client.is_cloud = True
+        source.client._get_user_instance.get_users = AsyncIterator(
+            [{"value": [MAILBOX_OWNER]}]
+        )
+
+        access_control_documents, content_documents = await _dls_documents(
+            source, MockAccount()
+        )
+
+    granted = _granted_identities(access_control_documents[0])
+
+    assert content_documents
+    for document in content_documents:
+        assert granted & set(document[ACCESS_CONTROL])
+
+
+@pytest.mark.asyncio
+async def test_content_documents_are_reachable_by_their_owner_on_server():
+    async with create_outlook_source() as source:
+        source.configuration.get_field("data_source").value = OUTLOOK_SERVER
+        source.client._get_user_instance.get_users = AsyncIterator(
+            [
+                {
+                    "attributes": {"mail": "dummy@es.local"},
+                    "dn": "CN=Dummy,CN=Users,DC=es,DC=local",
+                }
+            ]
+        )
+        account = MockAccount()
+        account.primary_smtp_address = "dummy@es.local"
+
+        access_control_documents, content_documents = await _dls_documents(
+            source, account
+        )
+
+    granted = _granted_identities(access_control_documents[0])
+
+    assert content_documents
+    for document in content_documents:
+        assert granted & set(document[ACCESS_CONTROL])
+
+
+@pytest.mark.asyncio
+async def test_content_documents_are_reachable_whatever_the_address_casing():
+    # Exchange reports a mailbox under the casing it was configured with, which
+    # is not necessarily the casing the directory reports for the same person.
+    async with create_outlook_source() as source:
+        source.client.is_cloud = True
+        source.client._get_user_instance.get_users = AsyncIterator(
+            [{"value": [MAILBOX_OWNER | {"mail": "Alex.Wilber@Gmail.com"}]}]
+        )
+        account = MockAccount()
+        account.primary_smtp_address = "alex.wilber@GMAIL.com"
+
+        access_control_documents, content_documents = await _dls_documents(
+            source, account
+        )
+
+    granted = _granted_identities(access_control_documents[0])
+
+    assert "email:alex.wilber@gmail.com" in granted
+    assert content_documents
+    for document in content_documents:
+        assert granted & set(document[ACCESS_CONTROL])
+
+
+@pytest.mark.asyncio
+async def test_decorate_with_access_control_drops_unknown_identities():
+    async with create_outlook_source() as source:
+        source._dls_enabled = MagicMock(return_value=True)
+
+        # A mailbox with no address prefixes to None, which must not be stored:
+        # a null in the terms list is noise no user can ever match.
+        document = source._decorate_with_access_control(
+            {"_id": "1"}, [None, "email:alex.wilber@gmail.com"]
+        )
+
+        assert document[ACCESS_CONTROL] == ["email:alex.wilber@gmail.com"]
+
+
+@pytest.mark.parametrize(
+    "email, expected",
+    [
+        ("Alex.Wilber@Example.COM", "email:alex.wilber@example.com"),
+        ("alex.wilber@example.com", "email:alex.wilber@example.com"),
+        ("", "email:"),
+        (None, None),
+    ],
+)
+def test_prefix_email_normalises_casing(email, expected):
+    assert _prefix_email(email) == expected


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/4290

With DLS enabled, the Outlook connector writes its two sides in different dialects. Access control documents grant **prefixed** identities, while every content document is decorated with the **raw** SMTP address:

```
ACL doc grants  : ["user_id:60e8a9c1-...", "name:Alex Wilber", "email:alex.wilber@gmail.com"]
content doc has : ["alex.wilber@gmail.com"]
overlap         : NONE
```

DLS filters `_allow_access_control` with a `terms` query, so the intersection being empty means the owner of a mailbox retrieves **none** of their own documents. This is pre-existing since DLS was added and affects all five `_decorate_with_access_control` call sites (mails, attachments, contacts, tasks, calendars).

This routes the mailbox address through `_prefix_email` at every call site. Casing is normalised inside that helper rather than at the call sites, because both sides of the comparison already share it, so the invariant holds by construction instead of by convention.

Two smaller things came along with it, both load-bearing rather than drive-by:

- **Casing.** A `terms` query is case-sensitive, and a mailbox's primary SMTP address is not guaranteed to match the casing the directory reports for the same person. Prefixing alone would leave that as a second way to silently match nothing.
- **`None` identities.** A mailbox with no address prefixes to `None`, and `_decorate_with_access_control` would previously store that null in the terms list. `es_access_control_query` already filters `None` on the access control side; this makes the content side agree.

### What this does not fix

Access control documents take the address from the directory (Graph's `mail` on cloud, the LDAP `mail` attribute on server), while content documents take it from the mailbox (`primary_smtp_address`). Those are normally the same address, and after this change they also agree on casing, but they are not guaranteed to be equal: a tenant using aliases or proxy addresses can have a directory `mail` that differs from the mailbox's primary SMTP address, and for those users the terms query still will not match. Covering that properly means granting every proxy address a mailbox answers to, which is a larger change and deserves its own issue. Recording it here so it is a known limitation rather than a surprise.

## Upgrade note

The incorrect values are stored on the content documents themselves, not only in the query template, so deploying this is not sufficient on its own. Affected deployments need a **full content sync** to rewrite `_allow_access_control` on every document; an access control sync alone will not do it. This differs from #4005, where only the stored query was wrong and re-running the access control sync was enough.

Worth knowing alongside that: documents indexed before DLS was switched on carry no `_allow_access_control` field, and the `must_not exists` clause in `DLS_QUERY` makes those visible to everyone. That is existing framework behaviour rather than anything this PR changes, but it does mean enabling DLS never retroactively protects already-indexed content.

## Verification

Beyond unit tests, I confirmed the bug and the fix end to end against a real Elasticsearch 8.19.0. Both documents were produced by driving the connector itself rather than written by hand, the index was created with the framework's own mappings, and the mustache template stored on the access control document was rendered by Elasticsearch and then executed.

Before:

| Document | main / 9.6 | 8.19 |
| --- | --- | --- |
| as the connector writes it today | **HIDDEN** | **HIDDEN** |
| same document, `email:` prefix applied | VISIBLE | VISIBLE |
| document with no `_allow_access_control` | VISIBLE | VISIBLE |

After, on this branch, the first row is `VISIBLE` in both configurations.

One thing worth knowing if you reproduce this: the two versions have to be paired correctly or you will get a misleading result. `main` queries `_allow_access_control.keyword` and applies no mappings, so dynamic mapping supplies `.keyword`; 8.19 queries `_allow_access_control.enum` and applies `Mappings.default_text_fields_mappings`, whose dynamic template supplies `.enum`. Each is internally consistent, and both fail for the same reason, which is what makes the prefix the sole cause.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes

**Tests.** Six new tests. The three `test_content_documents_are_reachable_*` ones assert the invariant directly — that the identities on content documents intersect the identities the access control document grants — for the cloud path, the server/LDAP path, and mismatched address casing. This is the dual-side assertion the Outlook suite was missing: it asserted the access control side with `assert len(acl) == 1` and never looked at `_allow_access_control` on content documents, which is why this survived. Jira, Confluence and OneDrive already assert both sides.

I checked the new tests are load-bearing by reverting only the source change and re-running them:

```
FAILED test_content_documents_are_reachable_by_their_owner
FAILED test_content_documents_are_reachable_by_their_owner_on_server
FAILED test_content_documents_are_reachable_whatever_the_address_casing
FAILED test_decorate_with_access_control_drops_unknown_identities
FAILED test_prefix_email_normalises_casing[Alex.Wilber@Example.COM-...]
```

Full suite on this branch: `2301 passed`, coverage 92.19%.

**Local run.** `make autoformat lint test PYTHON=python3.11`. Ruff is clean. `typecheck` reports 13 pyright `unknown import symbol` errors in `kibana.py`, `service_cli.py`, `agent/`, `cli/`, `es/`, `protocol/` and `services/` — all pre-existing on `main` and none in files this PR touches.

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)

This changes which documents a user can retrieve under Document Level Security, so it deserves a careful read. The change only ever *narrows* nothing and *widens* access from "nobody sees anything" to "the mailbox owner sees their own mailbox" — content documents still carry exactly one identity, the mailbox they came from, which is the same value as before with a prefix applied. No document becomes visible to anyone other than its own mailbox owner.

Worth flagging explicitly: documents with no `_allow_access_control` field are visible to everyone by design (the `must_not exists` clause in `DLS_QUERY`). That is unchanged here, and Outlook always sets the field when DLS is on.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4287 — the other bugfix from the same investigation

## Release Note

Fixed Document Level Security for the Outlook connector, where content documents were indexed with identities that did not match the ones granted by the access control documents, so no synced document was retrievable by the user who owned it.
