### PR TITLE
[8.19] fix(outlook): skip unrecognised EWS elements instead of aborting the sync (#4287)

### DIFF
--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -32,11 +32,12 @@ from exchangelib.errors import (
     ErrorManagedFolderNotFound,
     ErrorNonExistentMailbox,
 )
-from exchangelib.folders import Calendar, Messages
+from exchangelib.folders import BaseFolder, Calendar, Messages
 from exchangelib.items import (
     CalendarItem,
     Contact,
     DistributionList,
+    Item,
     MeetingCancellation,
     MeetingRequest,
     MeetingResponse,
@@ -169,6 +170,24 @@ END_SIGNAL = "FINISHED"
 
 # Folder-absent faults: skip the folder, keep syncing.
 FOLDER_SKIP_ERRORS = (ErrorFolderNotFound, ErrorManagedFolderNotFound)
+
+# exchangelib raises ValueError on unrecognised item tags (e.g. a stray
+# EndTimeZone). Degrade to Item so the sync continues; folder allowlists skip it.
+_reported_unexpected_item_tags = set()
+
+
+@classmethod
+def _tolerant_item_model_from_tag(cls, tag):
+    try:
+        return cls.ITEM_MODEL_MAP[tag]
+    except KeyError:
+        if tag not in _reported_unexpected_item_tags:
+            _reported_unexpected_item_tags.add(tag)
+            logger.warning(f"Unexpected EWS item tag {tag}; skipping")
+        return Item
+
+
+BaseFolder.item_model_from_tag = _tolerant_item_model_from_tag
 
 # Item types each formatter can render; a test keeps them in sync with exchangelib.
 MAIL_ITEM_TYPES = (Message, MeetingRequest, MeetingResponse, MeetingCancellation)

--- a/tests/sources/test_outlook.py
+++ b/tests/sources/test_outlook.py
@@ -23,11 +23,12 @@ from exchangelib.errors import (
     ErrorNonExistentMailbox,
     TransportError,
 )
-from exchangelib.folders import Calendar, Messages, Tasks
+from exchangelib.folders import BaseFolder, Calendar, Messages, Tasks
 from exchangelib.items import (
     CalendarItem,
     Contact,
     DistributionList,
+    Item,
     MeetingCancellation,
     MeetingRequest,
     MeetingResponse,
@@ -35,8 +36,10 @@ from exchangelib.items import (
     Task,
 )
 from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
+from exchangelib.util import to_xml
 
 from connectors.source import ConfigurableFieldValueError
+from connectors.sources import outlook as outlook_module
 from connectors.sources.outlook import (
     CALENDAR_ITEM_TYPES,
     INBOX_MAIL_OBJECT,
@@ -1782,6 +1785,73 @@ async def test_fetch_mails_accepts_all_mail_item_types(item_type):
 def test_item_type_allowlists_match_exchangelib(allowlist, folder_cls):
     # Fails if a library upgrade changes a folder's item types (update the formatter).
     assert set(allowlist) == set(folder_cls.supported_item_models)
+
+
+UNEXPECTED_ITEM_TAG = (
+    "{http://schemas.microsoft.com/exchange/services/2006/types}EndTimeZone"
+)
+# Stray EndTimeZone next to CalendarItem — the SDH response shape.
+UNEXPECTED_ELEMENT_RESPONSE = b"""<?xml version="1.0" encoding="utf-8"?>
+<m:Items xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+         xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+  <t:CalendarItem>
+    <t:ItemId Id="calendar_1" ChangeKey="change_key_1"/>
+    <t:Subject>Team sync</t:Subject>
+  </t:CalendarItem>
+  <t:EndTimeZone Id="(GMT+01:00) Amsterdam, Berlin, Bern, Rom, Stockholm, Wien"/>
+</m:Items>
+"""
+
+
+@pytest.mark.parametrize(
+    "item_model",
+    [CalendarItem, Contact, DistributionList, Item, Message, Task],
+    ids=lambda cls: cls.__name__,
+)
+def test_item_model_from_tag_still_resolves_known_tags(item_model):
+    assert BaseFolder.item_model_from_tag(item_model.response_tag()) is item_model
+
+
+def test_item_model_from_tag_degrades_unknown_tag_to_item():
+    outlook_module._reported_unexpected_item_tags.clear()
+
+    with patch("connectors.sources.outlook.logger") as logger:
+        assert BaseFolder.item_model_from_tag(UNEXPECTED_ITEM_TAG) is Item
+        assert BaseFolder.item_model_from_tag(UNEXPECTED_ITEM_TAG) is Item
+        logger.warning.assert_called_once()
+
+
+def test_unexpected_element_does_not_abort_folder_query():
+    items = [
+        BaseFolder.item_model_from_tag(element.tag).from_xml(elem=element, account=None)
+        for element in to_xml(UNEXPECTED_ELEMENT_RESPONSE).getroot()
+    ]
+
+    calendar_item, unexpected_item = items
+    assert isinstance(calendar_item, CalendarItem)
+    assert calendar_item.id == "calendar_1"
+    assert type(unexpected_item) is Item
+
+
+@pytest.mark.asyncio
+async def test_enqueue_calendars_skips_degraded_unknown_item():
+    async with create_outlook_source() as source:
+        source._logger = MagicMock()
+        account = MockAccount()
+        degraded_item = Item(id="unknown_1")
+
+        documents = [
+            document
+            async for document, _ in source._enqueue_calendars(
+                calendar=degraded_item,
+                child_calendar="Calendar",
+                timezone=TIMEZONE,
+                account=account,
+            )
+        ]
+
+        assert documents == []
+        source._logger.warning.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(outlook): skip unrecognised EWS elements instead of aborting the sync (#4287)

Made with [Cursor](https://cursor.com)