### PR TITLE
[8.19] fix(outlook): prefix content document identities so DLS can match them (#4291)

### DIFF
--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -216,7 +216,11 @@ def ews_format_to_datetime(source_datetime, timezone):
 
 
 def _prefix_email(email):
-    return prefix_identity("email", email)
+    # Access control documents and content documents both route addresses
+    # through here. DLS compares them with a case-sensitive terms query, and a
+    # mailbox's primary SMTP address does not always match the directory's
+    # casing, so normalise in the one place both sides share.
+    return prefix_identity("email", email.lower() if email else email)
 
 
 def _prefix_display_name(user):
@@ -229,6 +233,16 @@ def _prefix_user_id(user_id):
 
 def _prefix_job(job_title):
     return prefix_identity("job_title", job_title)
+
+
+def _mailbox_access_control(account):
+    """Identities allowed to read everything in a mailbox.
+
+    These have to stay in the same dialect as the identities granted by
+    `_user_access_control_doc`: DLS matches the two with a terms query, so an
+    address stored here unprefixed is invisible to every user.
+    """
+    return [_prefix_email(account.primary_smtp_address)]
 
 
 class TokenFetchFailed(Exception):
@@ -1114,8 +1128,9 @@ class OutlookDataSource(BaseDataSource):
 
     def _decorate_with_access_control(self, document, access_control):
         if self._dls_enabled():
+            identities = document.get(ACCESS_CONTROL, []) + access_control
             document[ACCESS_CONTROL] = list(
-                set(document.get(ACCESS_CONTROL, []) + access_control)
+                {identity for identity in identities if identity is not None}
             )
         return document
 
@@ -1202,7 +1217,7 @@ class OutlookDataSource(BaseDataSource):
             )
             yield (
                 self._decorate_with_access_control(
-                    document, [account.primary_smtp_address]
+                    document, _mailbox_access_control(account)
                 ),
                 partial(
                     self.get_content, attachment=copy(attachment), timezone=timezone
@@ -1226,7 +1241,7 @@ class OutlookDataSource(BaseDataSource):
             )
             yield (
                 self._decorate_with_access_control(
-                    document, [account.primary_smtp_address]
+                    document, _mailbox_access_control(account)
                 ),
                 None,
             )
@@ -1265,7 +1280,7 @@ class OutlookDataSource(BaseDataSource):
                 continue
             yield (
                 self._decorate_with_access_control(
-                    document, [account.primary_smtp_address]
+                    document, _mailbox_access_control(account)
                 ),
                 None,
             )
@@ -1286,7 +1301,7 @@ class OutlookDataSource(BaseDataSource):
             )
             yield (
                 self._decorate_with_access_control(
-                    document, [account.primary_smtp_address]
+                    document, _mailbox_access_control(account)
                 ),
                 None,
             )
@@ -1343,7 +1358,7 @@ class OutlookDataSource(BaseDataSource):
         )
         yield (
             self._decorate_with_access_control(
-                document, [account.primary_smtp_address]
+                document, _mailbox_access_control(account)
             ),
             None,
         )

--- a/tests/sources/test_outlook.py
+++ b/tests/sources/test_outlook.py
@@ -38,6 +38,7 @@ from exchangelib.items import (
 from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
 from exchangelib.util import to_xml
 
+from connectors.access_control import ACCESS_CONTROL
 from connectors.source import ConfigurableFieldValueError
 from connectors.sources import outlook as outlook_module
 from connectors.sources.outlook import (
@@ -57,6 +58,7 @@ from connectors.sources.outlook import (
     SSLCertificateError,
     UnauthorizedException,
     UsersFetchFailed,
+    _prefix_email,
 )
 from connectors.utils import get_pem_format
 from tests.commons import AsyncIterator
@@ -2008,3 +2010,127 @@ async def test_get_access_control_for_server(user_response):
         async for access_control in source.get_access_control():
             acl.append(access_control)
         assert len(acl) == 1
+
+
+# The directory entry for the person whose mailbox MockAccount stands in for.
+MAILBOX_OWNER = {
+    "id": "60e8a9c1-4d2f-4a3b-9a1e-2f0c5d7b8e11",
+    "displayName": "Alex Wilber",
+    "mail": "alex.wilber@gmail.com",
+    "jobTitle": "Engineer",
+}
+
+
+async def _dls_documents(source, account):
+    """Both sides of DLS for one mailbox: what is granted and what is stored."""
+    source._dls_enabled = MagicMock(return_value=True)
+    source.client._get_user_instance.get_user_accounts = AsyncIterator([account])
+
+    access_control_documents = [doc async for doc in source.get_access_control()]
+    content_documents = [doc async for doc, _ in source.get_docs()]
+
+    return access_control_documents, content_documents
+
+
+def _granted_identities(access_control_document):
+    return set(access_control_document["query"]["template"]["params"]["access_control"])
+
+
+@pytest.mark.asyncio
+async def test_content_documents_are_reachable_by_their_owner():
+    # DLS filters content with a terms query over the identities the access
+    # control document grants, so the two sides have to be written in the same
+    # dialect. Where they do not intersect, the owner of a mailbox can retrieve
+    # none of their own documents.
+    async with create_outlook_source() as source:
+        source.client.is_cloud = True
+        source.client._get_user_instance.get_users = AsyncIterator(
+            [{"value": [MAILBOX_OWNER]}]
+        )
+
+        access_control_documents, content_documents = await _dls_documents(
+            source, MockAccount()
+        )
+
+    granted = _granted_identities(access_control_documents[0])
+
+    assert content_documents
+    for document in content_documents:
+        assert granted & set(document[ACCESS_CONTROL])
+
+
+@pytest.mark.asyncio
+async def test_content_documents_are_reachable_by_their_owner_on_server():
+    async with create_outlook_source() as source:
+        source.configuration.get_field("data_source").value = OUTLOOK_SERVER
+        source.client._get_user_instance.get_users = AsyncIterator(
+            [
+                {
+                    "attributes": {"mail": "dummy@es.local"},
+                    "dn": "CN=Dummy,CN=Users,DC=es,DC=local",
+                }
+            ]
+        )
+        account = MockAccount()
+        account.primary_smtp_address = "dummy@es.local"
+
+        access_control_documents, content_documents = await _dls_documents(
+            source, account
+        )
+
+    granted = _granted_identities(access_control_documents[0])
+
+    assert content_documents
+    for document in content_documents:
+        assert granted & set(document[ACCESS_CONTROL])
+
+
+@pytest.mark.asyncio
+async def test_content_documents_are_reachable_whatever_the_address_casing():
+    # Exchange reports a mailbox under the casing it was configured with, which
+    # is not necessarily the casing the directory reports for the same person.
+    async with create_outlook_source() as source:
+        source.client.is_cloud = True
+        source.client._get_user_instance.get_users = AsyncIterator(
+            [{"value": [MAILBOX_OWNER | {"mail": "Alex.Wilber@Gmail.com"}]}]
+        )
+        account = MockAccount()
+        account.primary_smtp_address = "alex.wilber@GMAIL.com"
+
+        access_control_documents, content_documents = await _dls_documents(
+            source, account
+        )
+
+    granted = _granted_identities(access_control_documents[0])
+
+    assert "email:alex.wilber@gmail.com" in granted
+    assert content_documents
+    for document in content_documents:
+        assert granted & set(document[ACCESS_CONTROL])
+
+
+@pytest.mark.asyncio
+async def test_decorate_with_access_control_drops_unknown_identities():
+    async with create_outlook_source() as source:
+        source._dls_enabled = MagicMock(return_value=True)
+
+        # A mailbox with no address prefixes to None, which must not be stored:
+        # a null in the terms list is noise no user can ever match.
+        document = source._decorate_with_access_control(
+            {"_id": "1"}, [None, "email:alex.wilber@gmail.com"]
+        )
+
+        assert document[ACCESS_CONTROL] == ["email:alex.wilber@gmail.com"]
+
+
+@pytest.mark.parametrize(
+    "email, expected",
+    [
+        ("Alex.Wilber@Example.COM", "email:alex.wilber@example.com"),
+        ("alex.wilber@example.com", "email:alex.wilber@example.com"),
+        ("", "email:"),
+        (None, None),
+    ],
+)
+def test_prefix_email_normalises_casing(email, expected):
+    assert _prefix_email(email) == expected


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(outlook): prefix content document identities so DLS can match them (#4291)

Made with [Cursor](https://cursor.com)