### PR TITLE
[8.19] fix(confluence): index inherited page restrictions for DLS (#4095) (#4297)

### DIFF
--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -9,6 +9,7 @@ import asyncio
 import os
 from copy import copy
 from functools import partial
+from typing import NamedTuple
 from urllib.parse import urljoin
 
 import aiohttp
@@ -52,6 +53,7 @@ ATTACHMENT = "attachment"
 CONTENT = "content"
 DOWNLOAD = "download"
 SEARCH = "search"
+CONTENT_RESTRICTION = "content_restriction"
 USER = "user"
 USERS_FOR_DATA_CENTER = "users_for_data_center"
 SEARCH_FOR_DATA_CENTER = "search_for_data_center"
@@ -71,6 +73,7 @@ URLS = {
     SPACE: "rest/api/space?{api_query}",
     SPACE_PERMISSION: "rest/extender/1.0/permission/space/{space_key}/getSpacePermissionActors/VIEWSPACE",
     CONTENT: "rest/api/content/search?{api_query}",
+    CONTENT_RESTRICTION: "rest/api/content/{id}/restriction/byOperation/read?expand=restrictions.user,restrictions.group",
     ATTACHMENT: "rest/api/content/{id}/child/attachment?{api_query}",
     SEARCH: "rest/api/search?cql={query}",
     SEARCH_FOR_DATA_CENTER: "rest/api/search?cql={query}&start={start}",
@@ -122,6 +125,23 @@ class Unauthorized(Exception):
 
 class Forbidden(Exception):
     pass
+
+
+class ContentRestrictionFetchError(Exception):
+    """Raised when content restrictions cannot be evaluated safely for DLS."""
+
+    pass
+
+
+class EffectiveReadAccess(NamedTuple):
+    """Resolved view ACL for a page.
+
+    When use_space is True, fall back to space permissions.
+    When use_space is False, identities is the ACL to index (may be empty).
+    """
+
+    identities: set
+    use_space: bool
 
 
 class ConfluenceClient:
@@ -407,6 +427,32 @@ class ConfluenceClient:
                     labels = await self.fetch_label(document["id"])
                     document["labels"] = labels
                 yield document, attachment_count
+
+    async def fetch_content_restrictions(self, content_id):
+        """Return explicit read restrictions for content.
+
+        Returns:
+            dict: Restriction payload on success (may have empty user/group lists).
+            None: Content was not found (404); caller should skip this ancestor.
+
+        Raises:
+            ContentRestrictionFetchError: Restrictions could not be evaluated
+                (403/401/5xx/other). Callers must fail closed for DLS.
+        """
+        url = os.path.join(
+            self.host_url, URLS[CONTENT_RESTRICTION].format(id=content_id)
+        )
+        try:
+            response = await self.api_call(url=url)
+            return await response.json()
+        except NotFound:
+            return None
+        except Exception as exception:
+            self._logger.warning(
+                f"Unable to fetch restrictions for content '{content_id}'. Exception: {exception}."
+            )
+            msg = f"Unable to fetch restrictions for content '{content_id}'"
+            raise ContentRestrictionFetchError(msg) from exception
 
     async def fetch_attachments(self, content_id):
         async for response in self.paginated_api_call(
@@ -853,6 +899,52 @@ class ConfluenceDataSource(BaseDataSource):
 
         return identities
 
+    async def _resolve_effective_read_access(
+        self, child_restrictions, ancestors, extract_identities
+    ):
+        """Resolve effective view ACL from child + ancestor explicit restrictions.
+
+        Returns EffectiveReadAccess. use_space is True only when every layer was
+        successfully evaluated and none had explicit view restrictions.
+        On ambiguous ancestor fetch failure, returns empty identities and
+        use_space=False (fail closed for DLS).
+        """
+        if not self._dls_enabled():
+            return EffectiveReadAccess(identities=set(), use_space=False)
+
+        layers = []
+        child_identities = extract_identities(response=child_restrictions)
+        if child_identities:
+            layers.append(child_identities)
+
+        for ancestor in ancestors or []:
+            ancestor_id = ancestor.get("id")
+            if not ancestor_id:
+                continue
+
+            try:
+                restrictions = await self.confluence_client.fetch_content_restrictions(
+                    content_id=ancestor_id
+                )
+            except ContentRestrictionFetchError:
+                return EffectiveReadAccess(identities=set(), use_space=False)
+
+            if restrictions is None:
+                continue
+
+            identities = extract_identities(
+                response=restrictions.get("restrictions", {})
+            )
+            if identities:
+                layers.append(identities)
+
+        if not layers:
+            return EffectiveReadAccess(identities=set(), use_space=True)
+
+        return EffectiveReadAccess(
+            identities=set.intersection(*layers), use_space=False
+        )
+
     async def close(self):
         """Closes unclosed client session"""
         await self.confluence_client.close_session()
@@ -936,6 +1028,7 @@ class ConfluenceDataSource(BaseDataSource):
             Integer: Number of attachments in a page/blogpost
             List: List of permissions attached to document
             Dictionary: Dictionary of restrictions attached to document
+            List: List of ancestors (with their ids) of the document
         """
         async for (
             document,
@@ -981,6 +1074,7 @@ class ConfluenceDataSource(BaseDataSource):
                 document.get("restrictions", {})
                 .get("read", {})
                 .get("restrictions", {}),
+                document.get("ancestors", []),
             )
 
     async def fetch_attachments(
@@ -1231,14 +1325,22 @@ class ConfluenceDataSource(BaseDataSource):
                 space_key,
                 permissions,
                 restrictions,
+                ancestors,
             ) in self.fetch_documents(api_query):
                 # Pages and blog posts are open to viewing or editing by default,
                 # but you can restrict either viewing or editing to certain users or groups.
                 if self.confluence_client.data_source_type == CONFLUENCE_CLOUD:
-                    access_control = list(
-                        self._extract_identities(response=restrictions)
-                    )
-                    if len(access_control) == 0:
+                    extract_identities = self._extract_identities
+                else:
+                    extract_identities = self._extract_identities_for_datacenter
+
+                effective_access = await self._resolve_effective_read_access(
+                    child_restrictions=restrictions,
+                    ancestors=ancestors,
+                    extract_identities=extract_identities,
+                )
+                if effective_access.use_space:
+                    if self.confluence_client.data_source_type == CONFLUENCE_CLOUD:
                         # Every space has its own independent set of permissions, managed by the space admin(s),
                         # which determine the access settings for different users and groups.
                         access_control = list(
@@ -1246,11 +1348,7 @@ class ConfluenceDataSource(BaseDataSource):
                                 permissions=permissions, target_type=target_type
                             )
                         )
-                else:
-                    access_control = list(
-                        self._extract_identities_for_datacenter(response=restrictions)
-                    )
-                    if len(access_control) == 0:
+                    else:
                         permission = await self.fetch_server_space_permission(
                             space_key=space_key
                         )
@@ -1261,6 +1359,8 @@ class ConfluenceDataSource(BaseDataSource):
                                 )
                             )
                         )
+                else:
+                    access_control = list(effective_access.identities)
                 document = self._decorate_with_access_control(
                     document=document, access_control=access_control
                 )

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -31,6 +31,7 @@ from connectors.sources.confluence import (
     BadRequest,
     ConfluenceClient,
     ConfluenceDataSource,
+    ContentRestrictionFetchError,
     Forbidden,
     InternalServerError,
     InvalidConfluenceDataSourceTypeError,
@@ -486,6 +487,104 @@ PAGE_RESTRICTION_RESPONSE = {
         "size": 2,
     },
     "group": {"results": [], "size": 0},
+}
+
+CLOUD_INHERITED_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {
+            "results": [
+                {
+                    "type": "known",
+                    "accountType": "atlassian",
+                    "accountId": "user_id_9",
+                }
+            ],
+            "size": 1,
+        },
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin", "id": "group_id_admin"},
+                {"type": "group", "name": "group-power", "id": "group_id_power"},
+            ],
+            "size": 2,
+        },
+    },
+}
+DATA_CENTER_INHERITED_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {
+            "results": [{"type": "known", "username": "restricted_user"}],
+            "size": 1,
+        },
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin"},
+                {"type": "group", "name": "group-power-user"},
+            ],
+            "size": 2,
+        },
+    },
+}
+EMPTY_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {"results": [], "size": 0},
+        "group": {"results": [], "size": 0},
+    },
+}
+# Parent: admin, power, standard — used for intersection tests.
+CLOUD_PARENT_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {"results": [], "size": 0},
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin", "id": "group_id_admin"},
+                {"type": "group", "name": "group-power", "id": "group_id_power"},
+                {"type": "group", "name": "group-standard", "id": "group_id_standard"},
+            ],
+            "size": 3,
+        },
+    },
+}
+# Grandparent / narrower layer: admin, power only.
+CLOUD_GRANDPARENT_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {"results": [], "size": 0},
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin", "id": "group_id_admin"},
+                {"type": "group", "name": "group-power", "id": "group_id_power"},
+            ],
+            "size": 2,
+        },
+    },
+}
+# Child layer adds Betty but drops standard relative to parent after ∩.
+CLOUD_CHILD_RESTRICTION_RESPONSE = {
+    "operation": "read",
+    "restrictions": {
+        "user": {
+            "results": [
+                {
+                    "type": "known",
+                    "accountType": "atlassian",
+                    "accountId": "betty",
+                }
+            ],
+            "size": 1,
+        },
+        "group": {
+            "results": [
+                {"type": "group", "name": "group-admin", "id": "group_id_admin"},
+                {"type": "group", "name": "group-power", "id": "group_id_power"},
+            ],
+            "size": 2,
+        },
+    },
 }
 
 EXPECTED_QUERY_RESPONSE = {
@@ -1026,7 +1125,7 @@ async def test_fetch_documents():
         source.confluence_client.index_labels = True
         source.confluence_client.data_source_type = "confluence_cloud"
         # Execute
-        async for response, _, _, _, _ in source.fetch_documents(api_query=""):
+        async for response, _, _, _, _, _ in source.fetch_documents(api_query=""):
             assert response == EXPECTED_PAGE
 
 
@@ -1225,8 +1324,8 @@ async def test_download_attachment_with_text_extraction_enabled_adds_body():
     ConfluenceDataSource,
     "fetch_documents",
     side_effect=[
-        (AsyncIterator([[copy(EXPECTED_PAGE), 1, "space_key", [], {}]])),
-        (AsyncIterator([[copy(EXPECTED_BLOG), 1, "space_key", [], {}]])),
+        (AsyncIterator([[copy(EXPECTED_PAGE), 1, "space_key", [], {}, []]])),
+        (AsyncIterator([[copy(EXPECTED_BLOG), 1, "space_key", [], {}, []]])),
     ],
 )
 @mock.patch.object(
@@ -1760,6 +1859,317 @@ async def test_fetch_server_space_permission():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "api_side_effect, api_return, expected, raises",
+    [
+        (
+            None,
+            CLOUD_INHERITED_RESTRICTION_RESPONSE,
+            CLOUD_INHERITED_RESTRICTION_RESPONSE,
+            None,
+        ),
+        (NotFound(), None, None, None),
+        (Forbidden(), None, None, ContentRestrictionFetchError),
+        (Unauthorized(), None, None, ContentRestrictionFetchError),
+        (Exception("boom"), None, None, ContentRestrictionFetchError),
+    ],
+)
+async def test_fetch_content_restrictions(
+    api_side_effect, api_return, expected, raises
+):
+    async with create_confluence_source() as source:
+        if api_side_effect is not None:
+            patch_kwargs = {"side_effect": api_side_effect}
+        else:
+            async_response = AsyncMock()
+            async_response.json.return_value = api_return
+            patch_kwargs = {"return_value": async_response}
+
+        with mock.patch(
+            "connectors.sources.confluence.ConfluenceClient.api_call",
+            **patch_kwargs,
+        ):
+            if raises:
+                with pytest.raises(raises):
+                    await source.confluence_client.fetch_content_restrictions(
+                        content_id="123"
+                    )
+            else:
+                response = await source.confluence_client.fetch_content_restrictions(
+                    content_id="123"
+                )
+                assert response == expected
+
+
+async def _resolve_effective(
+    source,
+    *,
+    dls_enabled,
+    child_restrictions,
+    ancestors,
+    extract_identities,
+    fetch_return=None,
+    fetch_side_effect=None,
+):
+    source._dls_enabled = MagicMock(return_value=dls_enabled)
+    source.confluence_client.fetch_content_restrictions = AsyncMock(
+        return_value=fetch_return, side_effect=fetch_side_effect
+    )
+    result = await source._resolve_effective_read_access(
+        child_restrictions=child_restrictions,
+        ancestors=ancestors,
+        extract_identities=extract_identities,
+    )
+    return result, source.confluence_client.fetch_content_restrictions
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_intersects_ancestor_chain():
+    async with create_confluence_source() as source:
+        # Ancestors ordered root → parent. Parent is broader; grandparent narrower.
+        result, fetch_mock = await _resolve_effective(
+            source,
+            dls_enabled=True,
+            child_restrictions={},
+            ancestors=[{"id": "grandparent"}, {"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_side_effect=[
+                CLOUD_GRANDPARENT_RESTRICTION_RESPONSE,
+                CLOUD_PARENT_RESTRICTION_RESPONSE,
+            ],
+        )
+
+        assert result.use_space is False
+        assert result.identities == {
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
+        }
+        assert fetch_mock.call_args_list == [
+            mock.call(content_id="grandparent"),
+            mock.call(content_id="parent"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_intersects_child_and_ancestor():
+    async with create_confluence_source() as source:
+        result, _ = await _resolve_effective(
+            source,
+            dls_enabled=True,
+            child_restrictions=CLOUD_CHILD_RESTRICTION_RESPONSE["restrictions"],
+            ancestors=[{"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_return=CLOUD_PARENT_RESTRICTION_RESPONSE,
+        )
+
+        assert result.use_space is False
+        assert result.identities == {
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
+        }
+        assert "account_id:betty" not in result.identities
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_uses_child_when_ancestors_unrestricted():
+    async with create_confluence_source() as source:
+        result, fetch_mock = await _resolve_effective(
+            source,
+            dls_enabled=True,
+            child_restrictions=CLOUD_CHILD_RESTRICTION_RESPONSE["restrictions"],
+            ancestors=[{"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_return=EMPTY_RESTRICTION_RESPONSE,
+        )
+
+        assert result.use_space is False
+        assert result.identities == {
+            "account_id:betty",
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
+        }
+        fetch_mock.assert_called_once_with(content_id="parent")
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_skips_not_found_ancestor():
+    async with create_confluence_source() as source:
+        result, fetch_mock = await _resolve_effective(
+            source,
+            dls_enabled=True,
+            child_restrictions={},
+            ancestors=[{"id": "missing"}, {"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_side_effect=[None, CLOUD_GRANDPARENT_RESTRICTION_RESPONSE],
+        )
+
+        assert result.use_space is False
+        assert result.identities == {
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
+        }
+        assert fetch_mock.call_args_list == [
+            mock.call(content_id="missing"),
+            mock.call(content_id="parent"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_fails_closed_on_fetch_error():
+    async with create_confluence_source() as source:
+        result, _ = await _resolve_effective(
+            source,
+            dls_enabled=True,
+            child_restrictions={},
+            ancestors=[{"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_side_effect=ContentRestrictionFetchError("denied"),
+        )
+
+        assert result.use_space is False
+        assert result.identities == set()
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_uses_space_when_no_layers():
+    async with create_confluence_source() as source:
+        result, _ = await _resolve_effective(
+            source,
+            dls_enabled=True,
+            child_restrictions={},
+            ancestors=[{"id": "root"}, {"id": "parent"}],
+            extract_identities=source._extract_identities,
+            fetch_return=EMPTY_RESTRICTION_RESPONSE,
+        )
+
+        assert result.use_space is True
+        assert result.identities == set()
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_read_access_skips_calls_when_dls_disabled():
+    async with create_confluence_source() as source:
+        result, fetch_mock = await _resolve_effective(
+            source,
+            dls_enabled=False,
+            child_restrictions=CLOUD_CHILD_RESTRICTION_RESPONSE["restrictions"],
+            ancestors=[{"id": "parent"}],
+            extract_identities=source._extract_identities,
+        )
+        assert result.use_space is False
+        assert result.identities == set()
+        fetch_mock.assert_not_called()
+
+
+async def _run_page_blog_coro_with_documents(
+    source,
+    *,
+    data_source_type,
+    child_restrictions,
+    ancestors,
+    fetch_return=None,
+    fetch_side_effect=None,
+):
+    source._dls_enabled = MagicMock(return_value=True)
+    source.confluence_client.data_source_type = data_source_type
+    source.confluence_client.fetch_content_restrictions = AsyncMock(
+        return_value=fetch_return, side_effect=fetch_side_effect
+    )
+    source.fetch_server_space_permission = AsyncMock(
+        return_value={"permissions": {"VIEWSPACE": {"groups": ["all-licensed-users"]}}}
+    )
+
+    with mock.patch.object(
+        ConfluenceDataSource,
+        "fetch_documents",
+        return_value=AsyncIterator(
+            [
+                [
+                    {"_id": "child_page", "type": "page", "title": "Child"},
+                    0,
+                    "space_key",
+                    SPACE_PERMISSION_RESPONSE,
+                    child_restrictions,
+                    ancestors,
+                ]
+            ]
+        ),
+    ):
+        await source._page_blog_coro("api_query", "page")
+
+    _, (queued_document, _) = source.queue.get_nowait()
+    return queued_document, source
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data_source_type, extractor_response, expected_access_control",
+    [
+        (
+            CONFLUENCE_CLOUD,
+            CLOUD_INHERITED_RESTRICTION_RESPONSE,
+            [
+                "account_id:user_id_9",
+                "group_id:group_id_admin",
+                "group_id:group_id_power",
+            ],
+        ),
+        (
+            CONFLUENCE_DATA_CENTER,
+            DATA_CENTER_INHERITED_RESTRICTION_RESPONSE,
+            ["group:group-admin", "group:group-power-user", "user:restricted_user"],
+        ),
+    ],
+)
+async def test_page_blog_coro_applies_inherited_restrictions_over_space_permissions(
+    data_source_type, extractor_response, expected_access_control
+):
+    async with create_confluence_source(data_source=data_source_type) as source:
+        queued_document, source = await _run_page_blog_coro_with_documents(
+            source,
+            data_source_type=data_source_type,
+            child_restrictions={},
+            ancestors=[{"id": "parent_id"}],
+            fetch_return=extractor_response,
+        )
+        assert (
+            sorted(queued_document["_allow_access_control"]) == expected_access_control
+        )
+        source.fetch_server_space_permission.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_page_blog_coro_intersects_child_and_ancestor_restrictions():
+    async with create_confluence_source(data_source=CONFLUENCE_CLOUD) as source:
+        queued_document, source = await _run_page_blog_coro_with_documents(
+            source,
+            data_source_type=CONFLUENCE_CLOUD,
+            child_restrictions=CLOUD_CHILD_RESTRICTION_RESPONSE["restrictions"],
+            ancestors=[{"id": "parent_id"}],
+            fetch_return=CLOUD_PARENT_RESTRICTION_RESPONSE,
+        )
+        assert sorted(queued_document["_allow_access_control"]) == [
+            "group_id:group_id_admin",
+            "group_id:group_id_power",
+        ]
+        source.fetch_server_space_permission.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_page_blog_coro_fails_closed_without_space_fallback():
+    async with create_confluence_source(data_source=CONFLUENCE_CLOUD) as source:
+        queued_document, source = await _run_page_blog_coro_with_documents(
+            source,
+            data_source_type=CONFLUENCE_CLOUD,
+            child_restrictions={},
+            ancestors=[{"id": "parent_id"}],
+            fetch_side_effect=ContentRestrictionFetchError("denied"),
+        )
+        assert queued_document["_allow_access_control"] == []
+        source.fetch_server_space_permission.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_api_call_for_exception(patch_sleep):
     """This function test _api_call when credentials are incorrect"""
     async with create_confluence_source() as source:
@@ -1783,8 +2193,8 @@ async def test_get_permission():
     ConfluenceDataSource,
     "fetch_documents",
     side_effect=[
-        (AsyncIterator([[copy(EXPECTED_PAGE), 1, "space_key", [], {}]])),
-        (AsyncIterator([[copy(EXPECTED_BLOG), 1, "space_key", [], {}]])),
+        (AsyncIterator([[copy(EXPECTED_PAGE), 1, "space_key", [], {}, []]])),
+        (AsyncIterator([[copy(EXPECTED_BLOG), 1, "space_key", [], {}, []]])),
     ],
 )
 @pytest.mark.asyncio
@@ -1847,5 +2257,5 @@ async def test_fetch_documents_with_html():
             return_value=JSONAsyncMock(RESPONSE_PAGE_WITH_HTML)
         )
         source.confluence_client.index_labels = True
-        async for response, _, _, _, _ in source.fetch_documents(api_query=""):
+        async for response, _, _, _, _, _ in source.fetch_documents(api_query=""):
             assert response == EXPECTED_PAGE


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(confluence): index inherited page restrictions for DLS (#4095) (#4297)

Manual backport: auto-cherry-pick failed due to conflicts from the
monolithic → `atlassian/confluence/` package split. Same DLS behavior as
#4297, applied to `connectors/sources/confluence.py` on 8.19.

Made with [Cursor](https://cursor.com)