### PR TITLE
feat(confluence): support Data Center personal access tokens (#3253)

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -4475,7 +4475,7 @@ SOFTWARE.
 
 
 greenlet
-3.5.4
+3.5.5
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:

--- a/app/connectors_service/connectors/sources/atlassian/confluence/client.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/client.py
@@ -18,6 +18,8 @@ from connectors.sources.atlassian.confluence.constants import (
     CONFLUENCE_SERVER,
     CONTENT,
     CONTENT_RESTRICTION,
+    DATA_CENTER_BASIC_AUTH,
+    DATA_CENTER_PERSONAL_ACCESS_TOKEN,
     DATACENTER_USER_BATCH,
     DEFAULT_RETRY_SECONDS,
     LABEL,
@@ -111,35 +113,55 @@ class ConfluenceClient:
             return self.session
 
         self._logger.debug(f"Creating a '{self.data_source_type}' client session")
+        headers = {
+            "accept": "application/json",
+            "content-type": "application/json",
+        }
+        basic_auth = None
+
         if self.data_source_type == CONFLUENCE_CLOUD:
-            auth = (
-                self.configuration["account_email"],
-                self.configuration["api_token"],
+            basic_auth = aiohttp.BasicAuth(
+                login=self.configuration["account_email"],
+                password=self.configuration["api_token"],
             )
         elif self.data_source_type == CONFLUENCE_SERVER:
-            auth = (
-                self.configuration["username"],
-                self.configuration["password"],
+            basic_auth = aiohttp.BasicAuth(
+                login=self.configuration["username"],
+                password=self.configuration["password"],
             )
         elif self.data_source_type == CONFLUENCE_DATA_CENTER:
-            auth = (
-                self.configuration["data_center_username"],
-                self.configuration["data_center_password"],
-            )
+            if (
+                self.configuration["data_center_auth_method"]
+                == DATA_CENTER_PERSONAL_ACCESS_TOKEN
+            ):
+                headers["Authorization"] = (
+                    f"Bearer {self.configuration['data_center_personal_access_token']}"
+                )
+            elif (
+                self.configuration["data_center_auth_method"] == DATA_CENTER_BASIC_AUTH
+            ):
+                basic_auth = aiohttp.BasicAuth(
+                    login=self.configuration["data_center_username"],
+                    password=self.configuration["data_center_password"],
+                )
+            else:
+                msg = (
+                    "Unknown data center authentication method "
+                    f"'{self.configuration['data_center_auth_method']}' "
+                    "for Confluence connector"
+                )
+                self._logger.error(msg)
+                raise InvalidConfluenceDataSourceTypeError(msg)
         else:
             msg = f"Unknown data source type '{self.data_source_type}' for Confluence connector"
             self._logger.error(msg)
 
             raise InvalidConfluenceDataSourceTypeError(msg)
 
-        basic_auth = aiohttp.BasicAuth(login=auth[0], password=auth[1])
         timeout = aiohttp.ClientTimeout(total=None)  # pyright: ignore
         self.session = aiohttp.ClientSession(
             auth=basic_auth,
-            headers={
-                "accept": "application/json",
-                "content-type": "application/json",
-            },
+            headers=headers,
             timeout=timeout,
             raise_for_status=True,
         )

--- a/app/connectors_service/connectors/sources/atlassian/confluence/constants.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/constants.py
@@ -54,4 +54,6 @@ END_SIGNAL = "FINISHED_TASK"
 CONFLUENCE_CLOUD = "confluence_cloud"
 CONFLUENCE_SERVER = "confluence_server"
 CONFLUENCE_DATA_CENTER = "confluence_data_center"
+DATA_CENTER_BASIC_AUTH = "basic"
+DATA_CENTER_PERSONAL_ACCESS_TOKEN = "personal_access_token"  # noqa: S105
 WILDCARD = "*"

--- a/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
+++ b/app/connectors_service/connectors/sources/atlassian/confluence/datasource.py
@@ -30,6 +30,8 @@ from connectors.sources.atlassian.confluence.constants import (
     CONTENT,
     CONTENT_QUERY_CLOUD,
     CONTENT_QUERY_DATA_CENTER,
+    DATA_CENTER_BASIC_AUTH,
+    DATA_CENTER_PERSONAL_ACCESS_TOKEN,
     END_SIGNAL,
     MAX_CONCURRENCY,
     MAX_CONCURRENT_DOWNLOADS,
@@ -146,52 +148,93 @@ class ConfluenceDataSource(BaseDataSource):
                 "order": 3,
                 "type": "str",
             },
-            "data_center_username": {
+            "data_center_auth_method": {
                 "depends_on": [
                     {"field": "data_source", "value": CONFLUENCE_DATA_CENTER}
                 ],
-                "label": "Confluence Data Center username",
+                "display": "dropdown",
+                "label": "Confluence Data Center authentication method",
+                "options": [
+                    {
+                        "label": "Basic authentication",
+                        "value": DATA_CENTER_BASIC_AUTH,
+                    },
+                    {
+                        "label": "Personal access token",
+                        "value": DATA_CENTER_PERSONAL_ACCESS_TOKEN,
+                    },
+                ],
                 "order": 4,
+                "type": "str",
+                "value": DATA_CENTER_BASIC_AUTH,
+            },
+            "data_center_username": {
+                "depends_on": [
+                    {"field": "data_source", "value": CONFLUENCE_DATA_CENTER},
+                    {
+                        "field": "data_center_auth_method",
+                        "value": DATA_CENTER_BASIC_AUTH,
+                    },
+                ],
+                "label": "Confluence Data Center username",
+                "order": 5,
                 "type": "str",
             },
             "data_center_password": {
                 "depends_on": [
-                    {"field": "data_source", "value": CONFLUENCE_DATA_CENTER}
+                    {"field": "data_source", "value": CONFLUENCE_DATA_CENTER},
+                    {
+                        "field": "data_center_auth_method",
+                        "value": DATA_CENTER_BASIC_AUTH,
+                    },
                 ],
                 "label": "Confluence Data Center password",
                 "sensitive": True,
-                "order": 5,
+                "order": 6,
+                "type": "str",
+            },
+            "data_center_personal_access_token": {
+                "depends_on": [
+                    {"field": "data_source", "value": CONFLUENCE_DATA_CENTER},
+                    {
+                        "field": "data_center_auth_method",
+                        "value": DATA_CENTER_PERSONAL_ACCESS_TOKEN,
+                    },
+                ],
+                "label": "Confluence Data Center personal access token",
+                "sensitive": True,
+                "order": 7,
                 "type": "str",
             },
             "account_email": {
                 "depends_on": [{"field": "data_source", "value": CONFLUENCE_CLOUD}],
                 "label": "Confluence Cloud account email",
-                "order": 6,
+                "order": 8,
                 "type": "str",
             },
             "api_token": {
                 "depends_on": [{"field": "data_source", "value": CONFLUENCE_CLOUD}],
                 "label": "Confluence Cloud API token",
                 "sensitive": True,
-                "order": 7,
+                "order": 9,
                 "type": "str",
             },
             "confluence_url": {
                 "label": "Confluence URL",
-                "order": 8,
+                "order": 10,
                 "type": "str",
             },
             "spaces": {
                 "display": "textarea",
                 "label": "Confluence space keys",
-                "order": 9,
+                "order": 11,
                 "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
                 "type": "list",
             },
             "index_labels": {
                 "display": "toggle",
                 "label": "Enable indexing labels",
-                "order": 10,
+                "order": 12,
                 "tooltip": "Enabling this will increase the amount of network calls to the source, and may decrease performance",
                 "type": "bool",
                 "value": False,
@@ -199,21 +242,21 @@ class ConfluenceDataSource(BaseDataSource):
             "ssl_enabled": {
                 "display": "toggle",
                 "label": "Enable SSL",
-                "order": 11,
+                "order": 13,
                 "type": "bool",
                 "value": False,
             },
             "ssl_ca": {
                 "depends_on": [{"field": "ssl_enabled", "value": True}],
                 "label": "SSL certificate",
-                "order": 12,
+                "order": 14,
                 "type": "str",
             },
             "retry_count": {
                 "default_value": 3,
                 "display": "numeric",
                 "label": "Retries per request",
-                "order": 13,
+                "order": 15,
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
@@ -222,7 +265,7 @@ class ConfluenceDataSource(BaseDataSource):
                 "default_value": MAX_CONCURRENT_DOWNLOADS,
                 "display": "numeric",
                 "label": "Maximum concurrent downloads",
-                "order": 14,
+                "order": 16,
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
@@ -233,7 +276,7 @@ class ConfluenceDataSource(BaseDataSource):
             "use_document_level_security": {
                 "display": "toggle",
                 "label": "Enable document level security",
-                "order": 15,
+                "order": 17,
                 "tooltip": "Document level security ensures identities and permissions set in confluence are maintained in Elasticsearch. This enables you to restrict and personalize read-access users have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
                 "value": False,
@@ -241,7 +284,7 @@ class ConfluenceDataSource(BaseDataSource):
             "use_text_extraction_service": {
                 "display": "toggle",
                 "label": "Use text extraction service",
-                "order": 16,
+                "order": 18,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
                 "ui_restrictions": ["advanced"],

--- a/app/connectors_service/tests/sources/test_confluence.py
+++ b/app/connectors_service/tests/sources/test_confluence.py
@@ -39,6 +39,8 @@ from connectors.sources.atlassian.confluence.constants import (
     CONFLUENCE_SERVER,
     CONTENT_QUERY_CLOUD,
     CONTENT_QUERY_DATA_CENTER,
+    DATA_CENTER_BASIC_AUTH,
+    DATA_CENTER_PERSONAL_ACCESS_TOKEN,
     SPACE_QUERY_CLOUD,
     SPACE_QUERY_DATA_CENTER,
 )
@@ -606,13 +608,24 @@ EXPECTED_QUERY_RESPONSE = {
 
 @asynccontextmanager
 async def create_confluence_source(
-    use_text_extraction_service=False, data_source=CONFLUENCE_SERVER
+    use_text_extraction_service=False,
+    data_source=CONFLUENCE_SERVER,
+    data_center_auth_method=DATA_CENTER_BASIC_AUTH,
+    data_center_username="admin",
+    data_center_password="changeme",
+    data_center_personal_access_token="dc-pat-token",
 ):
     async with create_source(
         ConfluenceDataSource,
         data_source=data_source,
         username="admin",
         password="changeme",
+        account_email="me@example.com",
+        api_token="abc#123",
+        data_center_auth_method=data_center_auth_method,
+        data_center_username=data_center_username,
+        data_center_password=data_center_password,
+        data_center_personal_access_token=data_center_personal_access_token,
         confluence_url=HOST_URL,
         spaces="*",
         ssl_enabled=False,
@@ -667,8 +680,19 @@ async def test_validate_configuration_with_invalid_concurrent_downloads():
             # Confluence Data Center with blank dependent fields
             {
                 "data_source": CONFLUENCE_DATA_CENTER,
+                "data_center_auth_method": DATA_CENTER_BASIC_AUTH,
                 "data_center_username": "",
                 "data_center_password": "",
+                "account_email": "foo@bar.me",
+                "api_token": "foo",
+            }
+        ),
+        (
+            # Confluence Data Center PAT with blank token
+            {
+                "data_source": CONFLUENCE_DATA_CENTER,
+                "data_center_auth_method": DATA_CENTER_PERSONAL_ACCESS_TOKEN,
+                "data_center_personal_access_token": "",
                 "account_email": "foo@bar.me",
                 "api_token": "foo",
             }
@@ -712,11 +736,24 @@ async def test_validate_configuration_with_invalid_dependency_fields_raises_erro
             }
         ),
         (
-            # Confluence Data Center with blank dependent fields
+            # Confluence Data Center with blank non-dependent fields
             {
                 "data_source": CONFLUENCE_DATA_CENTER,
+                "data_center_auth_method": DATA_CENTER_BASIC_AUTH,
                 "data_center_username": "foo",
                 "data_center_password": "bar",
+                "account_email": "",
+                "api_token": "",
+            }
+        ),
+        (
+            # Confluence Data Center PAT with blank basic auth fields
+            {
+                "data_source": CONFLUENCE_DATA_CENTER,
+                "data_center_auth_method": DATA_CENTER_PERSONAL_ACCESS_TOKEN,
+                "data_center_username": "",
+                "data_center_password": "",
+                "data_center_personal_access_token": "confluence-dc-pat",
                 "account_email": "",
                 "api_token": "",
             }
@@ -847,23 +884,31 @@ class MockSSL:
 
 
 @pytest.mark.parametrize(
-    "field, data_source",
+    "field, data_source, auth_method",
     [
-        ("confluence_url", "confluence_cloud"),
-        ("account_email", "confluence_cloud"),
-        ("api_token", "confluence_cloud"),
-        ("username", "confluence_server"),
-        ("password", "confluence_server"),
-        ("data_center_username", "confluence_data_center"),
-        ("data_center_password", "confluence_data_center"),
+        ("confluence_url", "confluence_cloud", DATA_CENTER_BASIC_AUTH),
+        ("account_email", "confluence_cloud", DATA_CENTER_BASIC_AUTH),
+        ("api_token", "confluence_cloud", DATA_CENTER_BASIC_AUTH),
+        ("username", "confluence_server", DATA_CENTER_BASIC_AUTH),
+        ("password", "confluence_server", DATA_CENTER_BASIC_AUTH),
+        ("data_center_username", "confluence_data_center", DATA_CENTER_BASIC_AUTH),
+        ("data_center_password", "confluence_data_center", DATA_CENTER_BASIC_AUTH),
+        (
+            "data_center_personal_access_token",
+            "confluence_data_center",
+            DATA_CENTER_PERSONAL_ACCESS_TOKEN,
+        ),
     ],
 )
 @pytest.mark.asyncio
-async def test_validate_configuration_for_empty_fields(field, data_source):
+async def test_validate_configuration_for_empty_fields(field, data_source, auth_method):
     async with create_confluence_source() as source:
         source.confluence_client.configuration.get_field(
             "data_source"
         ).value = data_source
+        source.confluence_client.configuration.get_field(
+            "data_center_auth_method"
+        ).value = auth_method
         source.confluence_client.configuration.get_field(field).value = ""
 
         # Execute
@@ -1416,6 +1461,43 @@ async def test_get_session(data_source_type):
             pytest.fail(
                 f"Should not raise for valid data source type '{data_source_type}'. Exception: {e}"
             )
+
+
+@pytest.mark.asyncio
+async def test_get_session_data_center_basic_auth():
+    async with create_confluence_source(
+        data_source=CONFLUENCE_DATA_CENTER,
+        data_center_auth_method=DATA_CENTER_BASIC_AUTH,
+        data_center_username="dc-user",
+        data_center_password="dc-pass",
+    ) as source:
+        session = source.confluence_client._get_session()
+        assert isinstance(session._default_auth, aiohttp.BasicAuth)
+        assert session._default_auth.login == "dc-user"
+        assert session._default_auth.password == "dc-pass"
+        assert "Authorization" not in session.headers
+
+
+@pytest.mark.asyncio
+async def test_get_session_data_center_personal_access_token():
+    async with create_confluence_source(
+        data_source=CONFLUENCE_DATA_CENTER,
+        data_center_auth_method=DATA_CENTER_PERSONAL_ACCESS_TOKEN,
+        data_center_personal_access_token="confluence-dc-pat",
+    ) as source:
+        session = source.confluence_client._get_session()
+        assert session._default_auth is None
+        assert session.headers["Authorization"] == "Bearer confluence-dc-pat"
+
+
+@pytest.mark.asyncio
+async def test_get_session_data_center_invalid_auth_method():
+    async with create_confluence_source(data_source=CONFLUENCE_DATA_CENTER) as source:
+        source.confluence_client.configuration.get_field(
+            "data_center_auth_method"
+        ).value = "invalid"
+        with pytest.raises(InvalidConfluenceDataSourceTypeError):
+            source.confluence_client._get_session()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

* https://github.com/elastic/connectors/issues/3253

## Summary

Adds Personal Access Token (Bearer) authentication for the Confluence Data Center connector. Environments that disable password-based basic auth can authenticate with a DC PAT, matching Atlassian’s documented PAT usage (also called out in comments on #3253).

Default auth method remains basic username/password, so existing Data Center connectors keep working unchanged.

## UI
Basic:
<img width="87" height="160" alt="image" src="https://github.com/user-attachments/assets/12438a75-515f-446d-874d-afe719b6f09e" />
PAT:
<img width="88" height="138" alt="image" src="https://github.com/user-attachments/assets/31976c18-76c5-4145-a520-28f710a73423" />


## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4338

## Changes

- Add `data_center_auth_method` dropdown (`basic` default / `personal_access_token`) for Confluence Data Center
- Gate username/password behind basic auth; add sensitive `data_center_personal_access_token` for PAT
- Send `Authorization: Bearer <token>` for PAT sessions instead of HTTP Basic
- Unit tests for session construction, validation, and invalid auth method handling

## Testing

- `make clean install autoformat lint test PYTHON=python3.11` (passed; 2335 tests after a clean re-run)
- No live Confluence Data Center instance available locally for E2E PAT verification

## Notes for reviewers

- Follow-up Kibana PR is required for native connector create UI (`native_connectors.ts`)
- Mirrors the Jira DC PAT approach from #4338

## Release Note

Confluence Data Center connectors can authenticate with a personal access token (Bearer) when password-based basic auth is disabled.