### PR TITLE
fix(deps): bump setuptools to 83.0.0 for CVE-2026-59890

### DIFF
--- a/app/connectors_service/Makefile
+++ b/app/connectors_service/Makefile
@@ -28,6 +28,7 @@ config.yml:
 .venv/bin/python: | config.yml
 	$(PYTHON) -m venv .venv
 	.venv/bin/pip install --upgrade pip
+	.venv/bin/pip install setuptools==83.0.0
 	.venv/bin/python -m pip install build
 
 .venv/bin/pip-licenses: .venv/bin/python

--- a/app/connectors_service/pyproject.toml
+++ b/app/connectors_service/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/libs/connectors_sdk/Makefile
+++ b/libs/connectors_sdk/Makefile
@@ -5,6 +5,7 @@ SLOW_TEST_THRESHOLD = 1
 .venv/bin/python:
 	$(PYTHON) -m venv .venv
 	$(VENV_DIR)/pip install --upgrade pip
+	$(VENV_DIR)/pip install setuptools==83.0.0
 	$(VENV_DIR)/python -m pip install build
 	$(VENV_DIR)/pip install -e .
 
@@ -13,6 +14,7 @@ install: .venv/bin/python
 install-package:
 	$(PYTHON) -m venv .venv
 	$(VENV_DIR)/pip install --upgrade pip
+	$(VENV_DIR)/pip install setuptools==83.0.0
 	$(VENV_DIR)/python -m pip install build
 	$(VENV_DIR)/python -m build
 	$(VENV_DIR)/pip install dist/*.whl

--- a/libs/connectors_sdk/pyproject.toml
+++ b/libs/connectors_sdk/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Part of

* Security statement request: https://github.com/elastic/security/issues/12912
* CVE record: https://www.cve.org/CVERecord?id=CVE-2026-59890

## Summary

Pins `setuptools` to `83.0.0` (build-system requires `>=83.0.0`, Makefile install `==83.0.0`) to remediate **CVE-2026-59890** ([GHSA-h35f-9h28-mq5c](https://github.com/advisories/GHSA-h35f-9h28-mq5c)).

Prior to 83.0.0, setuptools `FileList` applied `MANIFEST.in` exclude directives without Unicode normalization, so on macOS APFS/HFS+ an NFD filename could bypass an NFC exclusion rule and be packed into an sdist.

**Not Affected** for product runtime: connectors does not exercise the vulnerable sdist/`MANIFEST.in` matching path as an attack surface for customers. Bumped proactively so image freezes / Snyk no longer report the CVE. On `8.19`, setuptools was explicitly pinned at `79.0.1`; on `main`/`9.x` it was an unpinned build/install dependency that still landed in the venv freeze.

Part of https://github.com/elastic/security/issues/12912

## Changes

* `app/connectors_service/pyproject.toml` / `libs/connectors_sdk/pyproject.toml`: `[build-system] requires = ["setuptools>=83.0.0"]`
* `app/connectors_service/Makefile` / `libs/connectors_sdk/Makefile`: install `setuptools==83.0.0` into the venv

Note: `8.19` uses the legacy `Makefile` pin (`setuptools==79.0.1`); auto-backport may need a manual equivalent change there.

### Scanner A/B (`CVE-2026-59890`)

| Tool | Before (`setuptools==79.0.1`) | After (`setuptools==83.0.0`) |
|------|--------|-------|
| pip-audit | reported (PYSEC-2026-3447 / CVE-2026-59890) | clear |
| Trivy | reported (CVE-2026-59890) | clear |
| Snyk | reported (SNYK-PYTHON-SETUPTOOLS-17895075 → CVE-2026-59890) | clear |

## Test plan

* [x] Scanner A/B confirms the CVE clears on all three tools that reported it
* [x] `make install` installs `setuptools==83.0.0`
* [x] `make test` — app 2302 passed; SDK 342 passed (`PYTHON=python3.11`)
* [ ] CI packaging / Trivy on rebuilt image

## Changes Requiring Extra Attention

* Security-related changes (dependency CVE remediation)

Made with [Cursor](https://cursor.com)