### PR TITLE
fix(confluence): index inherited page restrictions for DLS (#4095)

### DIFF
--- a/app/connectors_service/connectors/sources/atlassian/confluence/client.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/client.py
@@ -17,6 +17,7 @@ from connectors.sources.atlassian.confluence.constants import (
     CONFLUENCE_DATA_CENTER,
     CONFLUENCE_SERVER,
     CONTENT,
+    CONTENT_RESTRICTION,
     DATACENTER_USER_BATCH,
     DEFAULT_RETRY_SECONDS,
     LABEL,
@@ -352,6 +353,38 @@ class ConfluenceClient:
                     labels = await self.fetch_label(document["id"])
                     document["labels"] = labels
                 yield document, attachment_count
+
+    async def fetch_content_restrictions(self, content_id):
+        """Fetch the read restrictions applied directly to a single piece of content.
+
+        Confluence's REST API only returns restrictions set explicitly on the
+        requested content; inherited restrictions are not resolved server-side.
+        This is used to walk a page's ancestors and resolve the effective
+        (inherited) restrictions for pages that have none of their own.
+
+        Args:
+            content_id (str): Unique identifier of the Confluence content.
+
+        Returns:
+            dict: The restriction payload for the ``read`` operation, or an empty
+                dict when the content has no readable restrictions (e.g. it is a
+                draft, trashed, or otherwise inaccessible ancestor).
+        """
+        url = os.path.join(
+            self.host_url, URLS[CONTENT_RESTRICTION].format(id=content_id)
+        )
+        try:
+            response = await self.api_call(url=url)
+            return await response.json()
+        except (NotFound, Forbidden):
+            # The ancestor may be a draft/trashed page or one the connector's
+            # account cannot read; treat it as having no inheritable restriction.
+            return {}
+        except Exception as exception:
+            self._logger.warning(
+                f"Skipping restrictions for content '{content_id}'. Exception: {exception}."
+            )
+            return {}
 
     async def fetch_attachments(self, content_id):
         async for response in self.paginated_api_call(

--- a/app/connectors_service/connectors/sources/atlassian/confluence/client.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/client.py
@@ -70,6 +70,12 @@ class Forbidden(Exception):
     pass
 
 
+class ContentRestrictionFetchError(Exception):
+    """Raised when content restrictions cannot be evaluated safely for DLS."""
+
+    pass
+
+
 class ConfluenceClient:
     """Confluence client to handle API calls made to Confluence"""
 
@@ -355,20 +361,30 @@ class ConfluenceClient:
                 yield document, attachment_count
 
     async def fetch_content_restrictions(self, content_id):
-        """Return explicit read restrictions for content, or {} if unavailable."""
+        """Return explicit read restrictions for content.
+
+        Returns:
+            dict: Restriction payload on success (may have empty user/group lists).
+            None: Content was not found (404); caller should skip this ancestor.
+
+        Raises:
+            ContentRestrictionFetchError: Restrictions could not be evaluated
+                (403/401/5xx/other). Callers must fail closed for DLS.
+        """
         url = os.path.join(
             self.host_url, URLS[CONTENT_RESTRICTION].format(id=content_id)
         )
         try:
             response = await self.api_call(url=url)
             return await response.json()
-        except (NotFound, Forbidden):
-            return {}
+        except NotFound:
+            return None
         except Exception as exception:
             self._logger.warning(
-                f"Skipping restrictions for content '{content_id}'. Exception: {exception}."
+                f"Unable to fetch restrictions for content '{content_id}'. Exception: {exception}."
             )
-            return {}
+            msg = f"Unable to fetch restrictions for content '{content_id}'"
+            raise ContentRestrictionFetchError(msg) from exception
 
     async def fetch_attachments(self, content_id):
         async for response in self.paginated_api_call(

--- a/app/connectors_service/connectors/sources/atlassian/confluence/client.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/client.py
@@ -355,21 +355,7 @@ class ConfluenceClient:
                 yield document, attachment_count
 
     async def fetch_content_restrictions(self, content_id):
-        """Fetch the read restrictions applied directly to a single piece of content.
-
-        Confluence's REST API only returns restrictions set explicitly on the
-        requested content; inherited restrictions are not resolved server-side.
-        This is used to walk a page's ancestors and resolve the effective
-        (inherited) restrictions for pages that have none of their own.
-
-        Args:
-            content_id (str): Unique identifier of the Confluence content.
-
-        Returns:
-            dict: The restriction payload for the ``read`` operation, or an empty
-                dict when the content has no readable restrictions (e.g. it is a
-                draft, trashed, or otherwise inaccessible ancestor).
-        """
+        """Return explicit read restrictions for content, or {} if unavailable."""
         url = os.path.join(
             self.host_url, URLS[CONTENT_RESTRICTION].format(id=content_id)
         )
@@ -377,8 +363,6 @@ class ConfluenceClient:
             response = await self.api_call(url=url)
             return await response.json()
         except (NotFound, Forbidden):
-            # The ancestor may be a draft/trashed page or one the connector's
-            # account cannot read; treat it as having no inheritable restriction.
             return {}
         except Exception as exception:
             self._logger.warning(

--- a/app/connectors_service/connectors/sources/atlassian/confluence/constants.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/constants.py
@@ -15,6 +15,7 @@ ATTACHMENT = "attachment"
 CONTENT = "content"
 DOWNLOAD = "download"
 SEARCH = "search"
+CONTENT_RESTRICTION = "content_restriction"
 USER = "user"
 USERS_FOR_DATA_CENTER = "users_for_data_center"
 SEARCH_FOR_DATA_CENTER = "search_for_data_center"
@@ -33,6 +34,7 @@ URLS = {
     SPACE: "rest/api/space?{api_query}",
     SPACE_PERMISSION: "rest/extender/1.0/permission/space/{space_key}/getSpacePermissionActors/VIEWSPACE",
     CONTENT: "rest/api/content/search?{api_query}",
+    CONTENT_RESTRICTION: "rest/api/content/{id}/restriction/byOperation/read?expand=restrictions.user,restrictions.group",
     ATTACHMENT: "rest/api/content/{id}/child/attachment?{api_query}",
     SEARCH: "rest/api/search?cql={query}",
     SEARCH_FOR_DATA_CENTER: "rest/api/search?cql={query}&start={start}",

--- a/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
@@ -464,6 +464,44 @@ class ConfluenceDataSource(BaseDataSource):
 
         return identities
 
+    async def _resolve_inherited_restrictions(self, ancestors, extract_identities):
+        """Resolve the effective view restrictions inherited from ancestor pages.
+
+        A Confluence page with no restrictions of its own ("No restrictions")
+        still inherits the view restrictions of its ancestors. The REST API does
+        not expose these inherited restrictions directly, so we walk the ancestor
+        chain from the closest parent up to the root and return the identities of
+        the nearest ancestor that has explicit read restrictions.
+
+        Args:
+            ancestors (list): Ancestors of the document, ordered from the root to
+                the immediate parent (as returned by the Confluence API).
+            extract_identities (callable): Function that extracts the set of
+                access-control identities from a restrictions payload.
+
+        Returns:
+            set: Identities inherited from the nearest restricted ancestor, or an
+                empty set when no ancestor has explicit read restrictions.
+        """
+        if not self._dls_enabled():
+            return set()
+
+        for ancestor in reversed(ancestors or []):
+            ancestor_id = ancestor.get("id")
+            if not ancestor_id:
+                continue
+
+            restrictions = await self.confluence_client.fetch_content_restrictions(
+                content_id=ancestor_id
+            )
+            identities = extract_identities(
+                response=restrictions.get("restrictions", {})
+            )
+            if identities:
+                return identities
+
+        return set()
+
     async def close(self):
         """Closes unclosed client session"""
         await self.confluence_client.close_session()
@@ -547,6 +585,7 @@ class ConfluenceDataSource(BaseDataSource):
             Integer: Number of attachments in a page/blogpost
             List: List of permissions attached to document
             Dictionary: Dictionary of restrictions attached to document
+            List: List of ancestors (with their ids) of the document
         """
         async for (
             document,
@@ -592,6 +631,7 @@ class ConfluenceDataSource(BaseDataSource):
                 document.get("restrictions", {})
                 .get("read", {})
                 .get("restrictions", {}),
+                document.get("ancestors", []),
             )
 
     async def fetch_attachments(
@@ -842,14 +882,28 @@ class ConfluenceDataSource(BaseDataSource):
                 space_key,
                 permissions,
                 restrictions,
+                ancestors,
             ) in self.fetch_documents(api_query):
                 # Pages and blog posts are open to viewing or editing by default,
                 # but you can restrict either viewing or editing to certain users or groups.
                 if self.confluence_client.data_source_type == CONFLUENCE_CLOUD:
+                    extract_identities = self._extract_identities
+                else:
+                    extract_identities = self._extract_identities_for_datacenter
+
+                access_control = list(extract_identities(response=restrictions))
+                if len(access_control) == 0:
+                    # A page with "No restrictions" of its own still inherits the
+                    # view restrictions of its ancestors, so resolve those before
+                    # falling back to the broader space-level permissions.
                     access_control = list(
-                        self._extract_identities(response=restrictions)
+                        await self._resolve_inherited_restrictions(
+                            ancestors=ancestors,
+                            extract_identities=extract_identities,
+                        )
                     )
-                    if len(access_control) == 0:
+                if len(access_control) == 0:
+                    if self.confluence_client.data_source_type == CONFLUENCE_CLOUD:
                         # Every space has its own independent set of permissions, managed by the space admin(s),
                         # which determine the access settings for different users and groups.
                         access_control = list(
@@ -857,11 +911,7 @@ class ConfluenceDataSource(BaseDataSource):
                                 permissions=permissions, target_type=target_type
                             )
                         )
-                else:
-                    access_control = list(
-                        self._extract_identities_for_datacenter(response=restrictions)
-                    )
-                    if len(access_control) == 0:
+                    else:
                         permission = await self.fetch_server_space_permission(
                             space_key=space_key
                         )

--- a/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
@@ -9,6 +9,7 @@ import asyncio
 import os
 from copy import copy
 from functools import partial
+from typing import NamedTuple
 
 from connectors_sdk.source import BaseDataSource, ConfigurableFieldValueError
 from connectors_sdk.utils import (
@@ -17,7 +18,10 @@ from connectors_sdk.utils import (
 )
 
 from connectors.access_control import ACCESS_CONTROL
-from connectors.sources.atlassian.confluence.client import ConfluenceClient
+from connectors.sources.atlassian.confluence.client import (
+    ConfluenceClient,
+    ContentRestrictionFetchError,
+)
 from connectors.sources.atlassian.confluence.constants import (
     BLOGPOST,
     CONFLUENCE_CLOUD,
@@ -58,6 +62,17 @@ from connectors.utils import (
     MemQueue,
     html_to_text,
 )
+
+
+class EffectiveReadAccess(NamedTuple):
+    """Resolved view ACL for a page.
+
+    When use_space is True, fall back to space permissions.
+    When use_space is False, identities is the ACL to index (may be empty).
+    """
+
+    identities: set
+    use_space: bool
 
 
 class ConfluenceDataSource(BaseDataSource):
@@ -464,26 +479,51 @@ class ConfluenceDataSource(BaseDataSource):
 
         return identities
 
-    async def _resolve_inherited_restrictions(self, ancestors, extract_identities):
-        """Return identities from the nearest ancestor with explicit read restrictions."""
-        if not self._dls_enabled():
-            return set()
+    async def _resolve_effective_read_access(
+        self, child_restrictions, ancestors, extract_identities
+    ):
+        """Resolve effective view ACL from child + ancestor explicit restrictions.
 
-        for ancestor in reversed(ancestors or []):
+        Returns EffectiveReadAccess. use_space is True only when every layer was
+        successfully evaluated and none had explicit view restrictions.
+        On ambiguous ancestor fetch failure, returns empty identities and
+        use_space=False (fail closed for DLS).
+        """
+        if not self._dls_enabled():
+            return EffectiveReadAccess(identities=set(), use_space=False)
+
+        layers = []
+        child_identities = extract_identities(response=child_restrictions)
+        if child_identities:
+            layers.append(child_identities)
+
+        for ancestor in ancestors or []:
             ancestor_id = ancestor.get("id")
             if not ancestor_id:
                 continue
 
-            restrictions = await self.confluence_client.fetch_content_restrictions(
-                content_id=ancestor_id
-            )
+            try:
+                restrictions = await self.confluence_client.fetch_content_restrictions(
+                    content_id=ancestor_id
+                )
+            except ContentRestrictionFetchError:
+                return EffectiveReadAccess(identities=set(), use_space=False)
+
+            if restrictions is None:
+                continue
+
             identities = extract_identities(
                 response=restrictions.get("restrictions", {})
             )
             if identities:
-                return identities
+                layers.append(identities)
 
-        return set()
+        if not layers:
+            return EffectiveReadAccess(identities=set(), use_space=True)
+
+        return EffectiveReadAccess(
+            identities=set.intersection(*layers), use_space=False
+        )
 
     async def close(self):
         """Closes unclosed client session"""
@@ -874,16 +914,12 @@ class ConfluenceDataSource(BaseDataSource):
                 else:
                     extract_identities = self._extract_identities_for_datacenter
 
-                access_control = list(extract_identities(response=restrictions))
-                if len(access_control) == 0:
-                    # Inherit restrictions from the nearest restricted ancestor.
-                    access_control = list(
-                        await self._resolve_inherited_restrictions(
-                            ancestors=ancestors,
-                            extract_identities=extract_identities,
-                        )
-                    )
-                if len(access_control) == 0:
+                effective_access = await self._resolve_effective_read_access(
+                    child_restrictions=restrictions,
+                    ancestors=ancestors,
+                    extract_identities=extract_identities,
+                )
+                if effective_access.use_space:
                     if self.confluence_client.data_source_type == CONFLUENCE_CLOUD:
                         # Every space has its own independent set of permissions, managed by the space admin(s),
                         # which determine the access settings for different users and groups.
@@ -903,6 +939,8 @@ class ConfluenceDataSource(BaseDataSource):
                                 )
                             )
                         )
+                else:
+                    access_control = list(effective_access.identities)
                 document = self._decorate_with_access_control(
                     document=document, access_control=access_control
                 )

--- a/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
@@ -465,24 +465,7 @@ class ConfluenceDataSource(BaseDataSource):
         return identities
 
     async def _resolve_inherited_restrictions(self, ancestors, extract_identities):
-        """Resolve the effective view restrictions inherited from ancestor pages.
-
-        A Confluence page with no restrictions of its own ("No restrictions")
-        still inherits the view restrictions of its ancestors. The REST API does
-        not expose these inherited restrictions directly, so we walk the ancestor
-        chain from the closest parent up to the root and return the identities of
-        the nearest ancestor that has explicit read restrictions.
-
-        Args:
-            ancestors (list): Ancestors of the document, ordered from the root to
-                the immediate parent (as returned by the Confluence API).
-            extract_identities (callable): Function that extracts the set of
-                access-control identities from a restrictions payload.
-
-        Returns:
-            set: Identities inherited from the nearest restricted ancestor, or an
-                empty set when no ancestor has explicit read restrictions.
-        """
+        """Return identities from the nearest ancestor with explicit read restrictions."""
         if not self._dls_enabled():
             return set()
 
@@ -893,9 +876,7 @@ class ConfluenceDataSource(BaseDataSource):
 
                 access_control = list(extract_identities(response=restrictions))
                 if len(access_control) == 0:
-                    # A page with "No restrictions" of its own still inherits the
-                    # view restrictions of its ancestors, so resolve those before
-                    # falling back to the broader space-level permissions.
+                    # Inherit restrictions from the nearest restricted ancestor.
                     access_control = list(
                         await self._resolve_inherited_restrictions(
                             ancestors=ancestors,

--- a/app/connectors_service/tests/sources/test_confluence.py
+++ b/app/connectors_service/tests/sources/test_confluence.py
@@ -492,6 +492,45 @@ PAGE_RESTRICTION_RESPONSE = {
     "group": {"results": [], "size": 0},
 }
 
+CLOUD_INHERITED_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {
+            "results": [
+                {
+                    "type": "known",
+                    "accountType": "atlassian",
+                    "accountId": "user_id_9",
+                }
+            ],
+            "size": 1,
+        },
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin", "id": "group_id_admin"},
+                {"type": "group", "name": "group-power", "id": "group_id_power"},
+            ],
+            "size": 2,
+        },
+    },
+}
+DATA_CENTER_INHERITED_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {
+            "results": [{"type": "known", "username": "restricted_user"}],
+            "size": 1,
+        },
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin"},
+                {"type": "group", "name": "group-power-user"},
+            ],
+            "size": 2,
+        },
+    },
+}
+
 EXPECTED_QUERY_RESPONSE = {
     "content": {
         "id": "983041",
@@ -1030,7 +1069,7 @@ async def test_fetch_documents():
         source.confluence_client.index_labels = True
         source.confluence_client.data_source_type = "confluence_cloud"
         # Execute
-        async for response, _, _, _, _ in source.fetch_documents(api_query=""):
+        async for response, _, _, _, _, _ in source.fetch_documents(api_query=""):
             assert response == EXPECTED_PAGE
 
 
@@ -1229,8 +1268,8 @@ async def test_download_attachment_with_text_extraction_enabled_adds_body():
     ConfluenceDataSource,
     "fetch_documents",
     side_effect=[
-        (AsyncIterator([[copy(EXPECTED_PAGE), 1, "space_key", [], {}]])),
-        (AsyncIterator([[copy(EXPECTED_BLOG), 1, "space_key", [], {}]])),
+        (AsyncIterator([[copy(EXPECTED_PAGE), 1, "space_key", [], {}, []]])),
+        (AsyncIterator([[copy(EXPECTED_BLOG), 1, "space_key", [], {}, []]])),
     ],
 )
 @mock.patch.object(
@@ -1583,6 +1622,7 @@ async def test_fetch_confluence_server_users():
                         "space_key",
                         BLOG_POST_PERMISSION_RESPONSE,
                         {},
+                        [],
                     ]
                 ]
             )
@@ -1596,6 +1636,7 @@ async def test_fetch_confluence_server_users():
                         "space_key",
                         PAGE_PERMISSION_RESPONSE,
                         PAGE_RESTRICTION_RESPONSE,
+                        [],
                     ]
                 ]
             )
@@ -1764,6 +1805,182 @@ async def test_fetch_server_space_permission():
 
 
 @pytest.mark.asyncio
+async def test_fetch_content_restrictions_returns_payload():
+    async with create_confluence_source() as source:
+        async_response = AsyncMock()
+        async_response.json.return_value = CLOUD_INHERITED_RESTRICTION_RESPONSE
+        with mock.patch(
+            "connectors.sources.atlassian.confluence.ConfluenceClient.api_call",
+            return_value=async_response,
+        ):
+            response = await source.confluence_client.fetch_content_restrictions(
+                content_id="123"
+            )
+            assert response == CLOUD_INHERITED_RESTRICTION_RESPONSE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [NotFound(), Forbidden(), Exception("boom")])
+async def test_fetch_content_restrictions_returns_empty_on_error(exception):
+    """Unreadable ancestors (draft/trashed/forbidden) must not break the sync."""
+    async with create_confluence_source() as source:
+        with mock.patch(
+            "connectors.sources.atlassian.confluence.ConfluenceClient.api_call",
+            side_effect=exception,
+        ):
+            response = await source.confluence_client.fetch_content_restrictions(
+                content_id="123"
+            )
+            assert response == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_inherited_restrictions_uses_nearest_restricted_ancestor():
+    async with create_confluence_source() as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        # Ancestors are ordered from root to the immediate parent.
+        ancestors = [{"id": "root"}, {"id": "parent"}]
+        source.confluence_client.fetch_content_restrictions = AsyncMock(
+            return_value=CLOUD_INHERITED_RESTRICTION_RESPONSE
+        )
+
+        identities = await source._resolve_inherited_restrictions(
+            ancestors=ancestors, extract_identities=source._extract_identities
+        )
+
+        assert identities == {
+            "account_id:user_id_9",
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
+        }
+        # The nearest ancestor (immediate parent) is queried first and wins.
+        source.confluence_client.fetch_content_restrictions.assert_called_once_with(
+            content_id="parent"
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_inherited_restrictions_walks_up_until_a_restricted_ancestor():
+    async with create_confluence_source() as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        ancestors = [{"id": "root"}, {"id": "parent"}]
+        # The immediate parent has no restrictions; the root does.
+        source.confluence_client.fetch_content_restrictions = AsyncMock(
+            side_effect=[{}, DATA_CENTER_INHERITED_RESTRICTION_RESPONSE]
+        )
+
+        identities = await source._resolve_inherited_restrictions(
+            ancestors=ancestors,
+            extract_identities=source._extract_identities_for_datacenter,
+        )
+
+        assert identities == {
+            "user:restricted_user",
+            "group:group-admin",
+            "group:group-power-user",
+        }
+        assert source.confluence_client.fetch_content_restrictions.call_args_list == [
+            mock.call(content_id="parent"),
+            mock.call(content_id="root"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_inherited_restrictions_returns_empty_without_restricted_ancestor():
+    async with create_confluence_source() as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        source.confluence_client.fetch_content_restrictions = AsyncMock(return_value={})
+
+        identities = await source._resolve_inherited_restrictions(
+            ancestors=[{"id": "root"}, {"id": "parent"}],
+            extract_identities=source._extract_identities,
+        )
+
+        assert identities == set()
+
+
+@pytest.mark.asyncio
+async def test_resolve_inherited_restrictions_skips_calls_when_dls_disabled():
+    async with create_confluence_source() as source:
+        source._dls_enabled = MagicMock(return_value=False)
+        source.confluence_client.fetch_content_restrictions = AsyncMock()
+
+        identities = await source._resolve_inherited_restrictions(
+            ancestors=[{"id": "parent"}],
+            extract_identities=source._extract_identities,
+        )
+
+        assert identities == set()
+        source.confluence_client.fetch_content_restrictions.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data_source_type, extractor_response, expected_access_control",
+    [
+        (
+            CONFLUENCE_CLOUD,
+            CLOUD_INHERITED_RESTRICTION_RESPONSE,
+            [
+                "account_id:user_id_9",
+                "group_id:group_id_admin",
+                "group_id:group_id_power",
+            ],
+        ),
+        (
+            CONFLUENCE_DATA_CENTER,
+            DATA_CENTER_INHERITED_RESTRICTION_RESPONSE,
+            ["group:group-admin", "group:group-power-user", "user:restricted_user"],
+        ),
+    ],
+)
+async def test_page_blog_coro_applies_inherited_restrictions_over_space_permissions(
+    data_source_type, extractor_response, expected_access_control
+):
+    """A page with no own restrictions inherits its ancestor's restrictions
+    instead of falling back to the broader space-level permissions (issue #4095)."""
+    async with create_confluence_source(data_source=data_source_type) as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        source.confluence_client.data_source_type = data_source_type
+
+        page_document = {"_id": "child_page", "type": "page", "title": "Child"}
+        with mock.patch.object(
+            ConfluenceDataSource,
+            "fetch_documents",
+            return_value=AsyncIterator(
+                [
+                    [
+                        page_document,
+                        0,
+                        "space_key",
+                        SPACE_PERMISSION_RESPONSE,
+                        {},
+                        [{"id": "parent_id"}],
+                    ]
+                ]
+            ),
+        ):
+            source.confluence_client.fetch_content_restrictions = AsyncMock(
+                return_value=extractor_response
+            )
+            # The space-level fallback must not be used when a restricted ancestor exists.
+            source.fetch_server_space_permission = AsyncMock(
+                return_value={
+                    "permissions": {"VIEWSPACE": {"groups": ["all-licensed-users"]}}
+                }
+            )
+
+            await source._page_blog_coro("api_query", "page")
+
+        _, item = source.queue.get_nowait()
+        queued_document, _download = item
+        assert (
+            sorted(queued_document["_allow_access_control"]) == expected_access_control
+        )
+        source.fetch_server_space_permission.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_api_call_for_exception(patch_sleep):
     """This function test _api_call when credentials are incorrect"""
     async with create_confluence_source() as source:
@@ -1787,8 +2004,8 @@ async def test_get_permission():
     ConfluenceDataSource,
     "fetch_documents",
     side_effect=[
-        (AsyncIterator([[copy(EXPECTED_PAGE), 1, "space_key", [], {}]])),
-        (AsyncIterator([[copy(EXPECTED_BLOG), 1, "space_key", [], {}]])),
+        (AsyncIterator([[copy(EXPECTED_PAGE), 1, "space_key", [], {}, []]])),
+        (AsyncIterator([[copy(EXPECTED_BLOG), 1, "space_key", [], {}, []]])),
     ],
 )
 @pytest.mark.asyncio
@@ -1851,5 +2068,5 @@ async def test_fetch_documents_with_html():
             return_value=JSONAsyncMock(RESPONSE_PAGE_WITH_HTML)
         )
         source.confluence_client.index_labels = True
-        async for response, _, _, _, _ in source.fetch_documents(api_query=""):
+        async for response, _, _, _, _, _ in source.fetch_documents(api_query=""):
             assert response == EXPECTED_PAGE

--- a/app/connectors_service/tests/sources/test_confluence.py
+++ b/app/connectors_service/tests/sources/test_confluence.py
@@ -26,6 +26,7 @@ from connectors.sources.atlassian.confluence import (
 )
 from connectors.sources.atlassian.confluence.client import (
     BadRequest,
+    ContentRestrictionFetchError,
     Forbidden,
     InternalServerError,
     InvalidConfluenceDataSourceTypeError,
@@ -525,6 +526,65 @@ DATA_CENTER_INHERITED_RESTRICTION_RESPONSE = {
             "results": [
                 {"type": "group", "name": "group-admin"},
                 {"type": "group", "name": "group-power-user"},
+            ],
+            "size": 2,
+        },
+    },
+}
+EMPTY_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {"results": [], "size": 0},
+        "group": {"results": [], "size": 0},
+    },
+}
+# Parent: admin, power, standard — used for intersection tests.
+CLOUD_PARENT_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {"results": [], "size": 0},
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin", "id": "group_id_admin"},
+                {"type": "group", "name": "group-power", "id": "group_id_power"},
+                {"type": "group", "name": "group-standard", "id": "group_id_standard"},
+            ],
+            "size": 3,
+        },
+    },
+}
+# Grandparent / narrower layer: admin, power only.
+CLOUD_GRANDPARENT_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {"results": [], "size": 0},
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin", "id": "group_id_admin"},
+                {"type": "group", "name": "group-power", "id": "group_id_power"},
+            ],
+            "size": 2,
+        },
+    },
+}
+# Child layer adds Betty but drops standard relative to parent after ∩.
+CLOUD_CHILD_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {
+            "results": [
+                {
+                    "type": "known",
+                    "accountType": "atlassian",
+                    "accountId": "betty",
+                }
+            ],
+            "size": 1,
+        },
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin", "id": "group_id_admin"},
+                {"type": "group", "name": "group-power", "id": "group_id_power"},
             ],
             "size": 2,
         },
@@ -1806,19 +1866,23 @@ async def test_fetch_server_space_permission():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "api_side_effect, api_return, expected",
+    "api_side_effect, api_return, expected, raises",
     [
         (
             None,
             CLOUD_INHERITED_RESTRICTION_RESPONSE,
             CLOUD_INHERITED_RESTRICTION_RESPONSE,
+            None,
         ),
-        (NotFound(), None, {}),
-        (Forbidden(), None, {}),
-        (Exception("boom"), None, {}),
+        (NotFound(), None, None, None),
+        (Forbidden(), None, None, ContentRestrictionFetchError),
+        (Unauthorized(), None, None, ContentRestrictionFetchError),
+        (Exception("boom"), None, None, ContentRestrictionFetchError),
     ],
 )
-async def test_fetch_content_restrictions(api_side_effect, api_return, expected):
+async def test_fetch_content_restrictions(
+    api_side_effect, api_return, expected, raises
+):
     async with create_confluence_source() as source:
         if api_side_effect is not None:
             patch_kwargs = {"side_effect": api_side_effect}
@@ -1831,16 +1895,23 @@ async def test_fetch_content_restrictions(api_side_effect, api_return, expected)
             "connectors.sources.atlassian.confluence.ConfluenceClient.api_call",
             **patch_kwargs,
         ):
-            response = await source.confluence_client.fetch_content_restrictions(
-                content_id="123"
-            )
-            assert response == expected
+            if raises:
+                with pytest.raises(raises):
+                    await source.confluence_client.fetch_content_restrictions(
+                        content_id="123"
+                    )
+            else:
+                response = await source.confluence_client.fetch_content_restrictions(
+                    content_id="123"
+                )
+                assert response == expected
 
 
-async def _resolve_inherited(
+async def _resolve_effective(
     source,
     *,
     dls_enabled,
+    child_restrictions,
     ancestors,
     extract_identities,
     fetch_return=None,
@@ -1850,25 +1921,76 @@ async def _resolve_inherited(
     source.confluence_client.fetch_content_restrictions = AsyncMock(
         return_value=fetch_return, side_effect=fetch_side_effect
     )
-    identities = await source._resolve_inherited_restrictions(
-        ancestors=ancestors, extract_identities=extract_identities
+    result = await source._resolve_effective_read_access(
+        child_restrictions=child_restrictions,
+        ancestors=ancestors,
+        extract_identities=extract_identities,
     )
-    return identities, source.confluence_client.fetch_content_restrictions
+    return result, source.confluence_client.fetch_content_restrictions
 
 
 @pytest.mark.asyncio
-async def test_resolve_inherited_restrictions_uses_nearest_restricted_ancestor():
+async def test_resolve_effective_read_access_intersects_ancestor_chain():
     async with create_confluence_source() as source:
-        identities, fetch_mock = await _resolve_inherited(
+        # Ancestors ordered root → parent. Parent is broader; grandparent narrower.
+        result, fetch_mock = await _resolve_effective(
             source,
             dls_enabled=True,
-            ancestors=[{"id": "root"}, {"id": "parent"}],
+            child_restrictions={},
+            ancestors=[{"id": "grandparent"}, {"id": "parent"}],
             extract_identities=source._extract_identities,
-            fetch_return=CLOUD_INHERITED_RESTRICTION_RESPONSE,
+            fetch_side_effect=[
+                CLOUD_GRANDPARENT_RESTRICTION_RESPONSE,
+                CLOUD_PARENT_RESTRICTION_RESPONSE,
+            ],
         )
 
-        assert identities == {
-            "account_id:user_id_9",
+        assert result.use_space is False
+        assert result.identities == {
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
+        }
+        assert fetch_mock.call_args_list == [
+            mock.call(content_id="grandparent"),
+            mock.call(content_id="parent"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_intersects_child_and_ancestor():
+    async with create_confluence_source() as source:
+        result, _ = await _resolve_effective(
+            source,
+            dls_enabled=True,
+            child_restrictions=CLOUD_CHILD_RESTRICTION_RESPONSE["restrictions"],
+            ancestors=[{"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_return=CLOUD_PARENT_RESTRICTION_RESPONSE,
+        )
+
+        assert result.use_space is False
+        assert result.identities == {
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
+        }
+        assert "account_id:betty" not in result.identities
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_uses_child_when_ancestors_unrestricted():
+    async with create_confluence_source() as source:
+        result, fetch_mock = await _resolve_effective(
+            source,
+            dls_enabled=True,
+            child_restrictions=CLOUD_CHILD_RESTRICTION_RESPONSE["restrictions"],
+            ancestors=[{"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_return=EMPTY_RESTRICTION_RESPONSE,
+        )
+
+        assert result.use_space is False
+        assert result.identities == {
+            "account_id:betty",
             "group_id:group_id_admin",
             "group_id:group_id_power",
         }
@@ -1876,51 +1998,113 @@ async def test_resolve_inherited_restrictions_uses_nearest_restricted_ancestor()
 
 
 @pytest.mark.asyncio
-async def test_resolve_inherited_restrictions_walks_up_until_a_restricted_ancestor():
+async def test_resolve_effective_read_access_skips_not_found_ancestor():
     async with create_confluence_source() as source:
-        identities, fetch_mock = await _resolve_inherited(
+        result, fetch_mock = await _resolve_effective(
             source,
             dls_enabled=True,
-            ancestors=[{"id": "root"}, {"id": "parent"}],
-            extract_identities=source._extract_identities_for_datacenter,
-            fetch_side_effect=[{}, DATA_CENTER_INHERITED_RESTRICTION_RESPONSE],
+            child_restrictions={},
+            ancestors=[{"id": "missing"}, {"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_side_effect=[None, CLOUD_GRANDPARENT_RESTRICTION_RESPONSE],
         )
 
-        assert identities == {
-            "user:restricted_user",
-            "group:group-admin",
-            "group:group-power-user",
+        assert result.use_space is False
+        assert result.identities == {
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
         }
         assert fetch_mock.call_args_list == [
+            mock.call(content_id="missing"),
             mock.call(content_id="parent"),
-            mock.call(content_id="root"),
         ]
 
 
 @pytest.mark.asyncio
-async def test_resolve_inherited_restrictions_returns_empty_without_restricted_ancestor():
+async def test_resolve_effective_read_access_fails_closed_on_fetch_error():
     async with create_confluence_source() as source:
-        identities, _ = await _resolve_inherited(
+        result, _ = await _resolve_effective(
             source,
             dls_enabled=True,
-            ancestors=[{"id": "root"}, {"id": "parent"}],
+            child_restrictions={},
+            ancestors=[{"id": "parent"}],
             extract_identities=source._extract_identities,
-            fetch_return={},
+            fetch_side_effect=ContentRestrictionFetchError("denied"),
         )
-        assert identities == set()
+
+        assert result.use_space is False
+        assert result.identities == set()
 
 
 @pytest.mark.asyncio
-async def test_resolve_inherited_restrictions_skips_calls_when_dls_disabled():
+async def test_resolve_effective_read_access_uses_space_when_no_layers():
     async with create_confluence_source() as source:
-        identities, fetch_mock = await _resolve_inherited(
+        result, _ = await _resolve_effective(
+            source,
+            dls_enabled=True,
+            child_restrictions={},
+            ancestors=[{"id": "root"}, {"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_return=EMPTY_RESTRICTION_RESPONSE,
+        )
+
+        assert result.use_space is True
+        assert result.identities == set()
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_skips_calls_when_dls_disabled():
+    async with create_confluence_source() as source:
+        result, fetch_mock = await _resolve_effective(
             source,
             dls_enabled=False,
+            child_restrictions=CLOUD_CHILD_RESTRICTION_RESPONSE["restrictions"],
             ancestors=[{"id": "parent"}],
             extract_identities=source._extract_identities,
         )
-        assert identities == set()
+        assert result.use_space is False
+        assert result.identities == set()
         fetch_mock.assert_not_called()
+
+
+async def _run_page_blog_coro_with_documents(
+    source,
+    *,
+    data_source_type,
+    child_restrictions,
+    ancestors,
+    fetch_return=None,
+    fetch_side_effect=None,
+):
+    source._dls_enabled = MagicMock(return_value=True)
+    source.confluence_client.data_source_type = data_source_type
+    source.confluence_client.fetch_content_restrictions = AsyncMock(
+        return_value=fetch_return, side_effect=fetch_side_effect
+    )
+    source.fetch_server_space_permission = AsyncMock(
+        return_value={"permissions": {"VIEWSPACE": {"groups": ["all-licensed-users"]}}}
+    )
+
+    with mock.patch.object(
+        ConfluenceDataSource,
+        "fetch_documents",
+        return_value=AsyncIterator(
+            [
+                [
+                    {"_id": "child_page", "type": "page", "title": "Child"},
+                    0,
+                    "space_key",
+                    SPACE_PERMISSION_RESPONSE,
+                    child_restrictions,
+                    ancestors,
+                ]
+            ]
+        ),
+    ):
+        await source._page_blog_coro("api_query", "page")
+
+    _, (queued_document, _) = source.queue.get_nowait()
+    return queued_document, source
 
 
 @pytest.mark.asyncio
@@ -1947,39 +2131,47 @@ async def test_page_blog_coro_applies_inherited_restrictions_over_space_permissi
     data_source_type, extractor_response, expected_access_control
 ):
     async with create_confluence_source(data_source=data_source_type) as source:
-        source._dls_enabled = MagicMock(return_value=True)
-        source.confluence_client.data_source_type = data_source_type
-        source.confluence_client.fetch_content_restrictions = AsyncMock(
-            return_value=extractor_response
+        queued_document, source = await _run_page_blog_coro_with_documents(
+            source,
+            data_source_type=data_source_type,
+            child_restrictions={},
+            ancestors=[{"id": "parent_id"}],
+            fetch_return=extractor_response,
         )
-        source.fetch_server_space_permission = AsyncMock(
-            return_value={
-                "permissions": {"VIEWSPACE": {"groups": ["all-licensed-users"]}}
-            }
-        )
-
-        with mock.patch.object(
-            ConfluenceDataSource,
-            "fetch_documents",
-            return_value=AsyncIterator(
-                [
-                    [
-                        {"_id": "child_page", "type": "page", "title": "Child"},
-                        0,
-                        "space_key",
-                        SPACE_PERMISSION_RESPONSE,
-                        {},
-                        [{"id": "parent_id"}],
-                    ]
-                ]
-            ),
-        ):
-            await source._page_blog_coro("api_query", "page")
-
-        _, (queued_document, _) = source.queue.get_nowait()
         assert (
             sorted(queued_document["_allow_access_control"]) == expected_access_control
         )
+        source.fetch_server_space_permission.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_page_blog_coro_intersects_child_and_ancestor_restrictions():
+    async with create_confluence_source(data_source=CONFLUENCE_CLOUD) as source:
+        queued_document, source = await _run_page_blog_coro_with_documents(
+            source,
+            data_source_type=CONFLUENCE_CLOUD,
+            child_restrictions=CLOUD_CHILD_RESTRICTION_RESPONSE["restrictions"],
+            ancestors=[{"id": "parent_id"}],
+            fetch_return=CLOUD_PARENT_RESTRICTION_RESPONSE,
+        )
+        assert sorted(queued_document["_allow_access_control"]) == [
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
+        ]
+        source.fetch_server_space_permission.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_page_blog_coro_fails_closed_without_space_fallback():
+    async with create_confluence_source(data_source=CONFLUENCE_CLOUD) as source:
+        queued_document, source = await _run_page_blog_coro_with_documents(
+            source,
+            data_source_type=CONFLUENCE_CLOUD,
+            child_restrictions={},
+            ancestors=[{"id": "parent_id"}],
+            fetch_side_effect=ContentRestrictionFetchError("denied"),
+        )
+        assert queued_document["_allow_access_control"] == []
         source.fetch_server_space_permission.assert_not_called()
 
 

--- a/app/connectors_service/tests/sources/test_confluence.py
+++ b/app/connectors_service/tests/sources/test_confluence.py
@@ -1805,47 +1805,66 @@ async def test_fetch_server_space_permission():
 
 
 @pytest.mark.asyncio
-async def test_fetch_content_restrictions_returns_payload():
+@pytest.mark.parametrize(
+    "api_side_effect, api_return, expected",
+    [
+        (
+            None,
+            CLOUD_INHERITED_RESTRICTION_RESPONSE,
+            CLOUD_INHERITED_RESTRICTION_RESPONSE,
+        ),
+        (NotFound(), None, {}),
+        (Forbidden(), None, {}),
+        (Exception("boom"), None, {}),
+    ],
+)
+async def test_fetch_content_restrictions(api_side_effect, api_return, expected):
     async with create_confluence_source() as source:
-        async_response = AsyncMock()
-        async_response.json.return_value = CLOUD_INHERITED_RESTRICTION_RESPONSE
+        if api_side_effect is not None:
+            patch_kwargs = {"side_effect": api_side_effect}
+        else:
+            async_response = AsyncMock()
+            async_response.json.return_value = api_return
+            patch_kwargs = {"return_value": async_response}
+
         with mock.patch(
             "connectors.sources.atlassian.confluence.ConfluenceClient.api_call",
-            return_value=async_response,
+            **patch_kwargs,
         ):
             response = await source.confluence_client.fetch_content_restrictions(
                 content_id="123"
             )
-            assert response == CLOUD_INHERITED_RESTRICTION_RESPONSE
+            assert response == expected
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("exception", [NotFound(), Forbidden(), Exception("boom")])
-async def test_fetch_content_restrictions_returns_empty_on_error(exception):
-    """Unreadable ancestors (draft/trashed/forbidden) must not break the sync."""
-    async with create_confluence_source() as source:
-        with mock.patch(
-            "connectors.sources.atlassian.confluence.ConfluenceClient.api_call",
-            side_effect=exception,
-        ):
-            response = await source.confluence_client.fetch_content_restrictions(
-                content_id="123"
-            )
-            assert response == {}
+async def _resolve_inherited(
+    source,
+    *,
+    dls_enabled,
+    ancestors,
+    extract_identities,
+    fetch_return=None,
+    fetch_side_effect=None,
+):
+    source._dls_enabled = MagicMock(return_value=dls_enabled)
+    source.confluence_client.fetch_content_restrictions = AsyncMock(
+        return_value=fetch_return, side_effect=fetch_side_effect
+    )
+    identities = await source._resolve_inherited_restrictions(
+        ancestors=ancestors, extract_identities=extract_identities
+    )
+    return identities, source.confluence_client.fetch_content_restrictions
 
 
 @pytest.mark.asyncio
 async def test_resolve_inherited_restrictions_uses_nearest_restricted_ancestor():
     async with create_confluence_source() as source:
-        source._dls_enabled = MagicMock(return_value=True)
-        # Ancestors are ordered from root to the immediate parent.
-        ancestors = [{"id": "root"}, {"id": "parent"}]
-        source.confluence_client.fetch_content_restrictions = AsyncMock(
-            return_value=CLOUD_INHERITED_RESTRICTION_RESPONSE
-        )
-
-        identities = await source._resolve_inherited_restrictions(
-            ancestors=ancestors, extract_identities=source._extract_identities
+        identities, fetch_mock = await _resolve_inherited(
+            source,
+            dls_enabled=True,
+            ancestors=[{"id": "root"}, {"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_return=CLOUD_INHERITED_RESTRICTION_RESPONSE,
         )
 
         assert identities == {
@@ -1853,25 +1872,18 @@ async def test_resolve_inherited_restrictions_uses_nearest_restricted_ancestor()
             "group_id:group_id_admin",
             "group_id:group_id_power",
         }
-        # The nearest ancestor (immediate parent) is queried first and wins.
-        source.confluence_client.fetch_content_restrictions.assert_called_once_with(
-            content_id="parent"
-        )
+        fetch_mock.assert_called_once_with(content_id="parent")
 
 
 @pytest.mark.asyncio
 async def test_resolve_inherited_restrictions_walks_up_until_a_restricted_ancestor():
     async with create_confluence_source() as source:
-        source._dls_enabled = MagicMock(return_value=True)
-        ancestors = [{"id": "root"}, {"id": "parent"}]
-        # The immediate parent has no restrictions; the root does.
-        source.confluence_client.fetch_content_restrictions = AsyncMock(
-            side_effect=[{}, DATA_CENTER_INHERITED_RESTRICTION_RESPONSE]
-        )
-
-        identities = await source._resolve_inherited_restrictions(
-            ancestors=ancestors,
+        identities, fetch_mock = await _resolve_inherited(
+            source,
+            dls_enabled=True,
+            ancestors=[{"id": "root"}, {"id": "parent"}],
             extract_identities=source._extract_identities_for_datacenter,
+            fetch_side_effect=[{}, DATA_CENTER_INHERITED_RESTRICTION_RESPONSE],
         )
 
         assert identities == {
@@ -1879,7 +1891,7 @@ async def test_resolve_inherited_restrictions_walks_up_until_a_restricted_ancest
             "group:group-admin",
             "group:group-power-user",
         }
-        assert source.confluence_client.fetch_content_restrictions.call_args_list == [
+        assert fetch_mock.call_args_list == [
             mock.call(content_id="parent"),
             mock.call(content_id="root"),
         ]
@@ -1888,30 +1900,27 @@ async def test_resolve_inherited_restrictions_walks_up_until_a_restricted_ancest
 @pytest.mark.asyncio
 async def test_resolve_inherited_restrictions_returns_empty_without_restricted_ancestor():
     async with create_confluence_source() as source:
-        source._dls_enabled = MagicMock(return_value=True)
-        source.confluence_client.fetch_content_restrictions = AsyncMock(return_value={})
-
-        identities = await source._resolve_inherited_restrictions(
+        identities, _ = await _resolve_inherited(
+            source,
+            dls_enabled=True,
             ancestors=[{"id": "root"}, {"id": "parent"}],
             extract_identities=source._extract_identities,
+            fetch_return={},
         )
-
         assert identities == set()
 
 
 @pytest.mark.asyncio
 async def test_resolve_inherited_restrictions_skips_calls_when_dls_disabled():
     async with create_confluence_source() as source:
-        source._dls_enabled = MagicMock(return_value=False)
-        source.confluence_client.fetch_content_restrictions = AsyncMock()
-
-        identities = await source._resolve_inherited_restrictions(
+        identities, fetch_mock = await _resolve_inherited(
+            source,
+            dls_enabled=False,
             ancestors=[{"id": "parent"}],
             extract_identities=source._extract_identities,
         )
-
         assert identities == set()
-        source.confluence_client.fetch_content_restrictions.assert_not_called()
+        fetch_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1937,20 +1946,25 @@ async def test_resolve_inherited_restrictions_skips_calls_when_dls_disabled():
 async def test_page_blog_coro_applies_inherited_restrictions_over_space_permissions(
     data_source_type, extractor_response, expected_access_control
 ):
-    """A page with no own restrictions inherits its ancestor's restrictions
-    instead of falling back to the broader space-level permissions (issue #4095)."""
     async with create_confluence_source(data_source=data_source_type) as source:
         source._dls_enabled = MagicMock(return_value=True)
         source.confluence_client.data_source_type = data_source_type
+        source.confluence_client.fetch_content_restrictions = AsyncMock(
+            return_value=extractor_response
+        )
+        source.fetch_server_space_permission = AsyncMock(
+            return_value={
+                "permissions": {"VIEWSPACE": {"groups": ["all-licensed-users"]}}
+            }
+        )
 
-        page_document = {"_id": "child_page", "type": "page", "title": "Child"}
         with mock.patch.object(
             ConfluenceDataSource,
             "fetch_documents",
             return_value=AsyncIterator(
                 [
                     [
-                        page_document,
+                        {"_id": "child_page", "type": "page", "title": "Child"},
                         0,
                         "space_key",
                         SPACE_PERMISSION_RESPONSE,
@@ -1960,20 +1974,9 @@ async def test_page_blog_coro_applies_inherited_restrictions_over_space_permissi
                 ]
             ),
         ):
-            source.confluence_client.fetch_content_restrictions = AsyncMock(
-                return_value=extractor_response
-            )
-            # The space-level fallback must not be used when a restricted ancestor exists.
-            source.fetch_server_space_permission = AsyncMock(
-                return_value={
-                    "permissions": {"VIEWSPACE": {"groups": ["all-licensed-users"]}}
-                }
-            )
-
             await source._page_blog_coro("api_query", "page")
 
-        _, item = source.queue.get_nowait()
-        queued_document, _download = item
+        _, (queued_document, _) = source.queue.get_nowait()
         assert (
             sorted(queued_document["_allow_access_control"]) == expected_access_control
         )


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/4095

When a Confluence page has no page-level restrictions of its own but inherits view restrictions from ancestors — or has its own restrictions that must also satisfy parent restrictions — the connector previously either ignored inherited ACL or used only the nearest restricted ancestor / the child's list alone, then fell back to broad space-level permissions. That over-granted access in `_allow_access_control` (a Document Level Security gap).

Confluence's documented view model requires users to satisfy **both** parent and child view restrictions ([CONF57](https://confluence.atlassian.com/spaces/CONF57/pages/701434765/Page+Restrictions)). This change resolves the **effective** read ACL as the intersection of:

1. The child's explicit read restrictions (when non-empty), and
2. Every ancestor's explicit read restrictions (full chain, not nearest-only).

Behavior details:

- Fetch each ancestor via `rest/api/content/{id}/restriction/byOperation/read` (Confluence does not expose inherited restrictions inline; expanding `ancestors.restrictions...` on `content/search` 404s the whole batch on unreadable drafts — CONFCLOUD-77618).
- **200 + empty** → no restriction layer on that content; keep walking.
- **404** → skip that ancestor; keep walking.
- **403 / 401 / 5xx / other** → fail closed: index `_allow_access_control = []` and **do not** fall back to space ACL (sync continues).
- **No restriction layers** after a successful walk → fall back to space VIEWSPACE permissions (unchanged Cloud / Server / DC paths).
- Always runs this resolver even when the child has its own restrictions (child list alone is not the effective ACL).
- Attachments continue to reuse the page's resolved ACL.

Applies to Confluence Cloud, Server, and Data Center. Advanced Sync Rules / `search_by_query` ACL is unchanged (out of scope).

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

## Release Note

Confluence connector Document Level Security now indexes effective page view restrictions by intersecting the child's and all ancestors' explicit read restrictions, instead of falling back to broader space-level permissions when a child page has no restrictions of its own (or only its own list). Ambiguous ancestor restriction fetches fail closed without over-granting via space ACL.
