### PR TITLE
[8.19] fix(deps): bump setuptools to 83.0.0 for CVE-2026-59890 (#4296)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ install-agent: .venv/bin/elastic-ingest
 .venv/bin/elastic-ingest: .venv/bin/python
 	.venv/bin/pip install -r requirements/$(ARCH).txt
 	.venv/bin/pip install -r requirements/agent.txt
-	.venv/bin/python setup.py develop
+	# Compat mode: keep repo root on sys.path (needed by tests under setuptools 83+)
+	.venv/bin/pip install -e . --config-settings editable_mode=compat
 
 .venv/bin/ruff: .venv/bin/python
 	.venv/bin/pip install -r requirements/$(ARCH).txt

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ config.yml:
 .venv/bin/python: | config.yml
 	$(PYTHON) -m venv .venv
 	.venv/bin/pip install --upgrade pip
-	.venv/bin/pip install setuptools==79.0.1
+	.venv/bin/pip install setuptools==83.0.0
 
 .venv/bin/pip-licenses: .venv/bin/python
 	.venv/bin/pip install pip-licenses

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-#
-# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-# or more contributor license agreements. Licensed under the Elastic License 2.0;
-# you may not use this file except in compliance with the Elastic License 2.0.
-#


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(deps): bump setuptools to 83.0.0 for CVE-2026-59890 (#4296)

The auto-backport could not cherry-pick to `8.19` because the `main` change touches `app/connectors_service/` and `libs/connectors_sdk/` paths, which do not exist on this line. This applies the equivalent bump manually in the root `Makefile` (`setuptools==79.0.1` → `setuptools==83.0.0`).