### PR TITLE
[8.19] fix: skip SharePointHomeCacheList during SharePoint Online sync (#4306)

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -78,6 +78,9 @@ DRIVE_ITEMS_FIELDS = "id,content.downloadUrl,lastModifiedDateTime,lastModifiedBy
 # Exclude specific SharePoint paths entirely at the connector level (pre sync-rules)
 EXCLUDED_SHAREPOINT_PATH_SEGMENTS = ["/contentstorage/"]
 
+# System / non-content lists that Graph may still return; skip before REST follow-ups
+EXCLUDED_SHAREPOINT_LIST_NAMES = frozenset({"SharePointHomeCacheList"})
+
 
 def _is_excluded_sharepoint_url(url: str) -> bool:
     try:
@@ -2276,6 +2279,14 @@ class SharepointOnlineDataSource(BaseDataSource):
 
     async def site_lists(self, site, site_access_control, check_timestamp=False):
         async for site_list in self.client.site_lists(site["id"]):
+            site_list_name = site_list.get("name")
+            if site_list_name in EXCLUDED_SHAREPOINT_LIST_NAMES:
+                self._logger.debug(
+                    f"Skipping excluded SharePoint list '{site_list_name}' "
+                    f"on site '{site.get('webUrl', site.get('id'))}'"
+                )
+                continue
+
             if not check_timestamp or (
                 check_timestamp
                 and site_list["lastModifiedDateTime"] >= self.last_sync_time()
@@ -2283,7 +2294,6 @@ class SharepointOnlineDataSource(BaseDataSource):
                 site_list["_id"] = site_list["id"]
                 site_list["object_type"] = "site_list"
                 site_url = site["webUrl"]
-                site_list_name = site_list["name"]
 
                 has_unique_role_assignments = False
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -25,6 +25,7 @@ from connectors.sources.sharepoint_online import (
     ACCESS_CONTROL,
     DEFAULT_BACKOFF_MULTIPLIER,
     DEFAULT_RETRY_SECONDS,
+    EXCLUDED_SHAREPOINT_LIST_NAMES,
     WILDCARD,
     BadRequestError,
     DriveItemsPage,
@@ -56,6 +57,9 @@ from tests.sources.support import create_source
 SITE_LIST_ONE_NAME = "site-list-one-name"
 
 SITE_LIST_ONE_ID = "1"
+
+SHAREPOINT_HOME_CACHE_LIST_NAME = "SharePointHomeCacheList"
+SHAREPOINT_HOME_CACHE_LIST_ID = "sharepoint-home-cache-list-id"
 
 TIMESTAMP_FORMAT_PATCHED = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -2592,6 +2596,120 @@ class TestSharepointOnlineDataSource:
                 for site_list in site_lists
             )
             patch_sharepoint_client.site_list_role_assignments.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_site_lists_skips_sharepoint_home_cache_list(
+        self, patch_sharepoint_client
+    ):
+        assert SHAREPOINT_HOME_CACHE_LIST_NAME in EXCLUDED_SHAREPOINT_LIST_NAMES
+        patch_sharepoint_client.site_lists = AsyncIterator(
+            [
+                {
+                    "id": SITE_LIST_ONE_ID,
+                    "name": SITE_LIST_ONE_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+                {
+                    "id": SHAREPOINT_HOME_CACHE_LIST_ID,
+                    "name": SHAREPOINT_HOME_CACHE_LIST_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+            ]
+        )
+
+        async with create_spo_source() as source:
+            site = {"id": "1", "webUrl": "https://example.sharepoint.com/sites/Support"}
+            names = [
+                site_list["name"] async for site_list in source.site_lists(site, [])
+            ]
+
+            assert names == [SITE_LIST_ONE_NAME]
+
+    @pytest.mark.asyncio
+    async def test_site_lists_skips_sharepoint_home_cache_list_before_permission_fetch(
+        self, patch_sharepoint_client
+    ):
+        patch_sharepoint_client.site_lists = AsyncIterator(
+            [
+                {
+                    "id": SHAREPOINT_HOME_CACHE_LIST_ID,
+                    "name": SHAREPOINT_HOME_CACHE_LIST_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+                {
+                    "id": SITE_LIST_ONE_ID,
+                    "name": SITE_LIST_ONE_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+            ]
+        )
+        patch_sharepoint_client.site_list_role_assignments = AsyncIterator(
+            [
+                {
+                    "Member": {
+                        "odata.type": "SP.User",
+                        "UserPrincipalName": USER_TWO_NAME,
+                    },
+                }
+            ]
+        )
+
+        async with create_spo_source(use_document_level_security=True) as source:
+            site = {"id": "1", "webUrl": "https://example.sharepoint.com/sites/Support"}
+            site_lists = []
+            async for site_list in source.site_lists(site, ["site-acl"]):
+                site_lists.append(site_list)
+
+            assert [site_list["name"] for site_list in site_lists] == [
+                SITE_LIST_ONE_NAME
+            ]
+            patch_sharepoint_client.site_list_has_unique_role_assignments.assert_called_once_with(
+                site["webUrl"], SITE_LIST_ONE_NAME
+            )
+            patch_sharepoint_client.site_list_role_assignments.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_docs_skips_sharepoint_home_cache_list(
+        self, patch_sharepoint_client
+    ):
+        patch_sharepoint_client.site_lists = AsyncIterator(
+            [
+                {
+                    "id": SITE_LIST_ONE_ID,
+                    "name": SITE_LIST_ONE_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+                {
+                    "id": SHAREPOINT_HOME_CACHE_LIST_ID,
+                    "name": SHAREPOINT_HOME_CACHE_LIST_NAME,
+                    "lastModifiedDateTime": self.day_ago,
+                },
+            ]
+        )
+        attachment_list_titles = []
+
+        async def attachments_spy(site_web_url, list_title, list_item_id):
+            attachment_list_titles.append(list_title)
+            for attachment in self.site_list_item_attachments:
+                yield attachment
+
+        patch_sharepoint_client.site_list_item_attachments = attachments_spy
+
+        async with create_spo_source() as source:
+            source._dls_enabled = Mock(return_value=False)
+
+            results = []
+            async for doc, _download_func in source.get_docs():
+                results.append(doc)
+
+            site_list_names = [
+                doc["name"] for doc in results if doc.get("object_type") == "site_list"
+            ]
+            assert site_list_names == [SITE_LIST_ONE_NAME]
+            assert SHAREPOINT_HOME_CACHE_LIST_NAME not in attachment_list_titles
+            assert SITE_LIST_ONE_NAME in attachment_list_titles
+            # Same document set as sync without the excluded system list
+            assert len(results) == 11
 
     @pytest.mark.asyncio
     async def test_site_lists_with_unique_role_assignments(


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix: skip SharePointHomeCacheList during SharePoint Online sync (#4306)

> **Manual backport.** The auto-backport could not cherry-pick cleanly because on
> `8.19` the SharePoint Online source is still the monolithic
> `connectors/sources/sharepoint_online.py` rather than the refactored
> `sharepoint/sharepoint_online/` package used on `main`/`9.x`. The change itself
> is identical (same skip-by-name logic and tests).

## Related Pull Requests

* #4306 — original PR (merged to `main`)
* #4307 — `[9.4]` backport
* #4308 — `[9.5]` backport
* #4309 — `[9.3]` backport


Made with [Cursor](https://cursor.com)