### PR TITLE
fix: skip SharePointHomeCacheList during SharePoint Online sync

### DIFF
--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/constants.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/constants.py
@@ -75,3 +75,6 @@ SPO_MAX_EXPAND_SIZE = 20
 
 # Exclude specific SharePoint paths entirely at the connector level (pre sync-rules)
 EXCLUDED_SHAREPOINT_PATH_SEGMENTS = ["/contentstorage/"]
+
+# System / non-content lists that Graph may still return; skip before REST follow-ups
+EXCLUDED_SHAREPOINT_LIST_NAMES = frozenset({"SharePointHomeCacheList"})

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
@@ -30,6 +30,7 @@ from connectors.sources.sharepoint.sharepoint_online.client import (
 )
 from connectors.sources.sharepoint.sharepoint_online.constants import (
     CURSOR_SITE_DRIVE_KEY,
+    EXCLUDED_SHAREPOINT_LIST_NAMES,
     MAX_DOCUMENT_SIZE,
     SPO_API_MAX_BATCH_SIZE,
     SPO_MAX_EXPAND_SIZE,
@@ -1067,6 +1068,14 @@ class SharepointOnlineDataSource(BaseDataSource):
 
     async def site_lists(self, site, site_access_control, check_timestamp=False):
         async for site_list in self.client.site_lists(site["id"]):
+            site_list_name = site_list.get("name")
+            if site_list_name in EXCLUDED_SHAREPOINT_LIST_NAMES:
+                self._logger.debug(
+                    f"Skipping excluded SharePoint list '{site_list_name}' "
+                    f"on site '{site.get('webUrl', site.get('id'))}'"
+                )
+                continue
+
             if not check_timestamp or (
                 check_timestamp
                 and site_list["lastModifiedDateTime"] >= self.last_sync_time()
@@ -1074,7 +1083,6 @@ class SharepointOnlineDataSource(BaseDataSource):
                 site_list["_id"] = site_list["id"]
                 site_list["object_type"] = "site_list"
                 site_url = site["webUrl"]
-                site_list_name = site_list["name"]
 
                 has_unique_role_assignments = False
 

--- a/app/connectors_service/tests/sources/test_sharepoint_online.py
+++ b/app/connectors_service/tests/sources/test_sharepoint_online.py
@@ -45,6 +45,7 @@ from connectors.sources.sharepoint.sharepoint_online.client import (
 from connectors.sources.sharepoint.sharepoint_online.constants import (
     DEFAULT_BACKOFF_MULTIPLIER,
     DEFAULT_RETRY_SECONDS,
+    EXCLUDED_SHAREPOINT_LIST_NAMES,
     WILDCARD,
 )
 from connectors.sources.sharepoint.sharepoint_online.utils import (
@@ -61,6 +62,9 @@ from tests.sources.support import create_source
 SITE_LIST_ONE_NAME = "site-list-one-name"
 
 SITE_LIST_ONE_ID = "1"
+
+SHAREPOINT_HOME_CACHE_LIST_NAME = "SharePointHomeCacheList"
+SHAREPOINT_HOME_CACHE_LIST_ID = "sharepoint-home-cache-list-id"
 
 TIMESTAMP_FORMAT_PATCHED = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -2597,6 +2601,123 @@ class TestSharepointOnlineDataSource:
                 for site_list in site_lists
             )
             patch_sharepoint_client.site_list_role_assignments.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_site_lists_skips_sharepoint_home_cache_list(
+        self, patch_sharepoint_client
+    ):
+        assert SHAREPOINT_HOME_CACHE_LIST_NAME in EXCLUDED_SHAREPOINT_LIST_NAMES
+        patch_sharepoint_client.site_lists = AsyncIterator(
+            [
+                {
+                    "id": SITE_LIST_ONE_ID,
+                    "name": SITE_LIST_ONE_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+                {
+                    "id": SHAREPOINT_HOME_CACHE_LIST_ID,
+                    "name": SHAREPOINT_HOME_CACHE_LIST_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+            ]
+        )
+
+        async with create_spo_source() as source:
+            site = {"id": "1", "webUrl": "https://example.sharepoint.com/sites/Support"}
+            names = [
+                site_list["name"]
+                async for site_list in source.site_lists(site, [])
+            ]
+
+            assert names == [SITE_LIST_ONE_NAME]
+
+    @pytest.mark.asyncio
+    async def test_site_lists_skips_sharepoint_home_cache_list_before_permission_fetch(
+        self, patch_sharepoint_client
+    ):
+        patch_sharepoint_client.site_lists = AsyncIterator(
+            [
+                {
+                    "id": SHAREPOINT_HOME_CACHE_LIST_ID,
+                    "name": SHAREPOINT_HOME_CACHE_LIST_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+                {
+                    "id": SITE_LIST_ONE_ID,
+                    "name": SITE_LIST_ONE_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+            ]
+        )
+        patch_sharepoint_client.site_list_role_assignments = AsyncIterator(
+            [
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_TWO_NAME,
+                    },
+                }
+            ]
+        )
+
+        async with create_spo_source(use_document_level_security=True) as source:
+            site = {"id": "1", "webUrl": "https://example.sharepoint.com/sites/Support"}
+            site_lists = []
+            async for site_list in source.site_lists(site, ["site-acl"]):
+                site_lists.append(site_list)
+
+            assert [site_list["name"] for site_list in site_lists] == [
+                SITE_LIST_ONE_NAME
+            ]
+            patch_sharepoint_client.site_list_has_unique_role_assignments.assert_called_once_with(
+                site["webUrl"], SITE_LIST_ONE_NAME
+            )
+            patch_sharepoint_client.site_list_role_assignments.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_docs_skips_sharepoint_home_cache_list(
+        self, patch_sharepoint_client
+    ):
+        patch_sharepoint_client.site_lists = AsyncIterator(
+            [
+                {
+                    "id": SITE_LIST_ONE_ID,
+                    "name": SITE_LIST_ONE_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+                {
+                    "id": SHAREPOINT_HOME_CACHE_LIST_ID,
+                    "name": SHAREPOINT_HOME_CACHE_LIST_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+            ]
+        )
+        attachment_list_titles = []
+
+        async def attachments_spy(site_web_url, list_title, list_item_id):
+            attachment_list_titles.append(list_title)
+            for attachment in self.site_list_item_attachments:
+                yield attachment
+
+        patch_sharepoint_client.site_list_item_attachments = attachments_spy
+
+        async with create_spo_source() as source:
+            source._dls_enabled = Mock(return_value=False)
+
+            results = []
+            async for doc, _download_func in source.get_docs():
+                results.append(doc)
+
+            site_list_names = [
+                doc["name"]
+                for doc in results
+                if doc.get("object_type") == "site_list"
+            ]
+            assert site_list_names == [SITE_LIST_ONE_NAME]
+            assert SHAREPOINT_HOME_CACHE_LIST_NAME not in attachment_list_titles
+            assert SITE_LIST_ONE_NAME in attachment_list_titles
+            # Same document set as sync without the excluded system list
+            assert len(results) == 11
 
     @pytest.mark.asyncio
     async def test_site_lists_with_unique_role_assignments(

--- a/app/connectors_service/tests/sources/test_sharepoint_online.py
+++ b/app/connectors_service/tests/sources/test_sharepoint_online.py
@@ -2625,8 +2625,7 @@ class TestSharepointOnlineDataSource:
         async with create_spo_source() as source:
             site = {"id": "1", "webUrl": "https://example.sharepoint.com/sites/Support"}
             names = [
-                site_list["name"]
-                async for site_list in source.site_lists(site, [])
+                site_list["name"] async for site_list in source.site_lists(site, [])
             ]
 
             assert names == [SITE_LIST_ONE_NAME]
@@ -2709,9 +2708,7 @@ class TestSharepointOnlineDataSource:
                 results.append(doc)
 
             site_list_names = [
-                doc["name"]
-                for doc in results
-                if doc.get("object_type") == "site_list"
+                doc["name"] for doc in results if doc.get("object_type") == "site_list"
             ]
             assert site_list_names == [SITE_LIST_ONE_NAME]
             assert SHAREPOINT_HOME_CACHE_LIST_NAME not in attachment_list_titles


### PR DESCRIPTION
## Part of https://github.com/elastic/sdh-search/issues/1940

<!-- description -->

Skip the system list `SharePointHomeCacheList` by name during SharePoint Online sync. Graph can return this list; fetching its attachments via SharePoint REST returns Unauthorized and aborts the whole sync. Sync-rule exclusions cannot prevent this because they apply after fetch. This change skips the list early in `site_lists()` before DLS/item/attachment REST follow-ups.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

## Release Note

SharePoint Online connector now skips the system list SharePointHomeCacheList so syncs are not aborted by Unauthorized responses when fetching its attachments.

Made with [Cursor](https://cursor.com)